### PR TITLE
[CI] fix cargo fmt in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,4 +32,4 @@ jobs:
 
       - name: Run cargo fmt
         run: |
-          cargo fmt
+          cargo fmt -- --check

--- a/circuits/plonk-15-wires/src/nolookup/constraints.rs
+++ b/circuits/plonk-15-wires/src/nolookup/constraints.rs
@@ -417,7 +417,10 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
         )
         .interpolate();
         let endomul_scalarm = E::<F, D<F>>::from_vec_and_domain(
-            gates.iter().map(|gate| F::from((gate.typ == GateType::EndomulScalar) as u64)).collect(),
+            gates
+                .iter()
+                .map(|gate| F::from((gate.typ == GateType::EndomulScalar) as u64))
+                .collect(),
             domain.d1,
         )
         .interpolate();

--- a/circuits/plonk-15-wires/src/polynomials/endomul_scalar.rs
+++ b/circuits/plonk-15-wires/src/polynomials/endomul_scalar.rs
@@ -190,7 +190,6 @@ pub fn witness<F: PrimeField + std::fmt::Display>(
         w[3][row] = b;
 
         for (j, crumb_bits) in row_bits.chunks(2).enumerate() {
-
             let b0 = *crumb_bits[1];
             let b1 = *crumb_bits[0];
 

--- a/circuits/plonk-15-wires/src/polynomials/mod.rs
+++ b/circuits/plonk-15-wires/src/polynomials/mod.rs
@@ -1,9 +1,9 @@
-pub mod endosclmul;
+pub mod chacha;
+pub mod complete_add;
 pub mod endomul_scalar;
+pub mod endosclmul;
 pub mod generic;
 pub mod lookup;
 pub mod permutation;
 pub mod poseidon;
 pub mod varbasemul;
-pub mod chacha;
-pub mod complete_add;

--- a/circuits/plonk/src/polynomials/addition.rs
+++ b/circuits/plonk/src/polynomials/addition.rs
@@ -27,7 +27,7 @@ use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
 use ark_ff::{FftField, SquareRootField, Zero};
 use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
-use o1_utils::{ExtendedEvaluations, ExtendedDensePolynomial};
+use o1_utils::{ExtendedDensePolynomial, ExtendedEvaluations};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {
     // EC Affine addition constraint quotient poly contribution computation

--- a/circuits/plonk/src/polynomials/endosclmul.rs
+++ b/circuits/plonk/src/polynomials/endosclmul.rs
@@ -10,7 +10,7 @@ use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
 use ark_ff::{FftField, SquareRootField, Zero};
 use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
-use o1_utils::{ExtendedEvaluations, ExtendedDensePolynomial};
+use o1_utils::{ExtendedDensePolynomial, ExtendedEvaluations};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {
     // endomorphism optimised scalar multiplication constraint quotient poly contribution computation

--- a/circuits/plonk/src/polynomials/permutation.rs
+++ b/circuits/plonk/src/polynomials/permutation.rs
@@ -9,7 +9,7 @@ use crate::polynomial::WitnessOverDomains;
 use crate::scalars::{ProofEvaluations, RandomOracles};
 use ark_ff::{FftField, SquareRootField};
 use ark_poly::{univariate::DensePolynomial, Evaluations, Polynomial, Radix2EvaluationDomain as D};
-use o1_utils::{ExtendedEvaluations, ExtendedDensePolynomial};
+use o1_utils::{ExtendedDensePolynomial, ExtendedEvaluations};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {
     // permutation quotient poly contribution computation

--- a/circuits/plonk/src/polynomials/poseidon.rs
+++ b/circuits/plonk/src/polynomials/poseidon.rs
@@ -10,9 +10,7 @@ use crate::scalars::ProofEvaluations;
 use ark_ff::{FftField, SquareRootField, Zero};
 use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use o1_utils::{ExtendedDensePolynomial, ExtendedEvaluations};
-use oracle::{
-    poseidon::{sbox, ArithmeticSpongeParams, PlonkSpongeConstantsBasic},
-};
+use oracle::poseidon::{sbox, ArithmeticSpongeParams, PlonkSpongeConstantsBasic};
 use rayon::prelude::*;
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk/src/polynomials/varbasemul.rs
+++ b/circuits/plonk/src/polynomials/varbasemul.rs
@@ -9,7 +9,7 @@ use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
 use ark_ff::{FftField, SquareRootField, Zero};
 use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
-use o1_utils::{ExtendedEvaluations, ExtendedDensePolynomial};
+use o1_utils::{ExtendedDensePolynomial, ExtendedEvaluations};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {
     // scalar multiplication constraint quotient poly contribution computation

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -18,8 +18,8 @@ use ark_ec::{
 };
 use ark_ff::{Field, FpParameters, One, PrimeField, SquareRootField, UniformRand, Zero};
 use ark_poly::{
-    univariate::DensePolynomial, EvaluationDomain, Evaluations,
-    Radix2EvaluationDomain as D, UVPolynomial,
+    univariate::DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as D,
+    UVPolynomial,
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use core::ops::{Add, Sub};
@@ -549,16 +549,17 @@ where
         max: Option<usize>,
     ) -> PolyComm<G> {
         let is_zero = plnm.evals.iter().all(|x| x.is_zero());
-        let basis =
-            match self.lagrange_bases.get(&domain.size()) {
-                None => panic!("lagrange bases for size {} not found", domain.size()),
-                Some(v) => &v[..]
-            };
+        let basis = match self.lagrange_bases.get(&domain.size()) {
+            None => panic!("lagrange bases for size {} not found", domain.size()),
+            Some(v) => &v[..],
+        };
         if domain.size == plnm.domain().size {
             Self::commit_helper(&plnm.evals[..], basis, is_zero, max)
         } else if domain.size < plnm.domain().size {
             let s = (plnm.domain().size / domain.size) as usize;
-            let v : Vec<_> = (0..(domain.size as usize)).map(|i| plnm.evals[s * i]).collect();
+            let v: Vec<_> = (0..(domain.size as usize))
+                .map(|i| plnm.evals[s * i])
+                .collect();
             Self::commit_helper(&v[..], basis, is_zero, max)
         } else {
             panic!("desired commitment domain size greater than evaluations' domain size")

--- a/dlog/plonk-15-wires/src/index.rs
+++ b/dlog/plonk-15-wires/src/index.rs
@@ -22,10 +22,10 @@ use commitment_dlog::{
 };
 use oracle::poseidon::ArithmeticSpongeParams;
 use plonk_15_wires_circuits::{
-    polynomials::{chacha, lookup, poseidon, varbasemul, complete_add, endosclmul, endomul_scalar},
+    expr::{Column, ConstantExpr, Expr, Linearization, PolishToken},
     gate::{GateType, LookupInfo, LookupsUsed},
-    expr::{PolishToken, ConstantExpr, Expr, Column, Linearization},
     nolookup::constraints::{zk_polynomial, zk_w3, ConstraintSystem},
+    polynomials::{chacha, complete_add, endomul_scalar, endosclmul, lookup, poseidon, varbasemul},
     wires::*,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -167,8 +167,11 @@ where
             mul_comm: self.srs.commit_non_hiding(&self.cs.mulm, None),
             emul_comm: self.srs.commit_non_hiding(&self.cs.emulm, None),
 
-            endomul_scalar_comm:
-                self.srs.commit_evaluations_non_hiding(domain, &self.cs.endomul_scalar8, None),
+            endomul_scalar_comm: self.srs.commit_evaluations_non_hiding(
+                domain,
+                &self.cs.endomul_scalar8,
+                None,
+            ),
             chacha_comm: self.cs.chacha8.as_ref().map(|c| {
                 array_init(|i| self.srs.commit_evaluations_non_hiding(domain, &c[i], None))
             }),

--- a/dlog/plonk-15-wires/src/prover.rs
+++ b/dlog/plonk-15-wires/src/prover.rs
@@ -7,7 +7,7 @@ This source file implements prover's zk-proof primitive.
 pub use super::{index::Index, range};
 use crate::plonk_sponge::FrSponge;
 use ark_ec::AffineCurve;
-use ark_ff::{FftField, Field, Zero, One};
+use ark_ff::{FftField, Field, One, Zero};
 use ark_poly::{
     univariate::DensePolynomial, Evaluations, Polynomial, Radix2EvaluationDomain as D, UVPolynomial,
 };
@@ -15,16 +15,16 @@ use array_init::array_init;
 use commitment_dlog::commitment::{
     b_poly_coefficients, CommitmentCurve, CommitmentField, OpeningProof, PolyComm,
 };
+use lookup::CombinedEntry;
 use o1_utils::ExtendedDensePolynomial;
 use oracle::{rndoracle::ProofError, sponge::ScalarChallenge, FqSponge};
 use plonk_15_wires_circuits::{
-    expr::{Environment, LookupEnvironment, Constants, l0_1},
-    polynomials::{chacha, lookup, poseidon, varbasemul, complete_add, endomul_scalar, endosclmul},
+    expr::{l0_1, Constants, Environment, LookupEnvironment},
+    gate::{combine_table_entry, GateType, LookupInfo, LookupsUsed},
     nolookup::scalars::{LookupEvaluations, ProofEvaluations},
+    polynomials::{chacha, complete_add, endomul_scalar, endosclmul, lookup, poseidon, varbasemul},
     wires::{COLUMNS, PERMUTS},
-    gate::{combine_table_entry, LookupsUsed, LookupInfo, GateType},
 };
-use lookup::{CombinedEntry};
 use rand::thread_rng;
 use std::collections::HashMap;
 
@@ -34,7 +34,7 @@ type Fq<G> = <G as AffineCurve>::BaseField;
 #[derive(Clone)]
 pub struct LookupCommitments<G: AffineCurve> {
     pub sorted: Vec<PolyComm<G>>,
-    pub aggreg: PolyComm<G>
+    pub aggreg: PolyComm<G>,
 }
 
 #[derive(Clone)]
@@ -68,30 +68,31 @@ pub struct ProverProof<G: AffineCurve> {
 }
 
 fn combine_evaluations<F: FftField>(
-    init : (Evaluations<F, D<F>>, Evaluations<F, D<F>>),
+    init: (Evaluations<F, D<F>>, Evaluations<F, D<F>>),
     alpha: F,
     prev_alpha_pow: F,
     es: Vec<Evaluations<F, D<F>>>,
-    ) -> (Evaluations<F, D<F>>, Evaluations<F, D<F>>) {
-
+) -> (Evaluations<F, D<F>>, Evaluations<F, D<F>>) {
     let mut alpha_pow = prev_alpha_pow;
     let pows = (0..).map(|_| {
         alpha_pow *= alpha;
         alpha_pow
     });
 
-    es.into_iter().zip(pows).fold(init, |(mut a4, mut a8), (mut e, alpha_pow)| {
-        e.evals.iter_mut().for_each(|x| *x *= alpha_pow);
-        if e.domain().size == a4.domain().size {
-            a4 += &e;
-        } else if e.domain().size == a8.domain().size {
-            a8 += &e;
-        } else {
-            panic!("Bad evaluation")
-        }
-        drop(e);
-        (a4, a8)
-    })
+    es.into_iter()
+        .zip(pows)
+        .fold(init, |(mut a4, mut a8), (mut e, alpha_pow)| {
+            e.evals.iter_mut().for_each(|x| *x *= alpha_pow);
+            if e.domain().size == a4.domain().size {
+                a4 += &e;
+            } else if e.domain().size == a8.domain().size {
+                a8 += &e;
+            } else {
+                panic!("Bad evaluation")
+            }
+            drop(e);
+            (a4, a8)
+        })
 }
 
 impl<G: CommitmentCurve> ProverProof<G>
@@ -131,13 +132,13 @@ where
         let rng = &mut thread_rng();
 
         // commit to the wire values
-        let w_comm: [(PolyComm<G>, PolyComm<Fr<G>>); COLUMNS] =
-            array_init(|i| {
-                let e =
-                    Evaluations::<Fr<G>, D<Fr<G>>>::from_vec_and_domain(
-                        witness[i].clone(), index.cs.domain.d1);
-                index.srs.commit_evaluations(d1, &e, None, rng)
-            });
+        let w_comm: [(PolyComm<G>, PolyComm<Fr<G>>); COLUMNS] = array_init(|i| {
+            let e = Evaluations::<Fr<G>, D<Fr<G>>>::from_vec_and_domain(
+                witness[i].clone(),
+                index.cs.domain.d1,
+            );
+            index.srs.commit_evaluations(d1, &e, None, rng)
+        });
 
         // compute witness polynomials
         let w: [DensePolynomial<Fr<G>>; COLUMNS] = array_init(|i| {
@@ -158,15 +159,14 @@ where
         let lookup_used = lookup_info.lookup_used(&index.cs.gates);
 
         let joint_combiner_ = {
-            let s =
-                match lookup_used.as_ref() {
-                    None | Some(LookupsUsed::Single) => ScalarChallenge(Fr::<G>::zero()),
-                    Some(LookupsUsed::Joint) => ScalarChallenge(fq_sponge.challenge()),
-                };
+            let s = match lookup_used.as_ref() {
+                None | Some(LookupsUsed::Single) => ScalarChallenge(Fr::<G>::zero()),
+                Some(LookupsUsed::Joint) => ScalarChallenge(fq_sponge.challenge()),
+            };
             (s, s.to_field(&index.srs.endo_r))
         };
 
-        let joint_combiner : Fr<G> = joint_combiner_.1;
+        let joint_combiner: Fr<G> = joint_combiner_.1;
 
         // TODO: Looking-up a tuple (f_0, f_1, ..., f_{m-1}) in a tuple of tables (T_0, ..., T_{m-1}) is
         // reduced to a single lookup
@@ -210,14 +210,12 @@ where
         // their average length or something like that.
 
         let dummy_lookup_value = {
-            let x =
-                match lookup_used.as_ref() {
-                    None => Fr::<G>::zero(),
-                    Some(_) =>
-                        combine_table_entry(
-                            joint_combiner,
-                            index.cs.dummy_lookup_values[0].iter()),
-                };
+            let x = match lookup_used.as_ref() {
+                None => Fr::<G>::zero(),
+                Some(_) => {
+                    combine_table_entry(joint_combiner, index.cs.dummy_lookup_values[0].iter())
+                }
+            };
             CombinedEntry(x)
         };
 
@@ -225,41 +223,43 @@ where
             match lookup_used.as_ref() {
                 None => (None, None, None, None),
                 Some(_) => {
-                    let iter_lookup_table = || (0..n).map(|i| {
-                        let row = index.cs.lookup_tables8[0].iter().map(|e| & e.evals[8 * i]);
-                        CombinedEntry (
-                        combine_table_entry(joint_combiner, row) )
-                    });
-
+                    let iter_lookup_table = || {
+                        (0..n).map(|i| {
+                            let row = index.cs.lookup_tables8[0].iter().map(|e| &e.evals[8 * i]);
+                            CombinedEntry(combine_table_entry(joint_combiner, row))
+                        })
+                    };
 
                     // TODO: Once we switch to committing using lagrange commitments,
                     // `witness` will be consumed when we interpolate, so interpolation will
                     // have to moved below this.
-                    let lookup_sorted : Vec<Vec<CombinedEntry<Fr<G>>>> =
-                        lookup::sorted(
-                            dummy_lookup_value.clone(),
-                            iter_lookup_table,
-                            index.cs.lookup_table_lengths[0],
-                            d1,
-                            &index.cs.gates,
-                            &witness,
-                            joint_combiner)?;
+                    let lookup_sorted: Vec<Vec<CombinedEntry<Fr<G>>>> = lookup::sorted(
+                        dummy_lookup_value.clone(),
+                        iter_lookup_table,
+                        index.cs.lookup_table_lengths[0],
+                        d1,
+                        &index.cs.gates,
+                        &witness,
+                        joint_combiner,
+                    )?;
 
-                    let lookup_sorted : Vec<_> =
-                        lookup_sorted.into_iter().map(|chunk| {
-                            let v : Vec<_> = chunk.into_iter().map(|x| x.0).collect();
+                    let lookup_sorted: Vec<_> = lookup_sorted
+                        .into_iter()
+                        .map(|chunk| {
+                            let v: Vec<_> = chunk.into_iter().map(|x| x.0).collect();
                             lookup::zk_patch(v, d1, rng)
-                        }).collect();
+                        })
+                        .collect();
 
-                    let comm : Vec<_> =
-                        lookup_sorted.iter().map(|v|
-                                index.srs.commit_evaluations(d1, v, None, rng))
+                    let comm: Vec<_> = lookup_sorted
+                        .iter()
+                        .map(|v| index.srs.commit_evaluations(d1, v, None, rng))
                         .collect();
                     let coeffs : Vec<_> =
                         // TODO: We can avoid storing these coefficients.
                         lookup_sorted.iter().map(|e| e.clone().interpolate()).collect();
-                    let evals8 : Vec<_> =
-                        coeffs.iter()
+                    let evals8: Vec<_> = coeffs
+                        .iter()
                         .map(|v| v.evaluate_over_domain_by_ref(index.cs.domain.d8))
                         .collect();
 
@@ -327,54 +327,56 @@ where
         // evaluate polynomials over domains
         let lagrange = index.cs.evaluate(&w, &z);
 
-        let lookup_table_combined =
-            lookup_used.as_ref().map(|_| {
-                let joint_table = &index.cs.lookup_tables8[0];
-                let mut res = joint_table[joint_table.len() - 1].clone();
-                for col in joint_table.iter().rev().skip(1) {
-                    res.evals.iter_mut().for_each(|e| *e *= joint_combiner);
-                    res += &col;
-                }
-                res
-            });
+        let lookup_table_combined = lookup_used.as_ref().map(|_| {
+            let joint_table = &index.cs.lookup_tables8[0];
+            let mut res = joint_table[joint_table.len() - 1].clone();
+            for col in joint_table.iter().rev().skip(1) {
+                res.evals.iter_mut().for_each(|e| *e *= joint_combiner);
+                res += &col;
+            }
+            res
+        });
 
-        let lookup_env =
-            lookup_table_combined.as_ref()
+        let lookup_env = lookup_table_combined
+            .as_ref()
             .zip(lookup_sorted8.as_ref())
-            .zip(lookup_aggreg8.as_ref()).map(|((lookup_table_combined, lookup_sorted), lookup_aggreg)| {
-                LookupEnvironment {
+            .zip(lookup_aggreg8.as_ref())
+            .map(
+                |((lookup_table_combined, lookup_sorted), lookup_aggreg)| LookupEnvironment {
                     aggreg: &lookup_aggreg,
                     sorted: &lookup_sorted,
                     table: lookup_table_combined,
                     selectors: &index.cs.lookup_selectors,
-                }
-            });
+                },
+            );
 
         // compute quotient polynomial
         let env = {
             let mut index_evals = HashMap::new();
-                use GateType::*;
-                index_evals.insert(Poseidon, &index.cs.ps8);
-                index_evals.insert(CompleteAdd, &index.cs.complete_addl4);
-                index_evals.insert(Vbmul, &index.cs.mull8);
-                index_evals.insert(Endomul, &index.cs.emull);
-                index_evals.insert(EndomulScalar, &index.cs.endomul_scalar8);
-                [ChaCha0, ChaCha1, ChaCha2, ChaChaFinal].iter().enumerate().for_each(|(i, g)| {
+            use GateType::*;
+            index_evals.insert(Poseidon, &index.cs.ps8);
+            index_evals.insert(CompleteAdd, &index.cs.complete_addl4);
+            index_evals.insert(Vbmul, &index.cs.mull8);
+            index_evals.insert(Endomul, &index.cs.emull);
+            index_evals.insert(EndomulScalar, &index.cs.endomul_scalar8);
+            [ChaCha0, ChaCha1, ChaCha2, ChaChaFinal]
+                .iter()
+                .enumerate()
+                .for_each(|(i, g)| {
                     if let Some(c) = &index.cs.chacha8 {
                         index_evals.insert(*g, &c[i]);
                     }
                 });
 
             Environment {
-                constants:
-                    Constants {
-                        alpha: alpha,
-                        beta: beta,
-                        gamma: gamma,
-                        joint_combiner,
-                        endo_coefficient: index.cs.endo,
-                        mds: index.cs.fr_sponge_params.mds.clone(),
-                    },
+                constants: Constants {
+                    alpha: alpha,
+                    beta: beta,
+                    gamma: gamma,
+                    joint_combiner,
+                    endo_coefficient: index.cs.endo,
+                    mds: index.cs.fr_sponge_params.mds.clone(),
+                },
                 witness: &lagrange.d8.this.w,
                 coefficient: &index.cs.coefficients8,
                 vanishes_on_last_4_rows: &index.cs.vanishes_on_last_4_rows,
@@ -420,36 +422,30 @@ where
         t8 += &pos8;
         drop(pos8);
 
-        let t4 =
-            match index.cs.chacha8.as_ref() {
-                None => t4,
-                Some(_) => {
-                    let mut t4 = t4;
-                    let chacha = chacha::constraint(range::CHACHA.start).evaluations(&env);
-                    t4 += &chacha;
-                    drop(chacha);
-                    t4
-                }
-            };
+        let t4 = match index.cs.chacha8.as_ref() {
+            None => t4,
+            Some(_) => {
+                let mut t4 = t4;
+                let chacha = chacha::constraint(range::CHACHA.start).evaluations(&env);
+                t4 += &chacha;
+                drop(chacha);
+                t4
+            }
+        };
 
         // quotient polynomial for lookup
-        let (t4, t8) =
-            match lookup_used {
-                None => (t4, t8),
-                Some(_) => {
-                    combine_evaluations(
-                        (t4, t8),
-                        alpha,
-                        alphas[alphas.len() - 1],
-                        lookup::constraints(
-                            &index.cs.dummy_lookup_values[0],
-                            d1)
-                        .iter().map(|e| e.evaluations(&env))
-                        .collect()
-                        )
-                }
-            };
-
+        let (t4, t8) = match lookup_used {
+            None => (t4, t8),
+            Some(_) => combine_evaluations(
+                (t4, t8),
+                alpha,
+                alphas[alphas.len() - 1],
+                lookup::constraints(&index.cs.dummy_lookup_values[0], d1)
+                    .iter()
+                    .map(|e| e.evaluations(&env))
+                    .collect(),
+            ),
+        };
 
         // divide contributions with vanishing polynomial
         let (mut t, res) = (&(&t4.interpolate() + &t8.interpolate()) + &p)
@@ -476,20 +472,25 @@ where
         let zeta_omega = zeta * &omega;
 
         let lookup_evals = |e: Fr<G>| {
-            lookup_aggreg_coeffs.as_ref()
-            .zip(lookup_sorted_coeffs.as_ref())
-            .map(|(aggreg, sorted)|
-                LookupEvaluations {
+            lookup_aggreg_coeffs
+                .as_ref()
+                .zip(lookup_sorted_coeffs.as_ref())
+                .map(|(aggreg, sorted)| LookupEvaluations {
                     aggreg: aggreg.eval(e, index.max_poly_size),
-                    sorted: sorted.iter().map(|c| c.eval(e, index.max_poly_size)).collect(),
-                    table:
-                        index.cs.lookup_tables[0]
+                    sorted: sorted
+                        .iter()
+                        .map(|c| c.eval(e, index.max_poly_size))
+                        .collect(),
+                    table: index.cs.lookup_tables[0]
                         .iter()
                         .map(|p| p.eval(e, index.max_poly_size))
                         .rev()
                         .fold(vec![Fr::<G>::zero()], |acc, x| {
-                            acc.into_iter().zip(x.iter()).map(|(acc, x)| acc * joint_combiner + x).collect()
-                        })
+                            acc.into_iter()
+                                .zip(x.iter())
+                                .map(|(acc, x)| acc * joint_combiner + x)
+                                .collect()
+                        }),
                 })
         };
 
@@ -530,14 +531,15 @@ where
                 s: array_init(|i| DensePolynomial::eval_polynomial(&es.s[i], e1)),
                 w: array_init(|i| DensePolynomial::eval_polynomial(&es.w[i], e1)),
                 z: DensePolynomial::eval_polynomial(&es.z, e1),
-                lookup:
-                    es.lookup.as_ref().map(|l| {
-                        LookupEvaluations {
-                            table: DensePolynomial::eval_polynomial(&l.table, e1),
-                            aggreg: DensePolynomial::eval_polynomial(&l.aggreg, e1),
-                            sorted: l.sorted.iter().map(|p| DensePolynomial::eval_polynomial(p, e1)).collect(),
-                        }
-                    }),
+                lookup: es.lookup.as_ref().map(|l| LookupEvaluations {
+                    table: DensePolynomial::eval_polynomial(&l.table, e1),
+                    aggreg: DensePolynomial::eval_polynomial(&l.aggreg, e1),
+                    sorted: l
+                        .sorted
+                        .iter()
+                        .map(|p| DensePolynomial::eval_polynomial(p, e1))
+                        .collect(),
+                }),
                 generic_selector: DensePolynomial::eval_polynomial(&es.generic_selector, e1),
                 poseidon_selector: DensePolynomial::eval_polynomial(&es.poseidon_selector, e1),
             })
@@ -554,10 +556,7 @@ where
                     .perm_lnrz(&evals, zeta, beta, gamma, &alphas[range::PERM]);
 
             let f = {
-                let (_lin_constant, lin) =
-                    index
-                    .linearization
-                    .to_polynomial(&env, zeta, evals);
+                let (_lin_constant, lin) = index.linearization.to_polynomial(&env, zeta, evals);
                 f + lin
             };
 
@@ -653,13 +652,12 @@ where
                 w_comm: array_init(|i| w_comm[i].0.clone()),
                 z_comm: z_comm.0,
                 t_comm: t_comm.0,
-                lookup:
-                    lookup_aggreg_comm.zip(lookup_sorted_comm).map(|(a, s)| {
-                        LookupCommitments {
-                            aggreg: a.0,
-                            sorted: s.iter().map(|(x, _)| x.clone()).collect()
-                        }
-                    })
+                lookup: lookup_aggreg_comm.zip(lookup_sorted_comm).map(|(a, s)| {
+                    LookupCommitments {
+                        aggreg: a.0,
+                        sorted: s.iter().map(|(x, _)| x.clone()).collect(),
+                    }
+                }),
             },
             proof: index.srs.open(
                 group_map,

--- a/dlog/plonk-15-wires/src/range.rs
+++ b/dlog/plonk-15-wires/src/range.rs
@@ -8,7 +8,7 @@ pub const COMPLETE_ADD: Range<usize> = 18..25;
 pub const ENDML: Range<usize> = 25..36;
 pub const MUL: Range<usize> = 36..59;
 pub const ENDOMUL_SCALAR: Range<usize> = 59..70;
-pub const CHACHA: Range<usize> = 70..(70+9);
+pub const CHACHA: Range<usize> = 70..(70 + 9);
 
 /// Computes the powers of alpha, starting with alpha^2
 // TODO(mimoo): because of the way we do things, we never use alpha itself. This should instead return 1, alpha, alpha^2, etc. or better, an iterator

--- a/dlog/plonk-15-wires/tests/endomul_scalar.rs
+++ b/dlog/plonk-15-wires/tests/endomul_scalar.rs
@@ -1,37 +1,34 @@
+use ark_ec::{AffineCurve, ProjectiveCurve};
+use ark_ff::{BigInteger, BitIteratorLE, Field, One, PrimeField, UniformRand, Zero};
+use ark_poly::{univariate::DensePolynomial, EvaluationDomain, Radix2EvaluationDomain as D};
+use array_init::array_init;
 use colored::Colorize;
 use commitment_dlog::{
     commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve},
     srs::{endos, SRS},
 };
-use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_ff::{BigInteger, Field, PrimeField, BitIteratorLE, UniformRand, Zero, One};
-use ark_poly::{univariate::DensePolynomial, Radix2EvaluationDomain as D, EvaluationDomain};
-use plonk_15_wires_circuits::{
-    polynomials::endomul_scalar,
-    gate::{CircuitGate, GateType, LookupInfo, LookupsUsed},
-    expr::{PolishToken, Constants, Expr, Column, Linearization},
-    gates::poseidon::ROUNDS_PER_ROW,
-    nolookup::constraints::{zk_w3, ConstraintSystem},
-    nolookup::scalars::{ProofEvaluations, LookupEvaluations},
-    wires::*,
-};
+use groupmap::GroupMap;
 use mina_curves::pasta::{
-    fp::{Fp as F},
+    fp::Fp as F,
     pallas::{Affine as Other, Projective as OtherProjective},
     vesta::{Affine, VestaParameters},
 };
-use plonk_15_wires_protocol_dlog::{
-    index::{Index},
-    prover::ProverProof,
-};
-use rand::{rngs::StdRng, SeedableRng};
-use array_init::array_init;
-use std::fmt::{Formatter, Display};
-use groupmap::GroupMap;
 use oracle::{
     poseidon::{ArithmeticSponge, PlonkSpongeConstants15W, Sponge, SpongeConstants},
-    sponge::{ScalarChallenge, DefaultFqSponge, DefaultFrSponge},
+    sponge::{DefaultFqSponge, DefaultFrSponge, ScalarChallenge},
 };
+use plonk_15_wires_circuits::{
+    expr::{Column, Constants, Expr, Linearization, PolishToken},
+    gate::{CircuitGate, GateType, LookupInfo, LookupsUsed},
+    gates::poseidon::ROUNDS_PER_ROW,
+    nolookup::constraints::{zk_w3, ConstraintSystem},
+    nolookup::scalars::{LookupEvaluations, ProofEvaluations},
+    polynomials::endomul_scalar,
+    wires::*,
+};
+use plonk_15_wires_protocol_dlog::{index::Index, prover::ProverProof};
+use rand::{rngs::StdRng, SeedableRng};
+use std::fmt::{Display, Formatter};
 use std::{sync::Arc, time::Instant};
 
 const PUBLIC: usize = 0;
@@ -57,18 +54,16 @@ fn endomul_scalar_test() {
     for s in 0..num_scalars {
         for i in 0..rows_per_scalar {
             let row = rows_per_scalar * s + i;
-            gates.push(
-                CircuitGate {
-                    row,
-                    typ: GateType::EndomulScalar,
-                    wires: Wire::new(row),
-                    c: vec![],
-                });
+            gates.push(CircuitGate {
+                row,
+                typ: GateType::EndomulScalar,
+                wires: Wire::new(row),
+                c: vec![],
+            });
         }
     }
 
-    let cs = ConstraintSystem::<F>::create(
-        gates, vec![], fp_sponge_params, PUBLIC).unwrap();
+    let cs = ConstraintSystem::<F>::create(gates, vec![], fp_sponge_params, PUBLIC).unwrap();
     let n = cs.domain.d1.size as usize;
 
     let mut srs = SRS::create(cs.domain.d1.size as usize);
@@ -93,7 +88,9 @@ fn endomul_scalar_test() {
     let start = Instant::now();
     for i in 0..num_scalars {
         let x = {
-            let bits_lsb: Vec<_> = BitIteratorLE::new(F::rand(rng).into_repr()).take(num_bits).collect();
+            let bits_lsb: Vec<_> = BitIteratorLE::new(F::rand(rng).into_repr())
+                .take(num_bits)
+                .collect();
             F::from_repr(<F as PrimeField>::BigInt::from_bits_le(&bits_lsb[..])).unwrap()
         };
 
@@ -104,16 +101,15 @@ fn endomul_scalar_test() {
                 i * rows_per_scalar,
                 x,
                 endo_scalar_coeff,
-                num_bits));
+                num_bits
+            )
+        );
     }
 
     let start = Instant::now();
     let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(
-            &group_map,
-            &witness,
-            &index,
-            vec![]).unwrap();
+        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, &witness, &index, vec![])
+            .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
     let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];
@@ -125,5 +121,3 @@ fn endomul_scalar_test() {
         }
     }
 }
-
-

--- a/dlog/tests/endomul.rs
+++ b/dlog/tests/endomul.rs
@@ -1,37 +1,34 @@
+use ark_ec::{AffineCurve, ProjectiveCurve};
+use ark_ff::{BigInteger, BitIteratorLE, Field, One, PrimeField, UniformRand, Zero};
+use ark_poly::{univariate::DensePolynomial, EvaluationDomain, Radix2EvaluationDomain as D};
+use array_init::array_init;
 use colored::Colorize;
 use commitment_dlog::{
     commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve},
     srs::{endos, SRS},
 };
-use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_ff::{BigInteger, Field, PrimeField, BitIteratorLE, UniformRand, Zero, One};
-use ark_poly::{univariate::DensePolynomial, Radix2EvaluationDomain as D, EvaluationDomain};
-use plonk_15_wires_circuits::{
-    polynomials::endosclmul,
-    gate::{CircuitGate, GateType, LookupInfo, LookupsUsed},
-    expr::{PolishToken, Constants, Expr, Column, Linearization},
-    gates::poseidon::ROUNDS_PER_ROW,
-    nolookup::constraints::{zk_w3, ConstraintSystem},
-    nolookup::scalars::{ProofEvaluations, LookupEvaluations},
-    wires::*,
-};
+use groupmap::GroupMap;
 use mina_curves::pasta::{
-    fp::{Fp as F},
+    fp::Fp as F,
     pallas::{Affine as Other, Projective as OtherProjective},
     vesta::{Affine, VestaParameters},
 };
-use plonk_15_wires_protocol_dlog::{
-    index::{Index},
-    prover::ProverProof,
-};
-use rand::{rngs::StdRng, SeedableRng};
-use array_init::array_init;
-use std::fmt::{Formatter, Display};
-use groupmap::GroupMap;
 use oracle::{
     poseidon::{ArithmeticSponge, PlonkSpongeConstants15W, Sponge, SpongeConstants},
-    sponge::{ScalarChallenge, DefaultFqSponge, DefaultFrSponge},
+    sponge::{DefaultFqSponge, DefaultFrSponge, ScalarChallenge},
 };
+use plonk_15_wires_circuits::{
+    expr::{Column, Constants, Expr, Linearization, PolishToken},
+    gate::{CircuitGate, GateType, LookupInfo, LookupsUsed},
+    gates::poseidon::ROUNDS_PER_ROW,
+    nolookup::constraints::{zk_w3, ConstraintSystem},
+    nolookup::scalars::{LookupEvaluations, ProofEvaluations},
+    polynomials::endosclmul,
+    wires::*,
+};
+use plonk_15_wires_protocol_dlog::{index::Index, prover::ProverProof};
+use rand::{rngs::StdRng, SeedableRng};
+use std::fmt::{Display, Formatter};
 use std::{sync::Arc, time::Instant};
 
 const PUBLIC: usize = 0;
@@ -59,27 +56,24 @@ fn endomul_test() {
     for s in 0..num_scalars {
         for i in 0..chunks {
             let row = rows_per_scalar * s + i;
-            gates.push(
-                CircuitGate {
-                    row,
-                    typ: GateType::Endomul,
-                    wires: Wire::new(row),
-                    c: vec![],
-                });
+            gates.push(CircuitGate {
+                row,
+                typ: GateType::Endomul,
+                wires: Wire::new(row),
+                c: vec![],
+            });
         }
 
         let row = rows_per_scalar * s + chunks;
-        gates.push(
-            CircuitGate {
-                row: row,
-                typ: GateType::Zero,
-                wires: Wire::new(row),
-                c: vec![]
-            });
+        gates.push(CircuitGate {
+            row: row,
+            typ: GateType::Zero,
+            wires: Wire::new(row),
+            c: vec![],
+        });
     }
 
-    let cs = ConstraintSystem::<F>::create(
-        gates, vec![], fp_sponge_params, PUBLIC).unwrap();
+    let cs = ConstraintSystem::<F>::create(gates, vec![], fp_sponge_params, PUBLIC).unwrap();
     let n = cs.domain.d1.size as usize;
 
     let mut srs = SRS::create(cs.domain.d1.size as usize);
@@ -101,8 +95,13 @@ fn endomul_test() {
 
     let start = Instant::now();
     for i in 0..num_scalars {
-        let bits_lsb: Vec<_> = BitIteratorLE::new(F::rand(rng).into_repr()).take(num_bits).collect();
-        let x = <Other as AffineCurve>::ScalarField::from_repr(<F as PrimeField>::BigInt::from_bits_le(&bits_lsb[..])).unwrap();
+        let bits_lsb: Vec<_> = BitIteratorLE::new(F::rand(rng).into_repr())
+            .take(num_bits)
+            .collect();
+        let x = <Other as AffineCurve>::ScalarField::from_repr(
+            <F as PrimeField>::BigInt::from_bits_le(&bits_lsb[..]),
+        )
+        .unwrap();
 
         let x_scalar = ScalarChallenge(x).to_field(&endo_r);
 
@@ -115,33 +114,36 @@ fn endomul_test() {
             (acc.x, acc.y)
         };
 
-        let bits_msb: Vec<_> =
-            bits_lsb.iter().take(num_bits).map(|x| *x).rev().collect();
+        let bits_msb: Vec<_> = bits_lsb.iter().take(num_bits).map(|x| *x).rev().collect();
 
-        let res =
-            endosclmul::witness(
-                &mut witness,
-                i * rows_per_scalar,
-                endo_q,
-                (base.x, base.y),
-                &bits_msb,
-                acc0);
+        let res = endosclmul::witness(
+            &mut witness,
+            i * rows_per_scalar,
+            endo_q,
+            (base.x, base.y),
+            &bits_msb,
+            acc0,
+        );
 
         let expected = {
             let t = Other::prime_subgroup_generator();
             let mut acc = Other::new(acc0.0, acc0.1, false);
             for i in (0..(num_bits / 2)).rev() {
-                let b2i = F::from(bits_lsb[2*i] as u64);
-                let b2i1 = F::from(bits_lsb[2*i + 1] as u64);
+                let b2i = F::from(bits_lsb[2 * i] as u64);
+                let b2i1 = F::from(bits_lsb[2 * i + 1] as u64);
                 let xq = (F::one() + ((endo_q - F::one()) * b2i1)) * t.x;
                 let yq = (b2i.double() - F::one()) * t.y;
                 acc = acc + (acc + Other::new(xq, yq, false));
             }
             acc
         };
-        assert_eq!(expected,
-            Other::prime_subgroup_generator().into_projective().mul(x_scalar.into_repr())
-            .into_affine());
+        assert_eq!(
+            expected,
+            Other::prime_subgroup_generator()
+                .into_projective()
+                .mul(x_scalar.into_repr())
+                .into_affine()
+        );
 
         assert_eq!((expected.x, expected.y), res.acc);
         assert_eq!(x.into_repr(), res.n.into_repr());
@@ -149,11 +151,8 @@ fn endomul_test() {
 
     let start = Instant::now();
     let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(
-            &group_map,
-            &witness,
-            &index,
-            vec![]).unwrap();
+        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, &witness, &index, vec![])
+            .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
     let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];
@@ -165,4 +164,3 @@ fn endomul_test() {
         }
     }
 }
-

--- a/dlog/tests/turbo_plonk.rs
+++ b/dlog/tests/turbo_plonk.rs
@@ -28,7 +28,7 @@ use ark_poly::{
 use colored::Colorize;
 use commitment_dlog::{
     commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve},
-    srs::{SRS},
+    srs::SRS,
 };
 use groupmap::GroupMap;
 use mina_curves::pasta::{
@@ -42,7 +42,10 @@ use oracle::{
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use plonk_circuits::{constraints::ConstraintSystem, gate::CircuitGate, wires::GateWires};
-use plonk_protocol_dlog::{index::{SRSSpec, Index}, prover::ProverProof};
+use plonk_protocol_dlog::{
+    index::{Index, SRSSpec},
+    prover::ProverProof,
+};
 use rand::rngs::OsRng;
 use std::time::Instant;
 use std::{io, io::Write};


### PR DESCRIPTION
the first commit fixes the `cargo fmt` check in CI, it works as intended now:

<img width="499" alt="Screen Shot 2021-10-29 at 12 22 55 PM" src="https://user-images.githubusercontent.com/1316043/139490830-68d34c11-ab2f-40da-879b-130bbb916743.png">

the second commit runs `cargo fmt`