### PR TITLE
[ocaml] generate bindings from Rust code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,21 @@
 version: 2.1
-
 jobs:
     run-tests:
         docker:
-            - image: rust:1.52.1-buster
+            - image: cimg/rust:1.55.0
         steps:
             - checkout
             - run:
-                  name: Update submodules
-                  command: git submodule sync && git submodule update --init --recursive
+                name: Set up OCaml for ocaml-gen
+                command: sudo apt update && sudo apt install ocaml
             - run:
-                  name: Tests
-                  command: cargo test --release
-
+                name: Build
+                command: cargo build
+            - run:
+                name: Tests
+                command: cargo test --release
 workflows:
     version: 2
-    marlin_parallel:
+    proof_systems:
         jobs:
         - run-tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ members = [
     "dlog/plonk",
     "dlog/plonk-15-wires",
     "groupmap",
+    "ocaml-gen",
+    "ocaml-gen/derive",
     "oracle",
     "utils",
 ]

--- a/circuits/plonk-15-wires/Cargo.toml
+++ b/circuits/plonk-15-wires/Cargo.toml
@@ -9,7 +9,6 @@ path = "src/lib.rs"
 [dependencies]
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-poly = { version = "0.3.0", features = [ "parallel" ] }
-ocaml = { version = "0.18.1", optional = true }
 rand_core = { version = "0.5" }
 array-init = { version = "1.0.0" }
 rayon = { version = "1" }
@@ -22,8 +21,11 @@ mina-curves = { path = "../../curves" }
 o1-utils = { path = "../../utils" }
 oracle = { path = "../../oracle" }
 
+ocaml = { version = "0.22.1", optional = true }
+ocaml-gen = { path = "../../ocaml-gen", optional = true }
+
 [dev-dependencies]
 itertools = "0.10.1"
 
 [features]
-ocaml_types = [ "ocaml", "oracle/ocaml_types" ]
+ocaml_types = [ "ocaml", "ocaml-gen", "oracle/ocaml_types" ]

--- a/circuits/plonk-15-wires/src/lookup/scalars.rs
+++ b/circuits/plonk-15-wires/src/lookup/scalars.rs
@@ -35,8 +35,9 @@ impl<F: FftField> ProofEvaluations<Vec<F>> {
     }
 }
 
+/*
 #[derive(Clone)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::ToValue, ocaml::FromValue))]
+#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
 pub struct CamlProofEvaluations<Fs> {
     pub w: (Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs),
     pub z: Fs,
@@ -51,9 +52,9 @@ pub struct CamlProofEvaluations<Fs> {
 }
 
 #[cfg(feature = "ocaml_types")]
-unsafe impl<Fs: ocaml::ToValue> ocaml::ToValue for ProofEvaluations<Fs> {
-    fn to_value(self) -> ocaml::Value {
-        ocaml::ToValue::to_value(CamlProofEvaluations {
+unsafe impl<Fs: ocaml::IntoValue> ocaml::IntoValue for ProofEvaluations<Fs> {
+    fn into_value(self) -> ocaml::Value {
+        ocaml::IntoValue::to_value(CamlProofEvaluations {
             w: {
                 let [w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14] = self.w;
                 (
@@ -102,9 +103,10 @@ unsafe impl<Fs: ocaml::FromValue> ocaml::FromValue for ProofEvaluations<Fs> {
         }
     }
 }
+*/
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::ToValue, ocaml::FromValue))]
+#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
 pub struct RandomOracles<F: Field> {
     // Plonk oracles
     pub po: RO<F>,

--- a/circuits/plonk-15-wires/src/lookup/scalars.rs
+++ b/circuits/plonk-15-wires/src/lookup/scalars.rs
@@ -35,78 +35,7 @@ impl<F: FftField> ProofEvaluations<Vec<F>> {
     }
 }
 
-/*
-#[derive(Clone)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
-pub struct CamlProofEvaluations<Fs> {
-    pub w: (Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs),
-    pub z: Fs,
-    pub t: Fs,
-    pub f: Fs,
-    pub s: (Fs, Fs, Fs, Fs, Fs),
-    pub l: Fs,
-    pub lw: Fs,
-    pub h1: Fs,
-    pub h2: Fs,
-    pub tb: Fs,
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<Fs: ocaml::IntoValue> ocaml::IntoValue for ProofEvaluations<Fs> {
-    fn into_value(self) -> ocaml::Value {
-        ocaml::IntoValue::to_value(CamlProofEvaluations {
-            w: {
-                let [w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14] = self.w;
-                (
-                    w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14,
-                )
-            },
-            z: self.z,
-            t: self.t,
-            f: self.f,
-            s: {
-                let [s0, s1, s2, s3, s4] = self.s;
-                (s0, s1, s2, s3, s4)
-            },
-            l: self.l,
-            lw: self.lw,
-            h1: self.h1,
-            h2: self.h2,
-            tb: self.tb,
-        })
-    }
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<Fs: ocaml::FromValue> ocaml::FromValue for ProofEvaluations<Fs> {
-    fn from_value(v: ocaml::Value) -> Self {
-        let evals: CamlProofEvaluations<Fs> = ocaml::FromValue::from_value(v);
-        ProofEvaluations {
-            w: {
-                let (w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14) = evals.w;
-                [
-                    w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14,
-                ]
-            },
-            z: evals.z,
-            t: evals.t,
-            f: evals.f,
-            s: {
-                let (s0, s1, s2, s3, s4) = evals.s;
-                [s0, s1, s2, s3, s4]
-            },
-            l: evals.l,
-            lw: evals.lw,
-            h1: evals.h1,
-            h2: evals.h2,
-            tb: evals.tb,
-        }
-    }
-}
-*/
-
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
 pub struct RandomOracles<F: Field> {
     // Plonk oracles
     pub po: RO<F>,

--- a/circuits/plonk-15-wires/src/nolookup/scalars.rs
+++ b/circuits/plonk-15-wires/src/nolookup/scalars.rs
@@ -71,7 +71,7 @@ impl<F: Field> Default for RandomOracles<F> {
 #[cfg(feature = "ocaml_types")]
 pub mod caml {
     use super::*;
-    use ocaml_gen::{ocaml_gen, OcamlGen};
+    use ocaml_gen::OcamlGen;
     use oracle::sponge::caml::CamlScalarChallenge;
 
     //

--- a/circuits/plonk-15-wires/src/nolookup/scalars.rs
+++ b/circuits/plonk-15-wires/src/nolookup/scalars.rs
@@ -32,61 +32,7 @@ impl<F: FftField> ProofEvaluations<Vec<F>> {
     }
 }
 
-#[derive(Clone)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::ToValue, ocaml::FromValue))]
-pub struct CamlProofEvaluations<Fs> {
-    pub w: (Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs, Fs),
-    pub z: Fs,
-    pub t: Fs,
-    pub f: Fs,
-    pub s: (Fs, Fs, Fs, Fs, Fs),
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<Fs: ocaml::ToValue> ocaml::ToValue for ProofEvaluations<Fs> {
-    fn to_value(self) -> ocaml::Value {
-        ocaml::ToValue::to_value(CamlProofEvaluations {
-            w: {
-                let [w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14] = self.w;
-                (
-                    w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14,
-                )
-            },
-            z: self.z,
-            t: self.t,
-            f: self.f,
-            s: {
-                let [s0, s1, s2, s3, s4] = self.s;
-                (s0, s1, s2, s3, s4)
-            },
-        })
-    }
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<Fs: ocaml::FromValue> ocaml::FromValue for ProofEvaluations<Fs> {
-    fn from_value(v: ocaml::Value) -> Self {
-        let evals: CamlProofEvaluations<Fs> = ocaml::FromValue::from_value(v);
-        ProofEvaluations {
-            w: {
-                let (w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14) = evals.w;
-                [
-                    w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14,
-                ]
-            },
-            z: evals.z,
-            t: evals.t,
-            f: evals.f,
-            s: {
-                let (s0, s1, s2, s3, s4) = evals.s;
-                [s0, s1, s2, s3, s4]
-            },
-        }
-    }
-}
-
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::ToValue, ocaml::FromValue))]
 pub struct RandomOracles<F: Field> {
     pub beta: F,
     pub gamma: F,
@@ -114,6 +60,188 @@ impl<F: Field> Default for RandomOracles<F> {
             zeta_chal: c,
             v_chal: c,
             u_chal: c,
+        }
+    }
+}
+
+//
+// OCaml types
+//
+
+#[cfg(feature = "ocaml_types")]
+pub mod caml {
+    use super::*;
+    use ocaml_gen::{ocaml_gen, OcamlGen};
+    use oracle::sponge::caml::CamlScalarChallenge;
+
+    //
+    // ProofEvaluations<F> <-> CamlProofEvaluations<CamlF>
+    //
+
+    #[derive(Clone, ocaml::IntoValue, ocaml::FromValue, OcamlGen)]
+    pub struct CamlProofEvaluations<CamlF> {
+        pub w: (
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+        ),
+        pub z: Vec<CamlF>,
+        pub s: (
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+        ),
+    }
+
+    impl<F, CamlF> From<ProofEvaluations<Vec<F>>> for CamlProofEvaluations<CamlF>
+    where
+        F: Clone,
+        CamlF: From<F>,
+    {
+        fn from(pe: ProofEvaluations<Vec<F>>) -> Self {
+            let w = (
+                pe.w[0].iter().cloned().map(Into::into).collect(),
+                pe.w[1].iter().cloned().map(Into::into).collect(),
+                pe.w[2].iter().cloned().map(Into::into).collect(),
+                pe.w[3].iter().cloned().map(Into::into).collect(),
+                pe.w[4].iter().cloned().map(Into::into).collect(),
+                pe.w[5].iter().cloned().map(Into::into).collect(),
+                pe.w[6].iter().cloned().map(Into::into).collect(),
+                pe.w[7].iter().cloned().map(Into::into).collect(),
+                pe.w[8].iter().cloned().map(Into::into).collect(),
+                pe.w[9].iter().cloned().map(Into::into).collect(),
+                pe.w[10].iter().cloned().map(Into::into).collect(),
+                pe.w[11].iter().cloned().map(Into::into).collect(),
+                pe.w[12].iter().cloned().map(Into::into).collect(),
+                pe.w[13].iter().cloned().map(Into::into).collect(),
+                pe.w[14].iter().cloned().map(Into::into).collect(),
+            );
+            let s = (
+                pe.s[0].iter().cloned().map(Into::into).collect(),
+                pe.s[1].iter().cloned().map(Into::into).collect(),
+                pe.s[2].iter().cloned().map(Into::into).collect(),
+                pe.s[3].iter().cloned().map(Into::into).collect(),
+                pe.s[4].iter().cloned().map(Into::into).collect(),
+                pe.s[5].iter().cloned().map(Into::into).collect(),
+            );
+            Self {
+                w,
+                z: pe.z.into_iter().map(Into::into).collect(),
+                s,
+            }
+        }
+    }
+
+    impl<F, CamlF> Into<ProofEvaluations<Vec<F>>> for CamlProofEvaluations<CamlF>
+    where
+        CamlF: Into<F>,
+    {
+        fn into(self) -> ProofEvaluations<Vec<F>> {
+            let w = [
+                self.w.0.into_iter().map(Into::into).collect(),
+                self.w.1.into_iter().map(Into::into).collect(),
+                self.w.2.into_iter().map(Into::into).collect(),
+                self.w.3.into_iter().map(Into::into).collect(),
+                self.w.4.into_iter().map(Into::into).collect(),
+                self.w.5.into_iter().map(Into::into).collect(),
+                self.w.6.into_iter().map(Into::into).collect(),
+                self.w.7.into_iter().map(Into::into).collect(),
+                self.w.8.into_iter().map(Into::into).collect(),
+                self.w.9.into_iter().map(Into::into).collect(),
+                self.w.10.into_iter().map(Into::into).collect(),
+                self.w.11.into_iter().map(Into::into).collect(),
+                self.w.12.into_iter().map(Into::into).collect(),
+                self.w.13.into_iter().map(Into::into).collect(),
+                self.w.14.into_iter().map(Into::into).collect(),
+            ];
+            let s = [
+                self.s.0.into_iter().map(Into::into).collect(),
+                self.s.1.into_iter().map(Into::into).collect(),
+                self.s.2.into_iter().map(Into::into).collect(),
+                self.s.3.into_iter().map(Into::into).collect(),
+                self.s.4.into_iter().map(Into::into).collect(),
+                self.s.5.into_iter().map(Into::into).collect(),
+            ];
+            ProofEvaluations {
+                w,
+                z: self.z.into_iter().map(Into::into).collect(),
+                s,
+            }
+        }
+    }
+
+    //
+    // RandomOracles<F> <-> CamlRandomOracles<CamlF>
+    //
+
+    #[derive(ocaml::IntoValue, ocaml::FromValue, OcamlGen)]
+    pub struct CamlRandomOracles<CamlF> {
+        pub beta: CamlF,
+        pub gamma: CamlF,
+        pub alpha_chal: CamlScalarChallenge<CamlF>,
+        pub alpha: CamlF,
+        pub zeta: CamlF,
+        pub v: CamlF,
+        pub u: CamlF,
+        pub zeta_chal: CamlScalarChallenge<CamlF>,
+        pub v_chal: CamlScalarChallenge<CamlF>,
+        pub u_chal: CamlScalarChallenge<CamlF>,
+    }
+
+    impl<F, CamlF> From<RandomOracles<F>> for CamlRandomOracles<CamlF>
+    where
+        F: Field,
+        CamlF: From<F>,
+    {
+        fn from(ro: RandomOracles<F>) -> Self {
+            Self {
+                beta: ro.beta.into(),
+                gamma: ro.gamma.into(),
+                alpha_chal: ro.alpha_chal.into(),
+                alpha: ro.alpha.into(),
+                zeta: ro.zeta.into(),
+                v: ro.v.into(),
+                u: ro.u.into(),
+                zeta_chal: ro.zeta_chal.into(),
+                v_chal: ro.v_chal.into(),
+                u_chal: ro.u_chal.into(),
+            }
+        }
+    }
+
+    impl<F, CamlF> Into<RandomOracles<F>> for CamlRandomOracles<CamlF>
+    where
+        CamlF: Into<F>,
+        F: Field,
+    {
+        fn into(self) -> RandomOracles<F> {
+            RandomOracles {
+                beta: self.beta.into(),
+                gamma: self.gamma.into(),
+                alpha_chal: self.alpha_chal.into(),
+                alpha: self.alpha.into(),
+                zeta: self.zeta.into(),
+                v: self.v.into(),
+                u: self.u.into(),
+                zeta_chal: self.zeta_chal.into(),
+                v_chal: self.v_chal.into(),
+                u_chal: self.u_chal.into(),
+            }
         }
     }
 }

