### PR TITLE
[commitment] refactored the batch commitment

### DIFF
--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -29,8 +29,7 @@ type Fq<G> = <G as AffineCurve>::BaseField;
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
-pub struct PolyComm<C>
-{
+pub struct PolyComm<C> {
     pub unshifted: Vec<C>,
     pub shifted: Option<C>,
 }
@@ -924,5 +923,90 @@ impl<F: Field> Utils<F> for DensePolynomial<F> {
                 .evaluate(&elm)
             })
             .collect()
+    }
+}
+
+//
+// Tests
+//
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::srs::SRS;
+    use array_init::array_init;
+    use mina_curves::pasta::{fp::Fp, vesta::Affine as VestaG};
+    use oracle::poseidon::PlonkSpongeConstants as SC;
+    use oracle::{pasta::fq::params as spongeFqParams, sponge::DefaultFqSponge};
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn test_opening_proof() {
+        // create two polynomials
+        let coeffs: [Fp; 10] = array_init(|i| Fp::from(i as u32));
+        let poly1 = DensePolynomial::<Fp>::from_coefficients_slice(&coeffs);
+        let poly2 = DensePolynomial::<Fp>::from_coefficients_slice(&coeffs[..5]);
+
+        // create an SRS
+        let srs = SRS::<VestaG>::create(20);
+        let rng = &mut StdRng::from_seed([0u8; 32]);
+
+        // commit the two polynomials (and upperbound the second one)
+        let commitment = srs.commit(&poly1, None, rng);
+        let upperbound = poly2.degree() + 1;
+        let bounded_commitment = srs.commit(&poly2, Some(upperbound), rng);
+
+        // create an aggregated opening proof
+        let (u, v) = (Fp::rand(rng), Fp::rand(rng));
+        let group_map = <VestaG as CommitmentCurve>::Map::setup();
+        let sponge = DefaultFqSponge::<_, SC>::new(spongeFqParams());
+
+        let polys = vec![
+            (&poly1, None, commitment.1),
+            (&poly2, Some(upperbound), bounded_commitment.1),
+        ];
+        let elm = vec![Fp::rand(rng), Fp::rand(rng)];
+
+        let opening_proof = srs.open(&group_map, polys, &elm, v, u, sponge.clone(), rng);
+
+        // evaluate the polynomials at these two points
+        let poly1_chunked_evals = vec![
+            poly1.eval(elm[0], srs.g.len()),
+            poly1.eval(elm[1], srs.g.len()),
+        ];
+
+        fn sum(c: &[Fp]) -> Fp {
+            c.iter().fold(Fp::zero(), |a, &b| a + b)
+        }
+
+        assert_eq!(sum(&poly1_chunked_evals[0]), poly1.evaluate(&elm[0]));
+        assert_eq!(sum(&poly1_chunked_evals[1]), poly1.evaluate(&elm[1]));
+
+        let poly2_chunked_evals = vec![
+            poly2.eval(elm[0], srs.g.len()),
+            poly2.eval(elm[1], srs.g.len()),
+        ];
+
+        assert_eq!(sum(&poly2_chunked_evals[0]), poly2.evaluate(&elm[0]));
+        assert_eq!(sum(&poly2_chunked_evals[1]), poly2.evaluate(&elm[1]));
+
+        // verify the proof
+        let mut batch = vec![(
+            sponge,
+            elm.clone(),
+            v,
+            u,
+            vec![
+                (&commitment.0, poly1_chunked_evals.iter().collect(), None),
+                (
+                    &bounded_commitment.0,
+                    poly2_chunked_evals.iter().collect(),
+                    Some(upperbound),
+                ),
+            ],
+            &opening_proof,
+        )];
+
+        assert!(srs.verify(&group_map, &mut batch, rng));
     }
 }

--- a/dlog/commitment/tests/commitment.rs
+++ b/dlog/commitment/tests/commitment.rs
@@ -24,7 +24,7 @@ use rand::Rng;
 use std::time::{Duration, Instant};
 
 #[test]
