### PR TITLE
implementing serialization of types via Serde

### DIFF
--- a/circuits/plonk-15-wires/Cargo.toml
+++ b/circuits/plonk-15-wires/Cargo.toml
@@ -9,13 +9,16 @@ path = "src/lib.rs"
 [dependencies]
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-poly = { version = "0.3.0", features = [ "parallel" ] }
-rand_core = { version = "0.5" }
+ark-serialize = "0.3.0"
 array-init = { version = "1.0.0" }
 rayon = { version = "1" }
 blake2 = "0.9.1"
 rand = "0.8.0"
+rand_core = { version = "0.5" }
 num-derive = "0.3"
 num-traits = "0.2"
+serde = "1.0.130"
+serde_with = "1.10.0"
 
 mina-curves = { path = "../../curves" }
 o1-utils = { path = "../../utils" }
@@ -25,7 +28,11 @@ ocaml = { version = "0.22.1", optional = true }
 ocaml-gen = { path = "../../ocaml-gen", optional = true }
 
 [dev-dependencies]
+bincode = "1.3.3"
 itertools = "0.10.1"
+proptest = "1.0.0"
+proptest-derive = "0.3.0"
 
 [features]
+default = []
 ocaml_types = [ "ocaml", "ocaml-gen", "oracle/ocaml_types" ]

--- a/circuits/plonk-15-wires/src/domains.rs
+++ b/circuits/plonk-15-wires/src/domains.rs
@@ -1,10 +1,16 @@
 use ark_ff::FftField;
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
-#[derive(Debug, Clone, Copy)]
+#[serde_as]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct EvaluationDomains<F: FftField> {
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub d1: Domain<F>, // size n
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub d4: Domain<F>, // size 4n
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub d8: Domain<F>, // size 8n
 }
 

--- a/circuits/plonk-15-wires/src/gate.rs
+++ b/circuits/plonk-15-wires/src/gate.rs
@@ -8,10 +8,17 @@ use crate::{nolookup::constraints::ConstraintSystem, wires::*};
 use ark_ff::bytes::{FromBytes, ToBytes};
 use ark_ff::FftField;
 use num_traits::cast::{FromPrimitive, ToPrimitive};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
 
 #[repr(C)]