--- a/circuits/plonk-15-wires/src/polynomials/permutation.rs
+++ b/circuits/plonk-15-wires/src/polynomials/permutation.rs
@@ -5,7 +5,7 @@ This source file implements permutation constraint polynomials.
 *****************************************************************************************************************/
 
 use crate::nolookup::constraints::ConstraintSystem;
-use crate::nolookup::scalars::{ProofEvaluations, RandomOracles};
+use crate::nolookup::scalars::ProofEvaluations;
 use crate::polynomial::WitnessOverDomains;
 use crate::wires::*;
 use ark_ff::{FftField, SquareRootField, Zero};

--- a/circuits/plonk/Cargo.toml
+++ b/circuits/plonk/Cargo.toml
@@ -9,7 +9,6 @@ path = "src/lib.rs"
 [dependencies]
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-poly = { version = "0.3.0", features = [ "parallel" ] }
-ocaml = { version = "0.22.0", optional = true }
 rand_core = { version = "0.5" }
 array-init = { version = "1.0.0" }
 rayon = { version = "1" }
@@ -21,6 +20,9 @@ mina-curves = { path = "../../curves" }
 o1-utils = { path = "../../utils" }
 oracle = { path = "../../oracle" }
 
+ocaml = { version = "0.22.1", optional = true }
+ocaml-gen = { path = "../../ocaml-gen", optional = true }
+
 [features]
 
-ocaml_types = [ "ocaml", "oracle/ocaml_types" ]
+ocaml_types = [ "ocaml", "ocaml-gen", "oracle/ocaml_types" ]

--- a/circuits/plonk/src/scalars.rs
+++ b/circuits/plonk/src/scalars.rs
@@ -10,7 +10,6 @@ use o1_utils::ExtendedDensePolynomial as _;
 use oracle::sponge::ScalarChallenge;
 
 #[derive(Clone)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
 pub struct ProofEvaluations<Fs> {
     pub l: Fs,
     pub r: Fs,
@@ -38,7 +37,6 @@ impl<F: FftField> ProofEvaluations<Vec<F>> {
 }
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
 pub struct RandomOracles<F: Field> {
     pub beta: F,
     pub gamma: F,
@@ -66,6 +64,129 @@ impl<F: Field> RandomOracles<F> {
             zeta_chal: c,
             v_chal: c,
             u_chal: c,
+        }
+    }
+}
+
+//
+// OCaml types
+//
+
+#[cfg(feature = "ocaml_types")]
+pub mod caml {
+    use super::*;
+    use ocaml_gen::OcamlGen;
+    use oracle::sponge::caml::CamlScalarChallenge;
+
+    //
+    // ProofEvaluations<F> <-> CamlProofEvaluations<CamlF>
+    //
+
+    #[derive(Clone, ocaml::IntoValue, ocaml::FromValue, OcamlGen)]
+    pub struct CamlProofEvaluations<F> {
+        pub l: Vec<F>,
+        pub r: Vec<F>,
+        pub o: Vec<F>,
+        pub z: Vec<F>,
+        pub t: Vec<F>,
+        pub f: Vec<F>,
+        pub sigma1: Vec<F>,
+        pub sigma2: Vec<F>,
+    }
+
+    impl<F, CamlF> From<ProofEvaluations<Vec<F>>> for CamlProofEvaluations<CamlF>
+    where
+        CamlF: From<F>,
+    {
+        fn from(pe: ProofEvaluations<Vec<F>>) -> Self {
+            Self {
+                l: pe.l.into_iter().map(Into::into).collect(),
+                r: pe.r.into_iter().map(Into::into).collect(),
+                o: pe.o.into_iter().map(Into::into).collect(),
+                z: pe.z.into_iter().map(Into::into).collect(),
+                t: pe.t.into_iter().map(Into::into).collect(),
+                f: pe.f.into_iter().map(Into::into).collect(),
+                sigma1: pe.sigma1.into_iter().map(Into::into).collect(),
+                sigma2: pe.sigma2.into_iter().map(Into::into).collect(),
+            }
+        }
+    }
+
+    impl<F, CamlF> Into<ProofEvaluations<Vec<F>>> for CamlProofEvaluations<CamlF>
+    where
+        CamlF: Into<F>,
+    {
+        fn into(self) -> ProofEvaluations<Vec<F>> {
+            ProofEvaluations {
+                l: self.l.into_iter().map(Into::into).collect(),
+                r: self.r.into_iter().map(Into::into).collect(),
+                o: self.o.into_iter().map(Into::into).collect(),
+                z: self.z.into_iter().map(Into::into).collect(),
+                t: self.t.into_iter().map(Into::into).collect(),
+                f: self.f.into_iter().map(Into::into).collect(),
+                sigma1: self.sigma1.into_iter().map(Into::into).collect(),
+                sigma2: self.sigma2.into_iter().map(Into::into).collect(),
+            }
+        }
+    }
+
+    //
+    // RandomOracles<F> <-> CamlRandomOracles<CamlF>
+    //
+
+    #[derive(ocaml::IntoValue, ocaml::FromValue, OcamlGen)]
+    pub struct CamlRandomOracles<CamlF> {
+        pub beta: CamlF,
+        pub gamma: CamlF,
+        pub alpha_chal: CamlScalarChallenge<CamlF>,
+        pub alpha: CamlF,
+        pub zeta: CamlF,
+        pub v: CamlF,
+        pub u: CamlF,
+        pub zeta_chal: CamlScalarChallenge<CamlF>,
+        pub v_chal: CamlScalarChallenge<CamlF>,
+        pub u_chal: CamlScalarChallenge<CamlF>,
+    }
+
+    impl<F, CamlF> From<RandomOracles<F>> for CamlRandomOracles<CamlF>
+    where
+        F: Field,
+        CamlF: From<F>,
+    {
+        fn from(ro: RandomOracles<F>) -> Self {
+            Self {
+                beta: ro.beta.into(),
+                gamma: ro.gamma.into(),
+                alpha_chal: ro.alpha_chal.into(),
+                alpha: ro.alpha.into(),
+                zeta: ro.zeta.into(),
+                v: ro.v.into(),
+                u: ro.u.into(),
+                zeta_chal: ro.zeta_chal.into(),
+                v_chal: ro.v_chal.into(),
+                u_chal: ro.u_chal.into(),
+            }
+        }
+    }
+
+    impl<F, CamlF> Into<RandomOracles<F>> for CamlRandomOracles<CamlF>
+    where
+        CamlF: Into<F>,
+        F: Field,
+    {
+        fn into(self) -> RandomOracles<F> {
+            RandomOracles {
+                beta: self.beta.into(),
+                gamma: self.gamma.into(),
+                alpha_chal: self.alpha_chal.into(),
+                alpha: self.alpha.into(),
+                zeta: self.zeta.into(),
+                v: self.v.into(),
+                u: self.u.into(),
+                zeta_chal: self.zeta_chal.into(),
+                v_chal: self.v_chal.into(),
+                u_chal: self.u_chal.into(),
+            }
         }
     }
 }

--- a/dlog/commitment/Cargo.toml
+++ b/dlog/commitment/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 ark-poly = { version = "0.3.0", features = [ "parallel" ] }
-ocaml = { version = "0.22.0", optional = true }
+
 rand_core = { version = "0.6.0" }
 colored = "1.9.2"
 rand = "0.8.0"
@@ -21,6 +21,8 @@ mina-curves = { path = "../../curves" }
 o1-utils = { path = "../../utils" }
 oracle = { path = "../../oracle" }
 
-[features]
+ocaml = { version = "0.22.1", optional = true }
+ocaml-gen = { path = "../../ocaml-gen", optional = true }
 
-ocaml_types = [ "ocaml" ]
+[features]
+ocaml_types = [ "ocaml", "ocaml-gen" ]

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -18,8 +18,8 @@ use ark_ec::{
 };
 use ark_ff::{Field, FpParameters, One, PrimeField, SquareRootField, UniformRand, Zero};
 use ark_poly::{
-    univariate::DensePolynomial, EvaluationDomain, Evaluations, Polynomial,
-    Radix2EvaluationDomain as D, UVPolynomial,
+    univariate::DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as D,
+    UVPolynomial,
 };
 use core::ops::{Add, Sub};
 use groupmap::{BWParameters, GroupMap};
