### PR TITLE
[step 6] refactoring the ocaml bindings to accomodate arkworks 

### DIFF
--- a/circuits/plonk-5-wires/src/scalars.rs
+++ b/circuits/plonk-5-wires/src/scalars.rs
@@ -30,58 +30,7 @@ impl<F: FftField> ProofEvaluations<Vec<F>> {
         }
     }
 }
-
-#[derive(Clone)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::ToValue, ocaml::FromValue))]
-pub struct CamlProofEvaluations<Fs> {
-    pub w: (Fs, Fs, Fs, Fs, Fs),
-    pub z: Fs,
-    pub t: Fs,
-    pub f: Fs,
-    pub s: (Fs, Fs, Fs, Fs),
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<Fs: ocaml::ToValue> ocaml::ToValue for ProofEvaluations<Fs> {
-    fn to_value(self) -> ocaml::Value {
-        ocaml::ToValue::to_value(CamlProofEvaluations {
-            w: {
-                let [w0, w1, w2, w3, w4] = self.w;
-                (w0, w1, w2, w3, w4)
-            },
-            z: self.z,
-            t: self.t,
-            f: self.f,
-            s: {
-                let [s0, s1, s2, s3] = self.s;
-                (s0, s1, s2, s3)
-            },
-        })
-    }
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<Fs: ocaml::FromValue> ocaml::FromValue for ProofEvaluations<Fs> {
-    fn from_value(v: ocaml::Value) -> Self {
-        let evals: CamlProofEvaluations<Fs> = ocaml::FromValue::from_value(v);
-        ProofEvaluations {
-            w: {
-                let (w0, w1, w2, w3, w4) = evals.w;
-                [w0, w1, w2, w3, w4]
-            },
-            z: evals.z,
-            t: evals.t,
-            f: evals.f,
-            s: {
-                let (s0, s1, s2, s3) = evals.s;
-                [s0, s1, s2, s3]
-            },
-        }
-    }
-}
-
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::ToValue, ocaml::FromValue))]
 pub struct RandomOracles<F: Field> {
     pub beta: F,
     pub gamma: F,
@@ -109,6 +58,146 @@ impl<F: Field> RandomOracles<F> {
             zeta_chal: c,
             v_chal: c,
             u_chal: c,
+        }
+    }
+}
+
+//
+// OCaml types
+//
+
+#[cfg(feature = "ocaml_types")]
+pub mod caml {
+    use super::*;
+    use oracle::sponge::caml::CamlScalarChallenge;
+
+    //
+    // ProofEvaluations<F> <-> CamlProofEvaluations<CamlF>
+    //
+
+    #[derive(Clone, ocaml::ToValue, ocaml::FromValue)]
+    pub struct CamlProofEvaluations<F> {
+        pub w: (Vec<F>, Vec<F>, Vec<F>, Vec<F>, Vec<F>),
+        pub z: Vec<F>,
+        pub t: Vec<F>,
+        pub f: Vec<F>,
+        pub s: (Vec<F>, Vec<F>, Vec<F>, Vec<F>),
+    }
+
+    impl<F, CamlF> From<ProofEvaluations<Vec<F>>> for CamlProofEvaluations<CamlF>
+    where
+        F: Clone,
+        CamlF: From<F>,
+    {
+        fn from(pe: ProofEvaluations<Vec<F>>) -> Self {
+            let w = (
+                pe.w[0].iter().cloned().map(Into::into).collect(),
+                pe.w[1].iter().cloned().map(Into::into).collect(),
+                pe.w[2].iter().cloned().map(Into::into).collect(),
+                pe.w[3].iter().cloned().map(Into::into).collect(),
+                pe.w[4].iter().cloned().map(Into::into).collect(),
+            );
+            let s = (
+                pe.s[0].iter().cloned().map(Into::into).collect(),
+                pe.s[1].iter().cloned().map(Into::into).collect(),
+                pe.s[2].iter().cloned().map(Into::into).collect(),
+                pe.s[3].iter().cloned().map(Into::into).collect(),
+            );
+            Self {
+                w,
+                z: pe.z.into_iter().map(Into::into).collect(),
+                t: pe.t.into_iter().map(Into::into).collect(),
+                f: pe.f.into_iter().map(Into::into).collect(),
+                s,
+            }
+        }
+    }
+
+    impl<F, CamlF> Into<ProofEvaluations<Vec<F>>> for CamlProofEvaluations<CamlF>
+    where
+        CamlF: Into<F>,
+    {
+        fn into(self) -> ProofEvaluations<Vec<F>> {
+            let w = [
+                self.w.0.into_iter().map(Into::into).collect(),
+                self.w.1.into_iter().map(Into::into).collect(),
+                self.w.2.into_iter().map(Into::into).collect(),
+                self.w.3.into_iter().map(Into::into).collect(),
+                self.w.4.into_iter().map(Into::into).collect(),
+            ];
+            let s = [
+                self.s.0.into_iter().map(Into::into).collect(),
+                self.s.1.into_iter().map(Into::into).collect(),
+                self.s.2.into_iter().map(Into::into).collect(),
+                self.s.3.into_iter().map(Into::into).collect(),
+            ];
+            ProofEvaluations {
+                w,
+                z: self.z.into_iter().map(Into::into).collect(),
+                t: self.t.into_iter().map(Into::into).collect(),
+                f: self.f.into_iter().map(Into::into).collect(),
+                s,
+            }
+        }
+    }
+
+    //
+    // RandomOracles<F> <-> CamlRandomOracles<CamlF>
+    //
+
+    #[derive(ocaml::ToValue, ocaml::FromValue)]
+    pub struct CamlRandomOracles<CamlF> {
+        pub beta: CamlF,
+        pub gamma: CamlF,
+        pub alpha_chal: CamlScalarChallenge<CamlF>,
+        pub alpha: CamlF,
+        pub zeta: CamlF,
+        pub v: CamlF,
+        pub u: CamlF,
+        pub zeta_chal: CamlScalarChallenge<CamlF>,
+        pub v_chal: CamlScalarChallenge<CamlF>,
+        pub u_chal: CamlScalarChallenge<CamlF>,
+    }
+
+    impl<F, CamlF> From<RandomOracles<F>> for CamlRandomOracles<CamlF>
+    where
+        F: Field,
+        CamlF: From<F>,
+    {
+        fn from(ro: RandomOracles<F>) -> Self {
+            Self {
+                beta: ro.beta.into(),
+                gamma: ro.gamma.into(),
+                alpha_chal: ro.alpha_chal.into(),
+                alpha: ro.alpha.into(),
+                zeta: ro.zeta.into(),
+                v: ro.v.into(),
+                u: ro.u.into(),
+                zeta_chal: ro.zeta_chal.into(),
+                v_chal: ro.v_chal.into(),
+                u_chal: ro.u_chal.into(),
+            }
+        }
+    }
+
+    impl<F, CamlF> Into<RandomOracles<F>> for CamlRandomOracles<CamlF>
+    where
+        CamlF: Into<F>,
+        F: Field,
+    {
+        fn into(self) -> RandomOracles<F> {
+            RandomOracles {
+                beta: self.beta.into(),
+                gamma: self.gamma.into(),
+                alpha_chal: self.alpha_chal.into(),
+                alpha: self.alpha.into(),
+                zeta: self.zeta.into(),
+                v: self.v.into(),
+                u: self.u.into(),
+                zeta_chal: self.zeta_chal.into(),
+                v_chal: self.v_chal.into(),
+                u_chal: self.u_chal.into(),
+            }
         }
     }
 }

