### PR TITLE
[kimchi] adding benchmarks code

### DIFF
--- a/circuits/kimchi/src/gates/generic.rs
+++ b/circuits/kimchi/src/gates/generic.rs
@@ -27,18 +27,10 @@ impl<F: FftField> CircuitGate<F> {
     }
 
     /// creates an addition gate
-    pub fn create_generic_add(row: usize, wires: GateWires) -> Self {
+    pub fn create_generic_add(row: usize, wires: GateWires, left_coeff: F, right_coeff: F) -> Self {
         let on = F::one();
         let off = F::zero();
-        let qw: [F; GENERICS] = array_init(|col| {
-            if col < 2 {
-                on
-            } else if col == 2 {
-                -on
-            } else {
-                off
-            }
-        });
+        let qw: [F; GENERICS] = [left_coeff, right_coeff, -on];
         Self::create_generic(row, wires, qw, off, off)
     }
 
@@ -46,8 +38,8 @@ impl<F: FftField> CircuitGate<F> {
     pub fn create_generic_mul(row: usize, wires: GateWires) -> Self {
         let on = F::one();
         let off = F::zero();
-        let qw: [F; GENERICS] = array_init(|col| if col == 2 { on } else { off });
-        Self::create_generic(row, wires, qw, -on, off)
+        let qw: [F; GENERICS] = [off, off, -on];
+        Self::create_generic(row, wires, qw, on, off)
     }
 
     /// creates a constant gate
@@ -94,7 +86,7 @@ impl<F: FftField> CircuitGate<F> {
         ensure_eq!(
             zero,
             sum + mul + constant_selector,
-            "generic: incorrect sum"
+            "generic: incorrect sum or mul"
         );
 
         // TODO(mimoo): additional checks:

--- a/circuits/kimchi/src/polynomials/generic.rs
+++ b/circuits/kimchi/src/polynomials/generic.rs
@@ -164,8 +164,7 @@ mod tests {
         gate::CircuitGate,
         wires::{Wire, COLUMNS},
     };
-
-    use ark_ff::{UniformRand, Zero};
+    use ark_ff::{One, UniformRand, Zero};
     use array_init::array_init;
     use itertools::iterate;
     use mina_curves::pasta::fp::Fp;
@@ -179,7 +178,12 @@ mod tests {
         // create generic gates
         let mut gates_row = iterate(0usize, |&i| i + 1);
         let r = gates_row.next().unwrap();
-        gates.push(CircuitGate::create_generic_add(r, Wire::new(r))); // add
+        gates.push(CircuitGate::create_generic_add(
+            r,
+            Wire::new(r),
+            Fp::one(),
+            Fp::one(),
+        )); // add
         let r = gates_row.next().unwrap();
         gates.push(CircuitGate::create_generic_mul(r, Wire::new(r))); // mul
         let r = gates_row.next().unwrap();

--- a/dlog/kimchi/Cargo.toml
+++ b/dlog/kimchi/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [lib]
 path = "src/lib.rs"
+bench = false # needed for criterion (https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options)
 
 [dependencies]
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
@@ -21,17 +22,28 @@ serde = "1.0.130"
 serde_with = "1.10.0"
 sprs = "0.9.2"
 
-ocaml = { version = "0.22.2", optional = true }
-ocaml-gen = { path = "../../ocaml/ocaml-gen", optional = true}
-
 commitment_dlog = { path = "../commitment" }
+groupmap = { path = "../../groupmap" }
+mina-curves = { path = "../../curves" }
 o1-utils = { path = "../../utils" }
 oracle = { path = "../../oracle" }
 kimchi-circuits = { path = "../../circuits/kimchi" }
 
+ocaml = { version = "0.22.2", optional = true }
+ocaml-gen = { path = "../../ocaml/ocaml-gen", optional = true}
+
 [dev-dependencies]
-groupmap = { path = "../../groupmap" }
-mina-curves = { path = "../../curves" }
+# benchmarks
+criterion = "0.3"
+iai = "0.1"
+
+[[bench]]
+name = "proof_criterion"
+harness = false
+
+[[bench]]
+name = "proof_iai"
+harness = false
 
 [features]
 default = []

--- a/dlog/kimchi/benches/proof_criterion.rs
+++ b/dlog/kimchi/benches/proof_criterion.rs
@@ -1,0 +1,9 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use kimchi::bench::proof;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("proof 20", |b| b.iter(|| proof(black_box(20))));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/dlog/kimchi/benches/proof_iai.rs
+++ b/dlog/kimchi/benches/proof_iai.rs
@@ -1,0 +1,12 @@
+use iai::black_box;
+use kimchi::bench::proof;
+
+fn iai_benchmark_short() {
+    proof(black_box(20))
+}
+
+fn iai_benchmark_long() {
+    proof(black_box(30))
+}
+
+iai::main!(iai_benchmark_short, iai_benchmark_long);

--- a/dlog/kimchi/src/bench.rs
+++ b/dlog/kimchi/src/bench.rs
@@ -1,0 +1,123 @@
+use crate::{index::Index, prover::ProverProof};
+use ark_ff::{One, UniformRand, Zero};
+use ark_poly::{univariate::DensePolynomial, UVPolynomial};
+use array_init::array_init;
+use commitment_dlog::{
+    commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve},
+    srs::{endos, SRS},
+};
+use groupmap::GroupMap;
+use kimchi_circuits::{
+    gate::CircuitGate,
+    nolookup::constraints::ConstraintSystem,
+    wires::{Wire, COLUMNS},
+};
+use mina_curves::pasta::vesta::VestaParameters;
+use mina_curves::pasta::{fp::Fp, pallas::Affine as Other, vesta::Affine};
+use oracle::{
+    poseidon::PlonkSpongeConstants15W,
+    sponge::{DefaultFqSponge, DefaultFrSponge},
+};
+use rand::{rngs::StdRng, SeedableRng};
+use std::sync::Arc;
+
+type SpongeParams = PlonkSpongeConstants15W;
+type BaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;
+type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
+
+const MUL_GATES: usize = 1000;
+const ADD_GATES: usize = 1000;
+
+const LEFT: usize = 0;
+const RIGHT: usize = 1;
+const OUTPUT: usize = 2;
+
+/// Produces `num` proofs and verifies them one by one.
+pub fn proof(num: usize) {
+    // create the circuit
+    let mut gates = vec![];
+    let mut abs_row = 0;
+
+    for _ in 0..MUL_GATES {
+        let wires = Wire::new(abs_row);
+        gates.push(CircuitGate::<Fp>::create_generic_mul(abs_row, wires));
+        abs_row += 1;
+    }
+
+    for _ in 0..ADD_GATES {
+        let wires = Wire::new(abs_row);
+        gates.push(CircuitGate::create_generic_add(
+            abs_row,
+            wires,
+            Fp::one(),
+            Fp::one(),
+        ));
+        abs_row += 1;
+    }
+
+    // set up
+    let rng = &mut StdRng::from_seed([0u8; 32]);
+    let group_map = <Affine as CommitmentCurve>::Map::setup();
+
+    // create the index
+    let fp_sponge_params = oracle::pasta::fp::params();
+    let cs = ConstraintSystem::<Fp>::create(gates, vec![], fp_sponge_params, 0).unwrap();
+    let n = cs.domain.d1.size as usize;
+    let fq_sponge_params = oracle::pasta::fq::params();
+    let (endo_q, _endo_r) = endos::<Other>();
+    let mut srs = SRS::create(n);
+    srs.add_lagrange_basis(cs.domain.d1);
+    let srs = Arc::new(srs);
+    let index = Index::<Affine>::create(cs, fq_sponge_params, endo_q, srs);
+
+    for _ in 0..num {
+        // create witness
+        let mut witness: [Vec<Fp>; COLUMNS] =
+            array_init(|_| vec![Fp::zero(); MUL_GATES + ADD_GATES]);
+
+        for row in 0..MUL_GATES {
+            witness[LEFT][row] = 3u32.into();
+            witness[RIGHT][row] = 5u32.into();
+            witness[OUTPUT][row] = Fp::from(3u32 * 5);
+        }
+
+        for row in MUL_GATES..MUL_GATES + ADD_GATES {
+            witness[LEFT][row] = 3u32.into();
+            witness[RIGHT][row] = 5u32.into();
+            witness[OUTPUT][row] = Fp::from(3u32 + 5);
+        }
+
+        // previous opening for recursion
+        let prev = {
+            let k = ceil_log2(index.srs.g.len());
+            let chals: Vec<_> = (0..k).map(|_| Fp::rand(rng)).collect();
+            let comm = {
+                let coeffs = b_poly_coefficients(&chals);
+                let b = DensePolynomial::from_coefficients_vec(coeffs);
+                index.srs.commit_non_hiding(&b, None)
+            };
+            (chals, comm)
+        };
+
+        // add the proof to the batch
+        let mut batch = Vec::new();
+        batch.push(
+            ProverProof::create::<BaseSponge, ScalarSponge>(
+                &group_map,
+                witness,
+                &index,
+                vec![prev],
+            )
+            .unwrap(),
+        );
+
+        // verify the proof
+        let verifier_index = index.verifier_index();
+        let lgr_comms = vec![];
+        let batch: Vec<_> = batch
+            .iter()
+            .map(|proof| (&verifier_index, &lgr_comms, proof))
+            .collect();
+        ProverProof::verify::<BaseSponge, ScalarSponge>(&group_map, &batch).unwrap();
+    }
+}

--- a/dlog/kimchi/src/lib.rs
+++ b/dlog/kimchi/src/lib.rs
@@ -1,3 +1,6 @@
+/// Hosts the benchmarking logic
+pub mod bench;
+
 pub mod index;
 pub mod plonk_sponge;
 pub mod prover;


### PR DESCRIPTION
This PR adds a benchmark using:

* [criterion.rs](https://github.com/bheisler/criterion.rs) a benchmark crate
* [iai](https://github.com/bheisler/iai) a benchmark crate better suited for CI

@mrmr1993 @imeckler is this enough to benchmark what we want? I'm not sure how you've run the bench so far. This benchmark only uses a circuit of a few thousands of generic gates. We can add other gates into the mix, Ideally we would test all gates here. Also, this only benches:

- the witness creation (very basic one, since we don't do what's being done on the OCaml side like the creation of the permutation)
- the proof creation
- the verification of the proof

we could also separate the proof creation from the verification of the proof in two different benchmarks.