@@ -1007,6 +1007,7 @@ mod tests {
     use super::*;
 
     use crate::srs::SRS;
+    use ark_poly::Polynomial;
     use array_init::array_init;
     use mina_curves::pasta::{fp::Fp, vesta::Affine as VestaG};
     use oracle::poseidon::PlonkSpongeConstantsBasic as SC;
@@ -1137,7 +1138,7 @@ mod tests {
 #[cfg(feature = "ocaml_types")]
 pub mod caml {
     use super::*;
-    use ocaml_gen::{ocaml_gen, OcamlGen};
+    use ocaml_gen::OcamlGen;
 
     // polynomial commitment
 

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -34,7 +34,6 @@ type Fq<G> = <G as AffineCurve>::BaseField;
 
 /// A polynomial commitment.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
 pub struct PolyComm<C> {
     pub unshifted: Vec<C>,
     pub shifted: Option<C>,
@@ -152,7 +151,7 @@ impl<C: AffineCurve> PolyComm<C> {
                 if com.len() == 0 || elm.len() == 0 {
                     Vec::new()
                 } else {
-                    let n = com.iter().map(|c| c.unshifted.len()).max().unwrap();
+                    let n = Iterator::max(com.iter().map(|c| c.unshifted.len())).unwrap();
                     (0..n)
                         .map(|i| {
                             let mut points = Vec::new();
@@ -173,7 +172,6 @@ impl<C: AffineCurve> PolyComm<C> {
 }
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
 pub struct OpeningProof<G: AffineCurve> {
     pub lr: Vec<(G, G)>, // vector of rounds of L & R commitments
     pub delta: G,
@@ -1129,5 +1127,104 @@ mod tests {
         )];
 
         assert!(srs.verify(&group_map, &mut batch, rng));
+    }
+}
+
+//
+// OCaml types
+//
+
+#[cfg(feature = "ocaml_types")]
+pub mod caml {
+    use super::*;
+    use ocaml_gen::{ocaml_gen, OcamlGen};
+
+    // polynomial commitment
+
+    #[derive(Clone, ocaml::IntoValue, ocaml::FromValue, OcamlGen)]
+    pub struct CamlPolyComm<CamlG> {
+        pub unshifted: Vec<CamlG>,
+        pub shifted: Option<CamlG>,
+    }
+
+    //
+
+    impl<G, CamlG> From<PolyComm<G>> for CamlPolyComm<CamlG>
+    where
+        G: AffineCurve,
+        CamlG: From<G>,
+    {
+        fn from(polycomm: PolyComm<G>) -> Self {
+            Self {
+                unshifted: polycomm.unshifted.into_iter().map(Into::into).collect(),
+                shifted: polycomm.shifted.map(Into::into),
+            }
+        }
+    }
+
+    impl<G, CamlG> Into<PolyComm<G>> for CamlPolyComm<CamlG>
+    where
+        G: AffineCurve,
+        CamlG: Into<G>,
+    {
+        fn into(self) -> PolyComm<G> {
+            PolyComm {
+                unshifted: self.unshifted.into_iter().map(Into::into).collect(),
+                shifted: self.shifted.map(Into::into),
+            }
+        }
+    }
+
+    // opening proof
+
+    #[derive(ocaml::IntoValue, ocaml::FromValue, OcamlGen)]
+    pub struct CamlOpeningProof<G, F> {
+        pub lr: Vec<(G, G)>, // vector of rounds of L & R commitments
+        pub delta: G,
+        pub z1: F,
+        pub z2: F,
+        pub sg: G,
+    }
+
+    impl<G, CamlF, CamlG> From<OpeningProof<G>> for CamlOpeningProof<CamlG, CamlF>
+    where
+        G: AffineCurve,
+        CamlG: From<G>,
+        CamlF: From<G::ScalarField>,
+    {
+        fn from(opening_proof: OpeningProof<G>) -> Self {
+            Self {
+                lr: opening_proof
+                    .lr
+                    .into_iter()
+                    .map(|(g1, g2)| (g1.into(), g2.into()))
+                    .collect(),
+                delta: opening_proof.delta.into(),
+                z1: opening_proof.z1.into(),
+                z2: opening_proof.z2.into(),
+                sg: opening_proof.sg.into(),
+            }
+        }
+    }
+
+    impl<G, CamlF, CamlG> Into<OpeningProof<G>> for CamlOpeningProof<CamlG, CamlF>
+    where
+        G: AffineCurve,
+        CamlG: Into<G>,
+        CamlF: Into<G::ScalarField>,
+    {
+        fn into(self) -> OpeningProof<G> {
+            OpeningProof {
+                lr: self
+                    .lr
+                    .into_iter()
+                    .map(|(g1, g2)| (g1.into(), g2.into()))
+                    .collect(),
+                delta: self.delta.into(),
+                z1: self.z1.into(),
+                z2: self.z2.into(),
+                sg: self.sg.into(),
+            }
+        }
     }
 }

--- a/dlog/commitment/tests/commitment.rs
+++ b/dlog/commitment/tests/commitment.rs
@@ -1,20 +1,19 @@
 use ark_ff::{UniformRand, Zero};
+use ark_poly::{univariate::DensePolynomial, UVPolynomial};
+use colored::Colorize;
 use commitment_dlog::{
     commitment::{CommitmentCurve, OpeningProof, PolyComm},
     srs::SRS,
 };
+use groupmap::GroupMap;
 use mina_curves::pasta::{
     vesta::{Affine, VestaParameters},
     Fp,
 };
-use o1_utils::densepolynomial::ExtendedDensePolynomial;
+use o1_utils::ExtendedDensePolynomial as _;
 use oracle::poseidon::PlonkSpongeConstantsBasic as SC;
 use oracle::sponge::DefaultFqSponge;
-use oracle::FqSponge;
-
-use ark_poly::{univariate::DensePolynomial, UVPolynomial};
-use colored::Colorize;
-use groupmap::GroupMap;
+use oracle::FqSponge as _;
 use rand::Rng;
 use std::time::{Duration, Instant};
 

--- a/dlog/plonk-15-wires/Cargo.toml
+++ b/dlog/plonk-15-wires/Cargo.toml
@@ -17,7 +17,8 @@ sprs = "0.9.2"
 rayon = "1.5.0"
 array-init = "1.0.0"
 
-ocaml = { version = "0.18.1", optional = true }
+ocaml = { version = "0.22.1", optional = true }
+ocaml-gen = { path = "../../ocaml-gen", optional = true}
 
 commitment_dlog = { path = "../commitment" }
 o1-utils = { path = "../../utils" }
@@ -29,5 +30,5 @@ groupmap = { path = "../../groupmap" }
 mina-curves = { path = "../../curves" }
 
 [features]
-
-ocaml_types = [ "ocaml" ]
+default = []
+ocaml_types = [ "ocaml", "ocaml-gen", "plonk_15_wires_circuits/ocaml_types", "commitment_dlog/ocaml_types" ]

--- a/dlog/plonk-15-wires/src/prover.rs
+++ b/dlog/plonk-15-wires/src/prover.rs
@@ -18,7 +18,7 @@ use commitment_dlog::commitment::{
 use o1_utils::ExtendedDensePolynomial;
 use oracle::{rndoracle::ProofError, sponge::ScalarChallenge, FqSponge};
 use plonk_15_wires_circuits::{
-    nolookup::{constraints::ConstraintSystem, scalars::ProofEvaluations},
+    nolookup::scalars::ProofEvaluations,
     wires::{COLUMNS, PERMUTS},
 };
 use rand::thread_rng;

--- a/dlog/plonk-15-wires/src/prover.rs
+++ b/dlog/plonk-15-wires/src/prover.rs
@@ -35,65 +35,6 @@ pub struct ProverCommitments<G: AffineCurve> {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::ToValue, ocaml::FromValue))]
-#[cfg(feature = "ocaml_types")]
-pub struct CamlProverCommitments<G: AffineCurve> {
-    // polynomial commitments
-    pub w_comm: (
-        PolyComm<G>,
-        PolyComm<G>,
-        PolyComm<G>,
-        PolyComm<G>,
-        PolyComm<G>,
-    ),
-    pub z_comm: PolyComm<G>,
-    pub t_comm: PolyComm<G>,
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<G: AffineCurve + ocaml::ToValue> ocaml::ToValue for ProverCommitments<G>
-where
-    G::ScalarField: ocaml::ToValue,
-{
-    fn to_value(self) -> ocaml::Value {
-        let [w_comm0, w_comm1, w_comm2, w_comm3, w_comm4] = self.w_comm;
-        ocaml::ToValue::to_value(CamlProverCommitments {
-            w_comm: (w_comm0, w_comm1, w_comm2, w_comm3, w_comm4),
-            z_comm: self.z_comm,
-            t_comm: self.t_comm,
-        })
-    }
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<G: AffineCurve + ocaml::FromValue> ocaml::FromValue for ProverCommitments<G>
-where
-    G::ScalarField: ocaml::FromValue,
-{
-    fn from_value(v: ocaml::Value) -> Self {
-        let comms: CamlProverCommitments<G> = ocaml::FromValue::from_value(v);
-        let (w_comm0, w_comm1, w_comm2, w_comm3, w_comm4) = comms.w_comm;
-        ProverCommitments {
-            w_comm: [w_comm0, w_comm1, w_comm2, w_comm3, w_comm4],
-            z_comm: comms.z_comm,
-            t_comm: comms.t_comm,
-        }
-    }
-}
-
-#[cfg(feature = "ocaml_types")]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::ToValue, ocaml::FromValue))]
-struct CamlProverProof<G: AffineCurve> {
-    pub commitments: ProverCommitments<G>,
-    pub proof: OpeningProof<G>,
-    // OCaml doesn't have sized arrays, so we have to convert to a tuple..
-    pub evals: (ProofEvaluations<Vec<Fr<G>>>, ProofEvaluations<Vec<Fr<G>>>),
-    pub ft_eval1: Fr<G>,
-    pub public: Vec<Fr<G>>,
-    pub prev_challenges: Vec<(Vec<Fr<G>>, PolyComm<G>)>,
-}
-
-#[derive(Clone)]
 pub struct ProverProof<G: AffineCurve> {
     // polynomial commitments
     pub commitments: ProverCommitments<G>,
@@ -112,45 +53,6 @@ pub struct ProverProof<G: AffineCurve> {
 
     // The challenges underlying the optional polynomials folded into the proof
     pub prev_challenges: Vec<(Vec<Fr<G>>, PolyComm<G>)>,
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<G: AffineCurve + ocaml::ToValue> ocaml::ToValue for ProverProof<G>
-where
-    G::ScalarField: ocaml::ToValue,
-{
-    fn to_value(self) -> ocaml::Value {
-        ocaml::ToValue::to_value(CamlProverProof {
-            commitments: self.commitments,
-            proof: self.proof,
-            evals: {
-                let [evals0, evals1] = self.evals;
-                (evals0, evals1)
-            },
-            public: self.public,
-            prev_challenges: self.prev_challenges,
-        })
-    }
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<G: AffineCurve + ocaml::FromValue> ocaml::FromValue for ProverProof<G>
-where
-    G::ScalarField: ocaml::FromValue,
-{
-    fn from_value(v: ocaml::Value) -> Self {
-        let p: CamlProverProof<G> = ocaml::FromValue::from_value(v);
-        ProverProof {
-            commitments: p.commitments,
-            proof: p.proof,
-            evals: {
-                let (evals0, evals1) = p.evals;
-                [evals0, evals1]
-            },
-            public: p.public,
-            prev_challenges: p.prev_challenges,
-        }
-    }
 }
 
 impl<G: CommitmentCurve> ProverProof<G>
@@ -421,5 +323,200 @@ where
             public,
             prev_challenges,
         })
+    }
+}
+
+#[cfg(feature = "ocaml_types")]
+pub mod caml {
+    use super::*;
+    use commitment_dlog::commitment::caml::{CamlOpeningProof, CamlPolyComm};
+    use ocaml_gen::OcamlGen;
+    use plonk_15_wires_circuits::nolookup::scalars::caml::CamlProofEvaluations;
+
+    #[derive(ocaml::IntoValue, ocaml::FromValue, OcamlGen)]
+    pub struct CamlProverProof<CamlG, CamlF> {
+        pub commitments: CamlProverCommitments<CamlG>,
+        pub proof: CamlOpeningProof<CamlG, CamlF>,
+        // OCaml doesn't have sized arrays, so we have to convert to a tuple..
+        pub evals: (CamlProofEvaluations<CamlF>, CamlProofEvaluations<CamlF>),
+        pub ft_eval1: CamlF,
+        pub public: Vec<CamlF>,
+        pub prev_challenges: Vec<(Vec<CamlF>, CamlPolyComm<CamlG>)>,
+    }
+
+    #[derive(Clone, ocaml::IntoValue, ocaml::FromValue, OcamlGen)]
+    pub struct CamlProverCommitments<CamlG> {
+        // polynomial commitments
+        pub w_comm: (
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+            CamlPolyComm<CamlG>,
+        ),
+        pub z_comm: CamlPolyComm<CamlG>,
+        pub t_comm: CamlPolyComm<CamlG>,
+    }
+
+    // These implementations are handy for conversions such as:
+    // InternalType <-> Ocaml::Value
+    //
+    // It does this by hiding the required middle conversion step:
+    // InternalType <-> CamlInternalType <-> Ocaml::Value
+    //
+    // Note that some conversions are not always possible to shorten,
+    // because we don't always know how to convert the types.
+    // For example, to implement the conversion
+    // ProverCommitments<G> -> CamlProverCommitments<CamlG>
+    // we need to know how to convert G to CamlG.
+    // we don't know that information, unless we implemented some trait (e.g. ToCaml)
+    // we can do that, but instead we implemented the From trait for the reverse operations (From<G> for CamlG).
+    // it reduces the complexity, but forces us to do the conversion in two phases instead of one.
+
+    //
+    // CamlProverCommitments<CamlG> <-> ProverCommitments<G>
+    //
+
+    impl<G, CamlG> From<ProverCommitments<G>> for CamlProverCommitments<CamlG>
+    where
+        G: AffineCurve,
+        CamlPolyComm<CamlG>: From<PolyComm<G>>,
+    {
+        fn from(prover_comm: ProverCommitments<G>) -> Self {
+            let [w_comm0, w_comm1, w_comm2, w_comm3, w_comm4, w_comm5, w_comm6, w_comm7, w_comm8, w_comm9, w_comm10, w_comm11, w_comm12, w_comm13, w_comm14] =
+                prover_comm.w_comm;
+            Self {
+                w_comm: (
+                    w_comm0.into(),
+                    w_comm1.into(),
+                    w_comm2.into(),
+                    w_comm3.into(),
+                    w_comm4.into(),
+                    w_comm5.into(),
+                    w_comm6.into(),
+                    w_comm7.into(),
+                    w_comm8.into(),
+                    w_comm9.into(),
+                    w_comm10.into(),
+                    w_comm11.into(),
+                    w_comm12.into(),
+                    w_comm13.into(),
+                    w_comm14.into(),
+                ),
+                z_comm: prover_comm.z_comm.into(),
+                t_comm: prover_comm.t_comm.into(),
+            }
+        }
+    }
+
+    impl<G, CamlG> Into<ProverCommitments<G>> for CamlProverCommitments<CamlG>
+    where
+        G: AffineCurve,
+        CamlPolyComm<CamlG>: Into<PolyComm<G>>,
+    {
+        fn into(self) -> ProverCommitments<G> {
+            let (
+                w_comm0,
+                w_comm1,
+                w_comm2,
+                w_comm3,
+                w_comm4,
+                w_comm5,
+                w_comm6,
+                w_comm7,
+                w_comm8,
+                w_comm9,
+                w_comm10,
+                w_comm11,
+                w_comm12,
+                w_comm13,
+                w_comm14,
+            ) = self.w_comm;
+            ProverCommitments {
+                w_comm: [
+                    w_comm0.into(),
+                    w_comm1.into(),
+                    w_comm2.into(),
+                    w_comm3.into(),
+                    w_comm4.into(),
+                    w_comm5.into(),
+                    w_comm6.into(),
+                    w_comm7.into(),
+                    w_comm8.into(),
+                    w_comm9.into(),
+                    w_comm10.into(),
+                    w_comm11.into(),
+                    w_comm12.into(),
+                    w_comm13.into(),
+                    w_comm14.into(),
+                ],
+                z_comm: self.z_comm.into(),
+                t_comm: self.t_comm.into(),
+            }
+        }
+    }
+
+    //
+    // ProverProof<G> <-> CamlProverProof<CamlG, CamlF>
+    //
+
+    impl<G, CamlG, CamlF> From<ProverProof<G>> for CamlProverProof<CamlG, CamlF>
+    where
+        G: AffineCurve,
+        CamlG: From<G>,
+        CamlF: From<G::ScalarField>,
+    {
+        fn from(pp: ProverProof<G>) -> Self {
+            Self {
+                commitments: pp.commitments.into(),
+                proof: pp.proof.into(),
+                evals: (pp.evals[0].clone().into(), pp.evals[1].clone().into()),
+                ft_eval1: pp.ft_eval1.into(),
+                public: pp.public.into_iter().map(Into::into).collect(),
+                prev_challenges: pp
+                    .prev_challenges
+                    .into_iter()
+                    .map(|(v, c)| {
+                        let v = v.into_iter().map(Into::into).collect();
+                        (v, c.into())
+                    })
+                    .collect(),
+            }
+        }
+    }
+
+    impl<G, CamlG, CamlF> Into<ProverProof<G>> for CamlProverProof<CamlG, CamlF>
+    where
+        G: AffineCurve,
+        CamlG: Into<G>,
+        CamlF: Into<G::ScalarField>,
+    {
+        fn into(self) -> ProverProof<G> {
+            ProverProof {
+                commitments: self.commitments.into(),
+                proof: self.proof.into(),
+                evals: [self.evals.0.into(), self.evals.1.into()],
+                ft_eval1: self.ft_eval1.into(),
+                public: self.public.into_iter().map(Into::into).collect(),
+                prev_challenges: self
+                    .prev_challenges
+                    .into_iter()
+                    .map(|(v, c)| {
+                        let v = v.into_iter().map(Into::into).collect();
+                        (v, c.into())
+                    })
+                    .collect(),
+            }
+        }
     }
 }

--- a/dlog/plonk-15-wires/src/verifier.rs
+++ b/dlog/plonk-15-wires/src/verifier.rs
@@ -7,7 +7,7 @@ This source file implements zk-proof batch verifier functionality.
 pub use super::index::VerifierIndex as Index;
 pub use super::prover::{range, ProverProof};
 use crate::plonk_sponge::FrSponge;
-use ark_ec::{AffineCurve, ProjectiveCurve};
+use ark_ec::AffineCurve;
 use ark_ff::{Field, One, Zero};
 use ark_poly::{EvaluationDomain, Polynomial};
 use commitment_dlog::commitment::{

--- a/dlog/plonk/Cargo.toml
+++ b/dlog/plonk/Cargo.toml
@@ -10,7 +10,6 @@ path = "src/lib.rs"
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 ark-poly = { version = "0.3.0", features = [ "parallel" ] }
-ocaml = { version = "0.22.0", optional = true }
 rand_core = "0.6.0"
 colored = "1.9.3"
 rand = "0.8.0"
@@ -24,6 +23,9 @@ o1-utils = { path = "../../utils" }
 oracle = { path = "../../oracle" }
 plonk_circuits = { path = "../../circuits/plonk" }
 
+ocaml = { version = "0.22.1", optional = true }
+ocaml-gen = { path = "../../ocaml-gen", optional = true }
+
 [features]
 
-ocaml_types = [ "ocaml" ]
+ocaml_types = [ "ocaml", "ocaml-gen", "plonk_circuits/ocaml_types", "commitment_dlog/ocaml_types" ]

--- a/dlog/plonk/src/prover.rs
+++ b/dlog/plonk/src/prover.rs
@@ -27,23 +27,12 @@ type Fr<G> = <G as AffineCurve>::ScalarField;
 type Fq<G> = <G as AffineCurve>::BaseField;
 
 #[derive(Clone)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
 pub struct ProverCommitments<G: AffineCurve> {
     pub l_comm: PolyComm<G>,
     pub r_comm: PolyComm<G>,
     pub o_comm: PolyComm<G>,
     pub z_comm: PolyComm<G>,
     pub t_comm: PolyComm<G>,
-}
-
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
-struct CamlProverProof<G: AffineCurve> {
-    pub commitments: ProverCommitments<G>,
-    pub proof: OpeningProof<G>,
-    // OCaml doesn't have sized arrays, so we have to convert to a tuple..
-    pub evals: (ProofEvaluations<Vec<Fr<G>>>, ProofEvaluations<Vec<Fr<G>>>),
-    pub public: Vec<Fr<G>>,
-    pub prev_challenges: Vec<(Vec<Fr<G>>, PolyComm<G>)>,
 }
 
 #[derive(Clone)]
@@ -62,48 +51,6 @@ pub struct ProverProof<G: AffineCurve> {
 
     // The challenges underlying the optional polynomials folded into the proof
     pub prev_challenges: Vec<(Vec<Fr<G>>, PolyComm<G>)>,
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<G: AffineCurve + ocaml::IntoValue> ocaml::IntoValue for ProverProof<G>
-where
-    G::ScalarField: ocaml::IntoValue,
-{
-    fn into_value(self, runtime: &ocaml::Runtime) -> ocaml::Value {
-        ocaml::IntoValue::into_value(
-            CamlProverProof {
-                commitments: self.commitments,
-                proof: self.proof,
-                evals: {
-                    let [evals0, evals1] = self.evals;
-                    (evals0, evals1)
-                },
-                public: self.public,
-                prev_challenges: self.prev_challenges,
-            },
-            runtime,
-        )
-    }
-}
-
-#[cfg(feature = "ocaml_types")]
-unsafe impl<'a, G: AffineCurve + ocaml::FromValue<'a>> ocaml::FromValue<'a> for ProverProof<G>
-where
-    G::ScalarField: ocaml::FromValue<'a>,
-{
-    fn from_value(v: ocaml::Value) -> Self {
-        let p: CamlProverProof<G> = ocaml::FromValue::from_value(v);
-        ProverProof {
-            commitments: p.commitments,
-            proof: p.proof,
-            evals: {
-                let (evals0, evals1) = p.evals;
-                [evals0, evals1]
-            },
-            public: p.public,
-            prev_challenges: p.prev_challenges,
-        }
-    }
 }
 
 impl<G: CommitmentCurve> ProverProof<G>
@@ -476,5 +423,125 @@ where
         };
 
         Ok(proof)
+    }
+}
+
+//
+// OCaml types
+//
+
+#[cfg(feature = "ocaml_types")]
+pub mod caml {
+    use super::*;
+    use commitment_dlog::commitment::caml::{CamlOpeningProof, CamlPolyComm};
+    use ocaml_gen::OcamlGen;
+    use plonk_circuits::scalars::caml::CamlProofEvaluations;
+
+    //
+    // CamlProverCommitments<CamlG> <-> ProverCommitments<G>
+    //
+
+    /// The ocaml type for ProverCommitments
+    #[derive(ocaml::IntoValue, ocaml::FromValue, OcamlGen)]
+    pub struct CamlProverCommitments<CamlG> {
+        pub l_comm: CamlPolyComm<CamlG>,
+        pub r_comm: CamlPolyComm<CamlG>,
+        pub o_comm: CamlPolyComm<CamlG>,
+        pub z_comm: CamlPolyComm<CamlG>,
+        pub t_comm: CamlPolyComm<CamlG>,
+    }
+
+    impl<G, CamlG> From<ProverCommitments<G>> for CamlProverCommitments<CamlG>
+    where
+        G: AffineCurve,
+        CamlPolyComm<CamlG>: From<PolyComm<G>>,
+    {
+        fn from(prover_comm: ProverCommitments<G>) -> Self {
+            Self {
+                l_comm: prover_comm.l_comm.into(),
+                r_comm: prover_comm.r_comm.into(),
+                o_comm: prover_comm.o_comm.into(),
+                z_comm: prover_comm.z_comm.into(),
+                t_comm: prover_comm.t_comm.into(),
+            }
+        }
+    }
+
+    impl<G, CamlG> Into<ProverCommitments<G>> for CamlProverCommitments<CamlG>
+    where
+        G: AffineCurve,
+        CamlPolyComm<CamlG>: Into<PolyComm<G>>,
+    {
+        fn into(self) -> ProverCommitments<G> {
+            ProverCommitments {
+                l_comm: self.l_comm.into(),
+                r_comm: self.r_comm.into(),
+                o_comm: self.o_comm.into(),
+                z_comm: self.z_comm.into(),
+                t_comm: self.t_comm.into(),
+            }
+        }
+    }
+
+    //
+    // ProverProof<G> <-> CamlProverProof<CamlG, CamlF>
+    //
+
+    #[derive(ocaml::IntoValue, ocaml::FromValue, OcamlGen)]
+    pub struct CamlProverProof<CamlG, CamlF> {
+        pub commitments: CamlProverCommitments<CamlG>,
+        pub proof: CamlOpeningProof<CamlG, CamlF>,
+        // OCaml doesn't have sized arrays, so we have to convert to a tuple..
+        pub evals: (CamlProofEvaluations<CamlF>, CamlProofEvaluations<CamlF>),
+        pub public: Vec<CamlF>,
+        pub prev_challenges: Vec<(Vec<CamlF>, CamlPolyComm<CamlG>)>,
+    }
+
+    impl<G, CamlG, CamlF> From<ProverProof<G>> for CamlProverProof<CamlG, CamlF>
+    where
+        G: AffineCurve,
+        CamlG: From<G>,
+        CamlF: From<G::ScalarField>,
+    {
+        fn from(pp: ProverProof<G>) -> Self {
+            Self {
+                commitments: pp.commitments.into(),
+                proof: pp.proof.into(),
+                evals: (pp.evals[0].clone().into(), pp.evals[1].clone().into()),
+                public: pp.public.into_iter().map(Into::into).collect(),
+                prev_challenges: pp
+                    .prev_challenges
+                    .into_iter()
+                    .map(|(v, c)| {
+                        let v = v.into_iter().map(Into::into).collect();
+                        (v, c.into())
+                    })
+                    .collect(),
+            }
+        }
+    }
+
+    impl<G, CamlG, CamlF> Into<ProverProof<G>> for CamlProverProof<CamlG, CamlF>
+    where
+        G: AffineCurve,
+        CamlG: Into<G>,
+        CamlF: Into<G::ScalarField>,
+    {
+        fn into(self) -> ProverProof<G> {
+            ProverProof {
+                commitments: self.commitments.into(),
+                proof: self.proof.into(),
+                evals: [self.evals.0.into(), self.evals.1.into()],
+                public: self.public.into_iter().map(Into::into).collect(),
+                prev_challenges: self
+                    .prev_challenges
+                    .into_iter()
+                    .map(|(v, c)| {
+                        let v = v.into_iter().map(Into::into).collect();
+                        (v, c.into())
+                    })
+                    .collect(),
+            }
+        }
     }
 }

--- a/dlog/tests/poseidon_vesta_15_wires.rs
+++ b/dlog/tests/poseidon_vesta_15_wires.rs
@@ -1,4 +1,4 @@
-use ark_ff::{Field, One, UniformRand, Zero};
+use ark_ff::{UniformRand, Zero};
 use ark_poly::{univariate::DensePolynomial, UVPolynomial};
 use array_init::array_init;
 use colored::Colorize;

--- a/ocaml-gen/Cargo.toml
+++ b/ocaml-gen/Cargo.toml
@@ -3,9 +3,13 @@ name = "ocaml-gen"
 version = "0.1.0"
 edition = "2018"
 
+[lib]
+doctest = false
+
 [dependencies]
 ocaml-derive = { path = "./derive" }
 ocaml = { version = "0.22.1" }
 syn = "1.0.76"
 const-random = "0.1.13"
 convert_case = "0.4.0"
+

--- a/ocaml-gen/Cargo.toml
+++ b/ocaml-gen/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ocaml-gen"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+ocaml-derive = { path = "./derive" }
+ocaml = { version = "0.22.1" }
+syn = "1.0.76"
+const-random = "0.1.13"
+convert_case = "0.4.0"

--- a/ocaml-gen/derive/Cargo.toml
+++ b/ocaml-gen/derive/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 syn = { version = "1.0.76", features = ["full"] }

--- a/ocaml-gen/derive/Cargo.toml
+++ b/ocaml-gen/derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ocaml-derive"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0.76", features = ["full"] }
+quote = "1.0.9"
+proc-macro2 = "1.0.29"
+convert_case = "0.4.0"
+const-random = "0.1.13"

--- a/ocaml-gen/derive/src/lib.rs
+++ b/ocaml-gen/derive/src/lib.rs
@@ -1,0 +1,468 @@
+extern crate proc_macro;
+use convert_case::{Case, Casing};
+use proc_macro::TokenStream;
+use proc_macro2::{Ident, Span};
+use quote::quote;
+use syn::{
+    punctuated::Punctuated, Fields, FnArg, GenericArgument, GenericParam, PathArguments,
+    PredicateType, ReturnType, TraitBound, TraitBoundModifier, Type, TypeParamBound, TypePath,
+    WherePredicate,
+};
+
+/// A macro to create OCaml bindings for a function that uses #[ocaml::func]
+///
+/// Note that this macro must be placed first (before `#[ocaml::func]`).
+/// For example:
+///
+/// ```
+/// #[ocaml_gen]
+/// #[ocaml::func]
+/// pub fn something(arg1: String) {
+///   //...
+/// }
+/// ```
+///
+#[proc_macro_attribute]
+pub fn ocaml_gen(_attribute: TokenStream, item: TokenStream) -> TokenStream {
+    let item_fn: syn::ItemFn = syn::parse(item).unwrap();
+
+    let rust_name = &item_fn.sig.ident;
+    let inputs = &item_fn.sig.inputs;
+    let output = &item_fn.sig.output;
+
+    let ocaml_name = rust_ident_to_ocaml(rust_name.to_string());
+
+    let inputs: Vec<_> = inputs
+        .into_iter()
+        .filter_map(|i| match i {
+            FnArg::Typed(t) => Some(&t.ty),
+            _ => None,
+        })
+        .collect();
+
+    let return_value = match output {
+        ReturnType::Default => quote! { "unit".to_string() },
+        ReturnType::Type(_, t) => quote! {
+            <#t as ::ocaml_gen::ToOcaml>::to_ocaml(env, &[])
+        },
+    };
+
+    let rust_name_str = rust_name.to_string();
+
+    let fn_name = Ident::new(&format!("{}_to_ocaml", rust_name), Span::call_site());
+
+    let new_fn = quote! {
+        pub fn #fn_name(env: &::ocaml_gen::Env, rename: Option<&'static str>) -> String {
+            // function name
+            let ocaml_name = rename.unwrap_or(#ocaml_name);
+
+            // arguments
+            let mut args: Vec<String> = vec![];
+            #(
+                args.push(
+                    <#inputs as ::ocaml_gen::ToOcaml>::to_ocaml(env, &[])
+                );
+            );*
+            let inputs = if args.len() == 0 {
+                "unit".to_string()
+            } else {
+                args.join(" -> ")
+            };
+
+            // return value
+            let return_value = #return_value;
+
+            // return the binding
+            format!(
+                "external {} : {} -> {} = \"{}\"",
+                ocaml_name, inputs, return_value, #rust_name_str
+            )
+        }
+    };
+
+    let gen = quote! {
+        // don't forget to generate code that also contains the old function :)
+        #item_fn
+        #new_fn
+    };
+
+    gen.into()
+}
+
+//
+// OcamlGen
+//
+
+/// The OcamlGen derive macro.
+/// It generates implementations of ToOCaml and ToBinding on a type.
+/// The type must implement [ocaml::IntoValue] and [ocaml::FromValue]
+/// For example:
+///
+/// ```
+/// use ocaml_gen::OcamlGen;
+///
+/// #[OcamlGen]
+/// struct MyType {
+///   // ...
+/// }
+/// ```
+///
+#[proc_macro_derive(OcamlGen)]
+pub fn derive_ocaml_gen(item: TokenStream) -> TokenStream {
+    let item_struct: syn::ItemStruct =
+        syn::parse(item).expect("only structs are supported at the moment");
+    let name = &item_struct.ident;
+    let generics = &item_struct.generics.params;
+    let fields = &item_struct.fields;
+
+    //
+    // to_ocaml
+    //
+
+    let generics_ident: Vec<_> = generics
+        .iter()
+        .filter_map(|g| match g {
+            GenericParam::Type(t) => Some(&t.ident),
+            _ => None,
+        })
+        .map(|ident| ident)
+        .collect();
+
+    let name_str = name.to_string();
+
+    let to_ocaml = quote! {
+        fn to_ocaml(env: &::ocaml_gen::Env, generics: &[&str]) -> String {
+            // get type parameters
+            let mut generics_ocaml = vec![];
+            #(
+                generics_ocaml.push(
+                    <#generics_ident as ::ocaml_gen::ToOcaml>::to_ocaml(env, generics)
+                );
+            );*
+
+            // get name
+            let type_id = <Self as ::ocaml_gen::ToOcaml>::to_id();
+            let name = env.get_type(type_id);
+
+            // return the type description in OCaml
+            format!("({}) {}", generics_ocaml.join(", "), name)
+        }
+    };
+
+    //
+    // to_id
+    //
+
+    let to_id = quote! {
+        fn to_id() -> u128 {
+            ::ocaml_gen::const_random!(u128)
+        }
+    };
+
+    //
+    // to_binding
+    //
+
+    let generics_str: Vec<String> = generics
+        .iter()
+        .filter_map(|g| match g {
+            GenericParam::Type(t) => Some(&t.ident),
+            _ => None,
+        })
+        .map(|ident| ident.to_string())
+        .collect();
+
+    let body = match fields {
+        Fields::Named(fields) => {
+            let mut punctured_generics_name: Vec<String> = vec![];
+            let mut punctured_generics_type: Vec<String> = vec![];
+            let mut fields_to_call = vec![];
+            for field in &fields.named {
+                let name = field.ident.as_ref().expect("a named field has an ident");
+                punctured_generics_name.push(name.to_string());
+                if let Some(ty) = is_generic(&generics_str, &field.ty) {
+                    punctured_generics_type.push(format!("'{}", ty));
+                } else {
+                    punctured_generics_type.push("#".to_string());
+                    fields_to_call.push(&field.ty);
+                }
+            }
+            fields_to_call.reverse();
+
+            quote! {
+                let mut generics_ocaml: Vec<String> = vec![];
+                let punctured_generics_name: Vec<&str> = vec![
+                    #(#punctured_generics_name),*
+                ];
+                let punctured_generics_type: Vec<&str> = vec![
+                    #(#punctured_generics_type),*
+                ];
+
+                let mut missing_types: Vec<String> = vec![];
+                #(
+                    missing_types.push(
+                        <#fields_to_call as ::ocaml_gen::ToOcaml>::to_ocaml(env, &global_generics)
+                    );
+                );*
+
+                for (name, ty) in punctured_generics_name.into_iter().zip(punctured_generics_type) {
+                    if ty != "#" {
+                        generics_ocaml.push(
+                            format!("{}: {}", name, ty.to_string())
+                        );
+                    } else {
+                        let ty = missing_types
+                            .pop()
+                            .expect("number of types to call should match number of missing types");
+                        generics_ocaml.push(
+                            format!("{}: {}", name, ty)
+                        );
+                    }
+                }
+                format!("{{ {} }}", generics_ocaml.join("; "))
+            }
+        }
+        Fields::Unnamed(fields) => {
+            // TODO: when there's a single element,
+            // this will produce something like this:
+            //
+            // ```
+            // type ('field) scalar_challenge = 'field
+            // ```
+            //
+            // shouldn't we instead produce something like this?
+            //
+            // ```
+            // type ('field) scalar_challenge =  { inner: 'field }
+            // ```
+            let mut punctured_generics: Vec<String> = vec![];
+            let mut fields_to_call = vec![];
+            for field in &fields.unnamed {
+                if let Some(ident) = is_generic(&generics_str, &field.ty) {
+                    punctured_generics.push(format!("'{}", ident));
+                } else {
+                    punctured_generics.push("#".to_string());
+                    fields_to_call.push(&field.ty);
+                }
+            }
+            fields_to_call.reverse();
+
+            quote! {
+                let mut generics_ocaml: Vec<String> = vec![];
+
+                let punctured_generics: Vec<&str> = vec![
+                    #(#punctured_generics),*
+                ];
+
+                let mut missing_types: Vec<String> = vec![];
+                #(
+                    missing_types.push(&<#fields_to_call>::to_ocaml(env, &global_generics));
+                );*
+
+                for ty in punctured_generics {
+                    if ty != "#" {
+                        generics_ocaml.push(ty.to_string());
+                    } else {
+                        let ident = missing_types
+                            .pop()
+                            .expect("number of types to call should match number of missing types");
+                        generics_ocaml.push(ident);
+                    }
+                }
+
+                generics_ocaml.join(" * ")
+            }
+        }
+        _ => panic!("only named, and unnamed field supported"),
+    };
+
+    let ocaml_name = rust_ident_to_ocaml(name_str);
+
+    let to_binding = quote! {
+        fn to_binding(
+            env: &mut ::ocaml_gen::Env,
+            rename: Option<&'static str>,
+        ) -> String {
+            // register the new type
+            let ty_name = rename.unwrap_or(#ocaml_name);
+            let ty_id = <Self as ::ocaml_gen::ToOcaml>::to_id();
+            env.new_type(ty_id, ty_name);
+
+
+            let global_generics: Vec<&str> = vec![#(#generics_str),*];
+            let generics_ocaml = {
+                #body
+            };
+
+            let name = <Self as ::ocaml_gen::ToOcaml>::to_ocaml(env, &global_generics);
+
+            format!("type {} = {}", name, generics_ocaml)
+        }
+    };
+
+    //
+    // Implementations
+    //
+
+    let (impl_generics, ty_generics, _where_clause) = item_struct.generics.split_for_impl();
+
+    // add ToOcaml bounds to the generic types
+    let mut extended_generics = item_struct.generics.clone();
+    extended_generics.make_where_clause();
+    let mut extended_where_clause = extended_generics.where_clause.unwrap();
+    let path: syn::Path = syn::parse_str("::ocaml_gen::ToOcaml").unwrap();
+    let impl_to_ocaml = TraitBound {
+        paren_token: None,
+        modifier: TraitBoundModifier::None,
+        lifetimes: None,
+        path,
+    };
+    for generic in generics {
+        match generic {
+            GenericParam::Type(t) => {
+                let mut bounds = Punctuated::<TypeParamBound, syn::token::Add>::new();
+                bounds.push(TypeParamBound::Trait(impl_to_ocaml.clone()));
+
+                let path: syn::Path = syn::parse_str(&t.ident.to_string()).unwrap();
+
+                let bounded_ty = Type::Path(TypePath { qself: None, path });
+
+                extended_where_clause
+                    .predicates
+                    .push(WherePredicate::Type(PredicateType {
+                        lifetimes: None,
+                        bounded_ty,
+                        colon_token: syn::token::Colon {
+                            spans: [Span::call_site()],
+                        },
+                        bounds,
+                    }));
+            }
+            _ => (),
+        };
+    }
+
+    // generate implementations for ToOcaml and ToBinding
+    let gen = quote! {
+        impl #impl_generics ::ocaml_gen::ToOcaml for #name #ty_generics #extended_where_clause {
+            #to_ocaml
+            #to_id
+        }
+
+        impl #impl_generics ::ocaml_gen::ToBinding for #name #ty_generics  #extended_where_clause {
+            #to_binding
+        }
+    };
+    gen.into()
+}
+
+//
+// almost same code for custom types
+//
+
+/// Derives implementations for ToOcaml and ToBinding on a custom type
+/// For example:
+///
+/// ```
+/// use ocaml_gen::OCamlCustomType;
+///
+/// #[OCamlCustomType]
+/// struct MyCustomType {
+///   // ...
+/// }
+/// ```
+///
+#[proc_macro_derive(OCamlCustomType)]
+pub fn derive_ocaml_custom(item: TokenStream) -> TokenStream {
+    let item_struct: syn::ItemStruct =
+        syn::parse(item).expect("only structs are supported at the moment");
+    let name = &item_struct.ident;
+
+    //
+    // to_ocaml
+    //
+
+    let name_str = name.to_string();
+
+    let to_ocaml = quote! {
+        fn to_ocaml(env: &::ocaml_gen::Env, _generics: &[&str]) -> String {
+            let type_id = <Self as ::ocaml_gen::ToOcaml>::to_id();
+            env.get_type(type_id)
+        }
+    };
+
+    //
+    // to_id
+    //
+
+    let to_id = quote! {
+        fn to_id() -> u128 {
+            ::ocaml_gen::const_random!(u128)
+        }
+    };
+
+    //
+    // to_binding
+    //
+
+    let ocaml_name = rust_ident_to_ocaml(name_str);
+
+    let to_binding = quote! {
+        fn to_binding(
+            env: &mut ::ocaml_gen::Env,
+            rename: Option<&'static str>,
+        ) -> String {
+            // register the new type
+            let ty_name = rename.unwrap_or(#ocaml_name);
+            let ty_id = <Self as ::ocaml_gen::ToOcaml>::to_id();
+            env.new_type(ty_id, ty_name);
+            let name = <Self as ::ocaml_gen::ToOcaml>::to_ocaml(env, &[]);
+            format!("type {}", name)
+        }
+    };
+
+    //
+    // Implementations
+    //
+
+    let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
+
+    // generate implementations for ToOcaml and ToBinding
+    let gen = quote! {
+        impl #impl_generics ::ocaml_gen::ToOcaml for #name #ty_generics #where_clause {
+            #to_ocaml
+            #to_id
+        }
+
+        impl #impl_generics ::ocaml_gen::ToBinding for #name #ty_generics  #where_clause {
+            #to_binding
+        }
+    };
+
+    gen.into()
+}
+
+//
+// helpers
+//
+
+/// OCaml identifiers are snake_case, whereas Rust identifiers are CamelCase
+fn rust_ident_to_ocaml(ident: String) -> String {
+    ident.to_case(Case::Snake)
+}
+
+/// return true if the type passed is a generic
+fn is_generic(generics: &Vec<String>, ty: &Type) -> Option<String> {
+    match ty {
+        Type::Path(p) => {
+            if let Some(ident) = p.path.get_ident() {
+                let ident = ident.to_string();
+                if generics.contains(&ident) {
+                    return Some(ident);
+                }
+            }
+        }
+        _ => (),
+    }
+    return None;
+}