-#[derive(Clone, Debug, PartialEq, FromPrimitive, ToPrimitive)]
+#[derive(Clone, Debug, PartialEq, FromPrimitive, ToPrimitive, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "ocaml_types",
+    derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::OcamlEnum)
+)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub enum GateType {
     /// zero gate
     Zero,
@@ -31,7 +38,8 @@ pub enum GateType {
     Lookup,
 }
 
-#[derive(Clone, Debug)]
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CircuitGate<F: FftField> {
     /// row position in the circuit
     // TODO(mimoo): shouldn't this be u32 since we serialize it as a u32?
@@ -41,6 +49,8 @@ pub struct CircuitGate<F: FftField> {
     /// gate wires
     pub wires: GateWires,
     /// constraints vector
+    // TODO: rename
+    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
     pub c: Vec<F>,
 }
 
@@ -127,6 +137,66 @@ impl<F: FftField> CircuitGate<F> {
             GateType::Vbmul => self.verify_vbmul(witness),
             GateType::Endomul => self.verify_endomul(witness, cs),
             GateType::Lookup => self.verify_lookup(witness),
+        }
+    }
+}
+
+//
+// Tests
+//
+
+#[cfg(any(test, feature = "testing"))]
+mod tests {
+    use super::*;
+    use ark_ff::UniformRand as _;
+    use mina_curves::pasta::Fp;
+    use proptest::prelude::*;
+    use rand::SeedableRng as _;
+
+    // TODO: move to mina-curves
+    prop_compose! {
+        pub fn arb_fp()(seed: [u8; 32]) -> Fp {
+            let rng = &mut rand::rngs::StdRng::from_seed(seed);
+            Fp::rand(rng)
+        }
+    }
+
+    prop_compose! {
+        fn arb_fp_vec(max: usize)(seed: [u8; 32], num in 0..max) -> Vec<Fp> {
+            let rng = &mut rand::rngs::StdRng::from_seed(seed);
+            let mut v = vec![];
+            for _ in 0..num {
+                v.push(Fp::rand(rng))
+            }
+            v
+        }
+    }
+
+    prop_compose! {
+        fn arb_circuit_gate()(row in any::<usize>(), typ: GateType, wires: GateWires, c in arb_fp_vec(25)) -> CircuitGate<Fp> {
+            CircuitGate {
+                row,
+                typ,
+                wires,
+                c,
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_gate_serialization(cg in arb_circuit_gate()) {
+            let encoded = bincode::serialize(&cg).unwrap();
+            println!("gate: {:?}", cg);
+            println!("encoded gate: {:?}", encoded);
+            let decoded: CircuitGate<Fp> = bincode::deserialize(&encoded).unwrap();
+            println!("decoded gate: {:?}", decoded);
+            prop_assert_eq!(cg.row, decoded.row);
+            prop_assert_eq!(cg.typ, decoded.typ);
+            for i in 0..COLUMNS {
+                prop_assert_eq!(cg.wires[i], decoded.wires[i]);
+            }
+            prop_assert_eq!(cg.c, decoded.c);
         }
     }
 }

--- a/circuits/plonk-15-wires/src/nolookup/constraints.rs
+++ b/circuits/plonk-15-wires/src/nolookup/constraints.rs
@@ -19,50 +19,66 @@ use array_init::array_init;
 use blake2::{Blake2b, Digest};
 use o1_utils::ExtendedEvaluations;
 use oracle::poseidon::ArithmeticSpongeParams;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_with::serde_as;
 
-#[derive(Clone)]
+#[serde_as]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct ConstraintSystem<F: FftField> {
     // Basics
     // ------
     /// number of public inputs
     pub public: usize,
     /// evaluation domains
+    #[serde(bound = "EvaluationDomains<F>: Serialize + DeserializeOwned")]
     pub domain: EvaluationDomains<F>,
     /// circuit gates
+    #[serde(bound = "CircuitGate<F>: Serialize + DeserializeOwned")]
     pub gates: Vec<CircuitGate<F>>,
 
     // Polynomials over the monomial base
     // ----------------------------------
     /// permutation polynomial array
+    #[serde_as(as = "[o1_utils::serialization::SerdeAs; PERMUTS]")]
     pub sigmam: [DP<F>; PERMUTS],
     /// zero-knowledge polynomial
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub zkpm: DP<F>,
 
     // Generic constraint selector polynomials
     // ---------------------------------------
     /// linear wire constraint polynomial
+    #[serde_as(as = "[o1_utils::serialization::SerdeAs; GENERICS]")]
     pub qwm: [DP<F>; GENERICS],
     /// multiplication polynomial
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub qmm: DP<F>,
     /// constant wire polynomial
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub qc: DP<F>,
 
     // Poseidon selector polynomials
     // -----------------------------
     /// round constant polynomials
+    #[serde_as(as = "[[o1_utils::serialization::SerdeAs; SPONGE_WIDTH]; ROUNDS_PER_ROW]")]
     pub rcm: [[DP<F>; SPONGE_WIDTH]; ROUNDS_PER_ROW],
     /// poseidon constraint selector polynomial
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub psm: DP<F>,
 
     // ECC arithmetic selector polynomials
     // -----------------------------------
     /// EC point addition constraint selector polynomial
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub addm: DP<F>,
     /// EC point doubling constraint selector polynomial
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub doublem: DP<F>,
     /// mulm constraint selector polynomial
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub mulm: DP<F>,
     /// emulm constraint selector polynomial
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub emulm: DP<F>,
 
     //
@@ -72,63 +88,85 @@ pub struct ConstraintSystem<F: FftField> {
     // Generic constraint selector polynomials
     // ---------------------------------------
     /// left input wire polynomial over domain.d4
+    #[serde_as(as = "[o1_utils::serialization::SerdeAs; GENERICS]")]
     pub qwl: [E<F, D<F>>; GENERICS],
     /// multiplication evaluations over domain.d4
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub qml: E<F, D<F>>,
 
     // permutation polynomials
     // -----------------------
     /// permutation polynomial array evaluations over domain d1
+    #[serde_as(as = "[Vec<o1_utils::serialization::SerdeAs>; PERMUTS]")]
     pub sigmal1: [Vec<F>; PERMUTS],
     /// permutation polynomial array evaluations over domain d8
+    #[serde_as(as = "[o1_utils::serialization::SerdeAs; PERMUTS]")]
     pub sigmal8: [E<F, D<F>>; PERMUTS],
     /// SID polynomial
+    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
     pub sid: Vec<F>,
 
     // Poseidon selector polynomials
     // -----------------------------
     /// poseidon selector over domain.d4
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub ps4: E<F, D<F>>,
     /// poseidon selector over domain.d8
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub ps8: E<F, D<F>>,
 
     // ECC arithmetic selector polynomials
     // -----------------------------------
     /// EC point addition selector evaluations w over domain.d4
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub addl: E<F, D<F>>,
     /// EC point doubling selector evaluations w over domain.d8
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub doubl8: E<F, D<F>>,
     /// EC point doubling selector evaluations w over domain.d4
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub doubl4: E<F, D<F>>,
     /// scalar multiplication selector evaluations over domain.d4
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub mull4: E<F, D<F>>,
     /// scalar multiplication selector evaluations over domain.d8
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub mull8: E<F, D<F>>,
     /// endoscalar multiplication selector evaluations over domain.d8
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub emull: E<F, D<F>>,
 
     // Constant polynomials
     // --------------------
     /// 1-st Lagrange evaluated over domain.d8
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub l1: E<F, D<F>>,
     /// 0-th Lagrange evaluated over domain.d4
     // TODO(mimoo): be consistent with the paper/spec, call it L1 here or call it L0 there
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub l04: E<F, D<F>>,
     /// 0-th Lagrange evaluated over domain.d8
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub l08: E<F, D<F>>,
     /// zero evaluated over domain.d8
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub zero4: E<F, D<F>>,
     /// zero evaluated over domain.d8
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub zero8: E<F, D<F>>,
     /// zero-knowledge polynomial over domain.d8
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub zkpl: E<F, D<F>>,
 
     /// wire coordinate shifts
+    #[serde_as(as = "[o1_utils::serialization::SerdeAs; PERMUTS]")]
     pub shift: [F; PERMUTS],
     /// coefficient for the group endomorphism
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub endo: F,
 
     /// random oracle argument parameters
+    #[serde(skip)]
     pub fr_sponge_params: ArithmeticSpongeParams<F>,
 }
 

--- a/circuits/plonk-15-wires/src/wires.rs
+++ b/circuits/plonk-15-wires/src/wires.rs
@@ -54,3 +54,34 @@ impl FromBytes for Wire {
         Ok(Wire { row, col })
     }
 }
+
+#[cfg(feature = "ocaml_types")]
+pub mod caml {
+    use super::*;
+    use ocaml_gen::OcamlGen;
+    use std::convert::TryInto;
+
+    #[derive(ocaml::IntoValue, ocaml::FromValue, OcamlGen)]
+    pub struct CamlWire {
+        pub row: ocaml::Int,
+        pub col: ocaml::Int,
+    }
+
+    impl From<Wire> for CamlWire {
+        fn from(w: Wire) -> Self {
+            Self {
+                row: w.row.try_into().expect("usize -> isize"),
+                col: w.col.try_into().expect("usize -> isize"),
+            }
+        }
+    }
+
+    impl From<CamlWire> for Wire {
+        fn from(w: CamlWire) -> Self {
+            Self {
+                row: w.row.try_into().expect("isize -> usize"),
+                col: w.col.try_into().expect("isize -> usize"),
+            }
+        }
+    }
+}

--- a/circuits/plonk-15-wires/src/wires.rs
+++ b/circuits/plonk-15-wires/src/wires.rs
@@ -6,6 +6,7 @@ This source file implements Plonk circuit gate wires primitive.
 
 use ark_ff::bytes::{FromBytes, ToBytes};
 use array_init::array_init;
+use serde::{Deserialize, Serialize};
 use std::io::{Read, Result as IoResult, Write};
 
 pub const GENERICS: usize = 3;
@@ -16,7 +17,8 @@ pub const WIRES: [usize; COLUMNS] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1
 /// Wire documents the other cell that is wired to this one.
 /// If the cell represents an internal wire, an input to the circuit,
 /// or a final output of the circuit, the cell references itself.
-#[derive(Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct Wire {
     // TODO(mimoo): shouldn't we use u32 since we serialize them as u32?
     pub row: usize,

--- a/dlog/commitment/Cargo.toml
+++ b/dlog/commitment/Cargo.toml
@@ -7,14 +7,17 @@ edition = "2018"
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 ark-poly = { version = "0.3.0", features = [ "parallel" ] }
+ark-serialize = "0.3.0"
 
-rand_core = { version = "0.6.0" }
+array-init = "1.0.0"
+blake2 = "0.9.1"
 colored = "1.9.2"
 rand = "0.8.0"
+rand_core = { version = "0.6.0" }
 rayon = { version = "1" }
-blake2 = "0.9.1"
 itertools = "0.8.2"
-array-init = "1.0.0"
+serde = "1.0.130"
+serde_with = "1.10.0"
 
 groupmap = { path = "../../groupmap" }
 mina-curves = { path = "../../curves" }

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -27,13 +27,14 @@ use o1_utils::ExtendedDensePolynomial as _;
 use oracle::{sponge::ScalarChallenge, FqSponge};
 use rand_core::{CryptoRng, RngCore};
 use rayon::prelude::*;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::iter::Iterator;
 
 type Fr<G> = <G as AffineCurve>::ScalarField;
 type Fq<G> = <G as AffineCurve>::BaseField;
 
 /// A polynomial commitment.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PolyComm<C> {
     pub unshifted: Vec<C>,
     pub shifted: Option<C>,

--- a/dlog/plonk-15-wires/Cargo.toml
+++ b/dlog/plonk-15-wires/Cargo.toml
@@ -10,12 +10,15 @@ path = "src/lib.rs"
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 ark-poly = { version = "0.3.0", features = [ "parallel" ] }
-rand_core = { version = "0.5" }
+ark-serialize = "0.3.0"
+array-init = "1.0.0"
 colored = "2.0.0"
 rand = "0.8.0"
-sprs = "0.9.2"
+rand_core = { version = "0.5" }
 rayon = "1.5.0"
-array-init = "1.0.0"
+serde = "1.0.130"
+serde_with = "1.10.0"
+sprs = "0.9.2"
 
 ocaml = { version = "0.22.1", optional = true }
 ocaml-gen = { path = "../../ocaml-gen", optional = true}
@@ -28,6 +31,7 @@ plonk_15_wires_circuits = { path = "../../circuits/plonk-15-wires" }
 [dev-dependencies]
 groupmap = { path = "../../groupmap" }
 mina-curves = { path = "../../curves" }
+bincode = "1.3.3"
 
 [features]
 default = []

--- a/ocaml-gen/derive/src/lib.rs
+++ b/ocaml-gen/derive/src/lib.rs
@@ -139,7 +139,7 @@ pub fn derive_ocaml_enum(item: TokenStream) -> TokenStream {
 
             // get name
             let type_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
-            let name = env.get_type(type_id);
+            let name = env.get_type(type_id, #name_str);
 
             // return the type description in OCaml
             if generics_ocaml.is_empty() {
@@ -386,7 +386,7 @@ pub fn derive_ocaml_gen(item: TokenStream) -> TokenStream {
 
             // get name
             let type_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
-            let name = env.get_type(type_id);
+            let name = env.get_type(type_id, #name_str);
 
             // return the type description in OCaml
             if generics_ocaml.is_empty() {
@@ -632,7 +632,7 @@ pub fn derive_ocaml_custom(item: TokenStream) -> TokenStream {
     let ocaml_desc = quote! {
         fn ocaml_desc(env: &::ocaml_gen::Env, _generics: &[&str]) -> String {
             let type_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
-            env.get_type(type_id)
+            env.get_type(type_id, #name_str)
         }
     };
 

--- a/ocaml-gen/src/lib.rs
+++ b/ocaml-gen/src/lib.rs
@@ -72,12 +72,11 @@ impl Env {
     }
 
     /// retrieves a type that was declared previously
-    pub fn get_type(&self, ty: u128) -> String {
-        let (type_path, type_name) = self
-            .locations
-            .get(&ty)
-            // not a great error, I know
-            .expect("ocaml-gen: the type hasn't been declared");
+    pub fn get_type(&self, ty: u128, name: &str) -> String {
+        let (type_path, type_name) = self.locations.get(&ty).expect(&format!(
+            "ocaml-gen: the type {} hasn't been declared",
+            name
+        ));
 
         let type_path = type_path.join(".");
         let current_module = self.current_module.join(".");

--- a/oracle/Cargo.toml
+++ b/oracle/Cargo.toml
@@ -10,8 +10,11 @@ path = "src/lib.rs"
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 ark-poly = { version = "0.3.0", features = [ "parallel" ] }
+o1-utils = { path = "../utils" }
 rand = "0.8.0"
 rayon = { version = "1" }
+serde = { version = "1.0", features = ["derive"] }
+serde_with = "1.10.0"
 
 mina-curves = { path = "../curves" }
 
@@ -22,7 +25,6 @@ syn = { version = "1.0.76", optional = true }
 
 # for export_test_vectors
 num-bigint = { version = "0.4.0" }
-serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 hex = { version = "0.4" }
 ark-serialize = "0.3.0"

--- a/oracle/src/poseidon.rs
+++ b/oracle/src/poseidon.rs
@@ -5,6 +5,8 @@ This file implements Poseidon Hash Function primitive
 *****************************************************************************************************************/
 
 use ark_ff::Field;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 pub trait SpongeConstants {
     const ROUNDS_FULL: usize;
@@ -94,9 +96,12 @@ pub enum SpongeState {
     Squeezed(usize),
 }
 
-#[derive(Clone)]
+#[serde_as]
+#[derive(Clone, Serialize, Deserialize, Default, Debug)]
 pub struct ArithmeticSpongeParams<F: Field> {
+    #[serde_as(as = "Vec<Vec<o1_utils::serialization::SerdeAs>>")]
     pub round_constants: Vec<Vec<F>>,
+    #[serde_as(as = "Vec<Vec<o1_utils::serialization::SerdeAs>>")]
     pub mds: Vec<Vec<F>>,
 }
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,7 +7,10 @@ edition = "2018"
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 ark-poly = { version = "0.3.0", features = [ "parallel" ] }
+ark-serialize = "0.3.0"
 rayon = "1.3.0"
+serde = "1.0.130"
+serde_with = "1.10.0"
 
 [dev-dependencies]
 mina-curves = { path = "../curves" }

--- a/utils/src/dense_polynomial.rs
+++ b/utils/src/dense_polynomial.rs
@@ -1,5 +1,12 @@
+//! This adds a few utility functions for the [DensePolynomial] arkworks type.
+
 use ark_ff::Field;
 use ark_poly::{univariate::DensePolynomial, Polynomial, UVPolynomial};
+use serde_with::{DeserializeAs, SerializeAs};
+
+//
+// ExtendedDensePolynomial trait
+//
 
 /// An extension for the [DensePolynomial] type.
 pub trait ExtendedDensePolynomial<F: Field> {
@@ -67,6 +74,10 @@ impl<F: Field> ExtendedDensePolynomial<F> for DensePolynomial<F> {
         DensePolynomial { coeffs }
     }
 }
+
+//
+// Tests
+//
 
 #[cfg(test)]
 mod tests {

--- a/utils/src/evaluations.rs
+++ b/utils/src/evaluations.rs
@@ -1,19 +1,24 @@
+//! This adds a few utility functions for the [Evaluations] arkworks type.
+
 use ark_ff::FftField;
-use ark_poly::{Evaluations, Radix2EvaluationDomain as D};
+use ark_poly::{Evaluations, Radix2EvaluationDomain};
 use rayon::prelude::*;
+use serde_with::{DeserializeAs, SerializeAs};
 
 /// An extension for the [Evaluations] type.
 pub trait ExtendedEvaluations<F: FftField> {
     /// This function "scales" (multiplies) a polynomial with a scalar
     /// It is implemented to have the desired functionality for DensePolynomial
     fn scale(&self, elm: F) -> Self;
+    /// square each evaluation
     fn square(&self) -> Self;
+    /// raise each evaluation to some power `pow`
     fn pow(&self, pow: usize) -> Self;
     /// utility function for shifting poly along domain coordinate
     fn shift(&self, len: usize) -> Self;
 }
 
-impl<F: FftField> ExtendedEvaluations<F> for Evaluations<F, D<F>> {
+impl<F: FftField> ExtendedEvaluations<F> for Evaluations<F, Radix2EvaluationDomain<F>> {
     fn scale(&self, elm: F) -> Self {
         let mut result = self.clone();
         result.evals.par_iter_mut().for_each(|coeff| *coeff *= &elm);

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod densepolynomial;
 pub mod evaluations;
+pub mod serialization;
 
 pub use densepolynomial::ExtendedDensePolynomial;
 pub use evaluations::ExtendedEvaluations;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,6 +1,6 @@
-pub mod densepolynomial;
+pub mod dense_polynomial;
 pub mod evaluations;
 pub mod serialization;
 
-pub use densepolynomial::ExtendedDensePolynomial;
+pub use dense_polynomial::ExtendedDensePolynomial;
 pub use evaluations::ExtendedEvaluations;

--- a/utils/src/serialization.rs
+++ b/utils/src/serialization.rs
@@ -1,0 +1,81 @@
+//! This adds a few utility functions for serializing and deserializing
+//! [arkworks](http://arkworks.rs/) types that implement [CanonicalSerialize] and [CanonicalDeserialize].
+
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use serde_with::Bytes;
+
+//
+// Serialization with serde
+//
+
+pub mod serialization {
+    //! You can use this module for serialization and deserializing arkworks types with [serde].
+    //! Simply use the following attribute on your field:
+    //! `#[serde(with = "o1_utils::serialization::serialization") attribute"]`
+
+    use super::*;
+    use serde_with::{DeserializeAs, SerializeAs};
+
+    /// You can use this to serialize an arkworks type with serde and the "serialize_with" attribute.
+    /// See https://serde.rs/field-attrs.html
+    pub fn serialize<S>(val: impl CanonicalSerialize, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut bytes = vec![];
+        val.serialize(&mut bytes)
+            .map_err(serde::ser::Error::custom)?;
+
+        Bytes::serialize_as(&bytes, serializer)
+    }
+
+    /// You can use this to deserialize an arkworks type with serde and the "deserialize_with" attribute.
+    /// See https://serde.rs/field-attrs.html
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where
+        T: CanonicalDeserialize,
+        D: serde::Deserializer<'de>,
+    {
+        let bytes: Vec<u8> = Bytes::deserialize_as(deserializer)?;
+        T::deserialize(&mut &bytes[..]).map_err(serde::de::Error::custom)
+    }
+}
+
+//
+// Serialization with [serde_with]
+//
+
+/// You can use [SerdeAs] with [serde_with] in order to serialize and deserialize types that implement [CanonicalSerialize] and [CanonicalDeserialize],
+/// or containers of types that implement these traits (Vec, arrays, etc.)
+/// Simply add annotations like `#[serde_as(as = "o1_utils::serialization::SerdeAs")]`
+/// See https://docs.rs/serde_with/1.10.0/serde_with/guide/serde_as/index.html#switching-from-serdes-with-to-serde_as
+pub struct SerdeAs;
+
+impl<T> serde_with::SerializeAs<T> for SerdeAs
+where
+    T: CanonicalSerialize,
+{
+    fn serialize_as<S>(val: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut bytes = vec![];
+        val.serialize(&mut bytes)
+            .map_err(serde::ser::Error::custom)?;
+
+        Bytes::serialize_as(&bytes, serializer)
+    }
+}
+
+impl<'de, T> serde_with::DeserializeAs<'de, T> for SerdeAs
+where
+    T: CanonicalDeserialize,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let bytes: Vec<u8> = Bytes::deserialize_as(deserializer)?;
+        T::deserialize(&mut &bytes[..]).map_err(serde::de::Error::custom)
+    }
+}


### PR DESCRIPTION
We currently use serialization of our types by hand: https://github.com/MinaProtocol/mina/blob/develop/src/lib/marlin_plonk_bindings/stubs/src/index_serialization.rs

This is error-prone, and hard to maintain. As types and structs change, we need to make sure to change the serialization logic. The Rust-way is to use [Serde](https://serde.rs/), which offers a set of macros that we can use to implement serialization and deserialization traits for all of our types.

One of the problem we have is that [arkworks](http://arkworks.rs/), for some [yet-unknown reason](https://github.com/arkworks-rs/algebra/issues/178), doesn't implement `Serde::{Serialize, Deserialize}` on its types, but instead its own set of [ark-serialize](https://docs.rs/ark-serialize/0.3.0/ark_serialize/) traits. This means that we need to tell serde how to use these arkworks-specific traits to serialize and deserialize.

No biggy, the [serde_with](https://docs.rs/serde_with/1.10.0/serde_with) crate comes to the rescue.