### PR TITLE
Combine coefficient polynomials

### DIFF
--- a/circuits/plonk-15-wires/src/gates/generic.rs
+++ b/circuits/plonk-15-wires/src/gates/generic.rs
@@ -9,6 +9,9 @@ use crate::wires::{GateWires, COLUMNS, GENERICS};
 use ark_ff::FftField;
 use array_init::array_init;
 
+pub const MUL_COEFF: usize = GENERICS;
+pub const CONSTANT_COEFF: usize = GENERICS + 1;
+
 impl<F: FftField> CircuitGate<F> {
     // TODO(mimoo): why qw is length 15 if the polynomial side only uses 3?
     pub fn create_generic(row: usize, wires: GateWires, qw: [F; COLUMNS], qm: F, qc: F) -> Self {
@@ -101,5 +104,13 @@ impl<F: FftField> CircuitGate<F> {
 
         // all good
         return Ok(());
+    }
+
+    pub fn generic(&self) -> F {
+        if self.typ == GateType::Generic {
+            F::one()
+        } else {
+            F::zero()
+        }
     }
 }

--- a/circuits/plonk-15-wires/src/nolookup/scalars.rs
+++ b/circuits/plonk-15-wires/src/nolookup/scalars.rs
@@ -20,6 +20,10 @@ pub struct ProofEvaluations<Field> {
     /// permutation polynomials
     /// (PERMUTS-1 evaluations because the last permutation is only used in commitment form)
     pub s: [Field; PERMUTS - 1],
+    /// evaluation of the generic selector polynomial
+    pub generic_selector: Field,
+    /// evaluation of the poseidon selector polynomial
+    pub poseidon_selector: Field,
 }
 
 impl<F: FftField> ProofEvaluations<Vec<F>> {
@@ -28,6 +32,8 @@ impl<F: FftField> ProofEvaluations<Vec<F>> {
             s: array_init(|i| DensePolynomial::eval_polynomial(&self.s[i], pt)),
             w: array_init(|i| DensePolynomial::eval_polynomial(&self.w[i], pt)),
             z: DensePolynomial::eval_polynomial(&self.z, pt),
+            generic_selector: DensePolynomial::eval_polynomial(&self.generic_selector, pt),
+            poseidon_selector: DensePolynomial::eval_polynomial(&self.poseidon_selector, pt),
         }
     }
 }

--- a/circuits/plonk-15-wires/src/polynomials/generic.rs
+++ b/circuits/plonk-15-wires/src/polynomials/generic.rs
@@ -12,6 +12,7 @@ use ark_poly::{
     univariate::DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as D,
 };
 use o1_utils::ExtendedDensePolynomial;
