### PR TITLE
[kimchi][proof] add zero-knowledge rows in witness

### DIFF
--- a/circuits/plonk-15-wires/src/gate.rs
+++ b/circuits/plonk-15-wires/src/gate.rs
@@ -493,7 +493,7 @@ pub mod caml {
         T1: Clone,
         T2: From<T1>,
     {
-        std::array::IntoIter::new(a)
+        a.into_iter()
             .map(Into::into)
             .next_tuple()
             .expect("bug in array_to_tuple")

--- a/circuits/plonk-15-wires/src/nolookup/constraints.rs
+++ b/circuits/plonk-15-wires/src/nolookup/constraints.rs
@@ -21,6 +21,16 @@ use oracle::poseidon::ArithmeticSpongeParams;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
 
+//
+// Constants
+//
+
+pub const ZK_ROWS: u64 = 3;
+
+//
+// ConstraintSystem
+//
+
 #[serde_as]
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct ConstraintSystem<F: FftField> {
@@ -255,7 +265,7 @@ where
 
 /// Returns the end of the circuit, which is used for introducing zero-knowledge in the permutation polynomial
 pub fn zk_w3<F: FftField>(domain: D<F>) -> F {
-    domain.group_gen.pow(&[domain.size - 3])
+    domain.group_gen.pow(&[domain.size - (ZK_ROWS)])
 }
 
 /// Evaluates the polynomial
@@ -270,7 +280,7 @@ pub fn eval_zk_polynomial<F: FftField>(domain: D<F>, x: F) -> F {
 /// Evaluates the polynomial
 /// (x - w^{n - 4}) (x - w^{n - 3}) * (x - w^{n - 2}) * (x - w^{n - 1})
 pub fn eval_vanishes_on_last_4_rows<F: FftField>(domain: D<F>, x: F) -> F {
-    let w4 = domain.group_gen.pow(&[domain.size - 4]);
+    let w4 = domain.group_gen.pow(&[domain.size - (ZK_ROWS + 1)]);
     let w3 = domain.group_gen * w4;
     let w2 = domain.group_gen * w3;
     let w1 = domain.group_gen * w2;
@@ -282,7 +292,7 @@ pub fn eval_vanishes_on_last_4_rows<F: FftField>(domain: D<F>, x: F) -> F {
 pub fn vanishes_on_last_4_rows<F: FftField>(domain: D<F>) -> DP<F> {
     let x = DP::from_coefficients_slice(&[F::zero(), F::one()]);
     let c = |a: F| DP::from_coefficients_slice(&[a]);
-    let w4 = domain.group_gen.pow(&[domain.size - 4]);
+    let w4 = domain.group_gen.pow(&[domain.size - (ZK_ROWS + 1)]);
     let w3 = domain.group_gen * w4;
     let w2 = domain.group_gen * w3;
     let w1 = domain.group_gen * w2;
@@ -332,9 +342,8 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
 
         // +3 on gates.len() here to ensure that we have room for the zero-knowledge entries of the permutation polynomial
         // see https://minaprotocol.com/blog/a-more-efficient-approach-to-zero-knowledge-for-plonk
-        // TODO: hardcode this value somewhere
-        let domain = EvaluationDomains::<F>::create(gates.len() + 3)?;
-        assert!(domain.d1.size > 3);
+        let domain = EvaluationDomains::<F>::create(gates.len() + ZK_ROWS as usize)?;
+        assert!(domain.d1.size > ZK_ROWS);
 
         // pre-compute all the elements
         let mut sid = domain.d1.elements().map(|elm| elm).collect::<Vec<_>>();

--- a/circuits/plonk-15-wires/src/polynomials/chacha.rs
+++ b/circuits/plonk-15-wires/src/polynomials/chacha.rs
@@ -435,16 +435,13 @@ mod tests {
     use super::*;
     use crate::polynomials::chacha::constraint;
     use crate::{
-        expr::{Column, Constants, Expr, Linearization, PolishToken},
-        gate::{LookupInfo, LookupsUsed},
-        gates::poseidon::ROUNDS_PER_ROW,
-        nolookup::constraints::{zk_w3, ConstraintSystem},
+        expr::{Column, Constants, PolishToken},
+        gate::LookupInfo,
         nolookup::scalars::{LookupEvaluations, ProofEvaluations},
-        polynomials::{chacha, lookup},
         wires::*,
     };
     use ark_ff::UniformRand;
-    use ark_poly::{univariate::DensePolynomial, EvaluationDomain, Radix2EvaluationDomain as D};
+    use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as D};
     use array_init::array_init;
     use mina_curves::pasta::fp::Fp as F;
     use rand::{rngs::StdRng, SeedableRng};
@@ -491,10 +488,10 @@ mod tests {
 
         let expr = constraint::<F>(10);
         let linearized = expr.linearize(evaluated_cols).unwrap();
-        let expr_polish = expr.to_polish();
+        let _expr_polish = expr.to_polish();
         let linearized_polish = linearized.map(|e| e.to_polish());
 
-        let mut rng = &mut StdRng::from_seed([0u8; 32]);
+        let rng = &mut StdRng::from_seed([0u8; 32]);
 
         let d = D::new(1024).unwrap();
 

--- a/circuits/plonk-15-wires/src/polynomials/endomul_scalar.rs
+++ b/circuits/plonk-15-wires/src/polynomials/endomul_scalar.rs
@@ -183,18 +183,18 @@ pub fn witness<F: PrimeField + std::fmt::Display>(
     let one = F::one();
     let neg_one = -one;
 
-    for (i, row_bits) in bits_msb[..].chunks(bits_per_row).enumerate() {
-        let row = row0 + i;
-        w[0][row] = n;
-        w[2][row] = a;
-        w[3][row] = b;
+    let mut row = row0;
+    for row_bits in bits_msb[..].chunks(bits_per_row) {
+        w[0].push(n);
+        w[2].push(a);
+        w[3].push(b);
 
         for (j, crumb_bits) in row_bits.chunks(2).enumerate() {
             let b0 = *crumb_bits[1];
             let b1 = *crumb_bits[0];
 
             let crumb = F::from(b0 as u64) + F::from(b1 as u64).double();
-            w[6 + j][row] = crumb;
+            w[6 + j].push(crumb);
 
             a.double_in_place();
             b.double_in_place();
@@ -213,9 +213,13 @@ pub fn witness<F: PrimeField + std::fmt::Display>(
             n += crumb;
         }
 
-        w[1][row] = n;
-        w[4][row] = a;
-        w[5][row] = b;
+        w[1].push(n);
+        w[4].push(a);
+        w[5].push(b);
+
+        w[14].push(F::zero()); // unused
+
+        row += 1;
     }
 
     assert_eq!(x, n);

--- a/circuits/plonk-15-wires/src/polynomials/permutation.rs
+++ b/circuits/plonk-15-wires/src/polynomials/permutation.rs
@@ -16,7 +16,7 @@ use ark_poly::{
 use ark_poly::{Polynomial, UVPolynomial};
 use o1_utils::{ExtendedDensePolynomial, ExtendedEvaluations};
 use oracle::rndoracle::ProofError;
-use rand::rngs::ThreadRng;
+use rand::{CryptoRng, RngCore};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {
     /// permutation quotient poly contribution computation
@@ -122,7 +122,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
         witness: &[Vec<F>; COLUMNS],
         beta: &F,
         gamma: &F,
-        rng: &mut ThreadRng,
+        rng: &mut (impl RngCore + CryptoRng),
     ) -> Result<DensePolynomial<F>, ProofError> {
         let n = self.domain.d1.size as usize;
 

--- a/dlog/plonk-15-wires/tests/ec.rs
+++ b/dlog/plonk-15-wires/tests/ec.rs
@@ -1,34 +1,28 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_ff::{BigInteger, BitIteratorLE, Field, One, PrimeField, UniformRand, Zero};
-use ark_poly::{univariate::DensePolynomial, EvaluationDomain, Radix2EvaluationDomain as D};
+use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
 use array_init::array_init;
 use colored::Colorize;
 use commitment_dlog::{
-    commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve},
+    commitment::CommitmentCurve,
     srs::{endos, SRS},
 };
 use groupmap::GroupMap;
 use mina_curves::pasta::{
     fp::Fp as F,
-    pallas::{Affine as Other, Projective as OtherProjective},
+    pallas::Affine as Other,
     vesta::{Affine, VestaParameters},
 };
 use oracle::{
-    poseidon::{ArithmeticSponge, PlonkSpongeConstants15W, Sponge, SpongeConstants},
-    sponge::{DefaultFqSponge, DefaultFrSponge, ScalarChallenge},
+    poseidon::PlonkSpongeConstants15W,
+    sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use plonk_15_wires_circuits::{
-    expr::{Column, Constants, Expr, Linearization, PolishToken},
-    gate::{CircuitGate, GateType, LookupInfo, LookupsUsed},
-    gates::poseidon::ROUNDS_PER_ROW,
-    nolookup::constraints::{zk_w3, ConstraintSystem},
-    nolookup::scalars::{LookupEvaluations, ProofEvaluations},
-    polynomials::endosclmul,
+    gate::{CircuitGate, GateType},
+    nolookup::constraints::ConstraintSystem,
     wires::*,
 };
 use plonk_15_wires_protocol_dlog::{index::Index, prover::ProverProof};
 use rand::{rngs::StdRng, SeedableRng};
-use std::fmt::{Display, Formatter};
 use std::{sync::Arc, time::Instant};
 
 const PUBLIC: usize = 0;
@@ -64,21 +58,18 @@ fn ec_test() {
     srs.add_lagrange_basis(cs.domain.d1);
 
     let fq_sponge_params = oracle::pasta::fq::params();
-    let (endo_q, endo_r) = endos::<Other>();
+    let (endo_q, _endo_r) = endos::<Other>();
     let srs = Arc::new(srs);
 
     let index = Index::<Affine>::create(cs, fq_sponge_params, endo_q, srs);
 
-    let mut witness: [Vec<F>; COLUMNS] = array_init(|_| vec![F::zero(); n]);
+    let mut witness: [Vec<F>; COLUMNS] = array_init(|_| vec![]);
 
     let verifier_index = index.verifier_index();
     let group_map = <Affine as CommitmentCurve>::Map::setup();
 
     let lgr_comms = vec![];
     let rng = &mut StdRng::from_seed([0; 32]);
-
-    let start = Instant::now();
-    let mut g = Other::prime_subgroup_generator();
 
     let ps = {
         let p = Other::prime_subgroup_generator()
@@ -87,7 +78,7 @@ fn ec_test() {
             .into_affine();
         let mut res = vec![];
         let mut acc = p;
-        for i in 0..num_additions {
+        for _ in 0..num_additions {
             res.push(acc);
             acc = acc + p;
         }
@@ -101,7 +92,7 @@ fn ec_test() {
             .into_affine();
         let mut res = vec![];
         let mut acc = q;
-        for i in 0..num_additions {
+        for _ in 0..num_additions {
             res.push(acc);
             acc = acc + q;
         }
@@ -111,77 +102,89 @@ fn ec_test() {
     for i in 0..num_doubles {
         let p = ps[i];
 
-        let row = i;
         let p2 = p + p;
         let (x1, y1) = (p.x, p.y);
         let x1_squared = x1.square();
         // 2 * s * y1 = 3 * x1^2
         let s = (x1_squared.double() + x1_squared) / y1.double();
-        witness[0][row] = p.x;
-        witness[1][row] = p.y;
-        witness[2][row] = p.x;
-        witness[3][row] = p.y;
-        witness[4][row] = p2.x;
-        witness[5][row] = p2.y;
-        witness[6][row] = F::zero();
-        witness[7][row] = F::one();
-        witness[8][row] = s;
-        witness[9][row] = F::zero();
-        witness[10][row] = F::zero();
+
+        witness[0].push(p.x);
+        witness[1].push(p.y);
+        witness[2].push(p.x);
+        witness[3].push(p.y);
+        witness[4].push(p2.x);
+        witness[5].push(p2.y);
+        witness[6].push(F::zero());
+        witness[7].push(F::one());
+        witness[8].push(s);
+        witness[9].push(F::zero());
+        witness[10].push(F::zero());
+
+        witness[11].push(F::zero());
+        witness[12].push(F::zero());
+        witness[13].push(F::zero());
+        witness[14].push(F::zero());
     }
 
     for i in 0..num_additions {
         let p = ps[i];
         let q = qs[i];
 
-        let row = num_doubles + i;
-
         let pq = p + q;
         let (x1, y1) = (p.x, p.y);
         let (x2, y2) = (q.x, q.y);
         // (x2 - x1) * s = y2 - y1
         let s = (y2 - y1) / (x2 - x1);
-        witness[0][row] = x1;
-        witness[1][row] = y1;
-        witness[2][row] = x2;
-        witness[3][row] = y2;
-        witness[4][row] = pq.x;
-        witness[5][row] = pq.y;
-        witness[6][row] = F::zero();
-        witness[7][row] = F::zero();
-        witness[8][row] = s;
-        witness[9][row] = F::zero();
-        witness[10][row] = (x2 - x1).inverse().unwrap();
+        witness[0].push(x1);
+        witness[1].push(y1);
+        witness[2].push(x2);
+        witness[3].push(y2);
+        witness[4].push(pq.x);
+        witness[5].push(pq.y);
+        witness[6].push(F::zero());
+        witness[7].push(F::zero());
+        witness[8].push(s);
+        witness[9].push(F::zero());
+        witness[10].push((x2 - x1).inverse().unwrap());
+
+        witness[11].push(F::zero());
+        witness[12].push(F::zero());
+        witness[13].push(F::zero());
+        witness[14].push(F::zero());
     }
 
     for i in 0..num_infs {
         let p = ps[i];
         let q = -p;
 
-        let row = num_doubles + num_additions + i;
         let p2 = p + p;
         let (x1, y1) = (p.x, p.y);
         let x1_squared = x1.square();
         // 2 * s * y1 = -3 * x1^2
         let s = (x1_squared.double() + x1_squared) / y1.double();
-        witness[0][row] = p.x;
-        witness[1][row] = p.y;
-        witness[2][row] = q.x;
-        witness[3][row] = q.y;
-        witness[4][row] = p2.x;
-        witness[5][row] = p2.y;
-        witness[6][row] = F::one();
-        witness[7][row] = F::one();
-        witness[8][row] = s;
-        witness[9][row] = (q.y - p.y).inverse().unwrap();
-        witness[10][row] = F::zero();
+        witness[0].push(p.x);
+        witness[1].push(p.y);
+        witness[2].push(q.x);
+        witness[3].push(q.y);
+        witness[4].push(p2.x);
+        witness[5].push(p2.y);
+        witness[6].push(F::one());
+        witness[7].push(F::one());
+        witness[8].push(s);
+        witness[9].push((q.y - p.y).inverse().unwrap());
+        witness[10].push(F::zero());
+
+        witness[11].push(F::zero());
+        witness[12].push(F::zero());
+        witness[13].push(F::zero());
+        witness[14].push(F::zero());
     }
 
     index.cs.verify(&witness).unwrap();
 
     let start = Instant::now();
     let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, &witness, &index, vec![])
+        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index, vec![])
             .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 

--- a/dlog/plonk-15-wires/tests/endomul_scalar.rs
+++ b/dlog/plonk-15-wires/tests/endomul_scalar.rs
@@ -1,34 +1,28 @@
-use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_ff::{BigInteger, BitIteratorLE, Field, One, PrimeField, UniformRand, Zero};
-use ark_poly::{univariate::DensePolynomial, EvaluationDomain, Radix2EvaluationDomain as D};
+use ark_ff::{BigInteger, BitIteratorLE, PrimeField, UniformRand, Zero};
 use array_init::array_init;
 use colored::Colorize;
 use commitment_dlog::{
-    commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve},
+    commitment::CommitmentCurve,
     srs::{endos, SRS},
 };
 use groupmap::GroupMap;
 use mina_curves::pasta::{
     fp::Fp as F,
-    pallas::{Affine as Other, Projective as OtherProjective},
+    pallas::Affine as Other,
     vesta::{Affine, VestaParameters},
 };
 use oracle::{
-    poseidon::{ArithmeticSponge, PlonkSpongeConstants15W, Sponge, SpongeConstants},
+    poseidon::PlonkSpongeConstants15W,
     sponge::{DefaultFqSponge, DefaultFrSponge, ScalarChallenge},
 };
 use plonk_15_wires_circuits::{
-    expr::{Column, Constants, Expr, Linearization, PolishToken},
-    gate::{CircuitGate, GateType, LookupInfo, LookupsUsed},
-    gates::poseidon::ROUNDS_PER_ROW,
-    nolookup::constraints::{zk_w3, ConstraintSystem},
-    nolookup::scalars::{LookupEvaluations, ProofEvaluations},
+    gate::{CircuitGate, GateType},
+    nolookup::constraints::ConstraintSystem,
     polynomials::endomul_scalar,
     wires::*,
 };
 use plonk_15_wires_protocol_dlog::{index::Index, prover::ProverProof};
 use rand::{rngs::StdRng, SeedableRng};
-use std::fmt::{Display, Formatter};
 use std::{sync::Arc, time::Instant};
 
 const PUBLIC: usize = 0;
@@ -70,14 +64,14 @@ fn endomul_scalar_test() {
     srs.add_lagrange_basis(cs.domain.d1);
 
     let fq_sponge_params = oracle::pasta::fq::params();
-    let (endo_q, endo_r) = endos::<Other>();
+    let (endo_q, _endo_r) = endos::<Other>();
     let (_, endo_scalar_coeff) = endos::<Affine>();
 
     let srs = Arc::new(srs);
 
     let index = Index::<Affine>::create(cs, fq_sponge_params, endo_q, srs);
 
-    let mut witness: [Vec<F>; COLUMNS] = array_init(|_| vec![F::zero(); n]);
+    let mut witness: [Vec<F>; COLUMNS] = array_init(|_| vec![]);
 
     let verifier_index = index.verifier_index();
     let group_map = <Affine as CommitmentCurve>::Map::setup();
@@ -85,7 +79,7 @@ fn endomul_scalar_test() {
     let lgr_comms = vec![];
     let rng = &mut StdRng::from_seed([0; 32]);
 
-    let start = Instant::now();
+    //let start = Instant::now();
     for i in 0..num_scalars {
         let x = {
             let bits_lsb: Vec<_> = BitIteratorLE::new(F::rand(rng).into_repr())
@@ -108,7 +102,7 @@ fn endomul_scalar_test() {
 
     let start = Instant::now();
     let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, &witness, &index, vec![])
+        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index, vec![])
             .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 

--- a/dlog/tests/endomul.rs
+++ b/dlog/tests/endomul.rs
@@ -1,34 +1,29 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{BigInteger, BitIteratorLE, Field, One, PrimeField, UniformRand, Zero};
-use ark_poly::{univariate::DensePolynomial, EvaluationDomain, Radix2EvaluationDomain as D};
 use array_init::array_init;
 use colored::Colorize;
 use commitment_dlog::{
-    commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve},
+    commitment::CommitmentCurve,
     srs::{endos, SRS},
 };
 use groupmap::GroupMap;
 use mina_curves::pasta::{
     fp::Fp as F,
-    pallas::{Affine as Other, Projective as OtherProjective},
+    pallas::Affine as Other,
     vesta::{Affine, VestaParameters},
 };
 use oracle::{
-    poseidon::{ArithmeticSponge, PlonkSpongeConstants15W, Sponge, SpongeConstants},
+    poseidon::PlonkSpongeConstants15W,
     sponge::{DefaultFqSponge, DefaultFrSponge, ScalarChallenge},
 };
 use plonk_15_wires_circuits::{
-    expr::{Column, Constants, Expr, Linearization, PolishToken},
-    gate::{CircuitGate, GateType, LookupInfo, LookupsUsed},
-    gates::poseidon::ROUNDS_PER_ROW,
-    nolookup::constraints::{zk_w3, ConstraintSystem},
-    nolookup::scalars::{LookupEvaluations, ProofEvaluations},
+    gate::{CircuitGate, GateType},
+    nolookup::constraints::ConstraintSystem,
     polynomials::endosclmul,
     wires::*,
 };
 use plonk_15_wires_protocol_dlog::{index::Index, prover::ProverProof};
 use rand::{rngs::StdRng, SeedableRng};
-use std::fmt::{Display, Formatter};
 use std::{sync::Arc, time::Instant};
 
 const PUBLIC: usize = 0;
@@ -74,7 +69,6 @@ fn endomul_test() {
     }
 
     let cs = ConstraintSystem::<F>::create(gates, vec![], fp_sponge_params, PUBLIC).unwrap();
-    let n = cs.domain.d1.size as usize;
 
     let mut srs = SRS::create(cs.domain.d1.size as usize);
     srs.add_lagrange_basis(cs.domain.d1);
@@ -85,7 +79,8 @@ fn endomul_test() {
 
     let index = Index::<Affine>::create(cs, fq_sponge_params, endo_q, srs);
 
-    let mut witness: [Vec<F>; COLUMNS] = array_init(|_| vec![F::zero(); n]);
+    let mut witness: [Vec<F>; COLUMNS] =
+        array_init(|_| vec![F::zero(); rows_per_scalar * num_scalars]);
 
     let verifier_index = index.verifier_index();
     let group_map = <Affine as CommitmentCurve>::Map::setup();
@@ -93,7 +88,7 @@ fn endomul_test() {
     let lgr_comms = vec![];
     let rng = &mut StdRng::from_seed([0; 32]);
 
-    let start = Instant::now();
+    // let start = Instant::now();
     for i in 0..num_scalars {
         let bits_lsb: Vec<_> = BitIteratorLE::new(F::rand(rng).into_repr())
             .take(num_bits)
@@ -151,7 +146,7 @@ fn endomul_test() {
 
     let start = Instant::now();
     let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, &witness, &index, vec![])
+        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index, vec![])
             .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 

--- a/oracle/src/rndoracle.rs
+++ b/oracle/src/rndoracle.rs
@@ -10,6 +10,7 @@ use std::fmt;
 // TODO(mimoo): move this out of oracle
 #[derive(Debug, Clone, Copy)]
 pub enum ProofError {
+    NoRoomForZkInWitness,
     WitnessCsInconsistent,
     // TODO(mimoo): once this is moved, error can be propagated here
     WitnessGateError,

--- a/oracle/tests/poseidon_tests.rs
+++ b/oracle/tests/poseidon_tests.rs
@@ -1,4 +1,4 @@
-use ark_ff::{BigInteger256, PrimeField, UniformRand};
+use ark_ff::{BigInteger256, PrimeField};
 use ark_serialize::CanonicalDeserialize as _;
 use mina_curves::pasta::Fp;
 use oracle::poseidon::Sponge as _;


### PR DESCRIPTION
We currently add zero-knowledge rows to the witness on the OCaml side. This is not great as this library might be used by all sorts of people who might not think about adding the zero-knowledge stuff.