### PR TITLE
split the Succinct Marlin protocol polynomials

### DIFF
--- a/dlog/protocol/src/marlin_sponge.rs
+++ b/dlog/protocol/src/marlin_sponge.rs
@@ -40,7 +40,7 @@ impl<Fr: PrimeField> FrSponge<Fr> for DefaultFrSponge<Fr> {
     }
 
     fn absorb(&mut self, x: &Fr) {
-        self.sponge.absorb(&self.params, x);
+        self.sponge.absorb(&self.params, &[*x]);
     }
 
     fn challenge(&mut self) -> Fr {
@@ -51,23 +51,23 @@ impl<Fr: PrimeField> FrSponge<Fr> for DefaultFrSponge<Fr> {
 
     fn absorb_evaluations(&mut self, x_hat_beta1: &Fr, e: &ProofEvaluations<Fr>) {
         // beta1 evaluations
-        self.sponge.absorb(&self.params, x_hat_beta1);
+        self.sponge.absorb(&self.params, &[*x_hat_beta1]);
         for x in &[e.w, e.g1, e.h1, e.za, e.zb] {
-            self.sponge.absorb(&self.params, x);
+            self.sponge.absorb(&self.params, &[*x]);
         }
 
         // beta2 evaluations
         for x in &[e.g2, e.h2] {
-            self.sponge.absorb(&self.params, x);
+            self.sponge.absorb(&self.params, &[*x]);
         }
 
         // beta3 evaluations
         for x in &[e.g3, e.h3] {
-            self.sponge.absorb(&self.params, x);
+            self.sponge.absorb(&self.params, &[*x]);
         }
         for t in &[e.row, e.col, e.val] {
             for x in t {
-                self.sponge.absorb(&self.params, x);
+                self.sponge.absorb(&self.params, &[*x]);
             }
         }
     }
@@ -90,8 +90,8 @@ where
         if g.infinity {
             panic!("marlin sponge got zero curve point");
         } else {
-            self.sponge.absorb(&self.params, &g.x);
-            self.sponge.absorb(&self.params, &g.y);
+            self.sponge.absorb(&self.params, &[g.x]);
+            self.sponge.absorb(&self.params, &[g.y]);
         }
     }
 
@@ -103,7 +103,7 @@ where
         {
             self.sponge.absorb(
                 &self.params,
-                &P::BaseField::from_repr(<P::BaseField as PrimeField>::BigInt::from_bits(&bits)),
+                &[P::BaseField::from_repr(<P::BaseField as PrimeField>::BigInt::from_bits(&bits))],
             );
         } else {
             let low_bits = &bits[..(bits.len() - 1)];
@@ -114,11 +114,11 @@ where
             };
             self.sponge.absorb(
                 &self.params,
-                &P::BaseField::from_repr(<P::BaseField as PrimeField>::BigInt::from_bits(
+                &[P::BaseField::from_repr(<P::BaseField as PrimeField>::BigInt::from_bits(
                     &low_bits,
-                )),
+                ))],
             );
-            self.sponge.absorb(&self.params, &high_bit);
+            self.sponge.absorb(&self.params, &[high_bit]);
         }
     }
 

--- a/dlog/tests/batch.rs
+++ b/dlog/tests/batch.rs
@@ -17,7 +17,7 @@ use rand::Rng;
 type Fr = <Affine as AffineCurve>::ScalarField;
 
 #[test]