-fn dlog_commitment_test()
+fn test_commit()
 where
     <Fp as std::str::FromStr>::Err: std::fmt::Debug,
 {

--- a/dlog/commitment/tests/commitment.rs
+++ b/dlog/commitment/tests/commitment.rs
@@ -1,12 +1,8 @@
-/*****************************************************************************************************************
-
-This source file tests polynomial commitments, batched openings and
-verification of a batch of batched opening proofs of polynomial commitments
-
-*****************************************************************************************************************/
-
 use ark_ff::{UniformRand, Zero};
-use commitment_dlog::{commitment::CommitmentCurve, srs::SRS};
+use commitment_dlog::{
+    commitment::{CommitmentCurve, OpeningProof, PolyComm},
+    srs::SRS,
+};
 use mina_curves::pasta::{
     vesta::{Affine, VestaParameters},
     Fp,
@@ -23,119 +19,227 @@ use groupmap::GroupMap;
 use rand::Rng;
 use std::time::{Duration, Instant};
 
+// Note: Because the current API uses large tuples of types, I re-create types
+// in this test to facilitate aggregated proofs and batch verification of proofs.
+// TODO: improve the polynomial commitment API
+
+/// A commitment
+pub struct Commitment {
+    /// the commitment itself, potentially in chunks
+    chunked_commitment: PolyComm<Affine>,
+    /// an optional degree bound
+    bound: Option<usize>,
+}
+
+/// An evaluated commitment (given a number of evaluation points)
+pub struct EvaluatedCommitment {
+    /// the commitment
+    commit: Commitment,
+    /// the chunked evaluations given in the same order as the evaluation points
+    chunked_evals: Vec<ChunkedCommitmentEvaluation>,
+}
+
+/// A polynomial commitment evaluated at a point. Since a commitment can be chunked, the evaluations can also be chunked.
+pub type ChunkedCommitmentEvaluation = Vec<Fp>;
+
+mod verifier {
+    use super::*;
+
+    /// A type that describes what the verify() API expects
+    pub type BatchVerify<'a> = (
+        DefaultFqSponge<VestaParameters, SC>,
+        Vec<Fp>, // vector of evaluation points
+        Fp,      // scaling factor for polynoms
+        Fp,      // scaling factor for evaluation point powers
+        Vec<(
+            &'a PolyComm<Affine>, // polycommitment
+            Vec<&'a Vec<Fp>>,     // vector of evaluations
+            Option<usize>,        // optional degree bound
+        )>,
+        &'a OpeningProof<Affine>, // batched opening proof
+    );
+}
+
+mod prover {
+    use super::*;
+
+    /// This struct represents a commitment with associated secret information
+    pub struct CommitmentAndSecrets {
+        /// the commitment evaluated at some points
+        pub eval_commit: EvaluatedCommitment,
+        /// the polynomial
+        pub poly: DensePolynomial<Fp>,
+        /// the blinding part
+        pub chunked_blinding: PolyComm<Fp>,
+    }
+}
+
+/// This struct represents an aggregated evaluation proof for a number of polynomial commitments, as well as a number of evaluation points.
+pub struct AggregatedEvaluationProof {
+    /// a number of evaluation points
+    eval_points: Vec<Fp>,
+    /// a number of commitments evaluated at these evaluation points
+    eval_commitments: Vec<EvaluatedCommitment>,
+    /// the random value used to separate polynomials
+    polymask: Fp,
+    /// the random value used to separate evaluations
+    evalmask: Fp,
+    /// an Fq-sponge
+    fq_sponge: DefaultFqSponge<VestaParameters, SC>,
+    /// the actual evaluation proof
+    proof: OpeningProof<Affine>,
+}
+
+impl AggregatedEvaluationProof {
+    /// This function converts an aggregated evaluation proof into something the verify API understands
+    pub fn verify_type(&self) -> verifier::BatchVerify {
+        let mut coms = vec![];
+        for eval_com in &self.eval_commitments {
+            assert_eq!(self.eval_points.len(), eval_com.chunked_evals.len());
+            let evaluations = eval_com.chunked_evals.iter().collect();
+            coms.push((
+                &eval_com.commit.chunked_commitment,
+                evaluations,
+                eval_com.commit.bound,
+            ));
+        }
+
+        (
+            self.fq_sponge.clone(),
+            self.eval_points.clone(),
+            self.polymask,
+            self.evalmask,
+            coms,
+            &self.proof,
+        )
+    }
+}
+
 #[test]
+/// Tests polynomial commitments, batched openings and
+/// verification of a batch of batched opening proofs of polynomial commitments
 fn test_commit()
 where
     <Fp as std::str::FromStr>::Err: std::fmt::Debug,
 {
-    let rng = &mut rand::thread_rng();
-    let mut random = rand::thread_rng();
-
-    let size = 1 << 7;
-    let srs = SRS::<Affine>::create(size);
-
+    // setup
+    let mut rng = rand::thread_rng();
     let group_map = <Affine as CommitmentCurve>::Map::setup();
-    let sponge = DefaultFqSponge::<VestaParameters, SC>::new(oracle::pasta::fq::params());
+    let fq_sponge = DefaultFqSponge::<VestaParameters, SC>::new(oracle::pasta::fq::params());
 
-    let mut commit = Duration::new(0, 0);
-    let mut open = Duration::new(0, 0);
+    // create an SRS optimized for polynomials of degree 2^7 - 1
+    let srs = SRS::<Affine>::create(1 << 7);
 
-    let prfs = (0..7)
-        .map(|_| {
-            let length = (0..11)
-                .map(|_| {
-                    let polysize = 500;
-                    let len: usize = random.gen();
-                    (len % polysize) + 1
-                })
-                .collect::<Vec<_>>();
-            println!("{}{:?}", "sizes: ".bright_cyan(), length);
+    // TODO: move to bench
+    let mut time_commit = Duration::new(0, 0);
+    let mut time_open = Duration::new(0, 0);
 
-            let a = length
-                .iter()
-                .map(|s| {
-                    if *s == 0 {
-                        DensePolynomial::<Fp>::zero()
-                    } else {
-                        DensePolynomial::<Fp>::rand(s - 1, rng)
-                    }
-                })
-                .collect::<Vec<_>>();
-            let bounds = a
-                .iter()
-                .enumerate()
-                .map(|(i, v)| {
-                    if i % 2 == 0 {
-                        Some(v.coeffs.len())
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Vec<_>>();
+    // create 7 distinct "aggregated evaluation proofs"
+    let mut proofs = vec![];
+    for _ in 0..7 {
+        // generate 7 random evaluation points
+        let eval_points: Vec<Fp> = (0..7).map(|_| Fp::rand(&mut rng)).collect();
 
-            let x = (0..7).map(|_| Fp::rand(rng)).collect::<Vec<Fp>>();
-            let polymask = Fp::rand(rng);
-            let evalmask = Fp::rand(rng);
+        // create 11 polynomials of random degree (of at most 500)
+        // and commit to them
+        let mut commitments = vec![];
+        for i in 0..11 {
+            let len: usize = rng.gen();
+            let len = len % 500;
+            let poly = if len == 0 {
+                DensePolynomial::<Fp>::zero()
+            } else {
+                DensePolynomial::<Fp>::rand(len, &mut rng)
+            };
 
-            let mut start = Instant::now();
-            let comm = (0..a.len())
-                .map(|i| {
-                    (
-                        srs.commit(&a[i].clone(), bounds[i], rng),
-                        x.iter().map(|xx| a[i].eval(*xx, size)).collect::<Vec<_>>(),
-                        bounds[i],
-                    )
-                })
-                .collect::<Vec<_>>();
-            commit += start.elapsed();
+            // every other polynomial is upperbounded
+            let bound = if i % 2 == 0 {
+                Some(poly.coeffs.len())
+            } else {
+                None
+            };
 
-            start = Instant::now();
-            let proof = srs.open::<DefaultFqSponge<VestaParameters, SC>, _>(
-                &group_map,
-                (0..a.len())
-                    .map(|i| (&a[i], bounds[i], (comm[i].0).1.clone()))
-                    .collect::<Vec<_>>(),
-                &x.clone(),
-                polymask,
-                evalmask,
-                sponge.clone(),
-                rng,
-            );
-            open += start.elapsed();
+            // create commitments for each polynomial, and evaluate each polynomial at the 7 random points
+            let timer = Instant::now();
+            let (chunked_commitment, chunked_blinding) = srs.commit(&poly, bound, &mut rng);
+            time_commit += timer.elapsed();
 
-            let t = (sponge.clone(), x.clone(), polymask, evalmask, comm, proof);
-            t
-        })
-        .collect::<Vec<_>>();
+            let mut chunked_evals = vec![];
+            for point in eval_points.clone() {
+                chunked_evals.push(poly.eval(point, srs.g.len()));
+            }
 
-    let mut proofs = prfs
-        .iter()
-        .map(|proof| {
-            (
-                proof.0.clone(),
-                proof.1.clone(),
-                proof.2,
-                proof.3,
-                proof
-                    .4
-                    .iter()
-                    .map(|poly| {
-                        (
-                            &(poly.0).0,
-                            poly.1.iter().map(|vector| vector).collect::<Vec<_>>(),
-                            poly.2,
-                        )
-                    })
-                    .collect::<Vec<_>>(),
-                &proof.5,
-            )
-        })
-        .collect::<Vec<_>>();
+            let commit = Commitment {
+                chunked_commitment,
+                bound,
+            };
 
-    println!("{}{:?}", "commitment time: ".yellow(), commit);
-    println!("{}{:?}", "open time: ".magenta(), open);
+            let eval_commit = EvaluatedCommitment {
+                commit,
+                chunked_evals,
+            };
 
-    let start = Instant::now();
-    assert!(srs.verify::<DefaultFqSponge<VestaParameters, SC>, _>(&group_map, &mut proofs, rng));
-    println!("{}{:?}", "verification time: ".green(), start.elapsed());
+            commitments.push(prover::CommitmentAndSecrets {
+                eval_commit,
+                poly,
+                chunked_blinding,
+            });
+        }
+
+        // create aggregated evaluation proof
+        let mut polynomials = vec![];
+        for c in &commitments {
+            polynomials.push((
+                &c.poly,
+                c.eval_commit.commit.bound,
+                c.chunked_blinding.clone(),
+            ));
+        }
+
+        let polymask = Fp::rand(&mut rng);
+        let evalmask = Fp::rand(&mut rng);
+
+        let timer = Instant::now();
+        let proof = srs.open::<DefaultFqSponge<VestaParameters, SC>, _>(
+            &group_map,
+            polynomials,
+            &eval_points.clone(),
+            polymask,
+            evalmask,
+            fq_sponge.clone(),
+            &mut rng,
+        );
+        time_open += timer.elapsed();
+
+        // prepare for batch verification
+        let eval_commitments = commitments.into_iter().map(|c| c.eval_commit).collect();
+        proofs.push(AggregatedEvaluationProof {
+            eval_points,
+            eval_commitments,
+            polymask,
+            evalmask,
+            fq_sponge: fq_sponge.clone(),
+            proof,
+        });
+    }
+
+    println!("{} {:?}", "total commitment time:".yellow(), time_commit);
+    println!(
+        "{} {:?}",
+        "total evaluation proof creation time:".magenta(),
+        time_open
+    );
+
+    let timer = Instant::now();
+
+    // batch verify all the proofs
+    let mut batch: Vec<verifier::BatchVerify> = proofs.iter().map(|p| p.verify_type()).collect();
+    assert!(srs.verify::<DefaultFqSponge<VestaParameters, SC>, _>(&group_map, &mut batch, &mut rng));
+
+    // TODO: move to bench
+    println!(
+        "{} {:?}",
+        "batch verification time:".green(),
+        timer.elapsed()
+    );
 }


### PR DESCRIPTION
This commit cleans the batch commitment test to make it clearer. It also creates types in order to make it easier to create aggregated proofs and pass them to the verify API.

I also added a simpler unit test.