### PR TITLE
[kimchi] choosing messagepack as our serialization format

### DIFF
--- a/circuits/plonk-15-wires/Cargo.toml
+++ b/circuits/plonk-15-wires/Cargo.toml
@@ -30,7 +30,7 @@ ocaml = { version = "0.22.2", optional = true }
 ocaml-gen = { path = "../../ocaml/ocaml-gen", optional = true }
 
 [dev-dependencies]
-bincode = "1.3.3"
+rmp-serde = "0.15.5"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
 

--- a/circuits/plonk-15-wires/src/gate.rs
+++ b/circuits/plonk-15-wires/src/gate.rs
@@ -527,6 +527,7 @@ mod tests {
     use mina_curves::pasta::Fp;
     use proptest::prelude::*;
     use rand::SeedableRng as _;
+    use serde::{Deserialize, Serialize};
 
     // TODO: move to mina-curves
     prop_compose! {
@@ -561,10 +562,11 @@ mod tests {
     proptest! {
         #[test]
         fn test_gate_serialization(cg in arb_circuit_gate()) {
-            let encoded = bincode::serialize(&cg).unwrap();
+            let encoded = rmp_serde::to_vec(&cg).unwrap();
             println!("gate: {:?}", cg);
             println!("encoded gate: {:?}", encoded);
-            let decoded: CircuitGate<Fp> = bincode::deserialize(&encoded).unwrap();
+            let decoded: CircuitGate<Fp> = rmp_serde::from_read_ref(&encoded).unwrap();
+
             println!("decoded gate: {:?}", decoded);
             prop_assert_eq!(cg.row, decoded.row);
             prop_assert_eq!(cg.typ, decoded.typ);

--- a/dlog/plonk-15-wires/Cargo.toml
+++ b/dlog/plonk-15-wires/Cargo.toml
@@ -12,11 +12,11 @@ ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 ark-poly = { version = "0.3.0", features = [ "parallel" ] }
 ark-serialize = "0.3.0"
 array-init = "1.0.0"
-bincode = "1.3.3"
 colored = "2.0.0"
 rand = "0.8.0"
 rand_core = { version = "0.5" }
 rayon = "1.5.0"
+rmp-serde = "0.15.5"
 serde = "1.0.130"
 serde_with = "1.10.0"
 sprs = "0.9.2"
@@ -32,7 +32,6 @@ plonk_15_wires_circuits = { path = "../../circuits/plonk-15-wires" }
 [dev-dependencies]
 groupmap = { path = "../../groupmap" }
 mina-curves = { path = "../../curves" }
-bincode = "1.3.3"
 
 [features]
 default = []

--- a/dlog/plonk-15-wires/src/index.rs
+++ b/dlog/plonk-15-wires/src/index.rs
@@ -308,8 +308,8 @@ where
         };
 
         // deserialize
-        let mut verifier_index: Self =
-            bincode::deserialize_from(&mut reader).map_err(|e| e.to_string())?;
+        let mut verifier_index = Self::deserialize(&mut rmp_serde::Deserializer::new(reader))
+            .map_err(|e| e.to_string())?;
 
         // fill in the rest
         verifier_index.srs = srs;
@@ -333,6 +333,7 @@ where
 
         let writer = BufWriter::new(file);
 
-        bincode::serialize_into(writer, self).map_err(|e| e.to_string())
+        self.serialize(&mut rmp_serde::Serializer::new(writer))
+            .map_err(|e| e.to_string())
     }
 }


### PR DESCRIPTION
Quickly went through the different serialization format that we can use, and msgpack seems to be one of the smallest/fastest/most well-supported format.

The only other contestant is cbor, which seems to be originated from msgpack, and has an RFC. People have mix feelings, and the two standards seem close enough, that I chose the one with the best Rust support.