--- a/ocaml-gen/src/conv.rs
+++ b/ocaml-gen/src/conv.rs
@@ -1,0 +1,209 @@
+//! Implementations of [crate::ToOcaml] for types
+//! that have natural equivalents in OCaml.
+
+use crate::{Env, ToOcaml};
+use const_random::const_random;
+
+impl ToOcaml for [u8; 32] {
+    fn to_ocaml(env: &Env, _generics: &[&str]) -> String {
+        "bytes".to_string()
+    }
+
+    fn to_id() -> u128 {
+        const_random!(u128)
+    }
+}
+
+impl ToOcaml for &[u8] {
+    fn to_ocaml(env: &Env, _generics: &[&str]) -> String {
+        "bytes".to_string()
+    }
+
+    fn to_id() -> u128 {
+        const_random!(u128)
+    }
+}
+
+impl<T> ToOcaml for Vec<T>
+where
+    T: ToOcaml,
+{
+    fn to_ocaml(env: &Env, generics: &[&str]) -> String {
+        format!("{} array", T::to_ocaml(env, generics))
+    }
+
+    fn to_id() -> u128 {
+        const_random!(u128)
+    }
+}
+
+impl<T, E> ToOcaml for Result<T, E>
+where
+    T: ToOcaml,
+{
+    fn to_ocaml(env: &Env, generics: &[&str]) -> String {
+        T::to_ocaml(env, generics)
+    }
+
+    fn to_id() -> u128 {
+        const_random!(u128)
+    }
+}
+
+impl<T> ToOcaml for Option<T>
+where
+    T: ToOcaml,
+{
+    fn to_ocaml(env: &Env, generics: &[&str]) -> String {
+        format!("{} option", T::to_ocaml(env, generics))
+    }
+
+    fn to_id() -> u128 {
+        const_random!(u128)
+    }
+}
+
+impl ToOcaml for ocaml::Int {
+    fn to_ocaml(_env: &Env, _generics: &[&str]) -> String {
+        "int".to_string()
+    }
+
+    fn to_id() -> u128 {
+        const_random!(u128)
+    }
+}
+
+impl ToOcaml for String {
+    fn to_ocaml(_env: &Env, _generics: &[&str]) -> String {
+        "string".to_string()
+    }
+
+    fn to_id() -> u128 {
+        const_random!(u128)
+    }
+}
+
+impl ToOcaml for bool {
+    fn to_ocaml(_env: &Env, _generics: &[&str]) -> String {
+        "bool".to_string()
+    }
+
+    fn to_id() -> u128 {
+        const_random!(u128)
+    }
+}
+
+impl<T> ToOcaml for ocaml::Pointer<'_, T>
+where
+    T: ToOcaml,
+{
+    fn to_ocaml(env: &Env, generics: &[&str]) -> String {
+        T::to_ocaml(env, generics)
+    }
+
+    fn to_id() -> u128 {
+        const_random!(u128)
+    }
+}
+
+impl<T1, T2> ToOcaml for (T1, T2)
+where
+    T1: ToOcaml,
+    T2: ToOcaml,
+{
+    fn to_ocaml(env: &Env, generics: &[&str]) -> String {
+        let v = vec![T1::to_ocaml(env, generics), T2::to_ocaml(env, generics)];
+        v.join(" * ")
+    }
+
+    fn to_id() -> u128 {
+        const_random!(u128)
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> ToOcaml
+    for (
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+    )
+where
+    T1: ToOcaml,
+    T2: ToOcaml,
+    T3: ToOcaml,
+    T4: ToOcaml,
+    T5: ToOcaml,
+    T6: ToOcaml,
+    T7: ToOcaml,
+    T8: ToOcaml,
+    T9: ToOcaml,
+    T10: ToOcaml,
+    T11: ToOcaml,
+    T12: ToOcaml,
+    T13: ToOcaml,
+    T14: ToOcaml,
+    T15: ToOcaml,
+{
+    fn to_ocaml(env: &Env, generics: &[&str]) -> String {
+        let v = vec![
+            T1::to_ocaml(env, generics),
+            T2::to_ocaml(env, generics),
+            T3::to_ocaml(env, generics),
+            T4::to_ocaml(env, generics),
+            T5::to_ocaml(env, generics),
+            T6::to_ocaml(env, generics),
+            T7::to_ocaml(env, generics),
+            T8::to_ocaml(env, generics),
+            T9::to_ocaml(env, generics),
+            T10::to_ocaml(env, generics),
+            T11::to_ocaml(env, generics),
+            T12::to_ocaml(env, generics),
+            T13::to_ocaml(env, generics),
+            T14::to_ocaml(env, generics),
+            T15::to_ocaml(env, generics),
+        ];
+        v.join(" * ")
+    }
+
+    fn to_id() -> u128 {
+        const_random!(u128)
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6> ToOcaml for (T1, T2, T3, T4, T5, T6)
+where
+    T1: ToOcaml,
+    T2: ToOcaml,
+    T3: ToOcaml,
+    T4: ToOcaml,
+    T5: ToOcaml,
+    T6: ToOcaml,
+{
+    fn to_ocaml(env: &Env, generics: &[&str]) -> String {
+        let v = vec![
+            T1::to_ocaml(env, generics),
+            T2::to_ocaml(env, generics),
+            T3::to_ocaml(env, generics),
+            T4::to_ocaml(env, generics),
+            T5::to_ocaml(env, generics),
+            T6::to_ocaml(env, generics),
+        ];
+        v.join(" * ")
+    }
+
+    fn to_id() -> u128 {
+        const_random!(u128)
+    }
+}

--- a/ocaml-gen/src/conv.rs
+++ b/ocaml-gen/src/conv.rs
@@ -1,127 +1,127 @@
-//! Implementations of [crate::ToOcaml] for types
+//! Implementations of [crate::OCamlDesc] for types
 //! that have natural equivalents in OCaml.
 
-use crate::{Env, ToOcaml};
+use crate::{Env, OCamlDesc};
 use const_random::const_random;
 
-impl ToOcaml for [u8; 32] {
-    fn to_ocaml(env: &Env, _generics: &[&str]) -> String {
+impl OCamlDesc for [u8; 32] {
+    fn ocaml_desc(_env: &Env, _generics: &[&str]) -> String {
         "bytes".to_string()
     }
 
-    fn to_id() -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
 
-impl ToOcaml for &[u8] {
-    fn to_ocaml(env: &Env, _generics: &[&str]) -> String {
+impl OCamlDesc for &[u8] {
+    fn ocaml_desc(_env: &Env, _generics: &[&str]) -> String {
         "bytes".to_string()
     }
 
-    fn to_id() -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
 
-impl<T> ToOcaml for Vec<T>
+impl<T> OCamlDesc for Vec<T>
 where
-    T: ToOcaml,
+    T: OCamlDesc,
 {
-    fn to_ocaml(env: &Env, generics: &[&str]) -> String {
-        format!("{} array", T::to_ocaml(env, generics))
+    fn ocaml_desc(env: &Env, generics: &[&str]) -> String {
+        format!("{} array", T::ocaml_desc(env, generics))
     }
 
-    fn to_id() -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
 
-impl<T, E> ToOcaml for Result<T, E>
+impl<T, E> OCamlDesc for Result<T, E>
 where
-    T: ToOcaml,
+    T: OCamlDesc,
 {
-    fn to_ocaml(env: &Env, generics: &[&str]) -> String {
-        T::to_ocaml(env, generics)
+    fn ocaml_desc(env: &Env, generics: &[&str]) -> String {
+        T::ocaml_desc(env, generics)
     }
 
-    fn to_id() -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
 
-impl<T> ToOcaml for Option<T>
+impl<T> OCamlDesc for Option<T>
 where
-    T: ToOcaml,
+    T: OCamlDesc,
 {
-    fn to_ocaml(env: &Env, generics: &[&str]) -> String {
-        format!("{} option", T::to_ocaml(env, generics))
+    fn ocaml_desc(env: &Env, generics: &[&str]) -> String {
+        format!("{} option", T::ocaml_desc(env, generics))
     }
 
-    fn to_id() -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
 
-impl ToOcaml for ocaml::Int {
-    fn to_ocaml(_env: &Env, _generics: &[&str]) -> String {
+impl OCamlDesc for ocaml::Int {
+    fn ocaml_desc(_env: &Env, _generics: &[&str]) -> String {
         "int".to_string()
     }
 
-    fn to_id() -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
 
-impl ToOcaml for String {
-    fn to_ocaml(_env: &Env, _generics: &[&str]) -> String {
+impl OCamlDesc for String {
+    fn ocaml_desc(_env: &Env, _generics: &[&str]) -> String {
         "string".to_string()
     }
 
-    fn to_id() -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
 
-impl ToOcaml for bool {
-    fn to_ocaml(_env: &Env, _generics: &[&str]) -> String {
+impl OCamlDesc for bool {
+    fn ocaml_desc(_env: &Env, _generics: &[&str]) -> String {
         "bool".to_string()
     }
 
-    fn to_id() -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
 
-impl<T> ToOcaml for ocaml::Pointer<'_, T>
+impl<T> OCamlDesc for ocaml::Pointer<'_, T>
 where
-    T: ToOcaml,
+    T: OCamlDesc,
 {
-    fn to_ocaml(env: &Env, generics: &[&str]) -> String {
-        T::to_ocaml(env, generics)
+    fn ocaml_desc(env: &Env, generics: &[&str]) -> String {
+        T::ocaml_desc(env, generics)
     }
 
-    fn to_id() -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
 
-impl<T1, T2> ToOcaml for (T1, T2)
+impl<T1, T2> OCamlDesc for (T1, T2)
 where
-    T1: ToOcaml,
-    T2: ToOcaml,
+    T1: OCamlDesc,
+    T2: OCamlDesc,
 {
-    fn to_ocaml(env: &Env, generics: &[&str]) -> String {
-        let v = vec![T1::to_ocaml(env, generics), T2::to_ocaml(env, generics)];
+    fn ocaml_desc(env: &Env, generics: &[&str]) -> String {
+        let v = vec![T1::ocaml_desc(env, generics), T2::ocaml_desc(env, generics)];
         v.join(" * ")
     }
 
-    fn to_id() -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
 
-impl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> ToOcaml
+impl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> OCamlDesc
     for (
         T1,
         T2,
@@ -140,70 +140,70 @@ impl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> ToOcaml
         T15,
     )
 where
-    T1: ToOcaml,
-    T2: ToOcaml,
-    T3: ToOcaml,
-    T4: ToOcaml,
-    T5: ToOcaml,
-    T6: ToOcaml,
-    T7: ToOcaml,
-    T8: ToOcaml,
-    T9: ToOcaml,
-    T10: ToOcaml,
-    T11: ToOcaml,
-    T12: ToOcaml,
-    T13: ToOcaml,
-    T14: ToOcaml,
-    T15: ToOcaml,
+    T1: OCamlDesc,
+    T2: OCamlDesc,
+    T3: OCamlDesc,
+    T4: OCamlDesc,
+    T5: OCamlDesc,
+    T6: OCamlDesc,
+    T7: OCamlDesc,
+    T8: OCamlDesc,
+    T9: OCamlDesc,
+    T10: OCamlDesc,
+    T11: OCamlDesc,
+    T12: OCamlDesc,
+    T13: OCamlDesc,
+    T14: OCamlDesc,
+    T15: OCamlDesc,
 {
-    fn to_ocaml(env: &Env, generics: &[&str]) -> String {
+    fn ocaml_desc(env: &Env, generics: &[&str]) -> String {
         let v = vec![
-            T1::to_ocaml(env, generics),
-            T2::to_ocaml(env, generics),
-            T3::to_ocaml(env, generics),
-            T4::to_ocaml(env, generics),
-            T5::to_ocaml(env, generics),
-            T6::to_ocaml(env, generics),
-            T7::to_ocaml(env, generics),
-            T8::to_ocaml(env, generics),
-            T9::to_ocaml(env, generics),
-            T10::to_ocaml(env, generics),
-            T11::to_ocaml(env, generics),
-            T12::to_ocaml(env, generics),
-            T13::to_ocaml(env, generics),
-            T14::to_ocaml(env, generics),
-            T15::to_ocaml(env, generics),
+            T1::ocaml_desc(env, generics),
+            T2::ocaml_desc(env, generics),
+            T3::ocaml_desc(env, generics),
+            T4::ocaml_desc(env, generics),
+            T5::ocaml_desc(env, generics),
+            T6::ocaml_desc(env, generics),
+            T7::ocaml_desc(env, generics),
+            T8::ocaml_desc(env, generics),
+            T9::ocaml_desc(env, generics),
+            T10::ocaml_desc(env, generics),
+            T11::ocaml_desc(env, generics),
+            T12::ocaml_desc(env, generics),
+            T13::ocaml_desc(env, generics),
+            T14::ocaml_desc(env, generics),
+            T15::ocaml_desc(env, generics),
         ];
         v.join(" * ")
     }
 
-    fn to_id() -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
 
-impl<T1, T2, T3, T4, T5, T6> ToOcaml for (T1, T2, T3, T4, T5, T6)
+impl<T1, T2, T3, T4, T5, T6> OCamlDesc for (T1, T2, T3, T4, T5, T6)
 where
-    T1: ToOcaml,
-    T2: ToOcaml,
-    T3: ToOcaml,
-    T4: ToOcaml,
-    T5: ToOcaml,
-    T6: ToOcaml,
+    T1: OCamlDesc,
+    T2: OCamlDesc,
+    T3: OCamlDesc,
+    T4: OCamlDesc,
+    T5: OCamlDesc,
+    T6: OCamlDesc,
 {
-    fn to_ocaml(env: &Env, generics: &[&str]) -> String {
+    fn ocaml_desc(env: &Env, generics: &[&str]) -> String {
         let v = vec![
-            T1::to_ocaml(env, generics),
-            T2::to_ocaml(env, generics),
-            T3::to_ocaml(env, generics),
-            T4::to_ocaml(env, generics),
-            T5::to_ocaml(env, generics),
-            T6::to_ocaml(env, generics),
+            T1::ocaml_desc(env, generics),
+            T2::ocaml_desc(env, generics),
+            T3::ocaml_desc(env, generics),
+            T4::ocaml_desc(env, generics),
+            T5::ocaml_desc(env, generics),
+            T6::ocaml_desc(env, generics),
         ];
         v.join(" * ")
     }
 
-    fn to_id() -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }

--- a/ocaml-gen/src/lib.rs
+++ b/ocaml-gen/src/lib.rs
@@ -181,12 +181,12 @@ macro_rules! decl_func {
 #[macro_export]
 macro_rules! decl_type {
     ($env:expr, $ty:ty) => {{
-        let res = <$ty as ::ocaml_gen::OCamlBinding>::to_binding($env, None);
+        let res = <$ty as ::ocaml_gen::OCamlBinding>::ocaml_binding($env, None);
         println!("{}", res);
     }};
     // rename
     ($env:expr, $ty:ty => $new:expr) => {{
-        let res = <$ty as ::ocaml_gen::OCamlBinding>::to_binding($env, Some($new));
+        let res = <$ty as ::ocaml_gen::OCamlBinding>::ocaml_binding($env, Some($new));
         println!("{}", res);
     }};
 }

--- a/ocaml-gen/src/lib.rs
+++ b/ocaml-gen/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(concat_idents)]
 // TODO: get rid of nightly with https://github.com/dtolnay/paste ?
 
 //! Some doc is needed here.

--- a/ocaml-gen/src/lib.rs
+++ b/ocaml-gen/src/lib.rs
@@ -140,7 +140,6 @@ pub trait ToBinding {
 /// It is usually derived automatically via the [OcamlGen] macro,
 /// or the [OCamlCustomType] macro for custom types.
 pub trait ToOcaml {
-    // TODO: use TypeInfo instead
     fn to_ocaml(env: &Env, generics: &[&str]) -> String;
     fn to_id() -> u128;
 }

--- a/ocaml-gen/src/lib.rs
+++ b/ocaml-gen/src/lib.rs
@@ -1,0 +1,208 @@
+#![feature(concat_idents)]
+// TODO: get rid of nightly with https://github.com/dtolnay/paste ?
+
+//! Some doc is needed here.
+//!
+//! ```
+//! // create a binary for generating your OCaml types, and import all the types
+//! fn main() {
+//!   // the bindings are printed out for now
+//!   println!("(* this file is generated automatically *)\n");
+//!
+//!   // initialize your environment
+//!   let env = &mut Env::default();
+//!
+//!   // we need to create fake generic placeholders for generic structs
+//!   decl_fake_generic!(T1, 0);
+//!   decl_fake_generic!(T2, 1);
+//!
+//!   // declare a module Types containing a bunch of types
+//!   decl_module!(env, "Types", {
+//!       decl_type!(env, CamlScalarChallenge::<T1>);
+//!       // you can also rename a type
+//!       decl_type!(env, CamlRandomOracles::<T1> => "random_oracles");
+//!   });
+//!
+//!   decl_module!(env, "BigInt256", {
+//!       decl_type!(env, CamlBigInteger256 => "t");
+//!       // you will have to import all (*) so that this can find
+//!       // the underlying function called `caml_of_numeral_to_ocaml`
+//!       decl_func!(env, caml_of_numeral => "of_numeral");
+//!   });
+//! }
+//! ```
+//!
+
+extern crate ocaml_derive;
+use std::collections::{hash_map::Entry, HashMap};
+
+pub use const_random::const_random;
+use convert_case::{Case, Casing};
+pub use ocaml_derive::*;
+
+pub mod conv;
+
+//
+// Structs
+//
+
+/// The environment at some point in time during the declaration of OCaml bindings.
+/// It ensures that types cannot be declared twice, and that types that are
+/// renamed and/or relocated into module are referenced correctly.
+#[derive(Default, Debug)]
+pub struct Env {
+    /// every type (their path and their name) is stored here at declaration
+    locations: HashMap<u128, (Vec<&'static str>, &'static str)>,
+    /// the current path we're in (e.g. `ModA.ModB`)
+    current_module: Vec<&'static str>,
+}
+
+impl Drop for Env {
+    /// This makes sure that we close our OCaml modules (with the keyword `end`)
+    fn drop(&mut self) {
+        if self.current_module.len() != 0 {
+            panic!("you must call .root() on the environment to finalize the generation. You are currently still nested: {:?}", self.current_module);
+        }
+    }
+}
+
+impl Env {
+    /// Declares a new type. If the type was already declared, this will panic
+    pub fn new_type(&mut self, ty: u128, name: &'static str) {
+        match self.locations.entry(ty) {
+            Entry::Occupied(_) => panic!("ocaml-gen: cannot re-declare the same type twice"),
+            Entry::Vacant(v) => v.insert((self.current_module.clone(), name)),
+        };
+    }
+
+    /// retrieves a type that was declared previously
+    pub fn get_type(&self, ty: u128) -> String {
+        let (type_path, type_name) = self
+            .locations
+            .get(&ty)
+            // not a great error, I know
+            .expect("ocaml-gen: the type hasn't been declared");
+
+        let type_path = type_path.join(".");
+        let current_module = self.current_module.join(".");
+        if type_path == current_module {
+            type_name.to_string()
+        } else {
+            format!("{}.{}", type_path, type_name)
+        }
+    }
+
+    /// create a module and enters it
+    pub fn new_module(&mut self, mod_name: &'static str) -> String {
+        let camelized = mod_name.to_case(Case::Pascal); // Pascal = CamelCase
+        if camelized != mod_name {
+            panic!(
+                "ocaml-gen: OCaml uses CamelCase for module names, you provided: {}, and we expected: {}", mod_name, camelized
+            );
+        }
+
+        self.current_module.push(mod_name);
+        format!("module {} = struct ", mod_name)
+    }
+
+    /// go back up one module
+    pub fn parent(&mut self) -> String {
+        self.current_module
+            .pop()
+            .expect("ocaml-gen: you are already at the root");
+        "end".to_string()
+    }
+
+    /// you can call this to go back to the root and finalize the generation
+    pub fn root(&mut self) -> String {
+        let mut res = String::new();
+        for _ in &self.current_module {
+            res.push_str("end\n");
+        }
+        res
+    }
+}
+
+//
+// Traits
+//
+
+/// ToBinding is the trait implemented by types to generate their OCaml bindings.
+/// It is usually derived automatically via the [OcamlGen] macro,
+/// or the [OCamlCustomType] macro for custom types.
+/// For functions, refer to the [ocaml_gen] macro.
+pub trait ToBinding {
+    /// will generate the OCaml bindings for a type
+    fn to_binding(env: &mut Env, rename: Option<&'static str>) -> String;
+}
+
+/// ToOcaml is the trait implemented by types to facilitate generation of their OCaml bindings.
+/// It is usually derived automatically via the [OcamlGen] macro,
+/// or the [OCamlCustomType] macro for custom types.
+pub trait ToOcaml {
+    // TODO: use TypeInfo instead
+    fn to_ocaml(env: &Env, generics: &[&str]) -> String;
+    fn to_id() -> u128;
+}
+
+//
+// Func-like macros
+//
+
+/// Creates a module
+#[macro_export]
+macro_rules! decl_module {
+    ($env:expr, $name:expr, $b:block) => {{
+        println!("{}", $env.new_module($name));
+        $b
+        println!("{}", $env.parent());
+    }}
+}
+
+/// Declares the binding for a given function
+#[macro_export]
+macro_rules! decl_func {
+    ($env:expr, $func:ident) => {{
+        let f = concat_idents!($func, _to_ocaml);
+        let binding = f($env, None);
+        println!("{}", binding);
+    }};
+    // rename
+    ($env:expr, $func:ident => $new:expr) => {{
+        let f = concat_idents!($func, _to_ocaml);
+        let binding = f($env, Some($new));
+        println!("{}", binding);
+    }};
+}
+
+/// Declares the binding for a given type
+#[macro_export]
+macro_rules! decl_type {
+    ($env:expr, $ty:ty) => {{
+        let res = <$ty as ::ocaml_gen::ToBinding>::to_binding($env, None);
+        println!("{}", res);
+    }};
+    // rename
+    ($env:expr, $ty:ty => $new:expr) => {{
+        let res = <$ty as ::ocaml_gen::ToBinding>::to_binding($env, Some($new));
+        println!("{}", res);
+    }};
+}
+
+/// Creates a fake generic
+#[macro_export]
+macro_rules! decl_fake_generic {
+    ($name:ident, $i:expr) => {
+        pub struct $name;
+
+        impl ::ocaml_gen::ToOcaml for $name {
+            fn to_ocaml(_env: &::ocaml_gen::Env, generics: &[&str]) -> String {
+                format!("'{}", generics[$i])
+            }
+
+            fn to_id() -> u128 {
+                ::ocaml_gen::const_random!(u128)
+            }
+        }
+    };
+}

--- a/oracle/Cargo.toml
+++ b/oracle/Cargo.toml
@@ -10,10 +10,15 @@ path = "src/lib.rs"
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 ark-poly = { version = "0.3.0", features = [ "parallel" ] }
-mina-curves = { path = "../curves" }
-ocaml = { version = "0.22.0", optional = true }
 rand = "0.8.0"
 rayon = { version = "1" }
+
+mina-curves = { path = "../curves" }
+
+# for ocaml
+ocaml = { version = "0.22.1", optional = true }
+ocaml-gen = { path = "../ocaml-gen", optional = true }
+syn = { version = "1.0.76", optional = true }
 
 # for export_test_vectors
 num-bigint = { version = "0.4.0" }
@@ -26,7 +31,7 @@ ark-serialize = "0.3.0"
 hex = { version = "0.4" }
 
 [features]
-ocaml_types = [ "ocaml" ]
+ocaml_types = [ "ocaml", "ocaml-gen", "syn" ]
 
 # for test vectors
 default = ["3w"]

--- a/oracle/src/sponge.rs
+++ b/oracle/src/sponge.rs
@@ -11,7 +11,6 @@ const HIGH_ENTROPY_LIMBS: usize = 2;
 // TODO: move to a different file / module
 /// A challenge which is used as a scalar on a group element in the verifier
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ocaml_types", derive(ocaml::IntoValue, ocaml::FromValue))]
 pub struct ScalarChallenge<F>(pub F);
 
 pub fn endo_coefficient<F: PrimeField>() -> F {
@@ -198,5 +197,40 @@ where
 
     fn challenge_fq(&mut self) -> P::BaseField {
         self.squeeze_field()
+    }
+}
+
+//
+// OCaml types
+//
+
+#[cfg(feature = "ocaml_types")]
+pub mod caml {
+    use super::*;
+    use ocaml_gen::OcamlGen;
+
+    //
+    // ScalarChallenge<F> <-> CamlScalarChallenge<CamlF>
+    //
+
+    #[derive(Debug, Clone, ocaml::IntoValue, ocaml::FromValue, OcamlGen)]
+    pub struct CamlScalarChallenge<CamlF>(pub CamlF);
+
+    impl<F, CamlF> From<ScalarChallenge<F>> for CamlScalarChallenge<CamlF>
+    where
+        CamlF: From<F>,
+    {
+        fn from(sc: ScalarChallenge<F>) -> Self {
+            Self(sc.0.into())
+        }
+    }
+
+    impl<F, CamlF> Into<ScalarChallenge<F>> for CamlScalarChallenge<CamlF>
+    where
+        CamlF: Into<F>,
+    {
+        fn into(self) -> ScalarChallenge<F> {
+            ScalarChallenge(self.0.into())
+        }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.52.1"
+channel = "1.55.0"


### PR DESCRIPTION
The idea of this PR is to avoid writing the OCaml bindings by hand, and generate them automatically from the Rust code. ([I also recorded myself going over the code a bit if that helps](https://www.loom.com/share/a96000d653614e248f6b7639838db9fb).)

In the end, you end up writing this kind of code (taken from https://github.com/MinaProtocol/mina/pull/9525):

```rust
fn main() {
    println!("(* this file is generated automatically *)\n");
    let env = &mut Env::default();

    decl_fake_generic!(T1, 0);
    decl_fake_generic!(T2, 1);

    decl_module!(env, "Types", {
        decl_type!(env, CamlScalarChallenge::<T1> => "scalar_challenge");
        decl_type!(env, CamlRandomOracles::<T1> => "random_oracles");
        decl_type!(env, CamlProofEvaluations::<T1> => "proof_evaluations");
        decl_type!(env, CamlPolyComm::<T1> => "poly_comm");
        decl_type!(env, CamlOpeningProof::<T1, T2> => "opening_proof");
        decl_type!(env, CamlProverCommitments::<T1> => "prover_commitments");
        decl_type!(env, CamlProverProof<T1, T2> => "prover_proof");
    });

    decl_module!(env, "BigInt256", {
        decl_type!(env, CamlBigInteger256 => "t");
        decl_func!(env, caml_bigint_256_of_numeral => "of_numeral");
    });

    decl_module!(env, "Fp", {
        decl_type!(env, CamlFp => "t");
        decl_func!(env, caml_pasta_fp_size_in_bits => "size_in_bits");
        decl_func!(env, caml_pasta_fp_size);
        decl_func!(env, caml_pasta_fp_add);
```

to generate a single OCaml file containing:

```ocaml
(* this file is generated automatically *)

module Types = struct
  type 'CamlF scalar_challenge = 'CamlF

  type 'CamlF random_oracles = {
    beta : 'CamlF;
    gamma : 'CamlF;
    alpha_chal : 'CamlF scalar_challenge;
    alpha : 'CamlF;
    zeta : 'CamlF;
    v : 'CamlF;
    u : 'CamlF;
    zeta_chal : 'CamlF scalar_challenge;
    v_chal : 'CamlF scalar_challenge;
    u_chal : 'CamlF scalar_challenge;
  }

  type 'F proof_evaluations = {
    l : 'F array;
    r : 'F array;
    o : 'F array;
    z : 'F array;
    t : 'F array;
    f : 'F array;
    sigma1 : 'F array;
    sigma2 : 'F array;
  }

  type 'CamlG poly_comm = { unshifted : 'CamlG array; shifted : 'CamlG option }

  type ('G, 'F) opening_proof = {
    lr : 'G * 'G array;
    delta : 'G;
    z1 : 'F;
    z2 : 'F;
    sg : 'G;
  }

  type 'CamlG prover_commitments = {
    l_comm : 'CamlG poly_comm;
    r_comm : 'CamlG poly_comm;
    o_comm : 'CamlG poly_comm;
    z_comm : 'CamlG poly_comm;
    t_comm : 'CamlG poly_comm;
  }

  type ('CamlG, 'CamlF) prover_proof = {
    commitments : 'CamlG prover_commitments;
    proof : ('CamlG, 'CamlF) opening_proof;
    evals : 'CamlF proof_evaluations * 'CamlF proof_evaluations;
    public : 'CamlF array;
    prev_challenges : 'CamlF array * 'CamlG poly_comm array;
  }
end
module BigInt256 = struct
  type t

  external of_numeral : bytes -> int -> int -> t = "caml_bigint_256_of_numeral"
end

module Fp = struct
  type t

  external size_in_bits : unit -> int = "caml_pasta_fp_size_in_bits"

  external caml_pasta_fp_size : unit -> BigInt256.t = "caml_pasta_fp_size"

  external caml_pasta_fp_add : t -> t -> t = "caml_pasta_fp_add"
end
```

Essentially, it creates a number of macros to help derive the OCaml bindings.

* `#[derive(OcamlGen)]` derive macro for types. This implements the `OCamlDesc` and `OCamlBinding` traits.
* `#[derive(OcamlCustomTypes)]` derive macro for custom types. This also implements the `OCamlDesc` and `OCamlBinding` traits.
* `#[ocaml_gen]` attribute macro for functions, which creates a `*_to_ocaml()` function returning the generated OCaml binding

The traits it implements on types are the following ones:

```rust
/// OCamlBinding is the trait implemented by types to generate their OCaml bindings.
/// It is usually derived automatically via the [OcamlGen] macro,
/// or the [OCamlCustomType] macro for custom types.
/// For functions, refer to the [ocaml_gen] macro.
pub trait OCamlBinding {
    /// will generate the OCaml bindings for a type (called root type).
    /// It takes the current environment [Env],
    /// as well as an optional name (if you wish to rename the type in OCaml).
    fn ocaml_binding(env: &mut Env, rename: Option<&'static str>) -> String;
}

/// OCamlDesc is the trait implemented by types to facilitate generation of their OCaml bindings.
/// It is usually derived automatically via the [OcamlGen] macro,
/// or the [OCamlCustomType] macro for custom types.
pub trait OCamlDesc {
    /// describes the type in OCaml, given the current environment [Env]
    /// and the list of generic type parameters of the root type
    /// (the type that makes use of this type)
    fn ocaml_desc(env: &Env, generics: &[&str]) -> String;

    /// Returns a unique ID for the type. This ID will not change if concrete type parameters are used.
    fn unique_id() -> u128;
}
```

Essentially, the `ocaml_binding()` function is called to generate bindings for a type, and it'll call `ocaml_desc()` on all of its fields (recursively). The `ocaml_desc()` function is aware of the current environment (via the `Env` var), and can thus re-write types that have been renamed or relocated in some other module.

In order to avoid mixing types, a `unique_id()` function is also implemented, which returns a unique id per-type (regardless of the concrete type parameters used)