### PR TITLE
[kimchi][circuits] fix most clippy lints

### DIFF
--- a/circuits/kimchi/src/expr.rs
+++ b/circuits/kimchi/src/expr.rs
@@ -248,6 +248,7 @@ impl<F: Field> ConstantExpr<F> {
 pub struct CacheId(usize);
 
 /// A cache
+#[derive(Default)]
 pub struct Cache {
     next_id: usize,
 }
@@ -282,11 +283,6 @@ impl CacheId {
 }
 
 impl Cache {
-    /// Create a new cache
-    pub fn new() -> Self {
-        Cache { next_id: 0 }
-    }
-
     fn next_id(&mut self) -> CacheId {
         let id = self.next_id;
         self.next_id += 1;
@@ -393,7 +389,7 @@ impl Variable {
 impl<F: FftField> PolishToken<F> {
     /// Evaluate an RPN expression to a field element.
     pub fn evaluate<'c>(
-        toks: &Vec<PolishToken<F>>,
+        toks: &[PolishToken<F>],
         d: D<F>,
         pt: F,
         evals: &[ProofEvaluations<F>],
@@ -1526,7 +1522,7 @@ fn mul_monomials<F: Neg<Output = F> + Clone + One + Zero + PartialEq>(
             m.extend(m2);
             m.sort();
             let c1c2 = c1.clone() * c2.clone();
-            let v = res.entry(m).or_insert(Expr::<F>::zero());
+            let v = res.entry(m).or_insert_with(Expr::<F>::zero);
             *v = v.clone() + c1c2;
         }
     }

--- a/circuits/kimchi/src/gates/endosclmul.rs
+++ b/circuits/kimchi/src/gates/endosclmul.rs
@@ -53,8 +53,8 @@ impl<F: FftField> CircuitGate<F> {
     ) -> Result<(), String> {
         let this: [F; COLUMNS] = array_init(|i| witness[i][self.row]);
         let next: [F; COLUMNS] = array_init(|i| witness[i][self.row + 1]);
-        let xq1 = (F::one() + &((cs.endo - &F::one()) * &next[12])) * &this[0];
-        let xq2 = (F::one() + &((cs.endo - &F::one()) * &next[14])) * &this[0];
+        let xq1 = (F::one() + ((cs.endo - F::one()) * next[12])) * this[0];
+        let xq2 = (F::one() + ((cs.endo - F::one()) * next[14])) * this[0];
 
         ensure_eq!(self.typ, GateType::Endomul, "endomul: incorrect gate");
 

--- a/circuits/kimchi/src/gates/generic.rs
+++ b/circuits/kimchi/src/gates/generic.rs
@@ -86,14 +86,14 @@ impl<F: FftField> CircuitGate<F> {
 
         // toggling each column x[i] depending on the selectors c[i]
         let sum = (0..GENERICS)
-            .map(|i| self.c[i] * &this[i])
-            .fold(zero, |x, y| x + &y);
+            .map(|i| self.c[i] * this[i])
+            .fold(zero, |x, y| x + y);
 
         // multiplication
-        let mul = mul_selector * &left * &right;
+        let mul = mul_selector * left * right;
         ensure_eq!(
             zero,
-            sum + &mul + &constant_selector,
+            sum + mul + constant_selector,
             "generic: incorrect sum"
         );
 

--- a/circuits/kimchi/src/gates/poseidon.rs
+++ b/circuits/kimchi/src/gates/poseidon.rs
@@ -76,7 +76,7 @@ impl<F: FftField> CircuitGate<F> {
         row: usize,
         // first and last row of the poseidon circuit (because they are used in the permutation)
         first_and_last_row: [GateWires; 2],
-        round_constants: &Vec<Vec<F>>,
+        round_constants: &[Vec<F>],
     ) -> (Vec<Self>, usize) {
         let mut gates = vec![];
 

--- a/circuits/kimchi/src/gates/varbasemul.rs
+++ b/circuits/kimchi/src/gates/varbasemul.rs
@@ -189,122 +189,122 @@ impl<F: FftField> CircuitGate<F> {
         // (xp - xt) * s1 = yp – (2*b1-1)*yt
         ensure_eq!(
             zero,
-            (xp - &xt) * &s1 - &yp + &(yt * &(b1.double() - &one)),
+            (xp - xt) * s1 - yp + (yt * (b1.double() - one)),
             "eq 6 wrong"
         );
 
         // s1^2 - s2^2 = xt - xr
-        ensure_eq!(zero, s1.square() - &s2.square() - &xt + &xr, "eq 7 wrong");
+        ensure_eq!(zero, s1.square() - s2.square() - xt + xr, "eq 7 wrong");
 
         // (2*xp + xt – s1^2) * (s1 + s2) = 2*yp
         ensure_eq!(
             zero,
-            (xp.double() + &xt - &s1.square()) * &(s1 + &s2) - &yp.double(),
+            (xp.double() + xt - s1.square()) * (s1 + s2) - yp.double(),
             "eq 8 wrong"
         );
 
         // (xp – xr) * s2 = yr + yp
-        ensure_eq!(zero, (xp - &xr) * &s2 - &yr - &yp, "eq 9 wrong");
+        ensure_eq!(zero, (xp - xr) * s2 - yr - yp, "eq 9 wrong");
 
         // (xr - xt) * s3 = yr – (2b2-1)*yt
         ensure_eq!(
             zero,
-            (xr - &xt) * &s3 - &yr + &(yt * &(b2.double() - &one)),
+            (xr - xt) * s3 - yr + (yt * (b2.double() - one)),
             "eq 10 wrong"
         );
 
         // S3^2 – s4^2 = xt - xs
-        ensure_eq!(zero, s3.square() - &s4.square() - &xt + &xs, "eq 11 wrong");
+        ensure_eq!(zero, s3.square() - s4.square() - xt + xs, "eq 11 wrong");
 
         // (2*xr + xt – s3^2) * (s3 + s4) = 2*yr
         ensure_eq!(
             zero,
-            (xr.double() + &xt - &s3.square()) * &(s3 + &s4) - &yr.double(),
+            (xr.double() + xt - s3.square()) * (s3 + s4) - yr.double(),
             "eq 12 wrong"
         );
 
         // (xr – xs) * s4 = ys + yr
-        ensure_eq!(zero, (xr - &xs) * &s4 - &ys - &yr, "eq 13 wrong");
+        ensure_eq!(zero, (xr - xs) * s4 - ys - yr, "eq 13 wrong");
 
         // (xt - xp) * s1 = (2b1-1)*yt - yp
         ensure_eq!(
             zero,
-            (xt - &next_xp) * &next_s1 - (next_b1.double() - &one) * &yt + &next_yp,
+            (xt - next_xp) * next_s1 - (next_b1.double() - one) * yt + next_yp,
             "eq 14 wrong"
         );
 
         // (2*xp – s1^2 + xt) * ((xp – xr) * s1 + yr + yp) = (xp – xr) * 2*yp
         ensure_eq!(
             zero,
-            (next_xp.double() - &next_s1.square() + &xt)
-                * &((next_xp - &next_xr) * &next_s1 + &next_yr + &next_yp)
-                - (next_xp - &next_xr) * &next_yp.double(),
+            (next_xp.double() - next_s1.square() + xt)
+                * ((next_xp - next_xr) * next_s1 + next_yr + next_yp)
+                - (next_xp - next_xr) * next_yp.double(),
             "eq 15 wrong"
         );
 
         // (yr + yp)^2 = (xp – xr)^2 * (s1^2 – xt + xr)
         ensure_eq!(
             zero,
-            (next_yr + &next_yp).square()
-                - (next_xp - &next_xr).square() * &(next_s1.square() - &xt + &next_xr),
+            (next_yr + next_yp).square()
+                - (next_xp - next_xr).square() * (next_s1.square() - xt + next_xr),
             "eq 16 wrong"
         );
 
         // (xt - xr) * s3 = (2b2-1)*yt - yr
         ensure_eq!(
             zero,
-            (xt - &next_xr) * &next_s3 - (next_b2.double() - &one) * &yt - &next_yr,
+            (xt - next_xr) * next_s3 - (next_b2.double() - one) * yt - next_yr,
             "eq 17 wrong"
         );
 
         // (2*xr – s3^2 + xt) * ((xr – xv) * s3 + yv + yr) = (xr – xv) * 2*yr
         ensure_eq!(
             zero,
-            (next_xr.double() - &next_s3.square() + &xt)
-                * &((next_xr - &next_xv) * &next_s3 + &next_yv + &next_yr)
-                - (next_xr - &next_xv) * &next_yr.double(),
+            (next_xr.double() - next_s3.square() + xt)
+                * ((next_xr - next_xv) * next_s3 + next_yv + next_yr)
+                - (next_xr - next_xv) * next_yr.double(),
             "eq 18 wrong"
         );
 
         // (yv + yr)^2 = (xr – xv)^2 * (s3^2 – xt + xv)
         ensure_eq!(
             zero,
-            (next_yv + &next_yr).square()
-                - (next_xr - &next_xv).square() * &(next_s3.square() - &xt + &next_xv),
+            (next_yv + next_yr).square()
+                - (next_xr - next_xv).square() * (next_s3.square() - xt + next_xv),
             "eq 19 wrong"
         );
 
         // (xt - xv) * s5 = (2b3-1)*yt - yv
         ensure_eq!(
             zero,
-            (xt - &next_xv) * &next_s5 - (next_b3.double() - &one) * &yt + &next_yv,
+            (xt - next_xv) * next_s5 - (next_b3.double() - one) * yt + next_yv,
             "eq 20 wrong"
         );
 
         // (2*xv – s5^2 + xt) * ((xv – xs) * s5 + ys + yv) = (xv – xs) * 2*yv
         ensure_eq!(
             zero,
-            (next_xv.double() - &next_s5.square() + &xt)
-                * &((next_xv - &next_xs) * &next_s5 + &next_ys + &next_yv)
-                - (next_xv - &next_xs) * &next_yv.double(),
+            (next_xv.double() - next_s5.square() + xt)
+                * ((next_xv - next_xs) * next_s5 + next_ys + next_yv)
+                - (next_xv - next_xs) * next_yv.double(),
             "eq 21 wrong"
         );
 
         // (ys + yv)^2 = (xv – xs)^2 * (s5^2 – xt + xs)
         ensure_eq!(
             zero,
-            (next_ys + &next_yv).square()
-                - (next_xv - &next_xs).square() * &(next_s5.square() - &xt + &next_xs),
+            (next_ys + next_yv).square()
+                - (next_xv - next_xs).square() * (next_s5.square() - xt + next_xs),
             "eq 22 wrong"
         );
 
         // TODO(mimoo): this constraint is not in the PDF
         ensure_eq!(
             zero,
-            ((((next_xr.double() + &b1).double() + &b2).double() + &next_b1).double() + &next_b2)
+            ((((next_xr.double() + b1).double() + b2).double() + next_b1).double() + next_b2)
                 .double()
-                + &next_xs
-                - &xr,
+                + next_xs
+                - xr,
             "eq 23 wrong"
         );
 

--- a/circuits/kimchi/src/nolookup/constraints.rs
+++ b/circuits/kimchi/src/nolookup/constraints.rs
@@ -224,7 +224,7 @@ where
 
         // create a map of cells to their shifted value
         let map: [Vec<F>; PERMUTS] =
-            array_init(|i| domain.elements().map(|elm| shifts[i] * &elm).collect());
+            array_init(|i| domain.elements().map(|elm| shifts[i] * elm).collect());
 
         //
         Self { shifts, map }
@@ -309,12 +309,12 @@ pub fn zk_polynomial<F: FftField>(domain: D<F>) -> DP<F> {
 
     // (x-w3)(x-w2)(x-w1) =
     // x^3 - x^2(w1+w2+w3) + x(w1w2+w1w3+w2w3) - w1w2w3
-    let w1w2 = w1 * &w2;
+    let w1w2 = w1 * w2;
     DP::from_coefficients_slice(&[
-        -w1w2 * &w3,                      // 1
-        w1w2 + &(w1 * &w3) + &(w3 * &w2), // x
-        -w1 - &w2 - &w3,                  // x^2
-        F::one(),                         // x^3
+        -w1w2 * w3,                   // 1
+        w1w2 + (w1 * w3) + (w3 * w2), // x
+        -w1 - w2 - w3,                // x^2
+        F::one(),                     // x^3
     ])
 }
 
@@ -447,10 +447,9 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
 
         let chacha8 = {
             use GateType::*;
-            let has_chacha_gate = gates.iter().any(|gate| match gate.typ {
-                ChaCha0 | ChaCha1 | ChaCha2 | ChaChaFinal => true,
-                _ => false,
-            });
+            let has_chacha_gate = gates
+                .iter()
+                .any(|gate| matches!(gate.typ, ChaCha0 | ChaCha1 | ChaCha2 | ChaChaFinal));
             if !has_chacha_gate {
                 None
             } else {

--- a/circuits/kimchi/src/polynomials/chacha.rs
+++ b/circuits/kimchi/src/polynomials/chacha.rs
@@ -156,10 +156,10 @@ pub fn xor_table<F: Field>() -> Vec<Vec<F>> {
         }
     }
 
-    for i in 0..3 {
-        res[i].reverse();
+    for r in res.iter_mut().take(3) {
+        r.reverse();
         // Just to be safe.
-        assert!(res[i][res[i].len() - 1].is_zero());
+        assert!(r[r.len() - 1].is_zero());
     }
     res
 }

--- a/circuits/kimchi/src/polynomials/complete_add.rs
+++ b/circuits/kimchi/src/polynomials/complete_add.rs
@@ -65,7 +65,7 @@ pub fn constraint<F: Field>(alpha0: usize) -> (usize, E<F>) {
     // This variable is used to constrain same_x
     let x21_inv = w(10);
 
-    let mut cache = Cache::new();
+    let mut cache = Cache::default();
 
     let x21 = cache.cache(x2.clone() - x1.clone());
     let y21 = cache.cache(y2 - y1.clone());

--- a/circuits/kimchi/src/polynomials/endomul_scalar.rs
+++ b/circuits/kimchi/src/polynomials/endomul_scalar.rs
@@ -126,7 +126,7 @@ pub fn constraint<F: Field>(alpha0: usize) -> E<F> {
 
     let xs: [_; 8] = array_init(|i| witness_column(6 + i));
 
-    let mut cache = Cache::new();
+    let mut cache = Cache::default();
 
     let c_coeffs = [
         F::zero(),
@@ -224,30 +224,32 @@ pub fn witness<F: PrimeField + std::fmt::Display>(
 }
 
 fn c_func<F: Field>(x: F) -> F {
-    if x == F::from(0u64) {
-        F::zero()
-    } else if x == F::from(1u64) {
-        F::zero()
-    } else if x == F::from(2u64) {
-        -F::one()
-    } else if x == F::from(3u64) {
-        F::one()
-    } else {
-        panic!("c_func")
+    let zero = F::zero();
+    let one = F::one();
+    let two = F::from(2u64);
+    let three = F::from(3u64);
+
+    match x {
+        x if x.is_zero() => zero,
+        x if x == one => zero,
+        x if x == two => -one,
+        x if x == three => one,
+        _ => panic!("c_func"),
     }
 }
 
 fn d_func<F: Field>(x: F) -> F {
-    if x == F::from(0u64) {
-        -F::one()
-    } else if x == F::from(1u64) {
-        F::one()
-    } else if x == F::from(2u64) {
-        F::zero()
-    } else if x == F::from(3u64) {
-        F::zero()
-    } else {
-        panic!("c_func")
+    let zero = F::zero();
+    let one = F::one();
+    let two = F::from(2u64);
+    let three = F::from(3u64);
+
+    match x {
+        x if x.is_zero() => -one,
+        x if x == one => one,
+        x if x == two => zero,
+        x if x == three => zero,
+        _ => panic!("d_func"),
     }
 }
 

--- a/circuits/kimchi/src/polynomials/endosclmul.rs
+++ b/circuits/kimchi/src/polynomials/endosclmul.rs
@@ -57,7 +57,7 @@ pub fn constraint<F: Field>(alpha0: usize) -> E<F> {
     let xr = w(7);
     let yr = w(8);
 
-    let mut cache = Cache::new();
+    let mut cache = Cache::default();
 
     let s1 = w(9);
     let s3 = w(10);
@@ -125,7 +125,7 @@ pub fn witness<F: Field + std::fmt::Display>(
     row0: usize,
     endo: F,
     base: (F, F),
-    bits: &Vec<bool>,
+    bits: &[bool],
     acc0: (F, F),
 ) -> EndoMulResult<F> {
     let bits_per_row = 4;

--- a/circuits/kimchi/src/polynomials/generic.rs
+++ b/circuits/kimchi/src/polynomials/generic.rs
@@ -61,7 +61,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
     /// generic(zeta) * w[1](zeta),
     /// generic(zeta) * w[2](zeta)
     pub fn gnrc_scalars(w_zeta: &[F; COLUMNS], generic_zeta: F) -> Vec<F> {
-        let mut res = vec![generic_zeta * w_zeta[0] * &w_zeta[1]];
+        let mut res = vec![generic_zeta * w_zeta[0] * w_zeta[1]];
         res.extend((0..GENERICS).map(|i| generic_zeta * w_zeta[i]));
         res
     }
@@ -252,6 +252,6 @@ mod tests {
 
         // check that f(z) = t(z) * Z_H(z)
         let z_h_zeta = cs.domain.d1.evaluate_vanishing_polynomial(zeta);
-        assert!(f_zeta == t_zeta * &z_h_zeta);
+        assert!(f_zeta == t_zeta * z_h_zeta);
     }
 }

--- a/circuits/kimchi/src/polynomials/permutation.rs
+++ b/circuits/kimchi/src/polynomials/permutation.rs
@@ -89,7 +89,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
     /// permutation linearization poly contribution computation
     pub fn perm_lnrz(
         &self,
-        e: &Vec<ProofEvaluations<F>>,
+        e: &[ProofEvaluations<F>],
         zeta: F,
         beta: F,
         gamma: F,
@@ -101,7 +101,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
     }
 
     pub fn perm_scalars(
-        e: &Vec<ProofEvaluations<F>>,
+        e: &[ProofEvaluations<F>],
         beta: F,
         gamma: F,
         // TODO(mimoo): should only pass an iterator, to prevent different calls to re-use the same alphas!
@@ -112,8 +112,8 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
             .w
             .iter()
             .zip(e[0].s.iter())
-            .map(|(w, s)| gamma + &(beta * s) + w)
-            .fold(e[1].z * beta * alpha[0] * &zkp_zeta, |x, y| x * y)
+            .map(|(w, s)| gamma + (beta * s) + w)
+            .fold(e[1].z * beta * alpha[0] * zkp_zeta, |x, y| x * y)
     }
 
     /// permutation aggregation polynomial computation
@@ -150,7 +150,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
             z[j + 1] = witness
                 .iter()
                 .zip(self.sigmal1.iter())
-                .map(|(w, s)| w[j] + &(s[j] * beta) + gamma)
+                .map(|(w, s)| w[j] + (s[j] * beta) + gamma)
                 .fold(F::one(), |x, y| x * y)
         }
 
@@ -161,7 +161,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
             z[j + 1] *= witness
                 .iter()
                 .zip(self.shift.iter())
-                .map(|(w, s)| w[j] + &(self.sid[j] * beta * s) + gamma)
+                .map(|(w, s)| w[j] + (self.sid[j] * beta * s) + gamma)
                 .fold(x, |z, y| z * y)
         }
 

--- a/circuits/kimchi/src/polynomials/poseidon.rs
+++ b/circuits/kimchi/src/polynomials/poseidon.rs
@@ -70,7 +70,7 @@ pub const ROUND_EQUATIONS: [RoundEquation; ROUNDS_PER_ROW] = [
 // constrain the values of the (r+1)th state.
 pub fn constraint<F: FftField + SquareRootField>() -> E<F> {
     let mut res = vec![];
-    let mut cache = Cache::new();
+    let mut cache = Cache::default();
 
     let mut idx = 0;
 
@@ -112,7 +112,7 @@ pub fn constraint<F: FftField + SquareRootField>() -> E<F> {
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {
     pub fn psdn_scalars(
-        evals: &Vec<ProofEvaluations<F>>,
+        evals: &[ProofEvaluations<F>],
         params: &ArithmeticSpongeParams<F>,
         alpha: &[F],
     ) -> Vec<F> {
@@ -136,7 +136,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
                 .iter()
                 .zip(alp[eq.source].iter())
                 .map(|(p, a)| -*a * p)
-                .fold(acc, |x, y| x + &y)
+                .fold(acc, |x, y| x + y)
         });
 
         let mut rhs = F::zero();
@@ -154,8 +154,8 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
         let mut res = vec![lhs + rhs];
 
         // TODO(mimoo): how is that useful? we already have access to these
-        for i in 0..COLUMNS {
-            res.push(evals[0].poseidon_selector * alpha[i]);
+        for alpha in alpha.iter().take(COLUMNS) {
+            res.push(evals[0].poseidon_selector * alpha);
         }
         res
     }
@@ -163,7 +163,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
     /// poseidon linearization poly contribution computation f^7 + c(x) - f(wx)
     pub fn psdn_lnrz(
         &self,
-        evals: &Vec<ProofEvaluations<F>>,
+        evals: &[ProofEvaluations<F>],
         params: &ArithmeticSpongeParams<F>,
         alpha: &[F],
     ) -> DensePolynomial<F> {

--- a/circuits/kimchi/src/polynomials/varbasemul.rs
+++ b/circuits/kimchi/src/polynomials/varbasemul.rs
@@ -164,7 +164,7 @@ pub fn witness<F: FftField + std::fmt::Display>(
     w: &mut [Vec<F>; COLUMNS],
     row0: usize,
     base: (F, F),
-    bits: &Vec<bool>,
+    bits: &[bool],
     acc0: (F, F),
 ) -> VarbaseMulResult<F> {
     let l = LAYOUT;
@@ -178,9 +178,9 @@ pub fn witness<F: FftField + std::fmt::Display>(
         let row = row0 + 2 * chunk;
 
         set(w, row, l.n_prev, n_acc);
-        for i in 0..bits_per_chunk {
+        for (i, bs) in bs.iter().enumerate().take(bits_per_chunk) {
             n_acc.double_in_place();
-            n_acc += bs[i];
+            n_acc += bs;
             acc = single_bit_witness(
                 w,
                 row,
@@ -189,7 +189,7 @@ pub fn witness<F: FftField + std::fmt::Display>(
                 l.ss[i],
                 l.accs[i],
                 l.accs[i + 1],
-                bs[i],
+                *bs,
                 base,
                 acc,
             );
@@ -209,7 +209,7 @@ pub fn constraint<F: FftField>(alpha0: usize) -> E<F> {
         n_next,
     } = LAYOUT;
 
-    let mut c = Cache::new();
+    let mut c = Cache::default();
 
     let mut constraint = |i| single_bit(&mut c, bits[i], base, ss[i], accs[i], accs[i + 1]);
 


### PR DESCRIPTION
ran `cargo clippy` in circuits/kimchi and fixed most of the links. The rest of the lints are a bit more subtle as they complain about functions that either take too many arguments or return too many values. I'm happy that clippy lints these, but we have to think a bit more about how to transform these to types.