+use crate::gates::generic::{MUL_COEFF, CONSTANT_COEFF};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {
     /// generic constraint quotient poly contribution computation
@@ -21,47 +22,49 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
         public: &DensePolynomial<F>,
     ) -> (Evaluations<F, D<F>>, DensePolynomial<F>) {
         // w[0](x) * w[1](x) * qml(x)
-        let multiplication = &(&witness_d4[0] * &witness_d4[1]) * &self.qml;
+        let multiplication = &(&witness_d4[0] * &witness_d4[1]) * &self.coefficients4[MUL_COEFF];
 
         // presence of left, right, and output wire
         // w[0](x) * qwl[0](x) + w[1](x) * qwl[1](x) + w[2](x) * qwl[2](x)
-        let mut wires = self.zero4.clone();
-        for (w, q) in witness_d4.iter().zip(self.qwl.iter()) {
-            wires += &(w * q);
+        let mut eval_part = multiplication;
+        for (w, q) in witness_d4.iter().zip(self.coefficients4.iter()).take(GENERICS) {
+            eval_part += &(w * q);
         }
+        eval_part *= &self.generic4;
 
         // return in lagrange and monomial form for optimization purpose
-        let eval_part = &multiplication + &wires;
-        let poly_part = &self.qc + public;
+        let poly_part = &(&self.coefficientsm[CONSTANT_COEFF] * &self.genericm) + public;
         (eval_part, poly_part)
     }
 
-    /// produces w[0](zeta) * w[1](zeta), w[0](zeta), w[1](zeta), w[2](zeta), 1
-    pub fn gnrc_scalars(w_zeta: &[F; COLUMNS]) -> Vec<F> {
-        let mut res = vec![w_zeta[0] * &w_zeta[1]];
-        for i in 0..GENERICS {
-            res.push(w_zeta[i]);
-        }
+    /// produces
+    /// generic(zeta) * w[0](zeta) * w[1](zeta),
+    /// generic(zeta) * w[0](zeta),
+    /// generic(zeta) * w[1](zeta),
+    /// generic(zeta) * w[2](zeta)
+    pub fn gnrc_scalars(w_zeta: &[F; COLUMNS], generic_zeta: F) -> Vec<F> {
+        let mut res = vec![generic_zeta * w_zeta[0] * &w_zeta[1]];
+        res.extend((0..GENERICS).map(|i| generic_zeta * w_zeta[i]));
         return res;
     }
 
     /// generic constraint linearization poly contribution computation
-    pub fn gnrc_lnrz(&self, w_zeta: &[F; COLUMNS]) -> DensePolynomial<F> {
-        let scalars = Self::gnrc_scalars(w_zeta);
+    pub fn gnrc_lnrz(&self, w_zeta: &[F; COLUMNS], generic_zeta: F) -> DensePolynomial<F> {
+        let scalars = Self::gnrc_scalars(w_zeta, generic_zeta);
 
         // w[0](zeta) * qwm[0] + w[1](zeta) * qwm[1] + w[2](zeta) * qwm[2]
         let mut res = self
-            .qwm
+            .coefficientsm
             .iter()
             .zip(scalars[1..].iter())
             .map(|(q, s)| q.scale(*s))
             .fold(DensePolynomial::<F>::zero(), |x, y| &x + &y);
 
         // multiplication
-        res += &self.qmm.scale(scalars[0]);
+        res += &self.coefficientsm[MUL_COEFF].scale(scalars[0]);
 
         // constant selector
-        res += &self.qc;
+        res += &self.coefficientsm[CONSTANT_COEFF].scale(generic_zeta);
 
         // l * qwm[0] + r * qwm[1] + o * qwm[2] + l * r * qmm + qc
         res
@@ -74,32 +77,29 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
         public: &DensePolynomial<F>,
     ) -> bool {
         // multiplication
-        let multiplication = &(&witness[0] * &witness[1]) * &self.qmm;
+        let multiplication = &(&witness[0] * &witness[1]) * &self.coefficientsm[MUL_COEFF];
 
         // addition (of left, right, output wires)
-        if self.qwm.len() != GENERICS {
-            return false;
-        }
         let mut wires = DensePolynomial::zero();
-        for (w, q) in witness.iter().zip(self.qwm.iter()) {
+        for (w, q) in witness.iter().zip(self.coefficientsm.iter()).take(GENERICS) {
             wires += &(w * q);
         }
 
         // compute f
         let mut f = &multiplication + &wires;
-        f += &self.qc;
+        f += &self.coefficientsm[CONSTANT_COEFF];
         f += public;
 
         // verify that each row evaluates to zero
         let values: Vec<_> = witness
             .iter()
-            .zip(self.qwl.iter())
+            .zip(self.coefficients4.iter())
             .map(|(w, q)| (w, q.interpolate_by_ref()))
             .collect();
 
         //
         for (row, elem) in self.domain.d1.elements().enumerate() {
-            let qc = self.qc.evaluate(&elem);
+            let qc = self.coefficientsm[CONSTANT_COEFF].evaluate(&elem);
 
             // qc check
             if qc != F::zero() {
@@ -121,7 +121,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
                 }
                 println!(
                     "  q_M = {} | mul = {}",
-                    self.qmm.evaluate(&elem),
+                    self.coefficientsm[MUL_COEFF].evaluate(&elem),
                     multiplication.evaluate(&elem)
                 );
                 println!("  q_C = {}", qc);
@@ -227,7 +227,9 @@ mod tests {
 
         // compute linearization f(z)
         let w_zeta: [Fp; COLUMNS] = array_init(|col| witness[col].evaluate(&zeta));
-        let f = cs.gnrc_lnrz(&w_zeta);
+        let generic_zeta = cs.genericm.evaluate(&zeta);
+
+        let f = cs.gnrc_lnrz(&w_zeta, generic_zeta);
         let f_zeta = f.evaluate(&zeta);
 
         // check that f(z) = t(z) * Z_H(z)

--- a/dlog/plonk-15-wires/src/index.rs
+++ b/dlog/plonk-15-wires/src/index.rs
@@ -13,9 +13,8 @@ use commitment_dlog::{
     srs::SRS,
     CommitmentField,
 };
-use oracle::poseidon::{ArithmeticSpongeParams, PlonkSpongeConstants15W, SpongeConstants};
+use oracle::poseidon::{ArithmeticSpongeParams};
 use plonk_15_wires_circuits::{
-    gates::poseidon::ROUNDS_PER_ROW,
     nolookup::constraints::{zk_w3, ConstraintSystem},
     wires::*,
 };
@@ -93,16 +92,12 @@ pub struct VerifierIndex<'a, G: CommitmentCurve> {
     // index polynomial commitments
     /// permutation commitment array
     pub sigma_comm: [PolyComm<G>; PERMUTS],
-    /// wire commitment array
-    pub qw_comm: [PolyComm<G>; GENERICS],
-    /// multiplication commitment
-    pub qm_comm: PolyComm<G>,
-    /// constant wire commitment
-    pub qc_comm: PolyComm<G>,
+    /// coefficient commitment array
+    pub coefficients_comm: [PolyComm<G>; COLUMNS],
+    /// coefficient commitment array
+    pub generic_comm: PolyComm<G>,
 
     // poseidon polynomial commitments
-    /// round constant polynomial commitment array
-    pub rcm_comm: [[PolyComm<G>; PlonkSpongeConstants15W::SPONGE_WIDTH]; ROUNDS_PER_ROW],
     /// poseidon constraint selector polynomial commitment
     pub psm_comm: PolyComm<G>,
 
@@ -146,13 +141,9 @@ where
             domain: self.cs.domain.d1,
 
             sigma_comm: array_init(|i| srs.get_ref().commit_non_hiding(&self.cs.sigmam[i], None)),
-            qw_comm: array_init(|i| srs.get_ref().commit_non_hiding(&self.cs.qwm[i], None)),
-            qm_comm: srs.get_ref().commit_non_hiding(&self.cs.qmm, None),
-            qc_comm: srs.get_ref().commit_non_hiding(&self.cs.qc, None),
+            generic_comm: srs.get_ref().commit_non_hiding(&self.cs.genericm, None),
+            coefficients_comm: array_init(|i| srs.get_ref().commit_non_hiding(&self.cs.coefficientsm[i], None)),
 
-            rcm_comm: array_init(|i| {
-                array_init(|j| srs.get_ref().commit_non_hiding(&self.cs.rcm[i][j], None))
-            }),
             psm_comm: srs.get_ref().commit_non_hiding(&self.cs.psm, None),
 
             add_comm: srs.get_ref().commit_non_hiding(&self.cs.addm, None),

--- a/dlog/plonk-15-wires/src/prover.rs
+++ b/dlog/plonk-15-wires/src/prover.rs
@@ -182,6 +182,8 @@ where
             s: array_init(|i| index.cs.sigmam[0..PERMUTS - 1][i].eval(zeta, index.max_poly_size)),
             w: array_init(|i| w[i].eval(zeta, index.max_poly_size)),
             z: z.eval(zeta, index.max_poly_size),
+            generic_selector: index.cs.genericm.eval(zeta, index.max_poly_size),
+            poseidon_selector: index.cs.psm.eval(zeta, index.max_poly_size),
         };
         let chunked_evals_zeta_omega = ProofEvaluations::<Vec<Fr<G>>> {
             s: array_init(|i| {
@@ -189,6 +191,8 @@ where
             }),
             w: array_init(|i| w[i].eval(zeta_omega, index.max_poly_size)),
             z: z.eval(zeta_omega, index.max_poly_size),
+            generic_selector: index.cs.genericm.eval(zeta_omega, index.max_poly_size),
+            poseidon_selector: index.cs.psm.eval(zeta_omega, index.max_poly_size),
         };
 
         let chunked_evals = [chunked_evals_zeta.clone(), chunked_evals_zeta_omega.clone()];
@@ -205,12 +209,14 @@ where
                 s: array_init(|i| DensePolynomial::eval_polynomial(&es.s[i], e1)),
                 w: array_init(|i| DensePolynomial::eval_polynomial(&es.w[i], e1)),
                 z: DensePolynomial::eval_polynomial(&es.z, e1),
+                generic_selector: DensePolynomial::eval_polynomial(&es.generic_selector, e1),
+                poseidon_selector: DensePolynomial::eval_polynomial(&es.poseidon_selector, e1),
             })
             .collect::<Vec<_>>();
 
         // compute and evaluate linearization polynomial
         let f_chunked = {
-            let f = &(&(&(&(&(&index.cs.gnrc_lnrz(&evals[0].w)
+            let f = &(&(&(&(&(&index.cs.gnrc_lnrz(&evals[0].w, evals[0].generic_selector)
                 + &index.cs.psdn_lnrz(
                     &evals,
                     &index.cs.fr_sponge_params,

--- a/dlog/plonk-15-wires/src/verifier.rs
+++ b/dlog/plonk-15-wires/src/verifier.rs
@@ -17,6 +17,7 @@ use oracle::{rndoracle::ProofError, sponge::ScalarChallenge, FqSponge};
 use plonk_15_wires_circuits::{
     nolookup::{constraints::ConstraintSystem, scalars::RandomOracles},
     wires::*,
+    gates::generic::{MUL_COEFF, CONSTANT_COEFF},
 };
 use rand::thread_rng;
 
@@ -385,12 +386,12 @@ where
                 )];
 
                 // generic
-                commitments_part.push(&index.qm_comm);
-                commitments_part.extend(index.qw_comm.iter().map(|c| c).collect::<Vec<_>>());
-                scalars_part.extend(&ConstraintSystem::gnrc_scalars(&evals[0].w));
+                commitments_part.push(&index.coefficients_comm[MUL_COEFF]);
+                commitments_part.extend(index.coefficients_comm.iter().take(GENERICS).map(|c| c).collect::<Vec<_>>());
+                scalars_part.extend(&ConstraintSystem::gnrc_scalars(&evals[0].w, evals[0].generic_selector));
 
-                commitments_part.push(&index.qc_comm);
-                scalars_part.push(Fr::<G>::one());
+                commitments_part.push(&index.coefficients_comm[CONSTANT_COEFF]);
+                scalars_part.push(evals[0].generic_selector);
 
                 // poseidon
                 scalars_part.extend(&ConstraintSystem::psdn_scalars(
@@ -401,9 +402,8 @@ where
                 commitments_part.push(&index.psm_comm);
                 commitments_part.extend(
                     index
-                        .rcm_comm
+                        .coefficients_comm
                         .iter()
-                        .flatten()
                         .map(|c| c)
                         .collect::<Vec<_>>(),
                 );


### PR DESCRIPTION
Right now, for poseidon and generic gates, we have in the index

- 15 polynomials for poseidon round constants
- 1 selector polynomial for poseidon 
- 5 polynomials for generic gate coefficients (3 for linear terms, 1 for multiplication term, 1 for constant term)

This PR changes this set-up to have
- 15 polynomials for "coefficients", values that can be used by any gates. In poseidon rows these are the round constants, in generic rows, these are the coefficients as described above for the first 5, 0 for the rest).
- 1 selector polynomial for poseidon
- 1 selector polynomial for generic gates

So overall, this eliminates 4 polynomials, and correspondingly removes 4 commitments from verification keys. On the other hand, the change necessitates the addition of evaluations for the poseidon and generic selector polynomials, adding (1 + 1)*(2 evaluation points) = 4 evaluations to the proofs. I think this could probably reduced to making it so we only need to evaluate one additional polynomial with some more work if we want.