### PR TITLE
[WIP][ocaml-gen] fixes type aliasing and type collisions + add tests

### DIFF
--- a/ocaml/ocaml-gen/README.md
+++ b/ocaml/ocaml-gen/README.md
@@ -85,3 +85,10 @@ struct MyCustomType {
   // ...
 }
 ```
+
+## Guidance
+
+A few things to keep in mind:
+
+* declaring different types within the same namespace (module) is dangerous. For example, you can shadow a previous type by declaring a new type with the same name. Another example is that you can shadow a record field or tag name if another type has the same record field or tag name.
+* If you want to have different types that map to different concrete instantiations of the same generic custom type in Rust, you will have to create different types in Rust.

--- a/ocaml/ocaml-gen/derive/src/lib.rs
+++ b/ocaml/ocaml-gen/derive/src/lib.rs
@@ -142,7 +142,7 @@ pub fn derive_ocaml_enum(item: TokenStream) -> TokenStream {
             );*
 
             // get name
-            let type_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
+            let type_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id(false);
             let name = env.get_type(type_id, #name_str);
 
             // return the type description in OCaml
@@ -159,8 +159,17 @@ pub fn derive_ocaml_enum(item: TokenStream) -> TokenStream {
     //
 
     let unique_id = quote! {
-        fn unique_id() -> u128 {
-            ::ocaml_gen::const_random!(u128)
+        fn unique_id(stop_here: bool) -> u128 {
+            // this struct's unique id
+            let mut unique_id = ::ocaml_gen::const_random!(u128);
+
+            // XOR in the type parameters' unique ids
+            let mut generics_ocaml: Vec<String> = vec![];
+            #(
+                unique_id ^= <#generics_ident as ::ocaml_gen::OCamlDesc>::unique_id(stop_here);
+            );*
+
+            unique_id
         }
     };
 
@@ -269,11 +278,9 @@ pub fn derive_ocaml_enum(item: TokenStream) -> TokenStream {
             new_type: bool,
         ) -> String {
             // register the new type
-            if new_type {
-                let ty_name = rename.unwrap_or(#ocaml_name);
-                let ty_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
-                env.new_type(ty_id, ty_name);
-            }
+            let ty_name = rename.unwrap_or(#ocaml_name);
+            let ty_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id(false);
+            env.new_type(ty_id, ty_name);
 
             let global_generics: Vec<&str> = vec![#(#generics_str),*];
             let generics_ocaml = {
@@ -393,7 +400,7 @@ pub fn derive_ocaml_gen(item: TokenStream) -> TokenStream {
             );*
 
             // get name
-            let type_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
+            let type_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id(false);
             let name = env.get_type(type_id, #name_str);
 
             // return the type description in OCaml
@@ -410,8 +417,17 @@ pub fn derive_ocaml_gen(item: TokenStream) -> TokenStream {
     //
 
     let unique_id = quote! {
-        fn unique_id() -> u128 {
-            ::ocaml_gen::const_random!(u128)
+        fn unique_id(stop_here: bool) -> u128 {
+            // this struct's unique id
+            let mut unique_id = ::ocaml_gen::const_random!(u128);
+
+            // XOR in the type parameters' unique ids
+            let mut generics_ocaml: Vec<String> = vec![];
+            #(
+                unique_id ^= <#generics_ident as ::ocaml_gen::OCamlDesc>::unique_id(stop_here);
+            );*
+
+            unique_id
         }
     };
 
@@ -539,11 +555,9 @@ pub fn derive_ocaml_gen(item: TokenStream) -> TokenStream {
             new_type: bool,
         ) -> String {
             // register the new type
-            if new_type {
-                let ty_name = rename.unwrap_or(#ocaml_name);
-                let ty_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
-                env.new_type(ty_id, ty_name);
-            }
+            let ty_name = rename.unwrap_or(#ocaml_name);
+            let ty_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id(false);
+            env.new_type(ty_id, ty_name);
 
             let global_generics: Vec<&str> = vec![#(#generics_str),*];
             let generics_ocaml = {
@@ -643,7 +657,7 @@ pub fn derive_ocaml_custom(item: TokenStream) -> TokenStream {
 
     let ocaml_desc = quote! {
         fn ocaml_desc(env: &::ocaml_gen::Env, _generics: &[&str]) -> String {
-            let type_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
+            let type_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id(false);
             env.get_type(type_id, #name_str)
         }
     };
@@ -652,9 +666,32 @@ pub fn derive_ocaml_custom(item: TokenStream) -> TokenStream {
     // unique_id
     //
 
+    // we generate the unique_id based on this struct's unique id as well as the unique ids of its concrete type parameters.
+    // this is so that we can distinguish between different declaration of the same custom types but using different type parameters.
+    // see https://github.com/o1-labs/proof-systems/issues/172
+
+    let generics_ident: Vec<_> = item_struct
+        .generics
+        .params
+        .iter()
+        .filter_map(|g| match g {
+            GenericParam::Type(t) => Some(&t.ident),
+            _ => None,
+        })
+        .collect();
+
     let unique_id = quote! {
-        fn unique_id() -> u128 {
-            ::ocaml_gen::const_random!(u128)
+        fn unique_id(stop_here: bool) -> u128 {
+            // this struct's unique id
+            let mut unique_id = ::ocaml_gen::const_random!(u128);
+
+            // XOR in the type parameters' unique ids
+            let mut generics_ocaml: Vec<String> = vec![];
+            #(
+                unique_id ^= <#generics_ident as ::ocaml_gen::OCamlDesc>::unique_id(stop_here);
+            );*
+
+            unique_id
         }
     };
 

--- a/ocaml/ocaml-gen/derive/src/lib.rs
+++ b/ocaml/ocaml-gen/derive/src/lib.rs
@@ -114,14 +114,14 @@ pub fn func(_attribute: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_derive(Enum)]
 pub fn derive_ocaml_enum(item: TokenStream) -> TokenStream {
     let item_enum: syn::ItemEnum = syn::parse(item).expect("only enum are supported with Enum");
+    let name = &item_enum.ident;
+    let generics = &item_enum.generics.params;
 
     //
     // ocaml_desc
     //
 
-    let generics_ident: Vec<_> = item_enum
-        .generics
-        .params
+    let generics_ident: Vec<_> = generics
         .iter()
         .filter_map(|g| match g {
             GenericParam::Type(t) => Some(&t.ident),
@@ -129,7 +129,7 @@ pub fn derive_ocaml_enum(item: TokenStream) -> TokenStream {
         })
         .collect();
 
-    let name_str = item_enum.ident.to_string();
+    let name_str = name.to_string();
 
     let ocaml_desc = quote! {
         fn ocaml_desc(env: &::ocaml_gen::Env, generics: &[&str]) -> String {
@@ -142,11 +142,11 @@ pub fn derive_ocaml_enum(item: TokenStream) -> TokenStream {
             );*
 
             // get name
-            let type_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id(false);
+            let type_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
             let name = env.get_type(type_id, #name_str);
 
             // return the type description in OCaml
-            if generics_ocaml.is_empty() {
+            if generics.is_empty() || generics_ocaml.is_empty() {
                 name.to_string()
             } else {
                 format!("({}) {}", generics_ocaml.join(", "), name)
@@ -159,14 +159,13 @@ pub fn derive_ocaml_enum(item: TokenStream) -> TokenStream {
     //
 
     let unique_id = quote! {
-        fn unique_id(stop_here: bool) -> u128 {
+        fn unique_id() -> u128 {
             // this struct's unique id
             let mut unique_id = ::ocaml_gen::const_random!(u128);
 
             // XOR in the type parameters' unique ids
-            let mut generics_ocaml: Vec<String> = vec![];
             #(
-                unique_id ^= <#generics_ident as ::ocaml_gen::OCamlDesc>::unique_id(stop_here);
+                unique_id ^= <#generics_ident as ::ocaml_gen::OCamlDesc>::unique_id();
             );*
 
             unique_id
@@ -177,16 +176,62 @@ pub fn derive_ocaml_enum(item: TokenStream) -> TokenStream {
     // ocaml_binding
     //
 
-    let generics_str: Vec<String> = item_enum
-        .generics
-        .params
+    // list the generic type parameters
+    let generics_ident: Vec<_> = generics
         .iter()
         .filter_map(|g| match g {
             GenericParam::Type(t) => Some(&t.ident),
             _ => None,
         })
+        .collect();
+
+    let generics_str: Vec<String> = generics_ident
+        .iter()
         .map(|ident| ident.to_string())
         .collect();
+
+    // construct the generic version of this type
+    // i.e. ThisType<T1, T2, ...>
+    // this might be needed if we're aliasing this type
+
+    let fake_generics_counter: Vec<_> = (0..generics_ident.len()).collect();
+    let fake_generics: Vec<_> = fake_generics_counter
+        .iter()
+        .map(|i| quote::format_ident!("T{}", i.to_string()))
+        .collect();
+
+    let decl_fake_generics = {
+        quote! {
+            #(
+                pub struct #fake_generics;
+
+                impl ::ocaml_gen::OCamlDesc for #fake_generics {
+                    fn ocaml_desc(_env: &::ocaml_gen::Env, generics: &[&str]) -> String {
+                        // TODO: this should return the information that it is a generic
+                        format!("'{}", generics[#fake_generics_counter])
+                    }
+
+                    fn unique_id() -> u128 {
+                        // so that we can instantiate fake generics in different ways
+                        // without influencing the unique_id they return
+                        (0xdeadbeef as u128) ^ (#fake_generics_counter as u128)
+                    }
+                }
+            )*
+        }
+    };
+
+    let generic_ty = if generics.is_empty() {
+        quote! {
+            #name
+        }
+    } else {
+        quote! {
+            #name < #(#fake_generics),* >
+        }
+    };
+
+    //
 
     let body = {
         // we want to resolve types at runtime (to do relocation/renaming)
@@ -269,7 +314,7 @@ pub fn derive_ocaml_enum(item: TokenStream) -> TokenStream {
         }
     };
 
-    let ocaml_name = rust_ident_to_ocaml(name_str);
+    let ocaml_name = rust_ident_to_ocaml(name_str.clone());
 
     let ocaml_binding = quote! {
         fn ocaml_binding(
@@ -277,22 +322,54 @@ pub fn derive_ocaml_enum(item: TokenStream) -> TokenStream {
             rename: Option<&'static str>,
             new_type: bool,
         ) -> String {
-            // register the new type
-            let ty_name = rename.unwrap_or(#ocaml_name);
-            let ty_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id(false);
-            env.new_type(ty_id, ty_name);
-
+            // get generic part
             let global_generics: Vec<&str> = vec![#(#generics_str),*];
-            let generics_ocaml = {
+            let ty_desc = {
                 #body
             };
 
-            let name = <Self as ::ocaml_gen::OCamlDesc>::ocaml_desc(env, &global_generics);
+            //
+            let ty_name = rename.unwrap_or(#ocaml_name);
+            let ty_generics: Vec<_> = global_generics.iter().map(|x| format!("'{}", x)).collect();
 
+
+            //
             if new_type {
-                format!("type nonrec {} = {}", name, generics_ocaml)
+                let ty_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
+                env.new_type(ty_id, ty_name);
+
+                if ty_generics.is_empty() {
+                    format!("type nonrec {} = {}", ty_name, ty_desc)
+                } else {
+                    format!("type nonrec ({}) {} = {}", ty_generics.join(", "), ty_name, ty_desc)
+                }
+
             } else {
-                format!("type nonrec {} = {}", rename.expect("type alias must have a name"), name)
+                // get generics
+                let mut concrete_types: Vec<String> = vec![];
+                #(
+                    let concrete_ty_id = <#generics_ident as ::ocaml_gen::OCamlDesc>::unique_id();
+                    let concrete_ty_name = env.get_type(concrete_ty_id, stringify!(#generics_ident));
+                    concrete_types.push(concrete_ty_name);
+                );*
+
+                // register this alias type
+                let ty_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
+                env.new_type(ty_id, ty_name);
+
+                // get the aliased type
+                #decl_fake_generics
+                let aliased_ty_id = <#generic_ty as ::ocaml_gen::OCamlDesc>::unique_id();
+                let aliased_ty_name = env.get_type(aliased_ty_id, #name_str);
+
+                // display
+                let name = rename.expect("type alias must have a name");
+                if concrete_types.is_empty() {
+                    format!("type nonrec {} = {}", name, aliased_ty_name)
+                } else {
+                    format!("type nonrec {} = ({}) {}", name, concrete_types.join(", "), aliased_ty_name)
+                }
+
             }
         }
     };
@@ -368,7 +445,7 @@ pub fn derive_ocaml_enum(item: TokenStream) -> TokenStream {
 /// ```
 ///
 #[proc_macro_derive(Struct)]
