### PR TITLE
Abstract 5-wires gates over CircuitGate and ConstraintSystem

### DIFF
--- a/circuits/plonk-5-wires/src/constraints.rs
+++ b/circuits/plonk-5-wires/src/constraints.rs
@@ -20,7 +20,7 @@ pub struct ConstraintSystem<F: FftField>
 {
     pub public: usize,                  // number of public inputs
     pub domain: EvaluationDomains<F>,   // evaluation domains
-    pub gates:  Vec<CircuitGate<F>>,    // circuit gates
+    pub gates:  Vec<CircuitGate<F, GateType>>,    // circuit gates
 
     // POLYNOMIALS OVER THE MONOMIAL BASIS
 
@@ -107,7 +107,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
 {
     pub fn create
     (
-        mut gates: Vec<CircuitGate<F>>,
+        mut gates: Vec<CircuitGate<F, GateType>>,
         fr_sponge_params: ArithmeticSpongeParams<F>,
         public: usize,
     ) -> Option<Self>
@@ -120,7 +120,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
         let shift = [F::one(), shift[0], shift[1], shift[2], shift[3]];
 
         let n = domain.d1.size();
-        let mut padding = (gates.len()..n).map(|i| CircuitGate::<F>::zero(i, array_init(|j| Wire{col:WIRES[j], row:i}))).collect();
+        let mut padding = (gates.len()..n).map(|i| CircuitGate::<F, GateType>::zero(i, array_init(|j| Wire{col:WIRES[j], row:i}))).collect();
         gates.append(&mut padding);
 
         let s: [std::vec::Vec<F>; COLUMNS] = array_init(|i| domain.d1.elements().map(|elm| {shift[i] * &elm}).collect());

--- a/circuits/plonk-5-wires/src/gates/addition.rs
+++ b/circuits/plonk-5-wires/src/gates/addition.rs
@@ -30,11 +30,17 @@ This source file implements non-special point (with distinct abscissas) Weierstr
 *****************************************************************************************************************/
 
 use algebra::FftField;
-use crate::gate::{CircuitGate, GateType};
+use crate::gate::{CircuitGate};
 use crate::wires::{GateWires, COLUMNS};
+use crate::gates::zero::{ZeroGateType};
 use array_init::array_init;
 
-impl<F: FftField> CircuitGate<F>
+pub trait AddGateType : PartialEq
+{
+    const ADD: Self;
+}
+
+impl<F: FftField, GateType: ZeroGateType + AddGateType> CircuitGate<F, GateType>
 {
     pub fn create_add(row: usize, wires: &[GateWires; 2]) -> Vec<Self>
     {
@@ -42,14 +48,14 @@ impl<F: FftField> CircuitGate<F>
             CircuitGate
             {
                 row,
-                typ: GateType::Add,
+                typ: GateType::ADD,
                 wires: wires[0],
                 c: vec![]
             },
             CircuitGate
             {
                 row: row + 1,
-                typ: GateType::Zero,
+                typ: GateType::ZERO,
                 wires: wires[1],
                 c: vec![]
             },
@@ -61,7 +67,7 @@ impl<F: FftField> CircuitGate<F>
         let this: [F; COLUMNS] = array_init(|i| witness[i][self.row]);
         let next: [F; COLUMNS] = array_init(|i| witness[i][self.row+1]);
 
-        self.typ == GateType::Add
+        self.typ == GateType::ADD
         &&
         (this[2] - &this[0]) * &(next[1] + &this[1])
         ==
@@ -75,5 +81,5 @@ impl<F: FftField> CircuitGate<F>
         (this[2] - &this[0]) * &this[4] == F::one()
     }
 
-    pub fn add(&self) -> F {if self.typ == GateType::Add {F::one()} else {F::zero()}}
+    pub fn add(&self) -> F {if self.typ == GateType::ADD {F::one()} else {F::zero()}}
 }

--- a/circuits/plonk-5-wires/src/gates/addition.rs
+++ b/circuits/plonk-5-wires/src/gates/addition.rs
@@ -8,7 +8,7 @@ This source file implements non-special point (with distinct abscissas) Weierstr
         (x2 - x1) * r = 1
 
     Permutation constraints
-    
+
         -> x1
         -> y1
         -> x2

--- a/circuits/plonk-5-wires/src/gates/double.rs
+++ b/circuits/plonk-5-wires/src/gates/double.rs
@@ -35,18 +35,23 @@ The constraints above are derived from the following EC Affine arithmetic equati
 *****************************************************************************************************************/
 
 use algebra::FftField;
-use crate::gate::{CircuitGate, GateType};
+use crate::gate::{CircuitGate};
 use crate::wires::{GateWires, COLUMNS};
 use array_init::array_init;
 
-impl<F: FftField> CircuitGate<F>
+pub trait DoubleGateType : PartialEq
+{
+    const DOUBLE: Self;
+}
+
+impl<F: FftField, GateType: DoubleGateType> CircuitGate<F, GateType>
 {
     pub fn create_double(row: usize, wires: GateWires) -> Self
     {
         CircuitGate
         {
             row,
-            typ: GateType::Double,
+            typ: GateType::DOUBLE,
             wires,
             c: vec![]
         }
@@ -56,7 +61,7 @@ impl<F: FftField> CircuitGate<F>
     {
         let this: [F; COLUMNS] = array_init(|i| witness[i][self.row]);
 
-        self.typ == GateType::Double
+        self.typ == GateType::DOUBLE
         &&
         F::from(4 as u64) * &this[1].square() * &(this[2] + &this[0].double())
         ==
@@ -69,5 +74,5 @@ impl<F: FftField> CircuitGate<F>
         this[1] * &this[4] == F::one()
     }
 
-    pub fn double(&self) -> F {if self.typ == GateType::Double {F::one()} else {F::zero()}}
+    pub fn double(&self) -> F {if self.typ == GateType::DOUBLE {F::one()} else {F::zero()}}
 }

--- a/circuits/plonk-5-wires/src/gates/endosclmul.rs
+++ b/circuits/plonk-5-wires/src/gates/endosclmul.rs
@@ -53,18 +53,23 @@ The constraints above are derived from the following EC Affine arithmetic equati
 *****************************************************************************************************************/
 
 use algebra::FftField;
-use crate::gate::{CircuitGate, GateType};
+use crate::gate::{CircuitGate};
 use crate::{wires::{GateWires, COLUMNS}, constraints::ConstraintSystem};
 use array_init::array_init;
 
-impl<F: FftField> CircuitGate<F>
+pub trait EndomulGateType : PartialEq
+{
+    const ENDOMUL: Self;
+}
+
+impl<F: FftField, GateType: EndomulGateType> CircuitGate<F, GateType>
 {
     pub fn create_endomul(row: usize, wires: GateWires) -> Self
     {
         CircuitGate
         {
             row,
-            typ: GateType::Endomul,
+            typ: GateType::ENDOMUL,
             wires,
             c: vec![]
         }
@@ -76,7 +81,7 @@ impl<F: FftField> CircuitGate<F>
         let next: [F; COLUMNS] = array_init(|i| witness[i][self.row+1]);
         let xq = (F::one() + &((cs.endo - &F::one()) * &next[4])) * &this[0];
         
-        self.typ == GateType::Endomul
+        self.typ == GateType::ENDOMUL
         &&
         // verify booleanity of the scalar bits
         this[4] == this[4].square()
@@ -96,5 +101,5 @@ impl<F: FftField> CircuitGate<F>
         (next[2] - &next[0]) * &this[3] == next[1] + &next[3]
     }
 
-    pub fn endomul(&self) -> F {if self.typ == GateType::Endomul {F::one()} else {F::zero()}}
+    pub fn endomul(&self) -> F {if self.typ == GateType::ENDOMUL {F::one()} else {F::zero()}}
 }

--- a/circuits/plonk-5-wires/src/gates/generic.rs
+++ b/circuits/plonk-5-wires/src/gates/generic.rs
@@ -5,11 +5,16 @@ This source file implements Plonk generic constraint gate primitive.
 *****************************************************************************************************************/
 
 use algebra::FftField;
-use crate::gate::{CircuitGate, GateType};
+use crate::gate::{CircuitGate};
 use crate::wires::{COLUMNS, GateWires};
 use array_init::array_init;
 
-impl<F: FftField> CircuitGate<F>
+pub trait GenericGateType : PartialEq
+{
+    const GENERIC: Self;
+}
+
+impl<F: FftField, GateType: GenericGateType> CircuitGate<F, GateType>
 {
     pub fn create_generic
     (
@@ -27,7 +32,7 @@ impl<F: FftField> CircuitGate<F>
         CircuitGate
         {
             row,
-            typ: GateType::Generic,
+            typ: GateType::GENERIC,
             wires,
             c
         }
@@ -37,7 +42,7 @@ impl<F: FftField> CircuitGate<F>
     {
         let this: [F; COLUMNS] = array_init(|i| witness[i][self.row]);
 
-        self.typ == GateType::Generic &&
+        self.typ == GateType::GENERIC &&
         (
             (0..COLUMNS).map(|i| self.c[i] * &this[i]).fold(F::zero(), |x, y| x + &y) +
             &(self.c[COLUMNS] * &this[0] * &this[1]) +

--- a/circuits/plonk-5-wires/src/gates/mod.rs
+++ b/circuits/plonk-5-wires/src/gates/mod.rs
@@ -6,3 +6,4 @@ pub mod addition;
 pub mod varbasemul;
 pub mod endosclmul;
 pub mod varbasemulpck;
+pub mod zero;

--- a/circuits/plonk-5-wires/src/gates/packing.rs
+++ b/circuits/plonk-5-wires/src/gates/packing.rs
@@ -12,17 +12,22 @@ PACK gate constraints
 
 use algebra::FftField;
 use crate::wires::{GateWires, COLUMNS};
-use crate::gate::{CircuitGate, GateType};
+use crate::gate::{CircuitGate};
 use array_init::array_init;
 
-impl<F: FftField> CircuitGate<F>
+pub trait PackGateType : PartialEq
+{
+    const PACK: Self;
+}
+
+impl<F: FftField, GateType: PackGateType> CircuitGate<F, GateType>
 {
     pub fn create_pack(row: usize, wires: GateWires) -> Self
     {
         CircuitGate
         {
             row,
-            typ: GateType::Pack,
+            typ: GateType::PACK,
             wires,
             c: vec![]
         }
@@ -33,7 +38,7 @@ impl<F: FftField> CircuitGate<F>
         let this: [F; COLUMNS] = array_init(|i| witness[i][self.row]);
         let next: [F; COLUMNS] = array_init(|i| witness[i][self.row+1]);
 
-        self.typ == GateType::Pack
+        self.typ == GateType::PACK
         &&
         next[4] ==
             next[3] +
@@ -46,5 +51,5 @@ impl<F: FftField> CircuitGate<F>
         !(0..COLUMNS-1).map(|i| next[i]).any(|b| b != b.square())
     }
 
-    pub fn pack(&self) -> F {if self.typ == GateType::Pack {F::one()} else {F::zero()}}
+    pub fn pack(&self) -> F {if self.typ == GateType::PACK {F::one()} else {F::zero()}}
 }

--- a/circuits/plonk-5-wires/src/gates/poseidon.rs
+++ b/circuits/plonk-5-wires/src/gates/poseidon.rs
@@ -11,10 +11,15 @@ Constraint vector format:
 use algebra::FftField;
 use oracle::poseidon_5_wires::{PlonkSpongeConstants, sbox};
 use crate::{wires::GateWires, wires::{COLUMNS, WIRES}, constraints::ConstraintSystem};
-use crate::gate::{CircuitGate, GateType};
+use crate::gate::{CircuitGate};
 use array_init::array_init;
 
-impl<F: FftField> CircuitGate<F>
+pub trait PoseidonGateType : PartialEq
+{
+    const POSEIDON: Self;
+}
+
+impl<F: FftField, GateType: PoseidonGateType> CircuitGate<F, GateType>
 {
     pub fn create_poseidon
     (
@@ -26,7 +31,7 @@ impl<F: FftField> CircuitGate<F>
         CircuitGate
         {
             row,
-            typ: GateType::Poseidon,
+            typ: GateType::POSEIDON,
             wires,
             c
         }
@@ -41,12 +46,12 @@ impl<F: FftField> CircuitGate<F>
         let perm = cs.fr_sponge_params.mds.iter().enumerate().
             map(|(i, m)| rc[i] + &this.iter().zip(m.iter()).fold(F::zero(), |x, (s, &m)| m * s + x)).collect::<Vec<_>>();
 
-        self.typ == GateType::Poseidon && perm.iter().zip(next.iter()).all(|(p, n)| p == n)
+        self.typ == GateType::POSEIDON && perm.iter().zip(next.iter()).all(|(p, n)| p == n)
     }
 
-    pub fn ps(&self) -> F {if self.typ == GateType::Poseidon {F::one()} else {F::zero()}}
+    pub fn ps(&self) -> F {if self.typ == GateType::POSEIDON {F::one()} else {F::zero()}}
     pub fn rc(&self) -> [F; COLUMNS]
     {
-        array_init(|i| if self.typ == GateType::Poseidon {self.c[WIRES[i]]} else {F::zero()})
+        array_init(|i| if self.typ == GateType::POSEIDON {self.c[WIRES[i]]} else {F::zero()})
     }
 }

--- a/circuits/plonk-5-wires/src/gates/varbasemul.rs
+++ b/circuits/plonk-5-wires/src/gates/varbasemul.rs
@@ -60,18 +60,23 @@ The constraints above are derived from the following EC Affine arithmetic equati
 *****************************************************************************************************************/
 
 use algebra::FftField;
-use crate::gate::{CircuitGate, GateType};
+use crate::gate::{CircuitGate};
 use crate::wires::{GateWires, COLUMNS};
 use array_init::array_init;
 
-impl<F: FftField> CircuitGate<F>
+pub trait VbmulGateType : PartialEq
+{
+    const VBMUL1: Self;
+}
+
+impl<F: FftField, GateType: VbmulGateType> CircuitGate<F, GateType>
 {
     pub fn create_vbmul(row: usize, wires: GateWires) -> Self
     {
         CircuitGate
         {
             row,
-            typ: GateType::Vbmul1,
+            typ: GateType::VBMUL1,
             wires,
             c: vec![]
         }
@@ -82,7 +87,7 @@ impl<F: FftField> CircuitGate<F>
         let this: [F; COLUMNS] = array_init(|i| witness[i][self.row]);
         let next: [F; COLUMNS] = array_init(|i| witness[i][self.row+1]);
 
-        self.typ == GateType::Vbmul1
+        self.typ == GateType::VBMUL1
         &&
         // verify booleanity of the scalar bit
         this[4] == this[4].square()
@@ -100,5 +105,5 @@ impl<F: FftField> CircuitGate<F>
         (next[2] - &next[0]) * &this[3] == next[1] + &next[3]
     }
 
-    pub fn vbmul1(&self) -> F {if self.typ == GateType::Vbmul1 {F::one()} else {F::zero()}}
+    pub fn vbmul1(&self) -> F {if self.typ == GateType::VBMUL1 {F::one()} else {F::zero()}}
 }

--- a/circuits/plonk-5-wires/src/gates/varbasemulpck.rs
+++ b/circuits/plonk-5-wires/src/gates/varbasemulpck.rs
@@ -68,18 +68,23 @@ The constraints above are derived from the following EC Affine arithmetic equati
 *****************************************************************************************************************/
 
 use algebra::FftField;
-use crate::gate::{CircuitGate, GateType};
+use crate::gate::{CircuitGate};
 use crate::wires::{GateWires, COLUMNS};
 use array_init::array_init;
 
-impl<F: FftField> CircuitGate<F>
+pub trait VbmulpackGateType : PartialEq
+{
+    const VBMUL2: Self;
+}
+
+impl<F: FftField, GateType: VbmulpackGateType> CircuitGate<F, GateType>
 {
     pub fn create_vbmul2(row: usize, wires: GateWires) -> Self
     {
         CircuitGate
         {
             row,
-            typ: GateType::Vbmul2,
+            typ: GateType::VBMUL2,
             wires,
             c: vec![]
         }
@@ -90,7 +95,7 @@ impl<F: FftField> CircuitGate<F>
         let this: [F; COLUMNS] = array_init(|i| witness[i][self.row]);
         let next: [F; COLUMNS] = array_init(|i| witness[i][self.row+1]);
 
-        self.typ == GateType::Vbmul2
+        self.typ == GateType::VBMUL2
         &&
         // verify booleanity of the scalar bit
         this[3] == this[3].square()
@@ -110,5 +115,5 @@ impl<F: FftField> CircuitGate<F>
         this[4] == next[4].double() + &this[3]
     }
 
-    pub fn vbmul2(&self) -> F {if self.typ == GateType::Vbmul2 {F::one()} else {F::zero()}}
+    pub fn vbmul2(&self) -> F {if self.typ == GateType::VBMUL2 {F::one()} else {F::zero()}}
 }

--- a/circuits/plonk-5-wires/src/gates/zero.rs
+++ b/circuits/plonk-5-wires/src/gates/zero.rs
@@ -1,0 +1,23 @@
+use algebra::FftField;
+use crate::gate::{CircuitGate};
+use crate::wires::{GateWires};
+
+pub trait ZeroGateType
+{
+    const ZERO: Self;
+}
+
+impl<F: FftField, GateType: ZeroGateType> CircuitGate<F, GateType>
+{
+    // this function creates "empty" circuit gate
+    pub fn zero(row: usize, wires: GateWires) -> Self
+    {
+        CircuitGate
+        {
+            row,
+            typ: GateType::ZERO,
+            c: Vec::new(),
+            wires,
+        }
+    }
+}

--- a/circuits/plonk-5-wires/src/polynomials/addition.rs
+++ b/circuits/plonk-5-wires/src/polynomials/addition.rs
@@ -30,19 +30,22 @@ This source file implements non-special point Weierstrass curve addition constra
 
 *****************************************************************************************************************/
 
-use algebra::{FftField, SquareRootField};
-use ff_fft::{Evaluations, DensePolynomial, Radix2EvaluationDomain as D};
+use crate::constraints::CSConstants;
 use crate::polynomial::WitnessOverDomains;
-use oracle::utils::{EvalUtils, PolyUtils};
-use crate::constraints::ConstraintSystem;
 use crate::scalars::ProofEvaluations;
+use algebra::{FftField, SquareRootField};
+use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use oracle::utils::{EvalUtils, PolyUtils};
 
-impl<F: FftField + SquareRootField> ConstraintSystem<F>
-{
+pub trait CSAddGate<F: FftField + SquareRootField>: CSConstants<F> {
+    fn addm(&self) -> &DensePolynomial<F>; // constraint selector polynomial
+    fn addl(&self) -> &Evaluations<F, D<F>>; // selector evaluations over domain.d4
+
     // EC Affine addition constraint quotient poly contribution computation
-    pub fn ecad_quot(&self, polys: &WitnessOverDomains<F>, alpha: &[F]) -> Evaluations<F, D<F>>
-    {
-        if self.addm.is_zero() {return self.zero4.clone()}
+    fn ecad_quot(&self, polys: &WitnessOverDomains<F>, alpha: &[F]) -> Evaluations<F, D<F>> {
+        if self.addm().is_zero() {
+            return self.zero4().clone();
+        }
 
         let x1 = &polys.d4.this.w[0];
         let y1 = &polys.d4.this.w[1];
@@ -63,23 +66,20 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
         */
         let check_1 = &(&(x21 * y31) - &(&(y2 - y1) * x13));
         let check_2 = &(&(&(&(x1 + x2) + x3) * &x13.pow(2)) - &y31.pow(2));
-        let check_3 = &(&(x21 * r) - &self.l04);
+        let check_3 = &(&(x21 * r) - self.l04());
 
-        &(&(  &check_1.scale(alpha[0])
-            + &check_2.scale(alpha[1]))
-            + &check_3.scale(alpha[2]))
-        * &self.addl
+        &(&(&check_1.scale(alpha[0]) + &check_2.scale(alpha[1])) + &check_3.scale(alpha[2]))
+            * self.addl()
     }
 
-    pub fn ecad_scalars(evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> F
-    {
+    fn ecad_scalars(evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> F {
         let x1 = evals[0].w[0];
         let y1 = evals[0].w[1];
         let x2 = evals[0].w[2];
         let y2 = evals[0].w[3];
         let x3 = evals[1].w[0];
         let y3 = evals[1].w[1];
-        let r  = evals[0].w[4];
+        let r = evals[0].w[4];
 
         let y31 = y3 + y1;
         let x13 = x1 - x3;
@@ -89,14 +89,11 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
         let check_2 = ((x1 + x2 + x3) * x13.square()) - y31.square();
         let check_3 = (x21 * r) - F::one();
 
-          (check_1 * alpha[0])
-        + (check_2 * alpha[1])
-        + (check_3 * alpha[2])
+        (check_1 * alpha[0]) + (check_2 * alpha[1]) + (check_3 * alpha[2])
     }
 
     // EC Affine addition constraint linearization poly contribution computation
-    pub fn ecad_lnrz(&self, evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> DensePolynomial<F>
-    {
-        self.addm.scale(Self::ecad_scalars(evals, alpha))
+    fn ecad_lnrz(&self, evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> DensePolynomial<F> {
+        self.addm().scale(Self::ecad_scalars(evals, alpha))
     }
 }

--- a/circuits/plonk-5-wires/src/polynomials/double.rs
+++ b/circuits/plonk-5-wires/src/polynomials/double.rs
@@ -34,72 +34,61 @@ The constraints above are derived from the following EC Affine arithmetic equati
 
 *****************************************************************************************************************/
 
-use algebra::{FftField, SquareRootField};
-use ff_fft::{Evaluations, DensePolynomial, Radix2EvaluationDomain as D};
+use crate::constraints::CSConstants;
 use crate::polynomial::WitnessOverDomains;
-use oracle::utils::{EvalUtils, PolyUtils};
-use crate::constraints::ConstraintSystem;
 use crate::scalars::ProofEvaluations;
+use algebra::{FftField, SquareRootField};
+use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use oracle::utils::{EvalUtils, PolyUtils};
 
-impl<F: FftField + SquareRootField> ConstraintSystem<F>
-{
+pub trait CSDoubleGate<F: FftField + SquareRootField>: CSConstants<F> {
+    fn doublem(&self) -> &DensePolynomial<F>; // constraint selector polynomial
+    fn doublel(&self) -> &Evaluations<F, D<F>>; // selector evaluations over domain.d8
+
     // EC Affine doubling constraint quotient poly contribution computation
-    pub fn double_quot(&self, polys: &WitnessOverDomains<F>, alpha: &[F]) -> Evaluations<F, D<F>>
-    {
-        if self.doublem.is_zero() {return self.doublel.clone()}
+    fn double_quot(&self, polys: &WitnessOverDomains<F>, alpha: &[F]) -> Evaluations<F, D<F>> {
+        if self.doublem().is_zero() {
+            return self.doublel().clone();
+        }
 
         let x1 = &polys.d8.this.w[0];
         let y1 = &polys.d8.this.w[1];
         let x2 = &polys.d8.this.w[2];
         let y2 = &polys.d8.this.w[3];
-        let y1_inv  = &polys.d8.this.w[4];
+        let y1_inv = &polys.d8.this.w[4];
 
-        let check_1 =
-            &(  &y1.pow(2).scale(F::from(4 as u64))
-              * &(x2 + &x1.scale(F::from(2 as u64))))
-          - &x1.pow(4).scale(F::from(9 as u64));
+        let check_1 = &(&y1.pow(2).scale(F::from(4 as u64)) * &(x2 + &x1.scale(F::from(2 as u64))))
+            - &x1.pow(4).scale(F::from(9 as u64));
 
-        let check_2 =
-            &(  &y1.scale(F::from(2 as u64))
-              * &(y2 + y1))
-          - &(  &(x1 - x2)
-              * &x1.pow(2).scale(F::from(3 as u64)));
+        let check_2 = &(&y1.scale(F::from(2 as u64)) * &(y2 + y1))
+            - &(&(x1 - x2) * &x1.pow(2).scale(F::from(3 as u64)));
 
-        let check_3 = &(y1 * &y1_inv) - &self.l08;
+        let check_3 = &(y1 * &y1_inv) - &self.l08();
 
-        &(&(  &check_1.scale(alpha[0])
-            + &check_2.scale(alpha[1]))
-            + &check_3.scale(alpha[2]))
-        * &self.doublel
+        &(&(&check_1.scale(alpha[0]) + &check_2.scale(alpha[1])) + &check_3.scale(alpha[2]))
+            * &self.doublel()
     }
 
-    pub fn double_scalars(evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> F
-    {
+    fn double_scalars(evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> F {
         let x1 = evals[0].w[0];
         let y1 = evals[0].w[1];
         let x2 = evals[0].w[2];
         let y2 = evals[0].w[3];
         let y1_inv = evals[0].w[4];
 
-        let check_1 =
-            (  y1.square() * &F::from(4 as u64)
-             * &(x2 + &x1.double()))
-          - &(x1.square().square() * &F::from(9 as u64));
+        let check_1 = (y1.square() * &F::from(4 as u64) * &(x2 + &x1.double()))
+            - &(x1.square().square() * &F::from(9 as u64));
 
         let check_2 =
-            (y1.double() * &(y2 + &y1))
-          - &((x1 - &x2) * &x1.square() * &F::from(3 as u64));
+            (y1.double() * &(y2 + &y1)) - &((x1 - &x2) * &x1.square() * &F::from(3 as u64));
 
         let check_3 = y1 * &y1_inv - &F::one();
 
-          (check_1 * &alpha[0])
-        + &(check_2 * &alpha[1])
-        + &(check_3 * &alpha[2])
+        (check_1 * &alpha[0]) + &(check_2 * &alpha[1]) + &(check_3 * &alpha[2])
     }
 
     // EC Affine doubling constraint linearization poly contribution computation
-    pub fn double_lnrz(&self, evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> DensePolynomial<F>
-    {
-        self.doublem.scale(Self::double_scalars(evals, alpha))
+    fn double_lnrz(&self, evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> DensePolynomial<F> {
+        self.doublem().scale(Self::double_scalars(evals, alpha))
     }
 }

--- a/circuits/plonk-5-wires/src/polynomials/generic.rs
+++ b/circuits/plonk-5-wires/src/polynomials/generic.rs
@@ -4,36 +4,62 @@ This source file implements generic constraint polynomials.
 
 *****************************************************************************************************************/
 
-use algebra::{FftField, SquareRootField};
-use ff_fft::{Evaluations, DensePolynomial, Radix2EvaluationDomain as D};
+use crate::constraints::CSConstants;
 use crate::polynomial::WitnessOverDomains;
-use crate::constraints::ConstraintSystem;
 use crate::scalars::ProofEvaluations;
+pub use crate::wires::COLUMNS;
+use algebra::{FftField, SquareRootField};
+use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::PolyUtils;
 
-impl<F: FftField + SquareRootField> ConstraintSystem<F>
-{
+pub trait CSGenericGate<F: FftField + SquareRootField>: CSConstants<F> {
+    fn qwm(&self) -> &[DensePolynomial<F>; COLUMNS]; // linear wire constraint polynomial
+    fn qmm(&self) -> &DensePolynomial<F>; // multiplication polynomial
+    fn qc(&self) -> &DensePolynomial<F>; // constant wire polynomial
+    fn qwl(&self) -> &[Evaluations<F, D<F>>; COLUMNS]; // left input wire polynomial over domain.d4
+    fn qml(&self) -> &Evaluations<F, D<F>>; // multiplication evaluations over domain.d4
+
     // generic constraint quotient poly contribution computation
-    pub fn gnrc_quot(&self, polys: &WitnessOverDomains<F>, p: &DensePolynomial<F>) ->
-        (Evaluations<F, D<F>>, DensePolynomial<F>)
-    {
+    fn gnrc_quot(
+        &self,
+        polys: &WitnessOverDomains<F>,
+        p: &DensePolynomial<F>,
+    ) -> (Evaluations<F, D<F>>, DensePolynomial<F>) {
         (
-            &(&(&polys.d4.this.w[0] * &polys.d4.this.w[1]) * &self.qml) +
-            &polys.d4.this.w.iter().zip(self.qwl.iter()).map(|(w, q)| w * q).fold(self.zero4.clone(), |x, y| &x + &y),
-            &self.qc + &p
+            &(&(&polys.d4.this.w[0] * &polys.d4.this.w[1]) * &self.qml())
+                + &polys
+                    .d4
+                    .this
+                    .w
+                    .iter()
+                    .zip(self.qwl().iter())
+                    .map(|(w, q)| w * q)
+                    .fold(self.zero4().clone(), |x, y| &x + &y),
+            self.qc() + &p,
         )
     }
 
-    pub fn gnrc_scalars(evals: &ProofEvaluations<F>) -> Vec<F>
-    {
-        vec![evals.w[0] * &evals.w[1], evals.w[0], evals.w[1], evals.w[2], evals.w[3], evals.w[4], F::one()]
+    fn gnrc_scalars(evals: &ProofEvaluations<F>) -> Vec<F> {
+        vec![
+            evals.w[0] * &evals.w[1],
+            evals.w[0],
+            evals.w[1],
+            evals.w[2],
+            evals.w[3],
+            evals.w[4],
+            F::one(),
+        ]
     }
 
     // generic constraint linearization poly contribution computation
-    pub fn gnrc_lnrz(&self, evals: &ProofEvaluations<F>) -> DensePolynomial<F>
-    {
+    fn gnrc_lnrz(&self, evals: &ProofEvaluations<F>) -> DensePolynomial<F> {
         let scalars = Self::gnrc_scalars(evals);
-        &(&self.qmm.scale(scalars[0]) + &self.qc) +
-        &self.qwm.iter().zip(scalars[1..].iter()).map(|(q, s)| q.scale(*s)).fold(DensePolynomial::<F>::zero(), |x, y| &x + &y)
+        &(&self.qmm().scale(scalars[0]) + &self.qc())
+            + &self
+                .qwm()
+                .iter()
+                .zip(scalars[1..].iter())
+                .map(|(q, s)| q.scale(*s))
+                .fold(DensePolynomial::<F>::zero(), |x, y| &x + &y)
     }
 }

--- a/circuits/plonk-5-wires/src/polynomials/mod.rs
+++ b/circuits/plonk-5-wires/src/polynomials/mod.rs
@@ -1,9 +1,9 @@
-pub mod double;
-pub mod packing;
-pub mod generic;
-pub mod poseidon;
 pub mod addition;
-pub mod varbasemul;
+pub mod double;
 pub mod endosclmul;
+pub mod generic;
+pub mod packing;
 pub mod permutation;
+pub mod poseidon;
+pub mod varbasemul;
 pub mod varbasemulpck;

--- a/circuits/plonk-5-wires/src/polynomials/packing.rs
+++ b/circuits/plonk-5-wires/src/polynomials/packing.rs
@@ -10,19 +10,22 @@ PACK gate constraints
 
 *****************************************************************************************************************/
 
-use algebra::{FftField, SquareRootField};
-use ff_fft::{Evaluations, DensePolynomial, Radix2EvaluationDomain as D};
+use crate::constraints::CSConstants;
 use crate::polynomial::WitnessOverDomains;
-use oracle::utils::{EvalUtils, PolyUtils};
-use crate::constraints::ConstraintSystem;
 use crate::scalars::ProofEvaluations;
+use algebra::{FftField, SquareRootField};
+use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use oracle::utils::{EvalUtils, PolyUtils};
 
-impl<F: FftField + SquareRootField> ConstraintSystem<F>
-{
+pub trait CSPackGate<F: FftField + SquareRootField>: CSConstants<F> {
+    fn packm(&self) -> &DensePolynomial<F>; // constraint selector polynomial
+    fn packl(&self) -> &Evaluations<F, D<F>>; // selector evaluations over domain.d4
+
     // packing constraint quotient poly contribution computation
-    pub fn pack_quot(&self, polys: &WitnessOverDomains<F>, alpha: &[F]) -> Evaluations<F, D<F>>
-    {
-        if self.packm.is_zero() {return self.zero4.clone()}
+    fn pack_quot(&self, polys: &WitnessOverDomains<F>, alpha: &[F]) -> Evaluations<F, D<F>> {
+        if self.packm().is_zero() {
+            return self.zero4().clone();
+        }
 
         let b_0 = &polys.d4.next.w[3];
         let b_1 = &polys.d4.next.w[2];
@@ -31,29 +34,24 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
         let b_4 = &polys.d4.this.w[4];
         let res = &polys.d4.next.w[4];
 
-        let unpack =
-          &(&(&(&(&(  b_0
-                    + &b_1.scale(F::from(2 as u64)))
-                    + &b_2.scale(F::from(4 as u64)))
-                    + &b_3.scale(F::from(8 as u64)))
-                    + &b_4.scale(F::from(16 as u64)))
-                    - res);
+        let unpack = &(&(&(&(&(b_0 + &b_1.scale(F::from(2 as u64)))
+            + &b_2.scale(F::from(4 as u64)))
+            + &b_3.scale(F::from(8 as u64)))
+            + &b_4.scale(F::from(16 as u64)))
+            - res);
 
         let bin_3 = &(b_3 - &b_3.pow(2));
         let bin_2 = &(b_2 - &b_2.pow(2));
         let bin_1 = &(b_1 - &b_1.pow(2));
         let bin_0 = &(b_0 - &b_0.pow(2));
 
-        &(&(&(&(  &unpack.scale(alpha[0])
-                + &bin_3.scale(alpha[1]))
-                + &bin_2.scale(alpha[2]))
-                + &bin_1.scale(alpha[3]))
-                + &bin_0.scale(alpha[4]))
-        * &self.packl
+        &(&(&(&(&unpack.scale(alpha[0]) + &bin_3.scale(alpha[1])) + &bin_2.scale(alpha[2]))
+            + &bin_1.scale(alpha[3]))
+            + &bin_0.scale(alpha[4]))
+            * &self.packl()
     }
 
-    pub fn pack_scalars(evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> F
-    {
+    fn pack_scalars(evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> F {
         let b_0 = evals[1].w[3];
         let b_1 = evals[1].w[2];
         let b_2 = evals[1].w[1];
@@ -61,29 +59,27 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
         let b_4 = evals[0].w[4];
         let res = evals[1].w[4];
 
-        let unpack =
-            b_0
-          + b_1.double()
-          + b_2.double().double()
-          + b_3.double().double().double()
-          + b_4.double().double().double().double()
-          - res;
+        let unpack = b_0
+            + b_1.double()
+            + b_2.double().double()
+            + b_3.double().double().double()
+            + b_4.double().double().double().double()
+            - res;
 
         let bin_3 = b_3 - b_3.square();
         let bin_2 = b_2 - b_2.square();
         let bin_1 = b_1 - b_1.square();
         let bin_0 = b_0 - b_0.square();
 
-          unpack * alpha[0]
-        + bin_3 * alpha[1]
-        + bin_2 * alpha[2]
-        + bin_1 * alpha[3]
-        + bin_0 * alpha[4]
+        unpack * alpha[0]
+            + bin_3 * alpha[1]
+            + bin_2 * alpha[2]
+            + bin_1 * alpha[3]
+            + bin_0 * alpha[4]
     }
 
     // packing constraint linearization poly contribution computation
-    pub fn pack_lnrz(&self, evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> DensePolynomial<F>
-    {
-        self.packm.scale(Self::pack_scalars(evals, alpha))
+    fn pack_lnrz(&self, evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> DensePolynomial<F> {
+        self.packm().scale(Self::pack_scalars(evals, alpha))
     }
 }

--- a/circuits/plonk-5-wires/src/polynomials/poseidon.rs
+++ b/circuits/plonk-5-wires/src/polynomials/poseidon.rs
@@ -4,73 +4,123 @@ This source file implements Posedon constraint polynomials.
 
 *****************************************************************************************************************/
 
-use array_init::array_init;
-use algebra::{FftField, SquareRootField};
-use ff_fft::{Evaluations, DensePolynomial, Radix2EvaluationDomain as D};
-use oracle::{utils::{PolyUtils, EvalUtils}, poseidon_5_wires::{PlonkSpongeConstants,sbox}, poseidon::{ArithmeticSpongeParams}};
+use crate::constraints::CSConstants;
 use crate::polynomial::WitnessOverDomains;
-use crate::constraints::ConstraintSystem;
 use crate::scalars::ProofEvaluations;
 use crate::wires::COLUMNS;
+use algebra::{FftField, SquareRootField};
+use array_init::array_init;
+use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use oracle::{
+    poseidon::ArithmeticSpongeParams,
+    poseidon_5_wires::{sbox, PlonkSpongeConstants},
+    utils::{EvalUtils, PolyUtils},
+};
 
-impl<F: FftField + SquareRootField> ConstraintSystem<F> 
-{
+pub trait CSPoseidonGate<F: FftField + SquareRootField>: CSConstants<F> {
+    fn rcm(&self) -> &[DensePolynomial<F>; COLUMNS]; // round constant polynomials
+    fn psm(&self) -> &DensePolynomial<F>; // poseidon constraint selector polynomial
+    fn ps4(&self) -> &Evaluations<F, D<F>>; // selector over domain.d4
+    fn ps8(&self) -> &Evaluations<F, D<F>>; // selector over domain.d8
+
     // poseidon quotient poly contribution computation f^5 + c(x) - f(wx)
-    pub fn psdn_quot
-    (
-        &self, polys: &WitnessOverDomains<F>,
+    fn psdn_quot(
+        &self,
+        polys: &WitnessOverDomains<F>,
         params: &ArithmeticSpongeParams<F>,
-        alpha: &[F]
-    ) -> (Evaluations<F, D<F>>, Evaluations<F, D<F>>, DensePolynomial<F>)
-    {
-        if self.psm.is_zero() {return (self.zero4.clone(), self.zero8.clone(), DensePolynomial::<F>::zero())}
+        alpha: &[F],
+    ) -> (
+        Evaluations<F, D<F>>,
+        Evaluations<F, D<F>>,
+        DensePolynomial<F>,
+    ) {
+        if self.psm().is_zero() {
+            return (
+                self.zero4().clone(),
+                self.zero8().clone(),
+                DensePolynomial::<F>::zero(),
+            );
+        }
 
         let mut lro: [Evaluations<F, D<F>>; COLUMNS] = array_init(|i| polys.d8.this.w[i].clone());
-        lro.iter_mut().for_each(|p| p.evals.iter_mut().for_each(|p| *p = sbox::<F, PlonkSpongeConstants>(*p)));
+        lro.iter_mut().for_each(|p| {
+            p.evals
+                .iter_mut()
+                .for_each(|p| *p = sbox::<F, PlonkSpongeConstants>(*p))
+        });
 
-        let scalers = (0..COLUMNS).
-            map(|i| (0..COLUMNS).fold(F::zero(), |x, j| alpha[j] * params.mds[j][i] + x)).
-            collect::<Vec<_>>();
+        let scalers = (0..COLUMNS)
+            .map(|i| (0..COLUMNS).fold(F::zero(), |x, j| alpha[j] * params.mds[j][i] + x))
+            .collect::<Vec<_>>();
         (
-            &self.ps4 * &polys.d4.next.w.iter().zip(alpha[0..COLUMNS].iter()).map(|(p, a)| p.scale(-*a)).
-                fold(self.zero4.clone(), |x, y| &x + &y),
-            &self.ps8 * &lro.iter().zip(scalers.iter()).map(|(p, s)| p.scale(*s)).
-                fold(self.zero8.clone(), |x, y| &x + &y),
-            self.rcm.iter().zip(alpha[0..COLUMNS].iter()).map(|(p, a)| p.scale(*a)).
-                fold(DensePolynomial::<F>::zero(), |x, y| &x + &y),
+            self.ps4()
+                * &polys
+                    .d4
+                    .next
+                    .w
+                    .iter()
+                    .zip(alpha[0..COLUMNS].iter())
+                    .map(|(p, a)| p.scale(-*a))
+                    .fold(self.zero4().clone(), |x, y| &x + &y),
+            self.ps8()
+                * &lro
+                    .iter()
+                    .zip(scalers.iter())
+                    .map(|(p, s)| p.scale(*s))
+                    .fold(self.zero8().clone(), |x, y| &x + &y),
+            self.rcm()
+                .iter()
+                .zip(alpha[0..COLUMNS].iter())
+                .map(|(p, a)| p.scale(*a))
+                .fold(DensePolynomial::<F>::zero(), |x, y| &x + &y),
         )
     }
 
-    pub fn psdn_scalars
-    (
+    fn psdn_scalars(
         evals: &Vec<ProofEvaluations<F>>,
         params: &ArithmeticSpongeParams<F>,
-        alpha: &[F]
-    ) -> Vec<F>
-    {
-        let sbox = evals[0].w.iter().map(|&w| sbox::<F, PlonkSpongeConstants>(w)).collect::<Vec<_>>();
-        let lro = params.mds.iter().map
-        (
-            |m| sbox.iter().zip(m.iter()).fold(F::zero(), |x, (s, &m)| m * s + x)
-        ).collect::<Vec<_>>();
+        alpha: &[F],
+    ) -> Vec<F> {
+        let sbox = evals[0]
+            .w
+            .iter()
+            .map(|&w| sbox::<F, PlonkSpongeConstants>(w))
+            .collect::<Vec<_>>();
+        let lro = params
+            .mds
+            .iter()
+            .map(|m| {
+                sbox.iter()
+                    .zip(m.iter())
+                    .fold(F::zero(), |x, (s, &m)| m * s + x)
+            })
+            .collect::<Vec<_>>();
 
-        vec!
-        [
+        vec![
             (0..lro.len()).fold(F::zero(), |x, i| x + alpha[i] * (lro[i] - evals[1].w[i])),
-            alpha[0], alpha[1], alpha[2], alpha[3], alpha[4]
+            alpha[0],
+            alpha[1],
+            alpha[2],
+            alpha[3],
+            alpha[4],
         ]
     }
 
     // poseidon linearization poly contribution computation f^5 + c(x) - f(wx)
-    pub fn psdn_lnrz
-    (
+    fn psdn_lnrz(
         &self,
         evals: &Vec<ProofEvaluations<F>>,
         params: &ArithmeticSpongeParams<F>,
-        alpha: &[F]
-    ) -> DensePolynomial<F>
-    {
-        self.rcm.iter().zip(alpha[0..COLUMNS].iter()).map(|(r, a)| r.scale(*a)).
-            fold(self.psm.scale(Self::psdn_scalars(evals, params, alpha)[0]), |x, y| &x + &y)
+        alpha: &[F],
+    ) -> DensePolynomial<F> {
+        self.rcm()
+            .iter()
+            .zip(alpha[0..COLUMNS].iter())
+            .map(|(r, a)| r.scale(*a))
+            .fold(
+                self.psm()
+                    .scale(Self::psdn_scalars(evals, params, alpha)[0]),
+                |x, y| &x + &y,
+            )
     }
 }

--- a/circuits/plonk-5-wires/src/polynomials/varbasemul.rs
+++ b/circuits/plonk-5-wires/src/polynomials/varbasemul.rs
@@ -59,19 +59,22 @@ The constraints above are derived from the following EC Affine arithmetic equati
 
     *****************************************************************************************************************/
 
-use algebra::{FftField, SquareRootField};
-use ff_fft::{Evaluations, DensePolynomial, Radix2EvaluationDomain as D};
+use crate::constraints::CSConstants;
 use crate::polynomial::WitnessOverDomains;
-use oracle::utils::{EvalUtils, PolyUtils};
-use crate::constraints::ConstraintSystem;
 use crate::scalars::ProofEvaluations;
+use algebra::{FftField, SquareRootField};
+use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use oracle::utils::{EvalUtils, PolyUtils};
 
-impl<F: FftField + SquareRootField> ConstraintSystem<F>
-{
+pub trait CSVbmulGate<F: FftField + SquareRootField>: CSConstants<F> {
+    fn mul1m(&self) -> &DensePolynomial<F>; // constraint selector polynomial
+    fn mul1l(&self) -> &Evaluations<F, D<F>>; // selector evaluations over domain.d4
+
     // scalar multiplication constraint quotient poly contribution computation
-    pub fn vbmul_quot(&self, polys: &WitnessOverDomains<F>, alpha: &[F]) -> Evaluations<F, D<F>>
-    {
-        if self.mul1m.is_zero() {return self.zero4.clone()}
+    fn vbmul_quot(&self, polys: &WitnessOverDomains<F>, alpha: &[F]) -> Evaluations<F, D<F>> {
+        if self.mul1m().is_zero() {
+            return self.zero4().clone();
+        }
 
         let xt = &polys.d4.this.w[0];
         let yt = &polys.d4.this.w[1];
@@ -87,34 +90,26 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
 
         // (xp - xt) * s1 = yp – (2b-1)*yt
         let check_1 =
-          &(&(&(  &(xp - xt) * s1)
-                - yp)
-                + &(yt * &(&b.scale(F::from(2 as u64)) - &self.l04)));
+            &(&(&(&(xp - xt) * s1) - yp) + &(yt * &(&b.scale(F::from(2 as u64)) - &self.l04())));
 
         // s1^2 - s2^2 = xt - xs
         let check_2 = &(&(&(&s1.pow(2) - &s2.pow(2)) - xt) + xs);
 
         // (2*xp + xt – s1^2) * (s1 + s2) = 2*yp
-        let check_3 =
-          &(  &(  &(&xp.scale(F::from(2 as u64)) + xt) - &s1.pow(2))
-                * &(s1 + s2))
+        let check_3 = &(&(&(&xp.scale(F::from(2 as u64)) + xt) - &s1.pow(2)) * &(s1 + s2))
             - &yp.scale(F::from(2 as u64));
 
         // (xp – xs) * s2 = ys + yp
         let check_4 = &(&(&(xp - xs) * s2) - ys) - &yp;
 
-        &(&(&(&(
-            &bin.scale(alpha[0])
-          + &check_1.scale(alpha[1]))
-          + &check_2.scale(alpha[2]))
-          + &check_3.scale(alpha[3]))
-          + &check_4.scale(alpha[4]))
-        * &self.mul1l
+        &(&(&(&(&bin.scale(alpha[0]) + &check_1.scale(alpha[1])) + &check_2.scale(alpha[2]))
+            + &check_3.scale(alpha[3]))
+            + &check_4.scale(alpha[4]))
+            * &self.mul1l()
     }
 
     // scalar multiplication constraint linearization poly contribution computation
-    pub fn vbmul_scalars(evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> F
-    {
+    fn vbmul_scalars(evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> F {
         let xt = evals[0].w[0];
         let yt = evals[0].w[1];
         let s1 = evals[0].w[2];
@@ -139,16 +134,15 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
         // (xp – xs) * s2 = ys + yp
         let check_4 = ((xp - &xs) * &s2) - &ys - &yp;
 
-          bin * &alpha[0]
-        + &(check_1 * &alpha[1])
-        + &(check_2 * &alpha[2])
-        + &(check_3 * &alpha[3])
-        + &(check_4 * &alpha[4])
+        bin * &alpha[0]
+            + &(check_1 * &alpha[1])
+            + &(check_2 * &alpha[2])
+            + &(check_3 * &alpha[3])
+            + &(check_4 * &alpha[4])
     }
 
     // scalar multiplication constraint linearization poly contribution computation
-    pub fn vbmul_lnrz(&self, evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> DensePolynomial<F>
-    {
-        self.mul1m.scale(Self::vbmul_scalars(evals, alpha))
+    fn vbmul_lnrz(&self, evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> DensePolynomial<F> {
+        self.mul1m().scale(Self::vbmul_scalars(evals, alpha))
     }
 }

--- a/circuits/plonk-5-wires/src/polynomials/varbasemulpck.rs
+++ b/circuits/plonk-5-wires/src/polynomials/varbasemulpck.rs
@@ -68,19 +68,22 @@ The constraints above are derived from the following EC Affine arithmetic equati
 
 *****************************************************************************************************************/
 
-use algebra::{FftField, SquareRootField};
-use ff_fft::{Evaluations, DensePolynomial, Radix2EvaluationDomain as D};
+use crate::constraints::CSConstants;
 use crate::polynomial::WitnessOverDomains;
-use oracle::utils::{EvalUtils, PolyUtils};
-use crate::constraints::ConstraintSystem;
 use crate::scalars::ProofEvaluations;
+use algebra::{FftField, SquareRootField};
+use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use oracle::utils::{EvalUtils, PolyUtils};
 
-impl<F: FftField + SquareRootField> ConstraintSystem<F>
-{
+pub trait CSVbmulpackGate<F: FftField + SquareRootField>: CSConstants<F> {
+    fn mul2m(&self) -> &DensePolynomial<F>; // constraint selector polynomial
+    fn mul2l(&self) -> &Evaluations<F, D<F>>; // selector evaluations over domain.d8
+
     // scalar multiplication with packing constraint quotient poly contribution computation
-    pub fn vbmulpck_quot(&self, polys: &WitnessOverDomains<F>, alpha: &[F]) -> Evaluations<F, D<F>>
-    {
-        if self.mul2m.is_zero() {return self.zero8.clone()}
+    fn vbmulpck_quot(&self, polys: &WitnessOverDomains<F>, alpha: &[F]) -> Evaluations<F, D<F>> {
+        if self.mul2m().is_zero() {
+            return self.zero8().clone();
+        }
 
         let xt = &polys.d8.this.w[0];
         let yt = &polys.d8.this.w[1];
@@ -99,34 +102,27 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
 
         // (xp - xt) * s1 = yp – (2b-1)*yt
         let check_1 =
-          &(  &(&(&(xp - xt) * s1)
-            - &yp)
-            + &(yt * &(&b.scale(F::from(2 as u64)) - &self.l08)));
+            &(&(&(&(xp - xt) * s1) - &yp) + &(yt * &(&b.scale(F::from(2 as u64)) - &self.l08())));
 
         // (2*xp – s1^2 + xt) * ((xp – xs) * s1 + ys + yp) = (xp – xs) * 2*yp
-        let check_2 =
-          &(&(  &(&(&xp.scale(F::from(2 as u64)) - &s1.pow(2)) + xt)
-              * &(&(&(ps * s1) + ys) + yp))
+        let check_2 = &(&(&(&(&xp.scale(F::from(2 as u64)) - &s1.pow(2)) + xt)
+            * &(&(&(ps * s1) + ys) + yp))
             - &(&yp.scale(F::from(2 as u64)) * ps));
 
         // (ys + yp)^2 - (xp – xs)^2 * (s1^2 – xt + xs)
         let check_3 = &(&(ys + yp).pow(2) - &(&ps.pow(2) * &(&(&s1.pow(2) - xt) + xs)));
 
         // n1 - 2*n2 - b
-        let check_4 =  &(&(n1 - &n2.scale(F::from(2 as u64))) - &b);
+        let check_4 = &(&(n1 - &n2.scale(F::from(2 as u64))) - &b);
 
-        &(&(&(&(
-            &bin.scale(alpha[0])
-          + &check_1.scale(alpha[1]))
-          + &check_2.scale(alpha[2]))
-          + &check_3.scale(alpha[3]))
-          + &check_4.scale(alpha[4]))
-        * &self.mul2l
+        &(&(&(&(&bin.scale(alpha[0]) + &check_1.scale(alpha[1])) + &check_2.scale(alpha[2]))
+            + &check_3.scale(alpha[3]))
+            + &check_4.scale(alpha[4]))
+            * &self.mul2l()
     }
 
     // scalar multiplication with packing constraint linearization poly contribution computation
-    pub fn vbmulpck_scalars(evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> F
-    {
+    fn vbmulpck_scalars(evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> F {
         let xt = evals[0].w[0];
         let yt = evals[0].w[1];
         let s1 = evals[0].w[2];
@@ -146,10 +142,8 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
         let check_1 = (((xp - &xt) * &s1) - &yp) + &(yt * &(b.double() - &F::one()));
 
         // (2*xp – s1^2 + xt) * ((xp – xs) * s1 + ys + yp) = (xp – xs) * 2*yp
-        let check_2 =
-          (((xp.double() - &s1.square()) + &xt) *
-            &(((ps * &s1) + &ys) + &yp)) -
-            &(yp.double() * ps);
+        let check_2 = (((xp.double() - &s1.square()) + &xt) * &(((ps * &s1) + &ys) + &yp))
+            - &(yp.double() * ps);
 
         // (ys + yp)^2 - (xp – xs)^2 * (s1^2 – xt + xs)
         let check_3 = (ys + &yp).square() - &(ps.square() * &(s1.square() - &xt + &xs));
@@ -157,16 +151,15 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
         // n1 - 2*n2 - b
         let check_4 = (n1 - &(n2.double())) - &b;
 
-          bin * &alpha[0]
-        + &(check_1 * &alpha[1])
-        + &(check_2 * &alpha[2])
-        + &(check_3 * &alpha[3])
-        + &(check_4 * &alpha[4])
+        bin * &alpha[0]
+            + &(check_1 * &alpha[1])
+            + &(check_2 * &alpha[2])
+            + &(check_3 * &alpha[3])
+            + &(check_4 * &alpha[4])
     }
 
     // scalar multiplication with packing constraint linearization poly contribution computation
-    pub fn vbmulpck_lnrz(&self, evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> DensePolynomial<F>
-    {
-        self.mul2m.scale(Self::vbmulpck_scalars(evals, alpha))
+    fn vbmulpck_lnrz(&self, evals: &Vec<ProofEvaluations<F>>, alpha: &[F]) -> DensePolynomial<F> {
+        self.mul2m().scale(Self::vbmulpck_scalars(evals, alpha))
     }
 }

--- a/dlog/plonk-5-wires/src/prover.rs
+++ b/dlog/plonk-5-wires/src/prover.rs
@@ -4,14 +4,24 @@ This source file implements prover's zk-proof primitive.
 
 *********************************************************************************************/
 
-use algebra::{Field, AffineCurve, Zero, One, UniformRand};
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
-use commitment_dlog::commitment::{CommitmentField, CommitmentCurve, PolyComm, OpeningProof, b_poly_coefficients};
-use oracle::{FqSponge, utils::PolyUtils, rndoracle::ProofError, sponge_5_wires::ScalarChallenge};
-use plonk_5_wires_circuits::{scalars::{ProofEvaluations, RandomOracles}, wires::COLUMNS};
 pub use super::{index::Index, range};
-use crate::plonk_sponge::{FrSponge};
+use crate::plonk_sponge::FrSponge;
+use algebra::{AffineCurve, Field, One, UniformRand, Zero};
 use array_init::array_init;
+use commitment_dlog::commitment::{
+    b_poly_coefficients, CommitmentCurve, CommitmentField, OpeningProof, PolyComm,
+};
+use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use oracle::{rndoracle::ProofError, sponge_5_wires::ScalarChallenge, utils::PolyUtils, FqSponge};
+use plonk_5_wires_circuits::{
+    polynomials::{
+        addition::CSAddGate, double::CSDoubleGate, endosclmul::CSEndomulGate,
+        generic::CSGenericGate, packing::CSPackGate, poseidon::CSPoseidonGate,
+        varbasemul::CSVbmulGate, varbasemulpck::CSVbmulpackGate,
+    },
+    scalars::{ProofEvaluations, RandomOracles},
+    wires::COLUMNS,
+};
 use rand::thread_rng;
 
 type Fr<G> = <G as AffineCurve>::ScalarField;
@@ -64,9 +74,9 @@ unsafe impl<G: AffineCurve + ocaml::FromValue> ocaml::FromValue for ProverCommit
     }
 }
 
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::ToValue, ocaml::FromValue))]
-struct CamlProverProof<G: AffineCurve>
-{
+#[cfg(feature = "ocaml_types")]
+#[derive(ocaml::ToValue, ocaml::FromValue)]
+struct CamlProverProof<G: AffineCurve> {
     pub commitments: ProverCommitments<G>,
     pub proof: OpeningProof<G>,
     // OCaml doesn't have sized arrays, so we have to convert to a tuple..

--- a/dlog/plonk-5-wires/src/verifier.rs
+++ b/dlog/plonk-5-wires/src/verifier.rs
@@ -4,14 +4,25 @@ This source file implements zk-proof batch verifier functionality.
 
 *********************************************************************************************/
 
-use crate::plonk_sponge::FrSponge;
-pub use super::prover::{ProverProof, range};
 pub use super::index::VerifierIndex as Index;
-use oracle::{FqSponge, rndoracle::ProofError, sponge_5_wires::ScalarChallenge};
-use plonk_5_wires_circuits::{wires::COLUMNS, scalars::{RandomOracles}, constraints::ConstraintSystem};
-use commitment_dlog::commitment::{CommitmentField, CommitmentCurve, PolyComm, b_poly, b_poly_coefficients, combined_inner_product};
-use algebra::{Field, AffineCurve, Zero, One};
+pub use super::prover::{range, ProverProof};
+use crate::plonk_sponge::FrSponge;
+use algebra::{AffineCurve, Field, One, Zero};
+use commitment_dlog::commitment::{
+    b_poly, b_poly_coefficients, combined_inner_product, CommitmentCurve, CommitmentField, PolyComm,
+};
 use ff_fft::EvaluationDomain;
+use oracle::{rndoracle::ProofError, sponge_5_wires::ScalarChallenge, FqSponge};
+use plonk_5_wires_circuits::{
+    constraints::ConstraintSystem,
+    polynomials::{
+        addition::CSAddGate, double::CSDoubleGate, endosclmul::CSEndomulGate,
+        generic::CSGenericGate, packing::CSPackGate, poseidon::CSPoseidonGate,
+        varbasemul::CSVbmulGate, varbasemulpck::CSVbmulpackGate,
+    },
+    scalars::RandomOracles,
+    wires::COLUMNS,
+};
 use rand::thread_rng;
 
 type Fr<G> = <G as AffineCurve>::ScalarField;
@@ -227,7 +238,7 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
                 p.push(&index.double_comm);
 
                 // variable base endoscalar multiplication
-                s.push(ConstraintSystem::endomul_scalars(&evals, index.endo, &alpha[range::ENDML]));
+                s.push(ConstraintSystem::endomul_scalars(&evals, &index.endo, &alpha[range::ENDML]));
                 p.push(&index.emul_comm);
 
                 // packing

--- a/dlog/plonk/src/prover.rs
+++ b/dlog/plonk/src/prover.rs
@@ -27,9 +27,9 @@ pub struct ProverCommitments<G: AffineCurve>
     pub t_comm: PolyComm<G>,
 }
 
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::ToValue, ocaml::FromValue))]
-struct CamlProverProof<G: AffineCurve>
-{
+#[cfg(feature = "ocaml_types")]
+#[derive(ocaml::ToValue, ocaml::FromValue)]
+struct CamlProverProof<G: AffineCurve> {
     pub commitments: ProverCommitments<G>,
     pub proof: OpeningProof<G>,
     // OCaml doesn't have sized arrays, so we have to convert to a tuple..

--- a/dlog/tests/poseidon_tweedledee_5_wires.rs
+++ b/dlog/tests/poseidon_tweedledee_5_wires.rs
@@ -9,7 +9,7 @@ use oracle::{poseidon_5_wires::*, poseidon::{SpongeConstants, Sponge}, sponge_5_
 use commitment_dlog::{srs::{SRS, SRSSpec, endos}, commitment::{CommitmentCurve, ceil_log2, b_poly_coefficients}};
 use algebra::{tweedle::{dum::{Affine as Other}, dee::{Affine, TweedledeeParameters}, fp::Fp}, UniformRand};
 use plonk_5_wires_protocol_dlog::{prover::{ProverProof}, index::{Index}};
-use plonk_5_wires_circuits::{gate::CircuitGate, constraints::ConstraintSystem};
+use plonk_5_wires_circuits::{gate::{CircuitGate, GateType}, constraints::ConstraintSystem};
 use ff_fft::DensePolynomial;
 use std::{io, io::Write};
 use groupmap::GroupMap;
@@ -32,7 +32,7 @@ fn poseidon_tweedledee()
     // circuit gates
 
     let mut i = 0;
-    let mut gates: Vec<CircuitGate::<Fp>> = Vec::with_capacity(N);
+    let mut gates: Vec<CircuitGate::<Fp, GateType>> = Vec::with_capacity(N);
 
     // custom constraints for Poseidon hash function permutation
 
@@ -49,7 +49,7 @@ fn poseidon_tweedledee()
                 Wire{col:3, row:(i+PERIOD)%M},
                 Wire{col:4, row:(i+PERIOD)%M},
             ];
-            gates.push(CircuitGate::<Fp>::create_poseidon(i, wires, c[j].clone()));
+            gates.push(CircuitGate::<Fp, GateType>::create_poseidon(i, wires, c[j].clone()));
             i+=1;
         }
         let wires =
@@ -60,20 +60,20 @@ fn poseidon_tweedledee()
             Wire{col:3, row:(i+PERIOD)%M},
             Wire{col:4, row:(i+PERIOD)%M},
         ];
-        gates.push(CircuitGate::<Fp>::zero(i, wires));
+        gates.push(CircuitGate::<Fp, GateType>::zero(i, wires));
         i+=1;
     }
 
     for j in 0..PlonkSpongeConstants::ROUNDS_FULL-2
     {
-        gates.push(CircuitGate::<Fp>::create_poseidon(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}], c[j].clone()));
+        gates.push(CircuitGate::<Fp, GateType>::create_poseidon(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}], c[j].clone()));
         i+=1;
     }
-    gates.push(CircuitGate::<Fp>::zero(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
+    gates.push(CircuitGate::<Fp, GateType>::zero(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
     i+=1;
-    gates.push(CircuitGate::<Fp>::zero(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
+    gates.push(CircuitGate::<Fp, GateType>::zero(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
     i+=1;
-    gates.push(CircuitGate::<Fp>::zero(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
+    gates.push(CircuitGate::<Fp, GateType>::zero(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
     
     let srs = SRS::create(MAX_SIZE);
 

--- a/dlog/tests/poseidon_tweedledum_5_wires.rs
+++ b/dlog/tests/poseidon_tweedledum_5_wires.rs
@@ -9,7 +9,7 @@ use oracle::{poseidon_5_wires::*, poseidon::{SpongeConstants, Sponge}, sponge_5_
 use commitment_dlog::{srs::{SRS, SRSSpec, endos}, commitment::{CommitmentCurve, ceil_log2, b_poly_coefficients}};
 use algebra::{tweedle::{dee::{Affine as Other}, dum::{Affine, TweedledumParameters}, fq::Fq}, UniformRand};
 use plonk_5_wires_protocol_dlog::{prover::{ProverProof}, index::{Index}};
-use plonk_5_wires_circuits::{gate::CircuitGate, constraints::ConstraintSystem};
+use plonk_5_wires_circuits::{gate::{CircuitGate, GateType}, constraints::ConstraintSystem};
 use ff_fft::DensePolynomial;
 use std::{io, io::Write};
 use groupmap::GroupMap;
@@ -32,7 +32,7 @@ fn poseidon_tweedledum()
     // circuit gates
 
     let mut i = 0;
-    let mut gates: Vec<CircuitGate::<Fq>> = Vec::with_capacity(N);
+    let mut gates: Vec<CircuitGate::<Fq, GateType>> = Vec::with_capacity(N);
 
     // custom constraints for Poseidon hash function permutation
 
@@ -49,7 +49,7 @@ fn poseidon_tweedledum()
                 Wire{col:3, row:(i+PERIOD)%M},
                 Wire{col:4, row:(i+PERIOD)%M},
             ];
-            gates.push(CircuitGate::<Fq>::create_poseidon(i, wires, c[j].clone()));
+            gates.push(CircuitGate::<Fq, GateType>::create_poseidon(i, wires, c[j].clone()));
             i+=1;
         }
         let wires =
@@ -60,20 +60,20 @@ fn poseidon_tweedledum()
             Wire{col:3, row:(i+PERIOD)%M},
             Wire{col:4, row:(i+PERIOD)%M},
         ];
-        gates.push(CircuitGate::<Fq>::zero(i, wires));
+        gates.push(CircuitGate::<Fq, GateType>::zero(i, wires));
         i+=1;
     }
 
     for j in 0..PlonkSpongeConstants::ROUNDS_FULL-2
     {
-        gates.push(CircuitGate::<Fq>::create_poseidon(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}], c[j].clone()));
+        gates.push(CircuitGate::<Fq, GateType>::create_poseidon(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}], c[j].clone()));
         i+=1;
     }
-    gates.push(CircuitGate::<Fq>::zero(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
+    gates.push(CircuitGate::<Fq, GateType>::zero(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
     i+=1;
-    gates.push(CircuitGate::<Fq>::zero(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
+    gates.push(CircuitGate::<Fq, GateType>::zero(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
     i+=1;
-    gates.push(CircuitGate::<Fq>::zero(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
+    gates.push(CircuitGate::<Fq, GateType>::zero(i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
     
     let srs = SRS::create(MAX_SIZE);
 

--- a/dlog/tests/turbo_plonk_5_wires.rs
+++ b/dlog/tests/turbo_plonk_5_wires.rs
@@ -32,7 +32,7 @@ This source file tests constraints for the following computations:
 **********************************************************************************************************/
 
 use oracle::{poseidon_5_wires::*, poseidon::{SpongeConstants, Sponge, ArithmeticSpongeParams}, sponge_5_wires::{DefaultFqSponge, DefaultFrSponge}};
-use plonk_5_wires_circuits::{wires::Wire, gate::CircuitGate, constraints::ConstraintSystem};
+use plonk_5_wires_circuits::{wires::Wire, gate::{CircuitGate, GateType}, constraints::ConstraintSystem};
 use commitment_dlog::{srs::{SRS, SRSSpec, endos}, commitment::{CommitmentCurve, ceil_log2, b_poly_coefficients}};
 use algebra::{PrimeField, SquareRootField, Field, BigInteger, tweedle::{dum::{Affine as Other}, dee::{Affine, TweedledeeParameters}, fp::Fp}, One, Zero, UniformRand};
 use plonk_5_wires_protocol_dlog::{prover::{ProverProof}, index::{Index}};
@@ -74,12 +74,12 @@ fn turbo_plonk()
             | y3 | .. | .. | .. | .. |
         */
 
-        CircuitGate::<Fp>::create_generic(0, [Wire{col:0, row: 6}, Wire{col:1, row:0}, Wire{col:2, row:0}, Wire{col:3, row:0}, Wire{col:4, row:0}], [p, z, z, z, z], z, z),
-        CircuitGate::<Fp>::create_generic(1, [Wire{col:1, row: 6}, Wire{col:1, row:1}, Wire{col:2, row:1}, Wire{col:3, row:1}, Wire{col:4, row:1}], [p, z, z, z, z], z, z),
-        CircuitGate::<Fp>::create_generic(2, [Wire{col:4, row: 8}, Wire{col:1, row:2}, Wire{col:2, row:2}, Wire{col:3, row:2}, Wire{col:4, row:2}], [p, z, z, z, z], z, z),
-        CircuitGate::<Fp>::create_generic(3, [Wire{col:2, row: 7}, Wire{col:1, row:3}, Wire{col:2, row:3}, Wire{col:3, row:3}, Wire{col:4, row:3}], [p, z, z, z, z], z, z),
-        CircuitGate::<Fp>::create_generic(4, [Wire{col:3, row: 7}, Wire{col:1, row:4}, Wire{col:2, row:4}, Wire{col:3, row:4}, Wire{col:4, row:4}], [p, z, z, z, z], z, z),
-        CircuitGate::<Fp>::create_generic(5, [Wire{col:3, row:10}, Wire{col:1, row:5}, Wire{col:2, row:5}, Wire{col:3, row:5}, Wire{col:4, row:5}], [p, z, z, z, z], z, z),
+        CircuitGate::<Fp, GateType>::create_generic(0, [Wire{col:0, row: 6}, Wire{col:1, row:0}, Wire{col:2, row:0}, Wire{col:3, row:0}, Wire{col:4, row:0}], [p, z, z, z, z], z, z),
+        CircuitGate::<Fp, GateType>::create_generic(1, [Wire{col:1, row: 6}, Wire{col:1, row:1}, Wire{col:2, row:1}, Wire{col:3, row:1}, Wire{col:4, row:1}], [p, z, z, z, z], z, z),
+        CircuitGate::<Fp, GateType>::create_generic(2, [Wire{col:4, row: 8}, Wire{col:1, row:2}, Wire{col:2, row:2}, Wire{col:3, row:2}, Wire{col:4, row:2}], [p, z, z, z, z], z, z),
+        CircuitGate::<Fp, GateType>::create_generic(3, [Wire{col:2, row: 7}, Wire{col:1, row:3}, Wire{col:2, row:3}, Wire{col:3, row:3}, Wire{col:4, row:3}], [p, z, z, z, z], z, z),
+        CircuitGate::<Fp, GateType>::create_generic(4, [Wire{col:3, row: 7}, Wire{col:1, row:4}, Wire{col:2, row:4}, Wire{col:3, row:4}, Wire{col:4, row:4}], [p, z, z, z, z], z, z),
+        CircuitGate::<Fp, GateType>::create_generic(5, [Wire{col:3, row:10}, Wire{col:1, row:5}, Wire{col:2, row:5}, Wire{col:3, row:5}, Wire{col:4, row:5}], [p, z, z, z, z], z, z),
 
         /* generic constraint gates for Weierstrass curve group addition
 
@@ -104,11 +104,11 @@ fn turbo_plonk()
             | a2 | s  | y1 | y3 | .. |
         */
 
-        CircuitGate::<Fp>::create_generic( 6, [Wire{col:2, row: 8}, Wire{col:3, row: 8}, Wire{col:0, row: 7}, Wire{col:3, row: 6}, Wire{col:4, row: 6}], [p, n, p, z, z], z, z),
-        CircuitGate::<Fp>::create_generic( 7, [Wire{col:2, row: 6}, Wire{col:0, row: 8}, Wire{col:2, row:10}, Wire{col:3, row:11}, Wire{col:4, row: 7}], [z, z, p, n, z], p, z),
-        CircuitGate::<Fp>::create_generic( 8, [Wire{col:1, row: 8}, Wire{col:1, row:10}, Wire{col:0, row: 9}, Wire{col:2, row:11}, Wire{col:1, row: 9}], [z, z, p, p, p], n, z),
-        CircuitGate::<Fp>::create_generic( 9, [Wire{col:0, row:11}, Wire{col:0, row:12}, Wire{col:0, row:10}, Wire{col:3, row: 9}, Wire{col:4, row: 9}], [p, n, n, z, z], z, z),
-        CircuitGate::<Fp>::create_generic(10, [Wire{col:2, row: 9}, Wire{col:1, row: 7}, Wire{col:1, row:11}, Wire{col:1, row:12}, Wire{col:4, row:10}], [z, z, p, p, z], n, z),
+        CircuitGate::<Fp, GateType>::create_generic( 6, [Wire{col:2, row: 8}, Wire{col:3, row: 8}, Wire{col:0, row: 7}, Wire{col:3, row: 6}, Wire{col:4, row: 6}], [p, n, p, z, z], z, z),
+        CircuitGate::<Fp, GateType>::create_generic( 7, [Wire{col:2, row: 6}, Wire{col:0, row: 8}, Wire{col:2, row:10}, Wire{col:3, row:11}, Wire{col:4, row: 7}], [z, z, p, n, z], p, z),
+        CircuitGate::<Fp, GateType>::create_generic( 8, [Wire{col:1, row: 8}, Wire{col:1, row:10}, Wire{col:0, row: 9}, Wire{col:2, row:11}, Wire{col:1, row: 9}], [z, z, p, p, p], n, z),
+        CircuitGate::<Fp, GateType>::create_generic( 9, [Wire{col:0, row:11}, Wire{col:0, row:12}, Wire{col:0, row:10}, Wire{col:3, row: 9}, Wire{col:4, row: 9}], [p, n, n, z, z], z, z),
+        CircuitGate::<Fp, GateType>::create_generic(10, [Wire{col:2, row: 9}, Wire{col:1, row: 7}, Wire{col:1, row:11}, Wire{col:1, row:12}, Wire{col:4, row:10}], [z, z, p, p, z], n, z),
     ];
 
     /* custom constraint gates for Weierstrass curve group addition
@@ -117,7 +117,7 @@ fn turbo_plonk()
         | x3 | y3 | .. | .. | .. |
     */
 
-    let mut add = CircuitGate::<Fp>::create_add
+    let mut add = CircuitGate::<Fp, GateType>::create_add
     (
         11,
         &[
@@ -152,11 +152,11 @@ fn turbo_plonk()
 
     let mut double = vec!
     [
-        CircuitGate::<Fp>::create_generic(13, [Wire{col:1, row:13}, Wire{col:2, row:15}, Wire{col:2, row:14}, Wire{col:3, row:13}, Wire{col:4, row:13}], [z, z, n, z, z], p, z),
-        CircuitGate::<Fp>::create_generic(14, [Wire{col:2, row:16}, Wire{col:0, row:15}, Wire{col:2, row:13}, Wire{col:3, row:14}, Wire{col:4, row:14}], [z, z, (n.double() + &n), z, z], p.double(), z),
-        CircuitGate::<Fp>::create_generic(15, [Wire{col:1, row:15}, Wire{col:0, row:16}, Wire{col:1, row:17}, Wire{col:0, row:17}, Wire{col:4, row:15}], [z, z, n.double(), n, z], p, z),
-        CircuitGate::<Fp>::create_generic(16, [Wire{col:1, row:14}, Wire{col:2, row:17}, Wire{col:1, row:18}, Wire{col:3, row:18}, Wire{col:4, row:16}], [z, z, p, p, z], p, z),
-        CircuitGate::<Fp>::create_generic(17, [Wire{col:2, row:18}, Wire{col:0, row:18}, Wire{col:1, row:16}, Wire{col:3, row:17}, Wire{col:4, row:17}], [p, n, n, z, z], z, z),
+        CircuitGate::<Fp, GateType>::create_generic(13, [Wire{col:1, row:13}, Wire{col:2, row:15}, Wire{col:2, row:14}, Wire{col:3, row:13}, Wire{col:4, row:13}], [z, z, n, z, z], p, z),
+        CircuitGate::<Fp, GateType>::create_generic(14, [Wire{col:2, row:16}, Wire{col:0, row:15}, Wire{col:2, row:13}, Wire{col:3, row:14}, Wire{col:4, row:14}], [z, z, (n.double() + &n), z, z], p.double(), z),
+        CircuitGate::<Fp, GateType>::create_generic(15, [Wire{col:1, row:15}, Wire{col:0, row:16}, Wire{col:1, row:17}, Wire{col:0, row:17}, Wire{col:4, row:15}], [z, z, n.double(), n, z], p, z),
+        CircuitGate::<Fp, GateType>::create_generic(16, [Wire{col:1, row:14}, Wire{col:2, row:17}, Wire{col:1, row:18}, Wire{col:3, row:18}, Wire{col:4, row:16}], [z, z, p, p, z], p, z),
+        CircuitGate::<Fp, GateType>::create_generic(17, [Wire{col:2, row:18}, Wire{col:0, row:18}, Wire{col:1, row:16}, Wire{col:3, row:17}, Wire{col:4, row:17}], [p, n, n, z, z], z, z),
     ];
     gates.append(&mut double);
 
@@ -164,7 +164,7 @@ fn turbo_plonk()
         | x1 | y1 | x2 | y2 | r  |
     */
 
-    let double = CircuitGate::<Fp>::create_double
+    let double = CircuitGate::<Fp, GateType>::create_double
     (
         18,
         [Wire{col:0, row:0}, Wire{col:0, row: 3}, Wire{col:3, row:15}, Wire{col:3, row:16}, Wire{col:4, row:18}]
@@ -176,7 +176,7 @@ fn turbo_plonk()
     let c = &oracle::tweedle::fp5::params().round_constants;
     for i in 0..PlonkSpongeConstants::ROUNDS_FULL
     {
-        gates.push(CircuitGate::<Fp>::create_poseidon
+        gates.push(CircuitGate::<Fp, GateType>::create_poseidon
         (
             i+19,
             [
@@ -190,7 +190,7 @@ fn turbo_plonk()
         ));
     }
     let mut i = PlonkSpongeConstants::ROUNDS_FULL+19;
-    gates.push(CircuitGate::<Fp>::zero
+    gates.push(CircuitGate::<Fp, GateType>::zero
         (i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
     i += 1;
 
@@ -198,80 +198,80 @@ fn turbo_plonk()
     
     for _ in 0..64
     {
-        gates.push(CircuitGate::<Fp>::create_pack
+        gates.push(CircuitGate::<Fp, GateType>::create_pack
             (i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
         i += 1;
     }
-    gates.push(CircuitGate::<Fp>::zero
+    gates.push(CircuitGate::<Fp, GateType>::zero
         (i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
     i += 1;
     
     // custom constraint gates for short Weierstrass curve variable base scalar multiplication without packing
     
-    gates.push(CircuitGate::<Fp>::create_vbmul
+    gates.push(CircuitGate::<Fp, GateType>::create_vbmul
         (i, [Wire{col:0, row:i+2}, Wire{col:1, row:i+2}, Wire{col:2, row:i+512}, Wire{col:3, row:i}, Wire{col:3, row:i+512}]));
     i += 1;
-    gates.push(CircuitGate::<Fp>::zero
+    gates.push(CircuitGate::<Fp, GateType>::zero
         (i, [Wire{col:2, row:i+2}, Wire{col:3, row:i+2}, Wire{col:2, row:i+512}, Wire{col:3, row:i+512}, Wire{col:4, row:i}]));
     i += 1;
     for j in 0..254
     {
-        gates.push(CircuitGate::<Fp>::create_vbmul
+        gates.push(CircuitGate::<Fp, GateType>::create_vbmul
             (i+2*j, [Wire{col:0, row:i+2*j+2}, Wire{col:1, row:i+2*j+2}, Wire{col:2, row:i+2*j+512}, Wire{col:3, row:i+2*j}, Wire{col:3, row:i+512+2*j}]));
-        gates.push(CircuitGate::<Fp>::zero
+        gates.push(CircuitGate::<Fp, GateType>::zero
             (i+1+2*j, [Wire{col:2, row:i+3+2*j}, Wire{col:3, row:i+3+2*j}, Wire{col:0, row:i-1+2*j}, Wire{col:1, row:i-1+2*j}, Wire{col:4, row:i+1+2*j}]));
     }
     i += 508;
-    gates.push(CircuitGate::<Fp>::create_vbmul
+    gates.push(CircuitGate::<Fp, GateType>::create_vbmul
         (i, [Wire{col:0, row:i+2}, Wire{col:1, row:i+2}, Wire{col:2, row:i+512}, Wire{col:3, row:i}, Wire{col:3, row:i+512}]));
     i += 1;
-    gates.push(CircuitGate::<Fp>::zero
+    gates.push(CircuitGate::<Fp, GateType>::zero
         (i, [Wire{col:0, row:i+512}, Wire{col:1, row:i+512}, Wire{col:0, row:i-2}, Wire{col:1, row:i-2}, Wire{col:4, row:i}]));
     i += 1;
 
     // custom constraint gates for short Weierstrass curve variable base scalar multiplication with packing
     
-    gates.push(CircuitGate::<Fp>::create_vbmul2
+    gates.push(CircuitGate::<Fp, GateType>::create_vbmul2
         (i, [Wire{col:0, row:i+2}, Wire{col:1, row:i+2}, Wire{col:2, row:i-512}, Wire{col:4, row:i-512}, Wire{col:4, row:i+3}]));
     i += 1;
-    gates.push(CircuitGate::<Fp>::zero
+    gates.push(CircuitGate::<Fp, GateType>::zero
         (i, [Wire{col:2, row:i+2}, Wire{col:3, row:i+2}, Wire{col:2, row:i-512}, Wire{col:3, row:i-512}, Wire{col:4, row:i}]));
     i += 1;
     for j in 0..254
     {
-        gates.push(CircuitGate::<Fp>::create_vbmul2
+        gates.push(CircuitGate::<Fp, GateType>::create_vbmul2
             (i+2*j, [Wire{col:0, row:i+2*j+2}, Wire{col:1, row:i+2*j+2}, Wire{col:2, row:i+2*j-512}, Wire{col:4, row:i+2*j-512}, Wire{col:4, row:i+2*j+3}]));
-        gates.push(CircuitGate::<Fp>::zero
+        gates.push(CircuitGate::<Fp, GateType>::zero
             (i+1+2*j, [Wire{col:2, row:i+3+2*j}, Wire{col:3, row:i+3+2*j}, Wire{col:0, row:i-1+2*j}, Wire{col:1, row:i-1+2*j}, Wire{col:4, row:i+1+2*j-3}]));
     }
     i += 508;
-    gates.push(CircuitGate::<Fp>::create_vbmul2
+    gates.push(CircuitGate::<Fp, GateType>::create_vbmul2
         (i, [Wire{col:0, row:i-1022}, Wire{col:1, row:i-1022}, Wire{col:2, row:i-512}, Wire{col:4, row:i-512}, Wire{col:4, row:i}]));
     i += 1;
-    gates.push(CircuitGate::<Fp>::zero
+    gates.push(CircuitGate::<Fp, GateType>::zero
         (i, [Wire{col:0, row:i-512}, Wire{col:1, row:i-512}, Wire{col:0, row:i-2}, Wire{col:1, row:i-2}, Wire{col:4, row:i-3}]));
     i += 1;
     
     // custom constraint gates for short Weierstrass curve variable base endoscalar multiplication
     
-    gates.push(CircuitGate::<Fp>::create_endomul
+    gates.push(CircuitGate::<Fp, GateType>::create_endomul
         (i, [Wire{col:0, row:i+2}, Wire{col:1, row:i+2}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
     i += 1;
-    gates.push(CircuitGate::<Fp>::zero
+    gates.push(CircuitGate::<Fp, GateType>::zero
         (i, [Wire{col:2, row:i+2}, Wire{col:3, row:i+2}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
     i += 1;
     for j in 0..126
     {
-        gates.push(CircuitGate::<Fp>::create_endomul
+        gates.push(CircuitGate::<Fp, GateType>::create_endomul
             (i+2*j, [Wire{col:0, row:i+2+2*j}, Wire{col:1, row:i+2+2*j}, Wire{col:2, row:i+2*j}, Wire{col:3, row:i+2*j}, Wire{col:4, row:i+2*j}]));
-        gates.push(CircuitGate::<Fp>::zero
+        gates.push(CircuitGate::<Fp, GateType>::zero
             (i+1+2*j, [Wire{col:2, row:i+3+2*j}, Wire{col:3, row:i+3+2*j}, Wire{col:0, row:i-1+2*j}, Wire{col:1, row:i-1+2*j}, Wire{col:4, row:i+1+2*j}]));
     }
     i += 252;
-    gates.push(CircuitGate::<Fp>::create_endomul
+    gates.push(CircuitGate::<Fp, GateType>::create_endomul
         (i, [Wire{col:0, row:i-254}, Wire{col:1, row:i-254}, Wire{col:2, row:i}, Wire{col:3, row:i}, Wire{col:4, row:i}]));
     i += 1;
-    gates.push(CircuitGate::<Fp>::zero
+    gates.push(CircuitGate::<Fp, GateType>::zero
         (i, [Wire{col:0, row:i}, Wire{col:1, row:i}, Wire{col:0, row:i-2}, Wire{col:1, row:i-2}, Wire{col:4, row:i}]));
 
     let srs = SRS::create(MAX_SIZE);


### PR DESCRIPTION
This PR abstracts each of the gate implementations for 5-wires plonk over `CircuitGate` (for the `gates/*`) and `ConstraintSystem` (for the corresponding `polynomials/*`). This allows us to share these implementations between the 5-wires and 5-wires+plonk proof systems without duplicating these files.