### PR TITLE
Return Option<_>s or Result<_>s instead of panicking

### DIFF
--- a/circuits/plonk/src/constraints.rs
+++ b/circuits/plonk/src/constraints.rs
@@ -84,22 +84,23 @@ pub struct ConstraintSystem<F: FftField> {
     pub fr_sponge_params: ArithmeticSpongeParams<F>,
 }
 
-pub fn zk_w<F: FftField>(domain: D<F>) -> F {
-    domain.group_gen.pow(&[domain.size - 3])
+pub fn zk_w<F: FftField>(domain: D<F>) -> Option<F> {
+    if domain.size < 3 { return None }
+    Some(domain.group_gen.pow(&[domain.size - 3]))
 }
 
-pub fn zk_polynomial<F: FftField>(domain: D<F>) -> DensePolynomial<F> {
+pub fn zk_polynomial<F: FftField>(domain: D<F>) -> Option<DensePolynomial<F>> {
     // x^3 - x^2(w1+w2+w3) + x(w1w2+w1w3+w2w3) - w1w2w3
-    let w3 = zk_w(domain);
+    let w3 = zk_w(domain)?;
     let w2 = domain.group_gen * w3;
     let w1 = domain.group_gen * w2;
 
-    DensePolynomial::from_coefficients_slice(&[
+    Some(DensePolynomial::from_coefficients_slice(&[
         -w1 * &w2 * &w3,
         (w1 * &w2) + &(w1 * &w3) + &(w3 * &w2),
         -w1 - &w2 - &w3,
         F::one(),
-    ])
+    ]))
 }
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {
@@ -147,7 +148,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
         sid.append(&mut s);
 
         // x^3 - x^2(w1+w2+w3) + x(w1w2+w1w3+w2w3) - w1w2w3
-        let zkpm = zk_polynomial(domain.d1);
+        let zkpm = zk_polynomial(domain.d1)?;
 
         // compute generic constraint polynomials
         let qlm = Evaluations::<F, D<F>>::from_vec_and_domain(

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -60,19 +60,16 @@ pub fn shift_scalar<F: PrimeField>(x: F) -> F {
 }
 
 impl<C: AffineCurve> PolyComm<C> {
-    pub fn multi_scalar_mul(com: &Vec<&PolyComm<C>>, elm: &Vec<C::ScalarField>) -> Self {
-        PolyComm::<C> {
+    pub fn multi_scalar_mul(com: &Vec<&PolyComm<C>>, elm: &Vec<C::ScalarField>) -> Option<Self> {
+        Some(PolyComm::<C> {
             shifted: {
                 if com.len() == 0 || elm.len() == 0 || com[0].shifted == None {
                     None
                 } else {
                     let points = com
                         .iter()
-                        .map(|c| {
-                            assert!(c.shifted.is_some());
-                            c.shifted.unwrap()
-                        })
-                        .collect::<Vec<_>>();
+                        .map(|c| { c.shifted })
+                        .collect::<Option<Vec<_>>>()?;
                     let scalars = elm.iter().map(|s| s.into_repr()).collect::<Vec<_>>();
                     Some(VariableBaseMSM::multi_scalar_mul(&points, &scalars).into_affine())
                 }
@@ -81,7 +78,7 @@ impl<C: AffineCurve> PolyComm<C> {
                 if com.len() == 0 || elm.len() == 0 {
                     Vec::new()
                 } else {
-                    let n = com.iter().map(|c| c.unshifted.len()).max().unwrap();
+                    let n = com.iter().map(|c| c.unshifted.len()).max()?;
                     (0..n)
                         .map(|i| {
                             let mut points = Vec::new();
@@ -97,7 +94,7 @@ impl<C: AffineCurve> PolyComm<C> {
                         .collect::<Vec<_>>()
                 }
             },
-        }
+        })
     }
 }
 

--- a/dlog/plonk-5-wires/src/verifier.rs
+++ b/dlog/plonk-5-wires/src/verifier.rs
@@ -269,7 +269,7 @@ where
                         .map(|l| l)
                         .collect(),
                     &proof.public.iter().map(|s| -*s).collect(),
-                );
+                ).ok_or(ProofError::BadMultiScalarMul)?;
 
                 let (fq_sponge, _, oracles, alpha, p_eval, evlp, polys, zeta1, _) =
                     proof.oracles::<EFqSponge, EFrSponge>(index, &p_comm);
@@ -329,7 +329,7 @@ where
                 ));
                 p.extend([&index.mul1_comm, &index.mul2_comm].to_vec());
 
-                let f_comm = PolyComm::multi_scalar_mul(&p, &s);
+                let f_comm = PolyComm::multi_scalar_mul(&p, &s).ok_or(ProofError::BadMultiScalarMul)?;
 
                 // check linearization polynomial evaluation consistency
                 let zeta1m1 = zeta1 - &Fr::<G>::one();

--- a/dlog/plonk/src/index.rs
+++ b/dlog/plonk/src/index.rs
@@ -107,7 +107,9 @@ where
             emul2_comm: srs.get_ref().commit_non_hiding(&self.cs.emul2m, None),
             emul3_comm: srs.get_ref().commit_non_hiding(&self.cs.emul3m, None),
 
-            w: zk_w(self.cs.domain.d1),
+            // Safe to unwrap here because we've already successfully called this when creating the
+            // constraint system.
+            w: zk_w(self.cs.domain.d1).unwrap(),
             fr_sponge_params: self.cs.fr_sponge_params.clone(),
             fq_sponge_params: self.fq_sponge_params.clone(),
             endo: self.cs.endo,

--- a/dlog/plonk/src/prover.rs
+++ b/dlog/plonk/src/prover.rs
@@ -113,7 +113,9 @@ where
         prev_challenges: Vec<(Vec<Fr<G>>, PolyComm<G>)>,
     ) -> Result<Self, ProofError> {
         let n = index.cs.domain.d1.size as usize;
-        assert!(n <= index.srs.get_ref().g.len());
+        if n > index.srs.get_ref().g.len() {
+            return Err(ProofError::BadSrsLength);
+        }
         if witness.len() != 3 * n {
             return Err(ProofError::WitnessCsInconsistent);
         }
@@ -299,7 +301,7 @@ where
         fq_sponge.absorb_g(&t_comm.unshifted);
         fq_sponge.absorb_g(&vec![dummy; max_t_size - t_comm.unshifted.len()]);
         {
-            let s = t_comm.shifted.unwrap();
+            let s = t_comm.shifted.unwrap(); // Unwrap is fine here, we've just created the value.
             if s.is_zero() {
                 fq_sponge.absorb_g(&[dummy])
             } else {

--- a/oracle/src/rndoracle.rs
+++ b/oracle/src/rndoracle.rs
@@ -23,6 +23,8 @@ pub enum ProofError {
     EvaluationGroup,
     OracleCommit,
     RuntimeEnv,
+    BadMultiScalarMul,
+    BadSrsLength,
 }
 
 // Implement `Display` for ProofError


### PR DESCRIPTION
This PR tweaks the behaviour of some methods to ensure that we avoid panicking wherever possible.

This is motivated by compilation to WASM: there is no unwinding primitive there (yet), and so any panic is treated as an 'abort' instead, halting the WASM process.