-pub fn derive_ocaml_gen(item: TokenStream) -> TokenStream {
+pub fn derive_ocaml_struct(item: TokenStream) -> TokenStream {
     let item_struct: syn::ItemStruct =
         syn::parse(item).expect("only structs are supported with Struct");
     let name = &item_struct.ident;
@@ -400,11 +477,11 @@ pub fn derive_ocaml_gen(item: TokenStream) -> TokenStream {
             );*
 
             // get name
-            let type_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id(false);
+            let type_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
             let name = env.get_type(type_id, #name_str);
 
             // return the type description in OCaml
-            if generics_ocaml.is_empty() {
+            if generics.is_empty() || generics_ocaml.is_empty() {
                 name.to_string()
             } else {
                 format!("({}) {}", generics_ocaml.join(", "), name)
@@ -417,14 +494,13 @@ pub fn derive_ocaml_gen(item: TokenStream) -> TokenStream {
     //
 
     let unique_id = quote! {
-        fn unique_id(stop_here: bool) -> u128 {
+        fn unique_id() -> u128 {
             // this struct's unique id
             let mut unique_id = ::ocaml_gen::const_random!(u128);
 
             // XOR in the type parameters' unique ids
-            let mut generics_ocaml: Vec<String> = vec![];
             #(
-                unique_id ^= <#generics_ident as ::ocaml_gen::OCamlDesc>::unique_id(stop_here);
+                unique_id ^= <#generics_ident as ::ocaml_gen::OCamlDesc>::unique_id();
             );*
 
             unique_id
@@ -435,15 +511,62 @@ pub fn derive_ocaml_gen(item: TokenStream) -> TokenStream {
     // ocaml_binding
     //
 
-    let generics_str: Vec<String> = generics
+    // list the generic type parameters
+    let generics_ident: Vec<_> = generics
         .iter()
         .filter_map(|g| match g {
             GenericParam::Type(t) => Some(&t.ident),
             _ => None,
         })
+        .collect();
+
+    let generics_str: Vec<String> = generics_ident
+        .iter()
         .map(|ident| ident.to_string())
         .collect();
 
+    // construct the generic version of this type
+    // i.e. ThisType<T1, T2, ...>
+    // this might be needed if we're aliasing this type
+
+    let fake_generics_counter: Vec<_> = (0..generics_ident.len()).collect();
+    let fake_generics: Vec<_> = fake_generics_counter
+        .iter()
+        .map(|i| quote::format_ident!("T{}", i.to_string()))
+        .collect();
+
+    let decl_fake_generics = {
+        quote! {
+            #(
+                pub struct #fake_generics;
+
+                impl ::ocaml_gen::OCamlDesc for #fake_generics {
+                    fn ocaml_desc(_env: &::ocaml_gen::Env, generics: &[&str]) -> String {
+                        // TODO: this should return the information that it is a generic
+                        format!("'{}", generics[#fake_generics_counter])
+                    }
+
+                    fn unique_id() -> u128 {
+                        // so that we can instantiate fake generics in different ways
+                        // without influencing the unique_id they return
+                        (0xdeadbeef as u128) ^ (#fake_generics_counter as u128)
+                    }
+                }
+            )*
+        }
+    };
+
+    let generic_ty = if generics.is_empty() {
+        quote! {
+            #name
+        }
+    } else {
+        quote! {
+            #name < #(#fake_generics),* >
+        }
+    };
+
+    //
     let body = match fields {
         Fields::Named(fields) => {
             let mut punctured_generics_name: Vec<String> = vec![];
@@ -546,7 +669,7 @@ pub fn derive_ocaml_gen(item: TokenStream) -> TokenStream {
         _ => panic!("only named, and unnamed field supported"),
     };
 
-    let ocaml_name = rust_ident_to_ocaml(name_str);
+    let ocaml_name = rust_ident_to_ocaml(name_str.clone());
 
     let ocaml_binding = quote! {
         fn ocaml_binding(
@@ -554,22 +677,50 @@ pub fn derive_ocaml_gen(item: TokenStream) -> TokenStream {
             rename: Option<&'static str>,
             new_type: bool,
         ) -> String {
-            // register the new type
-            let ty_name = rename.unwrap_or(#ocaml_name);
-            let ty_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id(false);
-            env.new_type(ty_id, ty_name);
-
+            // get generic part
             let global_generics: Vec<&str> = vec![#(#generics_str),*];
-            let generics_ocaml = {
+            let ty_desc = {
                 #body
             };
 
-            let name = <Self as ::ocaml_gen::OCamlDesc>::ocaml_desc(env, &global_generics);
+            //
+            let ty_name = rename.unwrap_or(#ocaml_name);
+            let ty_generics: Vec<_> = global_generics.iter().map(|x| format!("'{}", x)).collect();
 
+            //
             if new_type {
-                format!("type nonrec {} = {}", name, generics_ocaml)
+                let ty_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
+                env.new_type(ty_id, ty_name);
+                if ty_generics.is_empty() {
+                    format!("type nonrec {} = {}", ty_name, ty_desc)
+                } else {
+                    format!("type nonrec ({}) {} = {}", ty_generics.join(", "), ty_name, ty_desc)
+                }
             } else {
-                format!("type nonrec {} = {}", rename.expect("type alias must have a name"), name)
+                // get generics
+                let mut concrete_types: Vec<String> = vec![];
+                #(
+                    let concrete_ty_id = <#generics_ident as ::ocaml_gen::OCamlDesc>::unique_id();
+                    let concrete_ty_name = env.get_type(concrete_ty_id, stringify!(#generics_ident));
+                    concrete_types.push(concrete_ty_name);
+                );*
+
+                // register this alias type
+                let ty_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
+                env.new_type(ty_id, ty_name);
+
+                // get the aliased type
+                #decl_fake_generics
+                let aliased_ty_id = <#generic_ty as ::ocaml_gen::OCamlDesc>::unique_id();
+                let aliased_ty_name = env.get_type(aliased_ty_id, #name_str);
+
+                // display
+                let name = rename.expect("type alias must have a name");
+                if concrete_types.is_empty() {
+                    format!("type nonrec {} = {}", name, aliased_ty_name)
+                } else {
+                    format!("type nonrec {} = ({}) {}", name, concrete_types.join(", "), aliased_ty_name)
+                }
             }
         }
     };
@@ -657,7 +808,7 @@ pub fn derive_ocaml_custom(item: TokenStream) -> TokenStream {
 
     let ocaml_desc = quote! {
         fn ocaml_desc(env: &::ocaml_gen::Env, _generics: &[&str]) -> String {
-            let type_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id(false);
+            let type_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
             env.get_type(type_id, #name_str)
         }
     };
@@ -681,17 +832,9 @@ pub fn derive_ocaml_custom(item: TokenStream) -> TokenStream {
         .collect();
 
     let unique_id = quote! {
-        fn unique_id(stop_here: bool) -> u128 {
+        fn unique_id() -> u128 {
             // this struct's unique id
-            let mut unique_id = ::ocaml_gen::const_random!(u128);
-
-            // XOR in the type parameters' unique ids
-            let mut generics_ocaml: Vec<String> = vec![];
-            #(
-                unique_id ^= <#generics_ident as ::ocaml_gen::OCamlDesc>::unique_id(stop_here);
-            );*
-
-            unique_id
+            ::ocaml_gen::const_random!(u128)
         }
     };
 
@@ -707,20 +850,17 @@ pub fn derive_ocaml_custom(item: TokenStream) -> TokenStream {
             rename: Option<&'static str>,
             new_type: bool,
         ) -> String {
-            // register the new type
-            if new_type {
-                let ty_name = rename.unwrap_or(#ocaml_name);
-                let ty_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
-                env.new_type(ty_id, ty_name);
+            if !new_type {
+                panic!("aliases of custom types are dangerous, as they do not provide any type safety. If you need to distinguish different usages of a single custom types, you'll have to create distinct custom types in Rust.")
             }
 
-            let name = <Self as ::ocaml_gen::OCamlDesc>::ocaml_desc(env, &[]);
+            // register the type
+            let ty_name = rename.unwrap_or(#ocaml_name);
+            let ty_id = <Self as ::ocaml_gen::OCamlDesc>::unique_id();
+            env.new_type(ty_id, ty_name);
 
-            if new_type {
-                format!("type nonrec {}", name)
-            } else {
-                format!("type nonrec {} = {}", rename.expect("type alias must have a name"), name)
-            }
+            // display
+            format!("type {}", ty_name)
         }
     };
 

--- a/ocaml/ocaml-gen/src/conv.rs
+++ b/ocaml/ocaml-gen/src/conv.rs
@@ -9,7 +9,7 @@ impl OCamlDesc for () {
         "unit".to_string()
     }
 
-    fn unique_id(_stop_here: bool) -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
@@ -19,7 +19,7 @@ impl OCamlDesc for [u8; 32] {
         "bytes".to_string()
     }
 
-    fn unique_id(_stop_here: bool) -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
@@ -29,7 +29,7 @@ impl OCamlDesc for &[u8] {
         "bytes".to_string()
     }
 
-    fn unique_id(_stop_here: bool) -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
@@ -42,11 +42,9 @@ where
         format!("({}) array", T::ocaml_desc(env, generics))
     }
 
-    fn unique_id(stop_here: bool) -> u128 {
+    fn unique_id() -> u128 {
         let mut unique_id = const_random!(u128);
-        if !stop_here {
-            unique_id ^= T::unique_id(stop_here);
-        }
+        unique_id ^= T::unique_id();
         unique_id
     }
 }
@@ -59,11 +57,9 @@ where
         T::ocaml_desc(env, generics)
     }
 
-    fn unique_id(stop_here: bool) -> u128 {
+    fn unique_id() -> u128 {
         let mut unique_id = const_random!(u128);
-        if !stop_here {
-            unique_id ^= T::unique_id(stop_here);
-        }
+        unique_id ^= T::unique_id();
         unique_id
     }
 }
@@ -76,11 +72,9 @@ where
         format!("({}) option", T::ocaml_desc(env, generics))
     }
 
-    fn unique_id(stop_here: bool) -> u128 {
+    fn unique_id() -> u128 {
         let mut unique_id = const_random!(u128);
-        if !stop_here {
-            unique_id ^= T::unique_id(stop_here);
-        }
+        unique_id ^= T::unique_id();
         unique_id
     }
 }
@@ -90,7 +84,7 @@ impl OCamlDesc for ocaml::Int {
         "int".to_string()
     }
 
-    fn unique_id(_stop_here: bool) -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
@@ -100,7 +94,7 @@ impl OCamlDesc for String {
         "string".to_string()
     }
 
-    fn unique_id(_stop_here: bool) -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
@@ -110,7 +104,7 @@ impl OCamlDesc for bool {
         "bool".to_string()
     }
 
-    fn unique_id(_stop_here: bool) -> u128 {
+    fn unique_id() -> u128 {
         const_random!(u128)
     }
 }
@@ -123,11 +117,9 @@ where
         T::ocaml_desc(env, generics)
     }
 
-    fn unique_id(stop_here: bool) -> u128 {
+    fn unique_id() -> u128 {
         let mut unique_id = const_random!(u128);
-        if !stop_here {
-            unique_id ^= T::unique_id(stop_here);
-        }
+        unique_id ^= T::unique_id();
         unique_id
     }
 }
@@ -142,12 +134,10 @@ where
         format!("({})", v.join(" * "))
     }
 
-    fn unique_id(stop_here: bool) -> u128 {
+    fn unique_id() -> u128 {
         let mut unique_id = const_random!(u128);
-        if !stop_here {
-            unique_id ^= T1::unique_id(stop_here);
-            unique_id ^= T2::unique_id(stop_here);
-        }
+        unique_id ^= T1::unique_id();
+        unique_id ^= T2::unique_id();
         unique_id
     }
 }
@@ -208,25 +198,23 @@ where
         format!("({})", v.join(" * "))
     }
 
-    fn unique_id(stop_here: bool) -> u128 {
+    fn unique_id() -> u128 {
         let mut unique_id = const_random!(u128);
-        if !stop_here {
-            unique_id ^= T1::unique_id(stop_here);
-            unique_id ^= T2::unique_id(stop_here);
-            unique_id ^= T3::unique_id(stop_here);
-            unique_id ^= T4::unique_id(stop_here);
-            unique_id ^= T5::unique_id(stop_here);
-            unique_id ^= T6::unique_id(stop_here);
-            unique_id ^= T7::unique_id(stop_here);
-            unique_id ^= T8::unique_id(stop_here);
-            unique_id ^= T9::unique_id(stop_here);
-            unique_id ^= T10::unique_id(stop_here);
-            unique_id ^= T11::unique_id(stop_here);
-            unique_id ^= T12::unique_id(stop_here);
-            unique_id ^= T13::unique_id(stop_here);
-            unique_id ^= T14::unique_id(stop_here);
-            unique_id ^= T15::unique_id(stop_here);
-        }
+        unique_id ^= T1::unique_id();
+        unique_id ^= T2::unique_id();
+        unique_id ^= T3::unique_id();
+        unique_id ^= T4::unique_id();
+        unique_id ^= T5::unique_id();
+        unique_id ^= T6::unique_id();
+        unique_id ^= T7::unique_id();
+        unique_id ^= T8::unique_id();
+        unique_id ^= T9::unique_id();
+        unique_id ^= T10::unique_id();
+        unique_id ^= T11::unique_id();
+        unique_id ^= T12::unique_id();
+        unique_id ^= T13::unique_id();
+        unique_id ^= T14::unique_id();
+        unique_id ^= T15::unique_id();
         unique_id
     }
 }
@@ -280,16 +268,14 @@ where
         v.join(" * ")
     }
 
-    fn unique_id(stop_here: bool) -> u128 {
+    fn unique_id() -> u128 {
         let mut unique_id = const_random!(u128);
-        if !stop_here {
-            unique_id ^= T1::unique_id(stop_here);
-            unique_id ^= T2::unique_id(stop_here);
-            unique_id ^= T3::unique_id(stop_here);
-            unique_id ^= T4::unique_id(stop_here);
-            unique_id ^= T5::unique_id(stop_here);
-            unique_id ^= T6::unique_id(stop_here);
-        }
+        unique_id ^= T1::unique_id();
+        unique_id ^= T2::unique_id();
+        unique_id ^= T3::unique_id();
+        unique_id ^= T4::unique_id();
+        unique_id ^= T5::unique_id();
+        unique_id ^= T6::unique_id();
         unique_id
     }
 }

--- a/ocaml/ocaml-gen/src/conv.rs
+++ b/ocaml/ocaml-gen/src/conv.rs
@@ -9,7 +9,7 @@ impl OCamlDesc for () {
         "unit".to_string()
     }
 
-    fn unique_id() -> u128 {
+    fn unique_id(_stop_here: bool) -> u128 {
         const_random!(u128)
     }
 }
@@ -19,7 +19,7 @@ impl OCamlDesc for [u8; 32] {
         "bytes".to_string()
     }
 
-    fn unique_id() -> u128 {
+    fn unique_id(_stop_here: bool) -> u128 {
         const_random!(u128)
     }
 }
@@ -29,7 +29,7 @@ impl OCamlDesc for &[u8] {
         "bytes".to_string()
     }
 
-    fn unique_id() -> u128 {
+    fn unique_id(_stop_here: bool) -> u128 {
         const_random!(u128)
     }
 }
@@ -42,8 +42,12 @@ where
         format!("({}) array", T::ocaml_desc(env, generics))
     }
 
-    fn unique_id() -> u128 {
-        const_random!(u128)
+    fn unique_id(stop_here: bool) -> u128 {
+        let mut unique_id = const_random!(u128);
+        if !stop_here {
+            unique_id ^= T::unique_id(stop_here);
+        }
+        unique_id
     }
 }
 
@@ -55,8 +59,12 @@ where
         T::ocaml_desc(env, generics)
     }
 
-    fn unique_id() -> u128 {
-        const_random!(u128)
+    fn unique_id(stop_here: bool) -> u128 {
+        let mut unique_id = const_random!(u128);
+        if !stop_here {
+            unique_id ^= T::unique_id(stop_here);
+        }
+        unique_id
     }
 }
 
@@ -68,8 +76,12 @@ where
         format!("({}) option", T::ocaml_desc(env, generics))
     }
 
-    fn unique_id() -> u128 {
-        const_random!(u128)
+    fn unique_id(stop_here: bool) -> u128 {
+        let mut unique_id = const_random!(u128);
+        if !stop_here {
+            unique_id ^= T::unique_id(stop_here);
+        }
+        unique_id
     }
 }
 
@@ -78,7 +90,7 @@ impl OCamlDesc for ocaml::Int {
         "int".to_string()
     }
 
-    fn unique_id() -> u128 {
+    fn unique_id(_stop_here: bool) -> u128 {
         const_random!(u128)
     }
 }
@@ -88,7 +100,7 @@ impl OCamlDesc for String {
         "string".to_string()
     }
 
-    fn unique_id() -> u128 {
+    fn unique_id(_stop_here: bool) -> u128 {
         const_random!(u128)
     }
 }
@@ -98,7 +110,7 @@ impl OCamlDesc for bool {
         "bool".to_string()
     }
 
-    fn unique_id() -> u128 {
+    fn unique_id(_stop_here: bool) -> u128 {
         const_random!(u128)
     }
 }
@@ -111,8 +123,12 @@ where
         T::ocaml_desc(env, generics)
     }
 
-    fn unique_id() -> u128 {
-        const_random!(u128)
+    fn unique_id(stop_here: bool) -> u128 {
+        let mut unique_id = const_random!(u128);
+        if !stop_here {
+            unique_id ^= T::unique_id(stop_here);
+        }
+        unique_id
     }
 }
 
@@ -126,8 +142,13 @@ where
         format!("({})", v.join(" * "))
     }
 
-    fn unique_id() -> u128 {
-        const_random!(u128)
+    fn unique_id(stop_here: bool) -> u128 {
+        let mut unique_id = const_random!(u128);
+        if !stop_here {
+            unique_id ^= T1::unique_id(stop_here);
+            unique_id ^= T2::unique_id(stop_here);
+        }
+        unique_id
     }
 }
 
@@ -187,8 +208,26 @@ where
         format!("({})", v.join(" * "))
     }
 
-    fn unique_id() -> u128 {
-        const_random!(u128)
+    fn unique_id(stop_here: bool) -> u128 {
+        let mut unique_id = const_random!(u128);
+        if !stop_here {
+            unique_id ^= T1::unique_id(stop_here);
+            unique_id ^= T2::unique_id(stop_here);
+            unique_id ^= T3::unique_id(stop_here);
+            unique_id ^= T4::unique_id(stop_here);
+            unique_id ^= T5::unique_id(stop_here);
+            unique_id ^= T6::unique_id(stop_here);
+            unique_id ^= T7::unique_id(stop_here);
+            unique_id ^= T8::unique_id(stop_here);
+            unique_id ^= T9::unique_id(stop_here);
+            unique_id ^= T10::unique_id(stop_here);
+            unique_id ^= T11::unique_id(stop_here);
+            unique_id ^= T12::unique_id(stop_here);
+            unique_id ^= T13::unique_id(stop_here);
+            unique_id ^= T14::unique_id(stop_here);
+            unique_id ^= T15::unique_id(stop_here);
+        }
+        unique_id
     }
 }
 
@@ -241,7 +280,16 @@ where
         v.join(" * ")
     }
 
-    fn unique_id() -> u128 {
-        const_random!(u128)
+    fn unique_id(stop_here: bool) -> u128 {
+        let mut unique_id = const_random!(u128);
+        if !stop_here {
+            unique_id ^= T1::unique_id(stop_here);
+            unique_id ^= T2::unique_id(stop_here);
+            unique_id ^= T3::unique_id(stop_here);
+            unique_id ^= T4::unique_id(stop_here);
+            unique_id ^= T5::unique_id(stop_here);
+            unique_id ^= T6::unique_id(stop_here);
+        }
+        unique_id
     }
 }

--- a/ocaml/ocaml-gen/src/lib.rs
+++ b/ocaml/ocaml-gen/src/lib.rs
@@ -131,8 +131,8 @@ pub trait OCamlDesc {
     /// (the type that makes use of this type)
     fn ocaml_desc(env: &Env, generics: &[&str]) -> String;
 
-    /// Returns a unique ID for the type. This ID will not change if concrete type parameters are used.
-    fn unique_id() -> u128;
+    /// Returns a unique ID for the type. This ID will not change if concrete type parameters are used, unless `stop_here` is set to `false`.
+    fn unique_id(stop_here: bool) -> u128;
 }
 
 //
@@ -237,7 +237,7 @@ macro_rules! decl_fake_generic {
                 format!("'{}", generics[$i])
             }
 
-            fn unique_id() -> u128 {
+            fn unique_id(_stop_here: bool) -> u128 {
                 ::ocaml_gen::const_random!(u128)
             }
         }

--- a/ocaml/ocaml-gen/src/lib.rs
+++ b/ocaml/ocaml-gen/src/lib.rs
@@ -39,7 +39,10 @@ impl Env {
     /// Declares a new type. If the type was already declared, this will panic. If you are declaring a custom type, use [new_custom_type].
     pub fn new_type(&mut self, ty: u128, name: &'static str) {
         match self.locations.entry(ty) {
-            Entry::Occupied(_) => panic!("ocaml-gen: cannot re-declare the same type twice"),
+            Entry::Occupied(_) => panic!(
+                "ocaml-gen: cannot re-declare the same type {} ({}) twice",
+                ty, name
+            ),
             Entry::Vacant(v) => v.insert((self.current_module.clone(), name)),
         };
     }
@@ -101,7 +104,7 @@ impl Env {
     pub fn root(&mut self) -> String {
         let mut res = String::new();
         for _ in &self.current_module {
-            res.push_str("end\n");
+            res.push_str("end");
         }
         res
     }
@@ -132,7 +135,7 @@ pub trait OCamlDesc {
     fn ocaml_desc(env: &Env, generics: &[&str]) -> String;
 
     /// Returns a unique ID for the type. This ID will not change if concrete type parameters are used, unless `stop_here` is set to `false`.
-    fn unique_id(stop_here: bool) -> u128;
+    fn unique_id() -> u128;
 }
 
 //
@@ -144,9 +147,9 @@ pub trait OCamlDesc {
 macro_rules! decl_module {
     ($w:expr, $env:expr, $name:expr, $b:block) => {{
         use std::io::Write;
-        write!($w, "\n{}{}\n", format_args!("{: >1$}", "", $env.nested() * 2), $env.new_module($name)).unwrap();
+        writeln!($w, "{}", $env.new_module($name)).unwrap();
         $b
-        write!($w, "{}{}\n\n", format_args!("{: >1$}", "", $env.nested() * 2 - 2), $env.parent()).unwrap();
+        writeln!($w, "{}", $env.parent()).unwrap();
     }}
 }
 
@@ -158,13 +161,7 @@ macro_rules! decl_func {
         ::ocaml_gen::paste! {
             let binding = [<$func _to_ocaml>]($env, None);
         }
-        write!(
-            $w,
-            "{}{}\n",
-            format_args!("{: >1$}", "", $env.nested() * 2),
-            binding,
-        )
-        .unwrap();
+        writeln!($w, "{}", binding,).unwrap();
     }};
     // rename
     ($w:expr, $env:expr, $func:ident => $new:expr) => {{
@@ -172,13 +169,7 @@ macro_rules! decl_func {
         ::ocaml_gen::paste! {
             let binding = [<$func _to_ocaml>]($env, Some($new));
         }
-        write!(
-            $w,
-            "{}{}\n",
-            format_args!("{: >1$}", "", $env.nested() * 2),
-            binding,
-        )
-        .unwrap();
+        writeln!($w, "{}", binding,).unwrap();
     }};
 }
 
@@ -188,25 +179,13 @@ macro_rules! decl_type {
     ($w:expr, $env:expr, $ty:ty) => {{
         use std::io::Write;
         let res = <$ty as ::ocaml_gen::OCamlBinding>::ocaml_binding($env, None, true);
-        write!(
-            $w,
-            "{}{}\n",
-            format_args!("{: >1$}", "", $env.nested() * 2),
-            res,
-        )
-        .unwrap();
+        writeln!($w, "{}", res,).unwrap();
     }};
     // rename
     ($w:expr, $env:expr, $ty:ty => $new:expr) => {{
         use std::io::Write;
         let res = <$ty as ::ocaml_gen::OCamlBinding>::ocaml_binding($env, Some($new), true);
-        write!(
-            $w,
-            "{}{}\n",
-            format_args!("{: >1$}", "", $env.nested() * 2),
-            res,
-        )
-        .unwrap();
+        writeln!($w, "{}", res,).unwrap();
     }};
 }
 
@@ -216,17 +195,12 @@ macro_rules! decl_type_alias {
     ($w:expr, $env:expr, $new:expr => $ty:ty) => {{
         use std::io::Write;
         let res = <$ty as ::ocaml_gen::OCamlBinding>::ocaml_binding($env, Some($new), false);
-        write!(
-            $w,
-            "{}{}\n",
-            format_args!("{: >1$}", "", $env.nested() * 2),
-            res,
-        )
-        .unwrap();
+        writeln!($w, "{}", res,).unwrap();
     }};
 }
 
-/// Creates a fake generic. This is a necessary hack, at the moment, to declare types (with the [decl_type] macro) that have generic parameters.
+/// Creates a "fake" generic. This is a necessary hack
+/// to handle types that have generic type parameters.
 #[macro_export]
 macro_rules! decl_fake_generic {
     ($name:ident, $i:expr) => {
@@ -234,11 +208,14 @@ macro_rules! decl_fake_generic {
 
         impl ::ocaml_gen::OCamlDesc for $name {
             fn ocaml_desc(_env: &::ocaml_gen::Env, generics: &[&str]) -> String {
+                // TODO: this should return the information that it is a generic
                 format!("'{}", generics[$i])
             }
 
-            fn unique_id(_stop_here: bool) -> u128 {
-                ::ocaml_gen::const_random!(u128)
+            fn unique_id() -> u128 {
+                // so that we can instantiate fake generics in different ways
+                // without influencing the unique_id they return
+                (0xdeadbeef as u128) ^ ($i as u128)
             }
         }
     };

--- a/ocaml/tests/src/generic_custom_type.rs
+++ b/ocaml/tests/src/generic_custom_type.rs
@@ -1,0 +1,65 @@
+#[derive(ocaml_gen::CustomType)]
+pub struct SomeGenericType<T> {
+    #[allow(dead_code)]
+    t: T,
+}
+
+impl<T> SomeGenericType<T> {
+    extern "C" fn finalize(v: ocaml::Raw) {
+        unsafe {
+            let mut v: ocaml::Pointer<Self> = v.as_pointer();
+            v.as_mut_ptr().drop_in_place();
+        }
+    }
+}
+
+ocaml::custom!(SomeGenericType<T> {
+    finalize: SomeGenericType::<T>::finalize,
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ocaml_gen::{decl_fake_generic, decl_type, decl_type_alias, Env};
+    use std::fmt::Write;
+
+    const SHOULD_COMPILE_TO: &str = r#"type some_generic_type"#;
+
+    #[test]
+    #[should_panic]
+    fn test_double_custom_definition() {
+        let mut w = String::new();
+        let env = &mut Env::default();
+
+        decl_fake_generic!(T1, 0);
+
+        decl_type!(w, env, SomeGenericType<T1>);
+
+        decl_type!(w, env, SomeGenericType<T1>);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_alias_of_custom() {
+        let mut w = String::new();
+        let env = &mut Env::default();
+
+        decl_fake_generic!(T1, 0);
+
+        decl_type!(w, env, SomeGenericType<T1>);
+
+        decl_type_alias!(w, env, "t2" => SomeGenericType<T1>);
+    }
+
+    #[test]
+    fn test_generic_custom_type() {
+        let mut w = String::new();
+        let env = &mut Env::default();
+
+        decl_fake_generic!(T1, 0);
+
+        decl_type!(w, env, SomeGenericType<T1>);
+
+        assert_eq!(SHOULD_COMPILE_TO, w.trim());
+    }
+}

--- a/ocaml/tests/src/lib.rs
+++ b/ocaml/tests/src/lib.rs
@@ -1,3 +1,6 @@
+// testing the single tuple edge-case
+// this should compile to single_tuple = { inner: string } instead of single_tuple = string
+
 #[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
 pub struct SingleTuple(String);
 

--- a/ocaml/tests/src/lib.rs
+++ b/ocaml/tests/src/lib.rs
@@ -1,17 +1,3 @@
-// testing the single tuple edge-case
-// this should compile to single_tuple = { inner: string } instead of single_tuple = string
-
-#[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
-pub struct SingleTuple(String);
-
-#[ocaml_gen::func]
-#[ocaml::func]
-pub fn new() -> SingleTuple {
-    SingleTuple(String::from("Hello"))
-}
-
-#[ocaml_gen::func]
-#[ocaml::func]
-pub fn print(s: SingleTuple) {
-    println!("{}", s.0);
-}
+pub mod generic_custom_type;
+pub mod single_tuple;
+pub mod type_alias;

--- a/ocaml/tests/src/main.rs
+++ b/ocaml/tests/src/main.rs
@@ -1,5 +1,5 @@
 use ocaml_gen::{decl_fake_generic, decl_func, decl_module, decl_type, decl_type_alias, Env};
-use ocamlgen_test_stubs::*;
+use ocamlgen_test_stubs::{single_tuple::*, type_alias::*};
 
 fn main() {
     let mut w = std::io::stdout();
@@ -24,33 +24,14 @@ fn type_alias(mut w: impl std::io::Write, env: &mut Env) {
     // something else
     decl_fake_generic!(T1, 0);
 
-    // type some_type = { t: 'T }
-    #[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
-    pub struct SomeType<T> {
-        t: T,
-    }
     decl_type!(w, env, SomeType<T1>);
 
-    // type some_concrete_type = { s: string }
-    #[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
-    pub struct SomeConcreteType {
-        s: String,
-    }
     decl_type!(w, env, SomeConcreteType);
 
     decl_module!(w, env, "A", {
         // type t2 = some_concrete_type some_type
         decl_type_alias!(w, env, "t2" => SomeType<SomeConcreteType>);
 
-        // external thing : unit -> t2 = "thing"
-        #[ocaml_gen::func]
-        #[ocaml::func]
-        pub fn thing() -> SomeType<SomeConcreteType> {
-            let t = SomeConcreteType {
-                s: "hey".to_string(),
-            };
-            SomeType { t }
-        }
         decl_func!(w, env, thing);
     });
 }

--- a/ocaml/tests/src/main.rs
+++ b/ocaml/tests/src/main.rs
@@ -1,11 +1,56 @@
-use ocaml_gen::{decl_func, decl_type, Env};
+use ocaml_gen::{decl_fake_generic, decl_func, decl_module, decl_type, decl_type_alias, Env};
 use ocamlgen_test_stubs::*;
 
 fn main() {
     let mut w = std::io::stdout();
-    let env = &mut Env::default();
+    let mut env = Env::default();
 
-    decl_type!(w, env, SingleTuple => "single_tuple");
+    single_tuple(&mut w, &mut env);
+    type_alias(&mut w, &mut env);
+}
+
+/// testing the single tuple edge-case
+/// this should compile to single_tuple = { inner: string } instead of single_tuple = string
+fn single_tuple(mut w: impl std::io::Write, env: &mut Env) {
+    decl_type!(w, env, SingleTuple);
+
     decl_func!(w, env, new => "new_t");
+
     decl_func!(w, env, print => "print_t");
+}
+
+/// Testing renaming/relocation of type aliases
+fn type_alias(mut w: impl std::io::Write, env: &mut Env) {
+    // something else
+    decl_fake_generic!(T1, 0);
+
+    // type some_type = { t: 'T }
+    #[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
+    pub struct SomeType<T> {
+        t: T,
+    }
+    decl_type!(w, env, SomeType<T1>);
+
+    // type some_concrete_type = { s: string }
+    #[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
+    pub struct SomeConcreteType {
+        s: String,
+    }
+    decl_type!(w, env, SomeConcreteType);
+
+    decl_module!(w, env, "A", {
+        // type t2 = some_concrete_type some_type
+        decl_type_alias!(w, env, "t2" => SomeType<SomeConcreteType>);
+
+        // external thing : unit -> t2 = "thing"
+        #[ocaml_gen::func]
+        #[ocaml::func]
+        pub fn thing() -> SomeType<SomeConcreteType> {
+            let t = SomeConcreteType {
+                s: "hey".to_string(),
+            };
+            SomeType { t }
+        }
+        decl_func!(w, env, thing);
+    });
 }

--- a/ocaml/tests/src/single_tuple.rs
+++ b/ocaml/tests/src/single_tuple.rs
@@ -1,0 +1,31 @@
+#[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
+pub struct SingleTuple(String);
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn new() -> SingleTuple {
+    SingleTuple(String::from("Hello"))
+}
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn print(s: SingleTuple) {
+    println!("{}", s.0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ocaml_gen::{decl_type, Env};
+    use std::fmt::Write;
+
+    const SHOULD_COMPILE_TO: &str = "type nonrec single_tuple = { inner: string } [@@boxed]";
+
+    #[test]
+    fn test_tupple() {
+        let mut w = String::new();
+        let env = &mut Env::default();
+        decl_type!(w, env, SingleTuple);
+        assert_eq!(SHOULD_COMPILE_TO, w.trim());
+    }
+}

--- a/ocaml/tests/src/type_alias.rs
+++ b/ocaml/tests/src/type_alias.rs
@@ -1,0 +1,63 @@
+#[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
+pub struct SomeType<T> {
+    t: T,
+}
+
+#[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
+pub struct SomeOtherType<P, Q> {
+    t1: P,
+    t2: Q,
+}
+
+#[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
+pub struct SomeConcreteType {
+    s: String,
+}
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn thing() -> SomeType<SomeConcreteType> {
+    let t = SomeConcreteType {
+        s: "hey".to_string(),
+    };
+    SomeType { t }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ocaml_gen::{decl_fake_generic, decl_func, decl_module, decl_type, decl_type_alias, Env};
+    use std::fmt::Write;
+
+    const SHOULD_COMPILE_TO: &str = r#"type nonrec ('T) t = { t: 'T }
+type nonrec ('P, 'Q) some_other_type = { t1: 'P; t2: 'Q }
+type nonrec some_concrete_type = { s: string }
+module A = struct 
+type nonrec t = (some_concrete_type) t
+type nonrec t2 = (some_concrete_type, some_concrete_type) some_other_type
+external thing : unit -> t = "thing"
+end"#;
+
+    #[test]
+    fn test_type_alias() {
+        let mut w = String::new();
+        let env = &mut Env::default();
+
+        decl_fake_generic!(T1, 0);
+        decl_fake_generic!(T2, 1);
+
+        decl_type!(w, env, SomeType<T1> => "t");
+        decl_type!(w, env, SomeOtherType<T1, T2>);
+
+        decl_type!(w, env, SomeConcreteType);
+        decl_module!(w, env, "A", {
+            println!("{:?}", env);
+            decl_type_alias!(w, env, "t" => SomeType<SomeConcreteType>);
+            decl_type_alias!(w, env, "t2" => SomeOtherType<SomeConcreteType, SomeConcreteType>);
+
+            decl_func!(w, env, thing);
+        });
+
+        assert_eq!(SHOULD_COMPILE_TO, w.trim());
+    }
+}


### PR DESCRIPTION
closes https://github.com/o1-labs/proof-systems/issues/176 and https://github.com/o1-labs/proof-systems/issues/196

I haven't tested it yet on mina, so let's not merged that yet.

update 1: I'm testing it now and mina is not happy. Especially, if the generic `SomeType<T>` is declared, but not `SomeType<SomeConcreteType>`, then a function that returns or expects a `SomeType<SomeConcreteType>` will have some trouble. I think if `SomeType<SomeConcreteType>` is not declared, we need to fallback on `SomeType<T>` before crashing. Investigating.

Note to myself:

* mimoo/backend2 is where I push this stuff here
* mimoo/backend_t is where I work on this stuff on the mina side