--- a/circuits/plonk-5-wires/src/scalars.rs
+++ b/circuits/plonk-5-wires/src/scalars.rs
@@ -75,7 +75,7 @@ pub mod caml {
     // ProofEvaluations<F> <-> CamlProofEvaluations<CamlF>
     //
 
-    #[derive(Clone, ocaml::ToValue, ocaml::FromValue)]
+    #[derive(Clone, ocaml::IntoValue, ocaml::FromValue)]
     pub struct CamlProofEvaluations<F> {
         pub w: (Vec<F>, Vec<F>, Vec<F>, Vec<F>, Vec<F>),
         pub z: Vec<F>,
@@ -145,7 +145,7 @@ pub mod caml {
     // RandomOracles<F> <-> CamlRandomOracles<CamlF>
     //
 
-    #[derive(ocaml::ToValue, ocaml::FromValue)]
+    #[derive(ocaml::IntoValue, ocaml::FromValue)]
     pub struct CamlRandomOracles<CamlF> {
         pub beta: CamlF,
         pub gamma: CamlF,

--- a/circuits/plonk/src/scalars.rs
+++ b/circuits/plonk/src/scalars.rs
@@ -9,7 +9,6 @@ use ark_poly::univariate::DensePolynomial;
 use oracle::{sponge::ScalarChallenge, utils::PolyUtils};
 
 #[derive(Clone)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
 pub struct ProofEvaluations<Fs> {
     pub l: Fs,
     pub r: Fs,
@@ -37,9 +36,7 @@ impl<F: FftField> ProofEvaluations<Vec<F>> {
 }
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
-pub struct RandomOracles<F: Field>
-{
+pub struct RandomOracles<F: Field> {
     pub beta: F,
     pub gamma: F,
     pub alpha_chal: ScalarChallenge<F>,
@@ -66,6 +63,128 @@ impl<F: Field> RandomOracles<F> {
             zeta_chal: c,
             v_chal: c,
             u_chal: c,
+        }
+    }
+}
+
+//
+// OCaml types
+//
+
+#[cfg(feature = "ocaml_types")]
+pub mod caml {
+    use super::*;
+    use oracle::sponge::caml::CamlScalarChallenge;
+
+    //
+    // ProofEvaluations<F> <-> CamlProofEvaluations<CamlF>
+    //
+
+    #[derive(Clone, ocaml::ToValue, ocaml::FromValue)]
+    pub struct CamlProofEvaluations<F> {
+        pub l: Vec<F>,
+        pub r: Vec<F>,
+        pub o: Vec<F>,
+        pub z: Vec<F>,
+        pub t: Vec<F>,
+        pub f: Vec<F>,
+        pub sigma1: Vec<F>,
+        pub sigma2: Vec<F>,
+    }
+
+    impl<F, CamlF> From<ProofEvaluations<Vec<F>>> for CamlProofEvaluations<CamlF>
+    where
+        CamlF: From<F>,
+    {
+        fn from(pe: ProofEvaluations<Vec<F>>) -> Self {
+            Self {
+                l: pe.l.into_iter().map(Into::into).collect(),
+                r: pe.r.into_iter().map(Into::into).collect(),
+                o: pe.o.into_iter().map(Into::into).collect(),
+                z: pe.z.into_iter().map(Into::into).collect(),
+                t: pe.t.into_iter().map(Into::into).collect(),
+                f: pe.f.into_iter().map(Into::into).collect(),
+                sigma1: pe.sigma1.into_iter().map(Into::into).collect(),
+                sigma2: pe.sigma2.into_iter().map(Into::into).collect(),
+            }
+        }
+    }
+
+    impl<F, CamlF> Into<ProofEvaluations<Vec<F>>> for CamlProofEvaluations<CamlF>
+    where
+        CamlF: Into<F>,
+    {
+        fn into(self) -> ProofEvaluations<Vec<F>> {
+            ProofEvaluations {
+                l: self.l.into_iter().map(Into::into).collect(),
+                r: self.r.into_iter().map(Into::into).collect(),
+                o: self.o.into_iter().map(Into::into).collect(),
+                z: self.z.into_iter().map(Into::into).collect(),
+                t: self.t.into_iter().map(Into::into).collect(),
+                f: self.f.into_iter().map(Into::into).collect(),
+                sigma1: self.sigma1.into_iter().map(Into::into).collect(),
+                sigma2: self.sigma2.into_iter().map(Into::into).collect(),
+            }
+        }
+    }
+
+    //
+    // RandomOracles<F> <-> CamlRandomOracles<CamlF>
+    //
+
+    #[derive(ocaml::ToValue, ocaml::FromValue)]
+    pub struct CamlRandomOracles<CamlF> {
+        pub beta: CamlF,
+        pub gamma: CamlF,
+        pub alpha_chal: CamlScalarChallenge<CamlF>,
+        pub alpha: CamlF,
+        pub zeta: CamlF,
+        pub v: CamlF,
+        pub u: CamlF,
+        pub zeta_chal: CamlScalarChallenge<CamlF>,
+        pub v_chal: CamlScalarChallenge<CamlF>,
+        pub u_chal: CamlScalarChallenge<CamlF>,
+    }
+
+    impl<F, CamlF> From<RandomOracles<F>> for CamlRandomOracles<CamlF>
+    where
+        F: Field,
+        CamlF: From<F>,
+    {
+        fn from(ro: RandomOracles<F>) -> Self {
+            Self {
+                beta: ro.beta.into(),
+                gamma: ro.gamma.into(),
+                alpha_chal: ro.alpha_chal.into(),
+                alpha: ro.alpha.into(),
+                zeta: ro.zeta.into(),
+                v: ro.v.into(),
+                u: ro.u.into(),
+                zeta_chal: ro.zeta_chal.into(),
+                v_chal: ro.v_chal.into(),
+                u_chal: ro.u_chal.into(),
+            }
+        }
+    }
+
+    impl<F, CamlF> Into<RandomOracles<F>> for CamlRandomOracles<CamlF>
+    where
+        CamlF: Into<F>,
+        F: Field,
+    {
+        fn into(self) -> RandomOracles<F> {
+            RandomOracles {
+                beta: self.beta.into(),
+                gamma: self.gamma.into(),
+                alpha_chal: self.alpha_chal.into(),
+                alpha: self.alpha.into(),
+                zeta: self.zeta.into(),
+                v: self.v.into(),
+                u: self.u.into(),
+                zeta_chal: self.zeta_chal.into(),
+                v_chal: self.v_chal.into(),
+                u_chal: self.u_chal.into(),
+            }
         }
     }
 }

--- a/circuits/plonk/src/scalars.rs
+++ b/circuits/plonk/src/scalars.rs
@@ -80,7 +80,7 @@ pub mod caml {
     // ProofEvaluations<F> <-> CamlProofEvaluations<CamlF>
     //
 
-    #[derive(Clone, ocaml::ToValue, ocaml::FromValue)]
+    #[derive(Clone, ocaml::IntoValue, ocaml::FromValue)]
     pub struct CamlProofEvaluations<F> {
         pub l: Vec<F>,
         pub r: Vec<F>,
@@ -132,7 +132,7 @@ pub mod caml {
     // RandomOracles<F> <-> CamlRandomOracles<CamlF>
     //
 
-    #[derive(ocaml::ToValue, ocaml::FromValue)]
+    #[derive(ocaml::IntoValue, ocaml::FromValue)]
     pub struct CamlRandomOracles<CamlF> {
         pub beta: CamlF,
         pub gamma: CamlF,

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -1084,7 +1084,7 @@ pub mod caml {
 
     // polynomial commitment
 
-    #[derive(Clone, ocaml::ToValue, ocaml::FromValue)]
+    #[derive(Clone, ocaml::IntoValue, ocaml::FromValue)]
     pub struct CamlPolyComm<CamlG> {
         pub unshifted: Vec<CamlG>,
         pub shifted: Option<CamlG>,
@@ -1120,7 +1120,7 @@ pub mod caml {
 
     // opening proof
 
-    #[derive(ocaml::ToValue, ocaml::FromValue)]
+    #[derive(ocaml::IntoValue, ocaml::FromValue)]
     pub struct CamlOpeningProof<G, F> {
         pub lr: Vec<(G, G)>, // vector of rounds of L & R commitments
         pub delta: G,

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -31,7 +31,6 @@ type Fr<G> = <G as AffineCurve>::ScalarField;
 type Fq<G> = <G as AffineCurve>::BaseField;
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
 pub struct PolyComm<C> {
     pub unshifted: Vec<C>,
     pub shifted: Option<C>,
@@ -104,7 +103,6 @@ impl<C: AffineCurve> PolyComm<C> {
 }
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
 pub struct OpeningProof<G: AffineCurve> {
     pub lr: Vec<(G, G)>, // vector of rounds of L & R commitments
     pub delta: G,
@@ -1073,5 +1071,103 @@ mod tests {
         )];
 
         assert!(srs.verify(&group_map, &mut batch, rng));
+    }
+}
+
+//
+// OCaml types
+//
+
+#[cfg(feature = "ocaml_types")]
+pub mod caml {
+    use super::*;
+
+    // polynomial commitment
+
+    #[derive(Clone, ocaml::ToValue, ocaml::FromValue)]
+    pub struct CamlPolyComm<CamlG> {
+        pub unshifted: Vec<CamlG>,
+        pub shifted: Option<CamlG>,
+    }
+
+    //
+
+    impl<G, CamlG> From<PolyComm<G>> for CamlPolyComm<CamlG>
+    where
+        G: AffineCurve,
+        CamlG: From<G>,
+    {
+        fn from(polycomm: PolyComm<G>) -> Self {
+            Self {
+                unshifted: polycomm.unshifted.into_iter().map(Into::into).collect(),
+                shifted: polycomm.shifted.map(Into::into),
+            }
+        }
+    }
+
+    impl<G, CamlG> Into<PolyComm<G>> for CamlPolyComm<CamlG>
+    where
+        G: AffineCurve,
+        CamlG: Into<G>,
+    {
+        fn into(self) -> PolyComm<G> {
+            PolyComm {
+                unshifted: self.unshifted.into_iter().map(Into::into).collect(),
+                shifted: self.shifted.map(Into::into),
+            }
+        }
+    }
+
+    // opening proof
+
+    #[derive(ocaml::ToValue, ocaml::FromValue)]
+    pub struct CamlOpeningProof<G, F> {
+        pub lr: Vec<(G, G)>, // vector of rounds of L & R commitments
+        pub delta: G,
+        pub z1: F,
+        pub z2: F,
+        pub sg: G,
+    }
+
+    impl<G, CamlF, CamlG> From<OpeningProof<G>> for CamlOpeningProof<CamlG, CamlF>
+    where
+        G: AffineCurve,
+        CamlG: From<G>,
+        CamlF: From<G::ScalarField>,
+    {
+        fn from(xxx: OpeningProof<G>) -> Self {
+            Self {
+                lr: xxx
+                    .lr
+                    .into_iter()
+                    .map(|(g1, g2)| (g1.into(), g2.into()))
+                    .collect(),
+                delta: xxx.delta.into(),
+                z1: xxx.z1.into(),
+                z2: xxx.z2.into(),
+                sg: xxx.sg.into(),
+            }
+        }
+    }
+
+    impl<G, CamlF, CamlG> Into<OpeningProof<G>> for CamlOpeningProof<CamlG, CamlF>
+    where
+        G: AffineCurve,
+        CamlG: Into<G>,
+        CamlF: Into<G::ScalarField>,
+    {
+        fn into(self) -> OpeningProof<G> {
+            OpeningProof {
+                lr: self
+                    .lr
+                    .into_iter()
+                    .map(|(g1, g2)| (g1.into(), g2.into()))
+                    .collect(),
+                delta: self.delta.into(),
+                z1: self.z1.into(),
+                z2: self.z2.into(),
+                sg: self.sg.into(),
+            }
+        }
     }
 }

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -1135,17 +1135,17 @@ pub mod caml {
         CamlG: From<G>,
         CamlF: From<G::ScalarField>,
     {
-        fn from(xxx: OpeningProof<G>) -> Self {
+        fn from(opening_proof: OpeningProof<G>) -> Self {
             Self {
-                lr: xxx
+                lr: opening_proof
                     .lr
                     .into_iter()
                     .map(|(g1, g2)| (g1.into(), g2.into()))
                     .collect(),
-                delta: xxx.delta.into(),
-                z1: xxx.z1.into(),
-                z2: xxx.z2.into(),
-                sg: xxx.sg.into(),
+                delta: opening_proof.delta.into(),
+                z1: opening_proof.z1.into(),
+                z2: opening_proof.z2.into(),
+                sg: opening_proof.sg.into(),
             }
         }
     }

--- a/dlog/plonk-5-wires/Cargo.toml
+++ b/dlog/plonk-5-wires/Cargo.toml
@@ -13,7 +13,6 @@ ark-poly = { version = "0.3.0", features = [ "parallel" ] }
 mina-curves = { path = "../../curves" }
 commitment_dlog = { path = "../commitment" }
 plonk_5_wires_circuits = { path = "../../circuits/plonk-5-wires" }
-ocaml = { version = "0.18.1", optional = true }
 oracle = { path = "../../oracle" }
 rand_core = "0.6.0"
 colored = "2.0.0"
@@ -22,6 +21,10 @@ sprs = "0.9.2"
 rayon = "1.5.0"
 array-init = "1.0.0"
 
+# ocaml-specific dependencies
+ocaml = { version = "0.18.1", optional = true }
+itertools = { version = "0.10.1", optional = true }
+
 [features]
 
-ocaml_types = [ "ocaml" ]
+ocaml_types = [ "ocaml", "itertools", "plonk_5_wires_circuits/ocaml_types", "commitment_dlog/ocaml_types" ]

--- a/dlog/plonk-5-wires/src/prover.rs
+++ b/dlog/plonk-5-wires/src/prover.rs
@@ -34,62 +34,6 @@ pub struct ProverCommitments<G: AffineCurve> {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::ToValue, ocaml::FromValue))]
-pub struct CamlProverCommitments<G: AffineCurve> {
-    // polynomial commitments
-    pub w_comm: (
-        PolyComm<G>,
-        PolyComm<G>,
-        PolyComm<G>,
-        PolyComm<G>,
-        PolyComm<G>,
-    ),
-    pub z_comm: PolyComm<G>,
-    pub t_comm: PolyComm<G>,
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<G: AffineCurve + ocaml::ToValue> ocaml::ToValue for ProverCommitments<G>
-where
-    G::ScalarField: ocaml::ToValue,
-{
-    fn to_value(self) -> ocaml::Value {
-        let [w_comm0, w_comm1, w_comm2, w_comm3, w_comm4] = self.w_comm;
-        ocaml::ToValue::to_value(CamlProverCommitments {
-            w_comm: (w_comm0, w_comm1, w_comm2, w_comm3, w_comm4),
-            z_comm: self.z_comm,
-            t_comm: self.t_comm,
-        })
-    }
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<G: AffineCurve + ocaml::FromValue> ocaml::FromValue for ProverCommitments<G>
-where
-    G::ScalarField: ocaml::FromValue,
-{
-    fn from_value(v: ocaml::Value) -> Self {
-        let comms: CamlProverCommitments<G> = ocaml::FromValue::from_value(v);
-        let (w_comm0, w_comm1, w_comm2, w_comm3, w_comm4) = comms.w_comm;
-        ProverCommitments {
-            w_comm: [w_comm0, w_comm1, w_comm2, w_comm3, w_comm4],
-            z_comm: comms.z_comm,
-            t_comm: comms.t_comm,
-        }
-    }
-}
-
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::ToValue, ocaml::FromValue))]
-struct CamlProverProof<G: AffineCurve> {
-    pub commitments: ProverCommitments<G>,
-    pub proof: OpeningProof<G>,
-    // OCaml doesn't have sized arrays, so we have to convert to a tuple..
-    pub evals: (ProofEvaluations<Vec<Fr<G>>>, ProofEvaluations<Vec<Fr<G>>>),
-    pub public: Vec<Fr<G>>,
-    pub prev_challenges: Vec<(Vec<Fr<G>>, PolyComm<G>)>,
-}
-
-#[derive(Clone)]
 pub struct ProverProof<G: AffineCurve> {
     // polynomial commitments
     pub commitments: ProverCommitments<G>,
@@ -105,45 +49,6 @@ pub struct ProverProof<G: AffineCurve> {
 
     // The challenges underlying the optional polynomials folded into the proof
     pub prev_challenges: Vec<(Vec<Fr<G>>, PolyComm<G>)>,
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<G: AffineCurve + ocaml::ToValue> ocaml::ToValue for ProverProof<G>
-where
-    G::ScalarField: ocaml::ToValue,
-{
-    fn to_value(self) -> ocaml::Value {
-        ocaml::ToValue::to_value(CamlProverProof {
-            commitments: self.commitments,
-            proof: self.proof,
-            evals: {
-                let [evals0, evals1] = self.evals;
-                (evals0, evals1)
-            },
-            public: self.public,
-            prev_challenges: self.prev_challenges,
-        })
-    }
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<G: AffineCurve + ocaml::FromValue> ocaml::FromValue for ProverProof<G>
-where
-    G::ScalarField: ocaml::FromValue,
-{
-    fn from_value(v: ocaml::Value) -> Self {
-        let p: CamlProverProof<G> = ocaml::FromValue::from_value(v);
-        ProverProof {
-            commitments: p.commitments,
-            proof: p.proof,
-            evals: {
-                let (evals0, evals1) = p.evals;
-                [evals0, evals1]
-            },
-            public: p.public,
-            prev_challenges: p.prev_challenges,
-        }
-    }
 }
 
 impl<G: CommitmentCurve> ProverProof<G>
@@ -432,5 +337,139 @@ where
             public,
             prev_challenges,
         })
+    }
+}
+
+//
+// OCaml types
+//
+
+#[cfg(feature = "ocaml_types")]
+pub mod caml {
+    use super::*;
+    use commitment_dlog::commitment::caml::{CamlOpeningProof, CamlPolyComm};
+    use itertools::Itertools;
+    use plonk_5_wires_circuits::scalars::caml::CamlProofEvaluations;
+
+    //
+    // ProverCommitments<G> <-> CamlProverCommitments<CamlG>
+    //
+
+    #[derive(Clone, ocaml::ToValue, ocaml::FromValue)]
+    pub struct CamlProverCommitments<CamlG> {
+        // polynomial commitments
+        pub w_comm: (
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+        ),
+        pub z_comm: CamlPolyComm<CamlG>,
+        pub t_comm: CamlPolyComm<CamlG>,
+    }
+
+    impl<G, CamlG> From<ProverCommitments<G>> for CamlProverCommitments<CamlG>
+    where
+        G: AffineCurve,
+        CamlPolyComm<CamlG>: From<PolyComm<G>>,
+    {
+        fn from(prover_comm: ProverCommitments<G>) -> Self {
+            let w_comm = prover_comm
+                .w_comm
+                .iter()
+                .cloned()
+                .map(Into::into)
+                .collect_tuple()
+                .expect("collect_tuple has a bug");
+            Self {
+                w_comm,
+                z_comm: prover_comm.z_comm.into(),
+                t_comm: prover_comm.t_comm.into(),
+            }
+        }
+    }
+
+    impl<G, CamlG> Into<ProverCommitments<G>> for CamlProverCommitments<CamlG>
+    where
+        G: AffineCurve,
+        CamlPolyComm<CamlG>: Into<PolyComm<G>>,
+    {
+        fn into(self) -> ProverCommitments<G> {
+            let w_comm = [
+                self.w_comm.0.into(),
+                self.w_comm.1.into(),
+                self.w_comm.2.into(),
+                self.w_comm.3.into(),
+                self.w_comm.4.into(),
+            ];
+            ProverCommitments {
+                w_comm,
+                z_comm: self.z_comm.into(),
+                t_comm: self.t_comm.into(),
+            }
+        }
+    }
+
+    //
+    // ProverProof<G> <-> CamlProverProof<CamlG>
+    //
+
+    #[derive(ocaml::ToValue, ocaml::FromValue)]
+    pub struct CamlProverProof<CamlG, CamlF> {
+        pub commitments: CamlProverCommitments<CamlG>,
+        pub proof: CamlOpeningProof<CamlG, CamlF>,
+        // OCaml doesn't have sized arrays, so we have to convert to a tuple..
+        pub evals: (CamlProofEvaluations<CamlF>, CamlProofEvaluations<CamlF>),
+        pub public: Vec<CamlF>,
+        pub prev_challenges: Vec<(Vec<CamlF>, CamlPolyComm<CamlG>)>,
+    }
+
+    impl<G, CamlG, CamlF> From<ProverProof<G>> for CamlProverProof<CamlG, CamlF>
+    where
+        G: AffineCurve,
+        CamlG: From<G>,
+        CamlF: From<G::ScalarField>,
+    {
+        fn from(pp: ProverProof<G>) -> Self {
+            Self {
+                commitments: pp.commitments.into(),
+                proof: pp.proof.into(),
+                evals: (pp.evals[0].clone().into(), pp.evals[1].clone().into()),
+                public: pp.public.into_iter().map(Into::into).collect(),
+                prev_challenges: pp
+                    .prev_challenges
+                    .into_iter()
+                    .map(|(v, c)| {
+                        let v = v.into_iter().map(Into::into).collect();
+                        (v, c.into())
+                    })
+                    .collect(),
+            }
+        }
+    }
+
+    impl<G, CamlG, CamlF> Into<ProverProof<G>> for CamlProverProof<CamlG, CamlF>
+    where
+        G: AffineCurve,
+        CamlG: Into<G>,
+        CamlF: Into<G::ScalarField>,
+    {
+        fn into(self) -> ProverProof<G> {
+            ProverProof {
+                commitments: self.commitments.into(),
+                proof: self.proof.into(),
+                evals: [self.evals.0.into(), self.evals.1.into()],
+                public: self.public.into_iter().map(Into::into).collect(),
+                prev_challenges: self
+                    .prev_challenges
+                    .into_iter()
+                    .map(|(v, c)| {
+                        let v = v.into_iter().map(Into::into).collect();
+                        (v, c.into())
+                    })
+                    .collect(),
+            }
+        }
     }
 }

--- a/dlog/plonk-5-wires/src/prover.rs
+++ b/dlog/plonk-5-wires/src/prover.rs
@@ -355,7 +355,7 @@ pub mod caml {
     // ProverCommitments<G> <-> CamlProverCommitments<CamlG>
     //
 
-    #[derive(Clone, ocaml::ToValue, ocaml::FromValue)]
+    #[derive(Clone, ocaml::IntoValue, ocaml::FromValue)]
     pub struct CamlProverCommitments<CamlG> {
         // polynomial commitments
         pub w_comm: (
@@ -415,7 +415,7 @@ pub mod caml {
     // ProverProof<G> <-> CamlProverProof<CamlG>
     //
 
-    #[derive(ocaml::ToValue, ocaml::FromValue)]
+    #[derive(ocaml::IntoValue, ocaml::FromValue)]
     pub struct CamlProverProof<CamlG, CamlF> {
         pub commitments: CamlProverCommitments<CamlG>,
         pub proof: CamlOpeningProof<CamlG, CamlF>,

--- a/dlog/plonk/Cargo.toml
+++ b/dlog/plonk/Cargo.toml
@@ -24,4 +24,4 @@ array-init = "0.1.1"
 
 [features]
 
-ocaml_types = [ "ocaml" ]
+ocaml_types = [ "ocaml", "plonk_circuits/ocaml_types", "commitment_dlog/ocaml_types" ]

--- a/dlog/plonk/src/prover.rs
+++ b/dlog/plonk/src/prover.rs
@@ -26,25 +26,12 @@ type Fr<G> = <G as AffineCurve>::ScalarField;
 type Fq<G> = <G as AffineCurve>::BaseField;
 
 #[derive(Clone)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
-pub struct ProverCommitments<G: AffineCurve>
-{
+pub struct ProverCommitments<G: AffineCurve> {
     pub l_comm: PolyComm<G>,
     pub r_comm: PolyComm<G>,
     pub o_comm: PolyComm<G>,
     pub z_comm: PolyComm<G>,
     pub t_comm: PolyComm<G>,
-}
-
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
-struct CamlProverProof<G: AffineCurve>
-{
-    pub commitments: ProverCommitments<G>,
-    pub proof: OpeningProof<G>,
-    // OCaml doesn't have sized arrays, so we have to convert to a tuple..
-    pub evals: (ProofEvaluations<Vec<Fr<G>>>, ProofEvaluations<Vec<Fr<G>>>),
-    pub public: Vec<Fr<G>>,
-    pub prev_challenges: Vec<(Vec<Fr<G>>, PolyComm<G>)>,
 }
 
 #[derive(Clone)]
@@ -63,42 +50,6 @@ pub struct ProverProof<G: AffineCurve> {
 
     // The challenges underlying the optional polynomials folded into the proof
     pub prev_challenges: Vec<(Vec<Fr<G>>, PolyComm<G>)>,
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<G: AffineCurve + ocaml::IntoValue> ocaml::IntoValue for ProverProof<G> where
-    G::ScalarField: ocaml::IntoValue {
-    fn into_value(self, runtime: &ocaml::Runtime) -> ocaml::Value {
-        ocaml::IntoValue::into_value(
-            CamlProverProof{
-                commitments: self.commitments,
-                proof: self.proof,
-                evals: {
-                    let [evals0, evals1] = self.evals;
-                    (evals0, evals1)
-                },
-                public: self.public,
-                prev_challenges: self.prev_challenges
-            }, runtime)
-    }
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<'a, G: AffineCurve + ocaml::FromValue<'a>> ocaml::FromValue<'a> for ProverProof<G> where
-    G::ScalarField: ocaml::FromValue<'a> {
-    fn from_value(v: ocaml::Value) -> Self {
-        let p: CamlProverProof<G> = ocaml::FromValue::from_value(v);
-        ProverProof {
-            commitments: p.commitments,
-            proof: p.proof,
-            evals: {
-                let (evals0, evals1) = p.evals;
-                [evals0, evals1]
-            },
-            public: p.public,
-            prev_challenges: p.prev_challenges,
-        }
-    }
 }
 
 impl<G: CommitmentCurve> ProverProof<G>
@@ -471,5 +422,124 @@ where
         };
 
         Ok(proof)
+    }
+}
+
+//
+// OCaml types
+//
+
+#[cfg(feature = "ocaml_types")]
+pub mod caml {
+    use super::*;
+    use commitment_dlog::commitment::caml::{CamlOpeningProof, CamlPolyComm};
+    use plonk_circuits::scalars::caml::CamlProofEvaluations;
+
+    //
+    // CamlProverCommitments<CamlG> <-> ProverCommitments<G>
+    //
+
+    /// The ocaml type for ProverCommitments
+    #[derive(ocaml::ToValue, ocaml::FromValue)]
+    pub struct CamlProverCommitments<CamlG> {
+        pub l_comm: CamlPolyComm<CamlG>,
+        pub r_comm: CamlPolyComm<CamlG>,
+        pub o_comm: CamlPolyComm<CamlG>,
+        pub z_comm: CamlPolyComm<CamlG>,
+        pub t_comm: CamlPolyComm<CamlG>,
+    }
+
+    impl<G, CamlG> From<ProverCommitments<G>> for CamlProverCommitments<CamlG>
+    where
+        G: AffineCurve,
+        CamlPolyComm<CamlG>: From<PolyComm<G>>,
+    {
+        fn from(prover_comm: ProverCommitments<G>) -> Self {
+            Self {
+                l_comm: prover_comm.l_comm.into(),
+                r_comm: prover_comm.r_comm.into(),
+                o_comm: prover_comm.o_comm.into(),
+                z_comm: prover_comm.z_comm.into(),
+                t_comm: prover_comm.t_comm.into(),
+            }
+        }
+    }
+
+    impl<G, CamlG> Into<ProverCommitments<G>> for CamlProverCommitments<CamlG>
+    where
+        G: AffineCurve,
+        CamlPolyComm<CamlG>: Into<PolyComm<G>>,
+    {
+        fn into(self) -> ProverCommitments<G> {
+            ProverCommitments {
+                l_comm: self.l_comm.into(),
+                r_comm: self.r_comm.into(),
+                o_comm: self.o_comm.into(),
+                z_comm: self.z_comm.into(),
+                t_comm: self.t_comm.into(),
+            }
+        }
+    }
+
+    //
+    // ProverProof<G> <-> CamlProverProof<CamlG, CamlF>
+    //
+
+    #[derive(ocaml::ToValue, ocaml::FromValue)]
+    pub struct CamlProverProof<CamlG, CamlF> {
+        pub commitments: CamlProverCommitments<CamlG>,
+        pub proof: CamlOpeningProof<CamlG, CamlF>,
+        // OCaml doesn't have sized arrays, so we have to convert to a tuple..
+        pub evals: (CamlProofEvaluations<CamlF>, CamlProofEvaluations<CamlF>),
+        pub public: Vec<CamlF>,
+        pub prev_challenges: Vec<(Vec<CamlF>, CamlPolyComm<CamlG>)>,
+    }
+
+    impl<G, CamlG, CamlF> From<ProverProof<G>> for CamlProverProof<CamlG, CamlF>
+    where
+        G: AffineCurve,
+        CamlG: From<G>,
+        CamlF: From<G::ScalarField>,
+    {
+        fn from(pp: ProverProof<G>) -> Self {
+            Self {
+                commitments: pp.commitments.into(),
+                proof: pp.proof.into(),
+                evals: (pp.evals[0].clone().into(), pp.evals[1].clone().into()),
+                public: pp.public.into_iter().map(Into::into).collect(),
+                prev_challenges: pp
+                    .prev_challenges
+                    .into_iter()
+                    .map(|(v, c)| {
+                        let v = v.into_iter().map(Into::into).collect();
+                        (v, c.into())
+                    })
+                    .collect(),
+            }
+        }
+    }
+
+    impl<G, CamlG, CamlF> Into<ProverProof<G>> for CamlProverProof<CamlG, CamlF>
+    where
+        G: AffineCurve,
+        CamlG: Into<G>,
+        CamlF: Into<G::ScalarField>,
+    {
+        fn into(self) -> ProverProof<G> {
+            ProverProof {
+                commitments: self.commitments.into(),
+                proof: self.proof.into(),
+                evals: [self.evals.0.into(), self.evals.1.into()],
+                public: self.public.into_iter().map(Into::into).collect(),
+                prev_challenges: self
+                    .prev_challenges
+                    .into_iter()
+                    .map(|(v, c)| {
+                        let v = v.into_iter().map(Into::into).collect();
+                        (v, c.into())
+                    })
+                    .collect(),
+            }
+        }
     }
 }

--- a/dlog/plonk/src/prover.rs
+++ b/dlog/plonk/src/prover.rs
@@ -440,7 +440,7 @@ pub mod caml {
     //
 
     /// The ocaml type for ProverCommitments
-    #[derive(ocaml::ToValue, ocaml::FromValue)]
+    #[derive(ocaml::IntoValue, ocaml::FromValue)]
     pub struct CamlProverCommitments<CamlG> {
         pub l_comm: CamlPolyComm<CamlG>,
         pub r_comm: CamlPolyComm<CamlG>,
@@ -485,7 +485,7 @@ pub mod caml {
     // ProverProof<G> <-> CamlProverProof<CamlG, CamlF>
     //
 
-    #[derive(ocaml::ToValue, ocaml::FromValue)]
+    #[derive(ocaml::IntoValue, ocaml::FromValue)]
     pub struct CamlProverProof<CamlG, CamlF> {
         pub commitments: CamlProverCommitments<CamlG>,
         pub proof: CamlOpeningProof<CamlG, CamlF>,

--- a/oracle/src/sponge.rs
+++ b/oracle/src/sponge.rs
@@ -10,7 +10,6 @@ const HIGH_ENTROPY_LIMBS: usize = 2;
 
 // A challenge which is used as a scalar on a group element in the verifier
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
 pub struct ScalarChallenge<F>(pub F);
 
 pub fn endo_coefficient<F: PrimeField>() -> F {
@@ -198,5 +197,39 @@ where
 
     fn challenge_fq(&mut self) -> P::BaseField {
         self.squeeze_field()
+    }
+}
+
+//
+// OCaml types
+//
+
+#[cfg(feature = "ocaml_types")]
+pub mod caml {
+    use super::*;
+
+    //
+    // ScalarChallenge<F> <-> CamlScalarChallenge<CamlF>
+    //
+
+    #[derive(Clone, ocaml::ToValue, ocaml::FromValue)]
+    pub struct CamlScalarChallenge<CamlF>(pub CamlF);
+
+    impl<F, CamlF> From<ScalarChallenge<F>> for CamlScalarChallenge<CamlF>
+    where
+        CamlF: From<F>,
+    {
+        fn from(sc: ScalarChallenge<F>) -> Self {
+            Self(sc.0.into())
+        }
+    }
+
+    impl<F, CamlF> Into<ScalarChallenge<F>> for CamlScalarChallenge<CamlF>
+    where
+        CamlF: Into<F>,
+    {
+        fn into(self) -> ScalarChallenge<F> {
+            ScalarChallenge(self.0.into())
+        }
     }
 }

--- a/oracle/src/sponge.rs
+++ b/oracle/src/sponge.rs
@@ -212,7 +212,7 @@ pub mod caml {
     // ScalarChallenge<F> <-> CamlScalarChallenge<CamlF>
     //
 
-    #[derive(Clone, ocaml::ToValue, ocaml::FromValue)]
+    #[derive(Clone, ocaml::IntoValue, ocaml::FromValue)]
     pub struct CamlScalarChallenge<CamlF>(pub CamlF);
 
     impl<F, CamlF> From<ScalarChallenge<F>> for CamlScalarChallenge<CamlF>


### PR DESCRIPTION
The upgrade from zexe to arkworks has removed the `ocaml::FromValue` and `ocaml::ToValue` implementations on a number of foreign types (e.g.`Fp`). Because of this, we're now working on wrapper types (e.g. `CamlFp(Fp)`) that don't necessarily implement the same traits, which makes things like this not work:

```rust
use ark_ec::AffineCurve;
// ...
#[cfg_attr(feature = "ocaml_types", derive(ocaml::ToValue, ocaml::FromValue))]
struct CamlProverProof<G: AffineCurve> {
    pub commitments: ProverCommitments<G>,
    pub proof: OpeningProof<G>,
    // OCaml doesn't have sized arrays, so we have to convert to a tuple..
    pub evals: (ProofEvaluations<Vec<Fr<G>>>, ProofEvaluations<Vec<Fr<G>>>),
    pub public: Vec<Fr<G>>,
    pub prev_challenges: Vec<(Vec<Fr<G>>, PolyComm<G>)>,
}

```

This PR creates (or refactor) equivalent OCaml-compatible types for all the structures that we need in Mina.

It also:

* moves the ocaml code into its own module, it's cleaner
* updates to the latest version ocaml-rs (so `ToValue` becomes `IntoValue`)