-fn batch_commitment_test()
+fn batch_commitment_dlog()
 where <Fp as std::str::FromStr>::Err : std::fmt::Debug
 {
     let rng = &mut OsRng;

--- a/pairing/circuits/src/compiled.rs
+++ b/pairing/circuits/src/compiled.rs
@@ -17,10 +17,10 @@ pub struct Compiled<E: PairingEngine>
     pub constraints: CsMat<E::Fr>,
 
     // compiled polynomial commitments
-    pub col_comm: E::G1Affine,
-    pub row_comm: E::G1Affine,
-    pub val_comm: E::G1Affine,
-    pub rc_comm: E::G1Affine,
+    pub col_comm: Vec<E::G1Affine>,
+    pub row_comm: Vec<E::G1Affine>,
+    pub val_comm: Vec<E::G1Affine>,
+    pub rc_comm: Vec<E::G1Affine>,
 
     // compiled polynomials and evaluations
     pub rc      : DensePolynomial<E::Fr>,
@@ -44,6 +44,7 @@ impl<E: PairingEngine> Compiled<E>
     //  k_group: evaluation domain for degere k (constrtraint matrix number of non-zero elements)
     //  b_group: evaluation domain for degere b (h_group*6-6)
     //  constraints: constraint matrix in dense form
+    //  size: maximal size of the polynomial chunks
     pub fn compile
     (
         urs: &URS<E>,
@@ -51,6 +52,7 @@ impl<E: PairingEngine> Compiled<E>
         k_group: EvaluationDomain<E::Fr>,
         b_group: EvaluationDomain<E::Fr>,
         constraints: CsMat<E::Fr>,
+        size: usize,
     ) -> Result<Self, ProofError>
     {
         let mut col_eval_k = vec![E::Fr::zero(); k_group.size as usize];
@@ -92,10 +94,10 @@ impl<E: PairingEngine> Compiled<E>
         Ok(Compiled::<E>
         {
             constraints,
-            rc_comm: urs.commit(&rc)?,
-            row_comm: urs.commit(&row)?,
-            col_comm: urs.commit(&col)?,
-            val_comm: urs.commit(&val)?,
+            rc_comm: urs.commit(&rc, size)?,
+            row_comm: urs.commit(&row, size)?,
+            col_comm: urs.commit(&col, size)?,
+            val_comm: urs.commit(&val, size)?,
             row_eval_b: Evaluations::<E::Fr>::from_vec_and_domain(b_group.fft(&row), b_group),
             col_eval_b: Evaluations::<E::Fr>::from_vec_and_domain(b_group.fft(&col), b_group),
             val_eval_b: Evaluations::<E::Fr>::from_vec_and_domain(b_group.fft(&val), b_group),

--- a/pairing/circuits/src/compiled.rs
+++ b/pairing/circuits/src/compiled.rs
@@ -5,7 +5,7 @@ This source file implements the compiled constraints primitive.
 *****************************************************************************************************************/
 
 use sprs::CsMat;
-use commitment_pairing::urs::URS;
+use commitment_pairing::{urs::URS, commitment::PolyComm};
 use oracle::rndoracle::ProofError;
 use algebra::{Field, PairingEngine};
 use ff_fft::{DensePolynomial, Evaluations, EvaluationDomain};
@@ -17,10 +17,10 @@ pub struct Compiled<E: PairingEngine>
     pub constraints: CsMat<E::Fr>,
 
     // compiled polynomial commitments
-    pub col_comm: Vec<E::G1Affine>,
-    pub row_comm: Vec<E::G1Affine>,
-    pub val_comm: Vec<E::G1Affine>,
-    pub rc_comm: Vec<E::G1Affine>,
+    pub col_comm: PolyComm<E::G1Affine>,
+    pub row_comm: PolyComm<E::G1Affine>,
+    pub val_comm: PolyComm<E::G1Affine>,
+    pub rc_comm: PolyComm<E::G1Affine>,
 
     // compiled polynomials and evaluations
     pub rc      : DensePolynomial<E::Fr>,
@@ -94,10 +94,10 @@ impl<E: PairingEngine> Compiled<E>
         Ok(Compiled::<E>
         {
             constraints,
-            rc_comm: urs.commit(&rc, None, size)?.0,
-            row_comm: urs.commit(&row, None, size)?.0,
-            col_comm: urs.commit(&col, None, size)?.0,
-            val_comm: urs.commit(&val, None, size)?.0,
+            rc_comm: urs.commit(&rc, None),
+            row_comm: urs.commit(&row, None),
+            col_comm: urs.commit(&col, None),
+            val_comm: urs.commit(&val, None),
             row_eval_b: Evaluations::<E::Fr>::from_vec_and_domain(b_group.fft(&row), b_group),
             col_eval_b: Evaluations::<E::Fr>::from_vec_and_domain(b_group.fft(&col), b_group),
             val_eval_b: Evaluations::<E::Fr>::from_vec_and_domain(b_group.fft(&val), b_group),

--- a/pairing/circuits/src/compiled.rs
+++ b/pairing/circuits/src/compiled.rs
@@ -94,10 +94,10 @@ impl<E: PairingEngine> Compiled<E>
         Ok(Compiled::<E>
         {
             constraints,
-            rc_comm: urs.commit(&rc, size)?,
-            row_comm: urs.commit(&row, size)?,
-            col_comm: urs.commit(&col, size)?,
-            val_comm: urs.commit(&val, size)?,
+            rc_comm: urs.commit(&rc, None, size)?.0,
+            row_comm: urs.commit(&row, None, size)?.0,
+            col_comm: urs.commit(&col, None, size)?.0,
+            val_comm: urs.commit(&val, None, size)?.0,
             row_eval_b: Evaluations::<E::Fr>::from_vec_and_domain(b_group.fft(&row), b_group),
             col_eval_b: Evaluations::<E::Fr>::from_vec_and_domain(b_group.fft(&col), b_group),
             val_eval_b: Evaluations::<E::Fr>::from_vec_and_domain(b_group.fft(&val), b_group),

--- a/pairing/circuits/src/index.rs
+++ b/pairing/circuits/src/index.rs
@@ -6,8 +6,8 @@ This source file implements Marlin Protocol Index primitive.
 
 use sprs::CsMat;
 use rand_core::RngCore;
-use commitment_pairing::urs::URS;
-use algebra::PairingEngine;
+use commitment_pairing::{urs::URS, commitment::PolyComm};
+use algebra::{PairingEngine, AffineCurve};
 use oracle::rndoracle::ProofError;
 use oracle::poseidon::ArithmeticSpongeParams;
 pub use super::compiled::Compiled;
@@ -81,11 +81,11 @@ pub struct Index<'a, E: PairingEngine>
     pub fq_sponge_params: ArithmeticSpongeParams<E::Fq>,
 }
 
-pub struct MatrixValues<A> {
-    pub row : Vec<A>,
-    pub col : Vec<A>,
-    pub val : Vec<A>,
-    pub rc : Vec<A>,
+pub struct MatrixValues<C: AffineCurve> {
+    pub row : PolyComm<C>,
+    pub col : PolyComm<C>,
+    pub val : PolyComm<C>,
+    pub rc : PolyComm<C>,
 }
 
 pub struct VerifierIndex<E: PairingEngine>

--- a/pairing/circuits/src/index.rs
+++ b/pairing/circuits/src/index.rs
@@ -38,17 +38,15 @@ impl<'a, E: PairingEngine> URSValue<'a, E> {
         ds: EvaluationDomains<E::Fr>,
         size: usize,
         rng : &'b mut dyn RngCore) -> URS<E> {
-        let max_degree = *[3*ds.h.size()-1, ds.b.size()].iter().max().unwrap();
 
         URS::<E>::create
         (
-            max_degree,
+            size,
             vec!
             [
-                ds.h.size()-1,
-                ds.k.size()-1,
+                ds.h.size()-1 % size,
+                ds.k.size()-1 % size,
             ],
-            size,
             rng
         )
     }
@@ -134,7 +132,6 @@ impl<'a, E: PairingEngine> Index<'a, E>
             URS::<E> {
                 gp: (0..self.domains.x.size()).map(|i| self.urs.get_ref().gp[i]).collect(),
                 hn: self.urs.get_ref().hn.clone(),
-                hp: self.urs.get_ref().hp.clone(),
                 hx: self.urs.get_ref().hx,
                 prf: self.urs.get_ref().prf,
                 depth: self.urs.get_ref().max_degree(),

--- a/pairing/commitment/src/commitment.rs
+++ b/pairing/commitment/src/commitment.rs
@@ -133,7 +133,7 @@ impl<E: PairingEngine> URS<E>
         <(
             E::Fr,
             E::Fr,
-            Vec<(PolyComm<E::G1Affine>, Vec<E::Fr>, Option<usize>)>,
+            Vec<(&PolyComm<E::G1Affine>, &Vec<E::Fr>, Option<usize>)>,
             E::G1Affine,
         )>,
         rng: &mut dyn RngCore

--- a/pairing/commitment/src/urs.rs
+++ b/pairing/commitment/src/urs.rs
@@ -20,6 +20,7 @@ pub struct URS<E: PairingEngine>
 {
     pub depth: usize,
     pub gp: Vec<E::G1Affine>, // g^(x^i) for 0 <= i < d
+    pub hp: Vec<E::G2Affine>, // h^(x^(size*i)) for 0 <= size*i < d
     pub hn: HashMap<usize, E::G2Affine>, // h^(x^-i) for 0 <= i < d
     pub hx: E::G2Affine,
     pub prf: E::G1Affine
@@ -40,6 +41,11 @@ impl<E: PairingEngine> URS<E>
         u64::write(&(self.gp.len() as u64), &mut writer)?;
         for x in &self.gp {
             E::G1Affine::write(x, &mut writer)?;
+        }
+
+        u64::write(&(self.hp.len() as u64), &mut writer)?;
+        for x in &self.hp {
+            E::G2Affine::write(x, &mut writer)?;
         }
 
         let m = self.hn.len();
@@ -64,6 +70,12 @@ impl<E: PairingEngine> URS<E>
             gp.push(E::G1Affine::read(&mut reader)?);
         }
 
+        let l = u64::read(&mut reader)?;
+        let mut hp = vec![];
+        for _ in 0..l {
+            hp.push(E::G2Affine::read(&mut reader)?);
+        }
+
         let m = u64::read(&mut reader)?;
         let mut hn = HashMap::new();
         for _ in 0..m {
@@ -75,20 +87,25 @@ impl<E: PairingEngine> URS<E>
         let hx = E::G2Affine::read(&mut reader)?;
         let prf = E::G1Affine::read(&mut reader)?;
 
-        Ok( URS { depth, gp, hn, hx, prf } )
+        Ok( URS { depth, gp, hp, hn, hx, prf } )
     }
 
     // This function creates URS instance for circuits up to depth d
     //     depth: maximal depth of the supported circuits
-    //     commitment degrees of the committed polynomials for supported circuits
+    //     degrees: commitment degrees of the committed polynomials for supported circuits
+    //     size: maximal size of the polynomial chunks
     //     rng: randomness source context
     pub fn create
     (
         depth: usize,
         degrees: Vec<usize>,
+        size: usize,
         rng: &mut dyn RngCore
     ) -> Self
     {
+        let mut degrees = degrees.clone();
+        degrees.push(depth);
+    
         let mut x = E::Fr::rand(rng);
         let size_in_bits = E::Fr::size_in_bits();
         let window_size = FixedBaseMSM::get_mul_window_size(depth+1);
@@ -107,6 +124,20 @@ impl<E: PairingEngine> URS<E>
             &(0..depth).map(|_| {let s = cur; cur *= &x; s}).collect::<Vec<E::Fr>>(),
         );
         ProjectiveCurve::batch_normalization(&mut gp);
+
+        let mut hp = FixedBaseMSM::multi_scalar_mul::<E::G2Projective>
+        (
+            size_in_bits,
+            window_size,
+            &FixedBaseMSM::get_window_table
+            (
+                size_in_bits,
+                window_size,
+                E::G2Projective::prime_subgroup_generator()
+            ),
+            &(0..depth).step_by(size).map(|i| x.pow([i as u64])).collect::<Vec<E::Fr>>(),
+        );
+        ProjectiveCurve::batch_normalization(&mut hp);
 
         let mut gx = E::G1Projective::prime_subgroup_generator();
         gx.mul_assign(x);
@@ -135,6 +166,7 @@ impl<E: PairingEngine> URS<E>
         {
             hn: hnh,
             gp: gp.into_iter().map(|e| e.into_affine()).collect(),
+            hp: hp.into_iter().map(|e| e.into_affine()).collect(),
             prf: E::G1Affine::from(gx),
             hx: E::G2Affine::from(hx),
             depth
@@ -142,11 +174,13 @@ impl<E: PairingEngine> URS<E>
     }
 
     // This function updates URS instance and computes the update proof
+    //     size: maximal size of the polynomial chunks
     //     rng: randomness source context
     //     RETURN: computed zk-proof
     pub fn update
     (
         &mut self,
+        size: usize,
         rng: &mut dyn RngCore
     )
     {
@@ -156,6 +190,11 @@ impl<E: PairingEngine> URS<E>
         {
             self.gp[i] = self.gp[i].mul(cur).into_affine();
             cur *= &x;
+        }
+
+        for i in 0..self.hp.len()
+        {
+            self.hp[i] = self.hp[i].mul(x.pow([(size*i) as u64])).into_affine();
         }
 
         self.prf = E::G1Affine::prime_subgroup_generator().mul(x).into_affine();
@@ -170,12 +209,14 @@ impl<E: PairingEngine> URS<E>
 
     // This function verifies the updated URS against the zk-proof and the previous URS instance
     //     hn1: previous URS gp[1]
+    //     size: maximal size of the polynomial chunks
     //     randomness source context
     //     RETURN: zk-proof verification status
     pub fn check
     (
         &mut self,
         hp1: E::G2Affine,
+        size: usize,
         rng: &mut dyn RngCore
     ) -> bool
     {
@@ -192,21 +233,43 @@ impl<E: PairingEngine> URS<E>
             if <E>::pairing(self.gp[*x.0], *x.1) != fk {return false}
         }
 
-        let rand = (1..self.gp.len()).map(|_| E::Fr::rand(rng).into_repr()).collect::<Vec<_>>();
+        let randg = (1..self.gp.len()).map(|_| E::Fr::rand(rng).into_repr()).collect::<Vec<_>>();
+        let randh = (1..self.hp.len()).map(|_| E::Fr::rand(rng).into_repr()).collect::<Vec<_>>();
         E::final_exponentiation(&E::miller_loop(&
         [
-            (&VariableBaseMSM::multi_scalar_mul
+            (
+                &VariableBaseMSM::multi_scalar_mul
                 (
                     &(1..self.gp.len()).map(|i| self.gp[i]).collect::<Vec<_>>(),
-                    &rand
-                ).into_affine().prepare(), &E::G2Affine::prime_subgroup_generator().prepare()
+                    &randg
+                ).into_affine().prepare(),
+                &E::G2Affine::prime_subgroup_generator().prepare()
             ),
-            (&VariableBaseMSM::multi_scalar_mul
+            (
+                &VariableBaseMSM::multi_scalar_mul
                 (
                     &(1..self.gp.len()).map(|i| self.gp[i-1]).collect::<Vec<_>>(),
-                    &rand
-                ).into_affine().prepare(), &(-self.hx).prepare()
+                    &randg
+                ).into_affine().prepare(),
+                &(-self.hx).prepare()
+            ),            
+            (
+                &E::G1Affine::prime_subgroup_generator().prepare(),
+                &VariableBaseMSM::multi_scalar_mul
+                (
+                    &(1..self.hp.len()).map(|i| self.hp[i]).collect::<Vec<_>>(),
+                    &randh
+                ).into_affine().prepare(),
             ),
+            (
+                &(-self.gp[size]).prepare(),
+                &VariableBaseMSM::multi_scalar_mul
+                (
+                    &(1..self.hp.len()).map(|i| self.hp[i-1]).collect::<Vec<_>>(),
+                    &randh
+                ).into_affine().prepare(),
+            ),
+            
         ])).unwrap() == E::Fqk::one()
     }
 }

--- a/pairing/commitment/src/urs.rs
+++ b/pairing/commitment/src/urs.rs
@@ -20,7 +20,6 @@ pub struct URS<E: PairingEngine>
 {
     pub depth: usize,
     pub gp: Vec<E::G1Affine>, // g^(x^i) for 0 <= i < d
-    pub hp: Vec<E::G2Affine>, // h^(x^(size*i)) for 0 <= size*i < d
     pub hn: HashMap<usize, E::G2Affine>, // h^(x^-i) for 0 <= i < d
     pub hx: E::G2Affine,
     pub prf: E::G1Affine
@@ -41,11 +40,6 @@ impl<E: PairingEngine> URS<E>
         u64::write(&(self.gp.len() as u64), &mut writer)?;
         for x in &self.gp {
             E::G1Affine::write(x, &mut writer)?;
-        }
-
-        u64::write(&(self.hp.len() as u64), &mut writer)?;
-        for x in &self.hp {
-            E::G2Affine::write(x, &mut writer)?;
         }
 
         let m = self.hn.len();
@@ -70,12 +64,6 @@ impl<E: PairingEngine> URS<E>
             gp.push(E::G1Affine::read(&mut reader)?);
         }
 
-        let l = u64::read(&mut reader)?;
-        let mut hp = vec![];
-        for _ in 0..l {
-            hp.push(E::G2Affine::read(&mut reader)?);
-        }
-
         let m = u64::read(&mut reader)?;
         let mut hn = HashMap::new();
         for _ in 0..m {
@@ -87,25 +75,20 @@ impl<E: PairingEngine> URS<E>
         let hx = E::G2Affine::read(&mut reader)?;
         let prf = E::G1Affine::read(&mut reader)?;
 
-        Ok( URS { depth, gp, hp, hn, hx, prf } )
+        Ok( URS { depth, gp, hn, hx, prf } )
     }
 
     // This function creates URS instance for circuits up to depth d
     //     depth: maximal depth of the supported circuits
-    //     degrees: commitment degrees of the committed polynomials for supported circuits
-    //     size: maximal size of the polynomial chunks
+    //     commitment degrees of the committed polynomials for supported circuits
     //     rng: randomness source context
     pub fn create
     (
         depth: usize,
         degrees: Vec<usize>,
-        size: usize,
         rng: &mut dyn RngCore
     ) -> Self
     {
-        let mut degrees = degrees.clone();
-        degrees.push(depth);
-    
         let mut x = E::Fr::rand(rng);
         let size_in_bits = E::Fr::size_in_bits();
         let window_size = FixedBaseMSM::get_mul_window_size(depth+1);
@@ -124,20 +107,6 @@ impl<E: PairingEngine> URS<E>
             &(0..depth).map(|_| {let s = cur; cur *= &x; s}).collect::<Vec<E::Fr>>(),
         );
         ProjectiveCurve::batch_normalization(&mut gp);
-
-        let mut hp = FixedBaseMSM::multi_scalar_mul::<E::G2Projective>
-        (
-            size_in_bits,
-            window_size,
-            &FixedBaseMSM::get_window_table
-            (
-                size_in_bits,
-                window_size,
-                E::G2Projective::prime_subgroup_generator()
-            ),
-            &(0..depth).step_by(size).map(|i| x.pow([i as u64])).collect::<Vec<E::Fr>>(),
-        );
-        ProjectiveCurve::batch_normalization(&mut hp);
 
         let mut gx = E::G1Projective::prime_subgroup_generator();
         gx.mul_assign(x);
@@ -166,7 +135,6 @@ impl<E: PairingEngine> URS<E>
         {
             hn: hnh,
             gp: gp.into_iter().map(|e| e.into_affine()).collect(),
-            hp: hp.into_iter().map(|e| e.into_affine()).collect(),
             prf: E::G1Affine::from(gx),
             hx: E::G2Affine::from(hx),
             depth
@@ -174,13 +142,11 @@ impl<E: PairingEngine> URS<E>
     }
 
     // This function updates URS instance and computes the update proof
-    //     size: maximal size of the polynomial chunks
     //     rng: randomness source context
     //     RETURN: computed zk-proof
     pub fn update
     (
         &mut self,
-        size: usize,
         rng: &mut dyn RngCore
     )
     {
@@ -190,11 +156,6 @@ impl<E: PairingEngine> URS<E>
         {
             self.gp[i] = self.gp[i].mul(cur).into_affine();
             cur *= &x;
-        }
-
-        for i in 0..self.hp.len()
-        {
-            self.hp[i] = self.hp[i].mul(x.pow([(size*i) as u64])).into_affine();
         }
 
         self.prf = E::G1Affine::prime_subgroup_generator().mul(x).into_affine();
@@ -209,14 +170,12 @@ impl<E: PairingEngine> URS<E>
 
     // This function verifies the updated URS against the zk-proof and the previous URS instance
     //     hn1: previous URS gp[1]
-    //     size: maximal size of the polynomial chunks
     //     randomness source context
     //     RETURN: zk-proof verification status
     pub fn check
     (
         &mut self,
         hp1: E::G2Affine,
-        size: usize,
         rng: &mut dyn RngCore
     ) -> bool
     {
@@ -233,43 +192,21 @@ impl<E: PairingEngine> URS<E>
             if <E>::pairing(self.gp[*x.0], *x.1) != fk {return false}
         }
 
-        let randg = (1..self.gp.len()).map(|_| E::Fr::rand(rng).into_repr()).collect::<Vec<_>>();
-        let randh = (1..self.hp.len()).map(|_| E::Fr::rand(rng).into_repr()).collect::<Vec<_>>();
+        let rand = (1..self.gp.len()).map(|_| E::Fr::rand(rng).into_repr()).collect::<Vec<_>>();
         E::final_exponentiation(&E::miller_loop(&
         [
-            (
-                &VariableBaseMSM::multi_scalar_mul
+            (&VariableBaseMSM::multi_scalar_mul
                 (
                     &(1..self.gp.len()).map(|i| self.gp[i]).collect::<Vec<_>>(),
-                    &randg
-                ).into_affine().prepare(),
-                &E::G2Affine::prime_subgroup_generator().prepare()
+                    &rand
+                ).into_affine().prepare(), &E::G2Affine::prime_subgroup_generator().prepare()
             ),
-            (
-                &VariableBaseMSM::multi_scalar_mul
+            (&VariableBaseMSM::multi_scalar_mul
                 (
                     &(1..self.gp.len()).map(|i| self.gp[i-1]).collect::<Vec<_>>(),
-                    &randg
-                ).into_affine().prepare(),
-                &(-self.hx).prepare()
-            ),            
-            (
-                &E::G1Affine::prime_subgroup_generator().prepare(),
-                &VariableBaseMSM::multi_scalar_mul
-                (
-                    &(1..self.hp.len()).map(|i| self.hp[i]).collect::<Vec<_>>(),
-                    &randh
-                ).into_affine().prepare(),
+                    &rand
+                ).into_affine().prepare(), &(-self.hx).prepare()
             ),
-            (
-                &(-self.gp[size]).prepare(),
-                &VariableBaseMSM::multi_scalar_mul
-                (
-                    &(1..self.hp.len()).map(|i| self.hp[i-1]).collect::<Vec<_>>(),
-                    &randh
-                ).into_affine().prepare(),
-            ),
-            
         ])).unwrap() == E::Fqk::one()
     }
 }

--- a/pairing/tests/group_addition.rs
+++ b/pairing/tests/group_addition.rs
@@ -73,6 +73,7 @@ where <Fp as std::str::FromStr>::Err : std::fmt::Debug
         b,
         c,
         4,
+        16,
         oracle::bn_382::fp::params() as ArithmeticSpongeParams<Fp>,
         oracle::bn_382::fq::params(),
         URSSpec::Generate(rng)

--- a/pairing/tests/group_addition.rs
+++ b/pairing/tests/group_addition.rs
@@ -215,8 +215,8 @@ where <Fp as std::str::FromStr>::Err : std::fmt::Debug
     // verify one proof serially
     match ProverProof::verify::<DefaultFqSponge<Bn_382G1Parameters>, DefaultFrSponge<Fp>>(&vec![batch[0].clone()], &verifier_index, rng)
     {
-        Ok(_) => {}
-        _ => {panic!("Failure verifying the prover's proof")}
+        true => {}
+        false => {panic!("Failure verifying the prover's proof")}
     }
 
     // verify the proofs in batch
@@ -224,8 +224,8 @@ where <Fp as std::str::FromStr>::Err : std::fmt::Debug
     start = Instant::now();
     match ProverProof::verify::<DefaultFqSponge<Bn_382G1Parameters>, DefaultFrSponge<Fp>>(&batch, &verifier_index, rng)
     {
-        Err(error) => {panic!("Failure verifying the prover's proofs in batch: {}", error)},
-        Ok(_) => {println!("{}{:?}", "Execution time: ".yellow(), start.elapsed());}
+        false => {panic!("Failure verifying the prover's proofs in batch")},
+        true => {println!("{}{:?}", "Execution time: ".yellow(), start.elapsed());}
     }
 }
 

--- a/pairing/tests/urs.rs
+++ b/pairing/tests/urs.rs
@@ -25,8 +25,7 @@ fn urs_test()
 
 fn test<E: PairingEngine>()
 {
-    let depth = 30;
-    let size = 8;
+    let size = 16;
     let iterations = 1;
     let mut rng = &mut OsRng;
 
@@ -35,9 +34,8 @@ fn test<E: PairingEngine>()
     let mut start = Instant::now();
     let mut urs = URS::<E>::create
     (
-        depth,
-        vec![3,7],
         size,
+        vec![3,7],
         &mut rng
     );
     println!("{}{:?}", "Execution time: ".yellow(), start.elapsed());
@@ -52,12 +50,12 @@ fn test<E: PairingEngine>()
 
         start = Instant::now();
         // update sample URS string for circuit depth of up to 'depth'
-        urs.update(size, &mut rng);
+        urs.update(&mut rng);
         println!("{}{:?}", "Execution time: ".yellow(), start.elapsed());
 
         println!("{}", "Verifying the update against its zk-proof".green());
         start = Instant::now();
-        assert_eq!(urs.check(hx, size, &mut rng), true);
+        assert_eq!(urs.check(hx, &mut rng), true);
         println!("{}{:?}", "Execution time: ".yellow(), start.elapsed());
     }
 }

--- a/pairing/tests/urs.rs
+++ b/pairing/tests/urs.rs
@@ -26,6 +26,7 @@ fn urs_test()
 fn test<E: PairingEngine>()
 {
     let depth = 30;
+    let size = 8;
     let iterations = 1;
     let mut rng = &mut OsRng;
 
@@ -36,6 +37,7 @@ fn test<E: PairingEngine>()
     (
         depth,
         vec![3,7],
+        size,
         &mut rng
     );
     println!("{}{:?}", "Execution time: ".yellow(), start.elapsed());
@@ -50,12 +52,12 @@ fn test<E: PairingEngine>()
 
         start = Instant::now();
         // update sample URS string for circuit depth of up to 'depth'
-        urs.update(&mut rng);
+        urs.update(size, &mut rng);
         println!("{}{:?}", "Execution time: ".yellow(), start.elapsed());
 
         println!("{}", "Verifying the update against its zk-proof".green());
         start = Instant::now();
-        assert_eq!(urs.check(hx, &mut rng), true);
+        assert_eq!(urs.check(hx, size, &mut rng), true);
         println!("{}{:?}", "Execution time: ".yellow(), start.elapsed());
     }
 }


### PR DESCRIPTION
This PR splits all the Succinct Marlin protocol polynomials into segments of a defined maximal size. Modifications include:

1. Polycommitment enhancements for splitting support
2. URS modifications to support polycommitment enhancements
3. Sponge adjustments to absorb commitment vectors
4. Protocol changes

The modified polycommitment schema, when committing to a polynomial without the degree bound, outputs, upon commitment, the unshifted (at the left edge of URS) commitments to the polynomial segments of defined maximal size. When committing to a polynomial with the degree bound, the schema outputs, in the case when the polynomial size is not strictly divisible by the maximal segment size, besides the unshifted commitments to the polynomial segments, the shifted (to the right edge of URS) commitment to the last segment of the polynomial. This contributes to moderately faster commitment computation since only the last segment needs to be right-shift committed.

For the verification of the consistency between shifted and unshifted commitments, therefore, it is sufficient to verify the consistency of the unshifted vs shifted commitments of the last (right-most) segment of the polynomial.

The URS G1 element GP array length equals, with this polycommitment schema, to the defined maximal size of the committed polynomial segments.

Observations:

The splitting of the Succinct Marlin protocol polynomials has been benchmarked against the small circuit of the pairing-based Marlin unit test.

No noticeable performance improvement (upon splitting the polynomials) has been observed upon benchmarking against the small circuit of the unit test. Without further detailed investigation, it is assumed that the possible benefit of the polynomial splitting upon polycommitment opening proof computations is negatively offset by the larger amount of work required for the sponge work with the commitment vectors (for both the prover and the verifier) as well as more work required for the polynomial evaluations by verifier.

The comparative benchmarking (with respect to the maximal size of the polynomial segments) needs to be done against large circuits to observe performance effects.
