### PR TITLE
Plookup with runtime tables

### DIFF
--- a/circuits/kimchi/src/expr.rs
+++ b/circuits/kimchi/src/expr.rs
@@ -44,6 +44,8 @@ pub struct LookupEnvironment<'a, F: FftField> {
     pub selectors: &'a Vec<Evaluations<F, D<F>>>,
     /// The evaluations of the combined lookup table polynomial.
     pub table: &'a Evaluations<F, D<F>>,
+    /// The evaluations of the runtime lookup table polynomial.
+    pub runtime_table: &'a Evaluations<F, D<F>>,
 }
 
 /// The collection of polynomials (all in evaluation form) and constants
@@ -86,6 +88,7 @@ impl<'a, F: FftField> Environment<'a, F> {
             LookupSorted(i) => lookup.map(|l| &l.sorted[*i]),
             LookupAggreg => lookup.map(|l| l.aggreg),
             LookupTable => lookup.map(|l| l.table),
+            RuntimeLookupTable => lookup.map(|l| l.runtime_table),
             Index(t) => match self.index.get(t) {
                 None => None,
                 Some(e) => Some(e),
@@ -127,6 +130,7 @@ pub enum Column {
     Index(GateType),
     Coefficient(usize),
     Indexer,
+    RuntimeLookupTable,
 }
 
 impl Column {
@@ -380,6 +384,7 @@ impl Variable {
             LookupSorted(i) => l.map(|l| l.sorted[i]),
             LookupAggreg => l.map(|l| l.aggreg),
             LookupTable => l.map(|l| l.table),
+            RuntimeLookupTable => l.map(|l| l.runtime_table),
             Index(GateType::Poseidon) => Ok(evals.poseidon_selector),
             Index(GateType::Generic) => Ok(evals.generic_selector),
             Coefficient(_) | LookupKindIndex(_) | Index(_) => {

--- a/circuits/kimchi/src/expr.rs
+++ b/circuits/kimchi/src/expr.rs
@@ -70,6 +70,8 @@ pub struct Environment<'a, F: FftField> {
     pub domain: EvaluationDomains<F>,
     /// Lookup specific polynomials
     pub lookup: Option<LookupEnvironment<'a, F>>,
+    /// Indexer polynomial
+    pub indexer: &'a Evaluations<F, D<F>>,
 }
 
 impl<'a, F: FftField> Environment<'a, F> {
@@ -88,6 +90,7 @@ impl<'a, F: FftField> Environment<'a, F> {
                 None => None,
                 Some(e) => Some(e),
             },
+            Indexer => Some(&self.indexer),
         }
     }
 }
@@ -123,6 +126,7 @@ pub enum Column {
     LookupKindIndex(usize),
     Index(GateType),
     Coefficient(usize),
+    Indexer,
 }
 
 impl Column {
@@ -381,6 +385,7 @@ impl Variable {
             Coefficient(_) | LookupKindIndex(_) | Index(_) => {
                 Err("Cannot get index evaluation (should have been linearized away)")
             }
+            Indexer => Ok(evals.indexer),
         }
     }
 }

--- a/circuits/kimchi/src/expr.rs
+++ b/circuits/kimchi/src/expr.rs
@@ -46,6 +46,8 @@ pub struct LookupEnvironment<'a, F: FftField> {
     pub table: &'a Evaluations<F, D<F>>,
     /// The evaluations of the runtime lookup table polynomial.
     pub runtime_table: &'a Evaluations<F, D<F>>,
+    /// The combined lookups chunked per row.
+    pub lookup_chunk: &'a Evaluations<F, D<F>>,
 }
 
 /// The collection of polynomials (all in evaluation form) and constants
@@ -88,6 +90,7 @@ impl<'a, F: FftField> Environment<'a, F> {
             LookupSorted(i) => lookup.map(|l| &l.sorted[*i]),
             LookupAggreg => lookup.map(|l| l.aggreg),
             LookupTable => lookup.map(|l| l.table),
+            LookupChunk => lookup.map(|l| l.lookup_chunk),
             RuntimeLookupTable => lookup.map(|l| l.runtime_table),
             Index(t) => match self.index.get(t) {
                 None => None,
@@ -126,6 +129,7 @@ pub enum Column {
     LookupSorted(usize),
     LookupAggreg,
     LookupTable,
+    LookupChunk,
     LookupKindIndex(usize),
     Index(GateType),
     Coefficient(usize),
@@ -384,6 +388,7 @@ impl Variable {
             LookupSorted(i) => l.map(|l| l.sorted[i]),
             LookupAggreg => l.map(|l| l.aggreg),
             LookupTable => l.map(|l| l.table),
+            LookupChunk => l.map(|l| l.lookup_chunk),
             RuntimeLookupTable => l.map(|l| l.runtime_table),
             Index(GateType::Poseidon) => Ok(evals.poseidon_selector),
             Index(GateType::Generic) => Ok(evals.generic_selector),

--- a/circuits/kimchi/src/expr.rs
+++ b/circuits/kimchi/src/expr.rs
@@ -1262,7 +1262,7 @@ impl<F: FftField> Expr<F> {
         } else if deg <= 8 * d1_size {
             Domain::D8
         } else {
-            panic!("constraint had degree {} > 8", deg);
+            panic!("constraint had degree {} > 8 * {}", deg, d1_size);
         };
 
         let mut cache = HashMap::new();

--- a/circuits/kimchi/src/gate.rs
+++ b/circuits/kimchi/src/gate.rs
@@ -46,7 +46,6 @@ pub struct LocalPosition {
 /// combination of locally-accessible cells.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct SingleLookup<F> {
-    table_id: usize,
     // Linear combination of local-positions
     pub value: Vec<(F, LocalPosition)>,
 }
@@ -83,6 +82,7 @@ impl<F: Field> SingleLookup<F> {
 /// A spec for checking that the given vector belongs to a vector-valued lookup table.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct JointLookup<F> {
+    pub table_id: u64,
     pub entry: Vec<SingleLookup<F>>,
 }
 
@@ -292,10 +292,10 @@ impl GateType {
                 let right = curr_row(7 + i);
                 let output = curr_row(11 + i);
                 let l = |loc: LocalPosition| SingleLookup {
-                    table_id: 0,
                     value: vec![(F::one(), loc)],
                 };
                 JointLookup {
+                    table_id: 0,
                     entry: vec![l(left), l(right), l(output)],
                 }
             })
@@ -320,18 +320,11 @@ impl GateType {
                 // Check
                 // XOR((nybble - low_bit)/2, (nybble - low_bit)/2) = 0.
                 let x = SingleLookup {
-                    table_id: 0,
                     value: vec![(one_half, nybble), (neg_one_half, low_bit)],
                 };
                 JointLookup {
-                    entry: vec![
-                        x.clone(),
-                        x,
-                        SingleLookup {
-                            table_id: 0,
-                            value: vec![],
-                        },
-                    ],
+                    table_id: 0,
+                    entry: vec![x.clone(), x, SingleLookup { value: vec![] }],
                 }
             })
             .collect();

--- a/circuits/kimchi/src/gate.rs
+++ b/circuits/kimchi/src/gate.rs
@@ -311,7 +311,7 @@ impl GateType {
             })
             .collect();
 
-        let lookup_pattern = (0..4)
+        let lookup_pattern = (0..3)
             .map(|i| {
                 let index = curr_row(2 * i);
                 let value = curr_row(2 * i + 1);

--- a/circuits/kimchi/src/gate.rs
+++ b/circuits/kimchi/src/gate.rs
@@ -317,7 +317,7 @@ impl GateType {
                 let value = curr_row(2 * i + 1);
                 JointLookup {
                     table_id: 1,
-                    entry: vec![l(index), l(value)],
+                    entry: vec![l(value), l(index)],
                 }
             })
             .collect();

--- a/circuits/kimchi/src/nolookup/constraints.rs
+++ b/circuits/kimchi/src/nolookup/constraints.rs
@@ -89,6 +89,12 @@ pub struct ConstraintSystem<F: FftField> {
     #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub endomul_scalarm: DP<F>,
 
+    // Runtime lookup polynomials
+    // --------------------------
+    /// the constant indexer polynomial, f(w^i) = i
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
+    pub indexer: DP<F>,
+
     //
     // Polynomials over lagrange base
     //
@@ -140,6 +146,9 @@ pub struct ConstraintSystem<F: FftField> {
     /// Lookup index
     #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]
     pub lookup8: Option<E<F, D<F>>>,
+    /// the constant indexer polynomial, f(w^i) = i
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
+    pub indexer8: E<F, D<F>>,
 
     // Constant polynomials
     // --------------------
@@ -544,6 +553,13 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
             }
         };
 
+        let indexer = E::<F, D<F>>::from_vec_and_domain(
+            (0..domain.d8.size).map(Into::into).collect(),
+            domain.d8,
+        )
+        .interpolate();
+        let indexer8 = indexer.evaluate_over_domain_by_ref(domain.d8);
+
         // constant polynomials
         let l1 = DP::from_coefficients_slice(&[F::zero(), F::one()])
             .evaluate_over_domain_by_ref(domain.d8);
@@ -643,6 +659,8 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
             zkpl,
             zkpm,
             vanishes_on_last_4_rows,
+            indexer,
+            indexer8,
             lookup8,
             gates,
             shift: shifts.shifts,

--- a/circuits/kimchi/src/nolookup/constraints.rs
+++ b/circuits/kimchi/src/nolookup/constraints.rs
@@ -553,11 +553,15 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
             }
         };
 
-        let indexer = E::<F, D<F>>::from_vec_and_domain(
-            (0..domain.d8.size).map(Into::into).collect(),
-            domain.d8,
-        )
-        .interpolate();
+        let indexer = {
+            // NB: The indexer is in reverse order, to allow the runtime table to be 'snakified'
+            // with the lookup table
+            let indexes: Vec<_> = (0..domain.d1.size - ZK_ROWS)
+                .rev()
+                .map(Into::into)
+                .collect();
+            E::<F, D<F>>::from_vec_and_domain(indexes, domain.d1).interpolate()
+        };
         let indexer8 = indexer.evaluate_over_domain_by_ref(domain.d8);
 
         // constant polynomials

--- a/circuits/kimchi/src/nolookup/scalars.rs
+++ b/circuits/kimchi/src/nolookup/scalars.rs
@@ -38,6 +38,8 @@ pub struct ProofEvaluations<Field> {
     pub generic_selector: Field,
     /// evaluation of the poseidon selector polynomial
     pub poseidon_selector: Field,
+    /// evaluation of the indexer polynomial
+    pub indexer: Field,
 }
 
 impl<F: FftField> ProofEvaluations<Vec<F>> {
@@ -57,6 +59,7 @@ impl<F: FftField> ProofEvaluations<Vec<F>> {
             }),
             generic_selector: DensePolynomial::eval_polynomial(&self.generic_selector, pt),
             poseidon_selector: DensePolynomial::eval_polynomial(&self.poseidon_selector, pt),
+            indexer: DensePolynomial::eval_polynomial(&self.indexer, pt),
         }
     }
 }
@@ -184,6 +187,7 @@ pub mod caml {
         ),
         pub generic_selector: Vec<CamlF>,
         pub poseidon_selector: Vec<CamlF>,
+        pub indexer: Vec<CamlF>,
     }
 
     //

--- a/circuits/kimchi/src/nolookup/scalars.rs
+++ b/circuits/kimchi/src/nolookup/scalars.rs
@@ -22,6 +22,8 @@ pub struct LookupEvaluations<Field> {
     pub table: Field,
     /// runtime lookup table polynomial
     pub runtime_table: Field,
+    /// chunked row lookups
+    pub lookup_chunk: Field,
 }
 
 // TODO: this should really be vectors here, perhaps create another type for chuncked evaluations?
@@ -59,6 +61,7 @@ impl<F: FftField> ProofEvaluations<Vec<F>> {
                     .map(|x| DensePolynomial::eval_polynomial(x, pt))
                     .collect(),
                 runtime_table: DensePolynomial::eval_polynomial(&l.runtime_table, pt),
+                lookup_chunk: DensePolynomial::eval_polynomial(&l.lookup_chunk, pt),
             }),
             generic_selector: DensePolynomial::eval_polynomial(&self.generic_selector, pt),
             poseidon_selector: DensePolynomial::eval_polynomial(&self.poseidon_selector, pt),

--- a/circuits/kimchi/src/nolookup/scalars.rs
+++ b/circuits/kimchi/src/nolookup/scalars.rs
@@ -20,6 +20,8 @@ pub struct LookupEvaluations<Field> {
     // TODO: May be possible to optimize this away?
     /// lookup table polynomial
     pub table: Field,
+    /// runtime lookup table polynomial
+    pub runtime_table: Field,
 }
 
 // TODO: this should really be vectors here, perhaps create another type for chuncked evaluations?
@@ -56,6 +58,7 @@ impl<F: FftField> ProofEvaluations<Vec<F>> {
                     .iter()
                     .map(|x| DensePolynomial::eval_polynomial(x, pt))
                     .collect(),
+                runtime_table: DensePolynomial::eval_polynomial(&l.runtime_table, pt),
             }),
             generic_selector: DensePolynomial::eval_polynomial(&self.generic_selector, pt),
             poseidon_selector: DensePolynomial::eval_polynomial(&self.poseidon_selector, pt),

--- a/circuits/kimchi/src/nolookup/scalars.rs
+++ b/circuits/kimchi/src/nolookup/scalars.rs
@@ -122,6 +122,8 @@ pub mod caml {
         pub sorted: Vec<Vec<CamlF>>,
         pub aggreg: Vec<CamlF>,
         pub table: Vec<CamlF>,
+        pub runtime_table: Vec<CamlF>,
+        pub lookup_chunk: Vec<CamlF>,
     }
 
     impl<F, CamlF> From<LookupEvaluations<Vec<F>>> for CamlLookupEvaluations<CamlF>
@@ -138,6 +140,8 @@ pub mod caml {
                     .collect(),
                 aggreg: le.aggreg.into_iter().map(Into::into).collect(),
                 table: le.table.into_iter().map(Into::into).collect(),
+                runtime_table: le.runtime_table.into_iter().map(Into::into).collect(),
+                lookup_chunk: le.lookup_chunk.into_iter().map(Into::into).collect(),
             }
         }
     }
@@ -155,6 +159,8 @@ pub mod caml {
                     .collect(),
                 aggreg: pe.aggreg.into_iter().map(Into::into).collect(),
                 table: pe.table.into_iter().map(Into::into).collect(),
+                runtime_table: pe.runtime_table.into_iter().map(Into::into).collect(),
+                lookup_chunk: pe.lookup_chunk.into_iter().map(Into::into).collect(),
             }
         }
     }
@@ -237,6 +243,7 @@ pub mod caml {
                 s,
                 generic_selector: pe.generic_selector.into_iter().map(Into::into).collect(),
                 poseidon_selector: pe.poseidon_selector.into_iter().map(Into::into).collect(),
+                indexer: pe.indexer.into_iter().map(Into::into).collect(),
             }
         }
     }
@@ -280,6 +287,7 @@ pub mod caml {
                 lookup: None,
                 generic_selector: cpe.generic_selector.into_iter().map(Into::into).collect(),
                 poseidon_selector: cpe.poseidon_selector.into_iter().map(Into::into).collect(),
+                indexer: cpe.indexer.into_iter().map(Into::into).collect(),
             }
         }
     }

--- a/circuits/kimchi/src/polynomials/chacha.rs
+++ b/circuits/kimchi/src/polynomials/chacha.rs
@@ -475,7 +475,7 @@ mod tests {
             for i in 0..COLUMNS {
                 h.insert(Column::Witness(i));
             }
-            for i in 0..(lookup_info.max_per_row + 1) {
+            for i in 0..(lookup_info.max_per_row + 2) {
                 h.insert(Column::LookupSorted(i));
             }
             h.insert(Column::Z);
@@ -503,7 +503,7 @@ mod tests {
             generic_selector: F::zero(),
             poseidon_selector: F::zero(),
             lookup: Some(LookupEvaluations {
-                sorted: (0..(lookup_info.max_per_row + 1))
+                sorted: (0..(lookup_info.max_per_row + 2))
                     .map(|_| F::rand(rng))
                     .collect(),
                 aggreg: F::rand(rng),

--- a/circuits/kimchi/src/polynomials/chacha.rs
+++ b/circuits/kimchi/src/polynomials/chacha.rs
@@ -509,6 +509,7 @@ mod tests {
                 aggreg: F::rand(rng),
                 table: F::rand(rng),
                 runtime_table: F::rand(rng),
+                lookup_chunk: F::rand(rng),
             }),
             indexer: F::zero(),
         };

--- a/circuits/kimchi/src/polynomials/chacha.rs
+++ b/circuits/kimchi/src/polynomials/chacha.rs
@@ -508,6 +508,7 @@ mod tests {
                     .collect(),
                 aggreg: F::rand(rng),
                 table: F::rand(rng),
+                runtime_table: F::rand(rng),
             }),
             indexer: F::zero(),
         };

--- a/circuits/kimchi/src/polynomials/chacha.rs
+++ b/circuits/kimchi/src/polynomials/chacha.rs
@@ -509,6 +509,7 @@ mod tests {
                 aggreg: F::rand(rng),
                 table: F::rand(rng),
             }),
+            indexer: F::zero(),
         };
         let evals = vec![eval(), eval()];
 

--- a/circuits/kimchi/src/polynomials/lookup.rs
+++ b/circuits/kimchi/src/polynomials/lookup.rs
@@ -364,9 +364,6 @@ pub fn sorted<
             sorted[i].push(end_val);
         }
 
-        let final_sorted = &mut sorted[max_lookups_per_row];
-        final_sorted.push(final_sorted[final_sorted.len() - 1].clone());
-
         // snake-ify (see top comment)
         for s in sorted.iter_mut().skip(1).step_by(2) {
             s.reverse();

--- a/circuits/kimchi/src/polynomials/lookup.rs
+++ b/circuits/kimchi/src/polynomials/lookup.rs
@@ -355,6 +355,9 @@ pub fn sorted<
             sorted[i].push(end_val);
         }
 
+        let final_sorted = &mut sorted[max_lookups_per_row];
+        final_sorted.push(final_sorted[final_sorted.len() - 1].clone());
+
         // snake-ify (see top comment)
         for s in sorted.iter_mut().skip(1).step_by(2) {
             s.reverse();

--- a/dlog/kimchi/src/bench.rs
+++ b/dlog/kimchi/src/bench.rs
@@ -105,6 +105,7 @@ pub fn proof(num: usize) {
             ProverProof::create::<BaseSponge, ScalarSponge>(
                 &group_map,
                 witness,
+                vec![],
                 &index,
                 vec![prev],
             )

--- a/dlog/kimchi/src/index.rs
+++ b/dlog/kimchi/src/index.rs
@@ -258,6 +258,7 @@ where
                 h.insert(Z);
                 h.insert(LookupAggreg);
                 h.insert(LookupTable);
+                h.insert(LookupChunk);
                 h.insert(Index(GateType::Poseidon));
                 h.insert(Index(GateType::Generic));
                 h

--- a/dlog/kimchi/src/index.rs
+++ b/dlog/kimchi/src/index.rs
@@ -252,7 +252,7 @@ where
                 for i in 0..COLUMNS {
                     h.insert(Witness(i));
                 }
-                for i in 0..(lookup_info.max_per_row + 1) {
+                for i in 0..(lookup_info.max_per_row + 2) {
                     h.insert(LookupSorted(i));
                 }
                 h.insert(Z);

--- a/dlog/kimchi/src/index.rs
+++ b/dlog/kimchi/src/index.rs
@@ -120,6 +120,8 @@ pub struct VerifierIndex<G: CommitmentCurve> {
     /// Lookup polynomial commitments
     #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
     pub lookup_comm: Option<PolyComm<G>>,
+    #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
+    pub indexer_comm: PolyComm<G>,
 
     /// wire coordinate shifts
     #[serde_as(as = "[o1_utils::serialization::SerdeAs; PERMUTS]")]
@@ -188,6 +190,9 @@ where
                 .lookup8
                 .as_ref()
                 .map(|c| self.srs.commit_evaluations_non_hiding(domain, &c, None)),
+            indexer_comm: self
+                .srs
+                .commit_evaluations_non_hiding(domain, &self.cs.indexer8, None),
             lookup_selectors: self
                 .cs
                 .lookup_selectors

--- a/dlog/kimchi/src/index.rs
+++ b/dlog/kimchi/src/index.rs
@@ -258,6 +258,8 @@ where
                 h.insert(Z);
                 h.insert(LookupAggreg);
                 h.insert(LookupTable);
+                h.insert(Indexer);
+                h.insert(RuntimeLookupTable);
                 h.insert(LookupChunk);
                 h.insert(Index(GateType::Poseidon));
                 h.insert(Index(GateType::Generic));

--- a/dlog/kimchi/src/index.rs
+++ b/dlog/kimchi/src/index.rs
@@ -61,6 +61,8 @@ where
     /// maximal size of the quotient polynomial according to the supported constraints
     pub max_quot_size: usize,
 
+    pub max_joint_size: usize,
+
     /// random oracle argument parameters
     #[serde(skip)]
     pub fq_sponge_params: ArithmeticSpongeParams<Fq<G>>,
@@ -129,6 +131,8 @@ pub struct VerifierIndex<G: CommitmentCurve> {
     #[serde(skip)]
     pub endo: Fr<G>,
 
+    pub max_joint_size: usize,
+
     pub lookup_used: Option<LookupsUsed>,
     #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
     pub lookup_tables: Vec<Vec<PolyComm<G>>>,
@@ -192,6 +196,8 @@ where
                 })
                 .collect(),
 
+            max_joint_size: self.max_joint_size,
+
             w: zk_w3(self.cs.domain.d1),
             fr_sponge_params: self.cs.fr_sponge_params.clone(),
             fq_sponge_params: self.fq_sponge_params.clone(),
@@ -253,7 +259,7 @@ where
             let expr = if lookup_used.is_some() {
                 expr + Expr::combine_constraints(
                     2 + super::range::CHACHA.end,
-                    lookup::constraints(&cs.dummy_lookup_values[0], cs.domain.d1),
+                    lookup::constraints(&cs.dummy_lookup_values[0], 0, cs.domain.d1),
                 )
             } else {
                 expr
@@ -273,6 +279,7 @@ where
             max_quot_size: cs.domain.d8.size as usize - 7,
             fq_sponge_params,
             max_poly_size,
+            max_joint_size: lookup_info.max_joint_size,
             srs,
             cs,
             lookup_used,

--- a/dlog/kimchi/src/index.rs
+++ b/dlog/kimchi/src/index.rs
@@ -117,6 +117,10 @@ pub struct VerifierIndex<G: CommitmentCurve> {
     #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
     pub chacha_comm: Option<[PolyComm<G>; 4]>,
 
+    /// Lookup polynomial commitments
+    #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
+    pub lookup_comm: Option<PolyComm<G>>,
+
     /// wire coordinate shifts
     #[serde_as(as = "[o1_utils::serialization::SerdeAs; PERMUTS]")]
     pub shift: [Fr<G>; PERMUTS],
@@ -179,6 +183,11 @@ where
             chacha_comm: self.cs.chacha8.as_ref().map(|c| {
                 array_init(|i| self.srs.commit_evaluations_non_hiding(domain, &c[i], None))
             }),
+            lookup_comm: self
+                .cs
+                .lookup8
+                .as_ref()
+                .map(|c| self.srs.commit_evaluations_non_hiding(domain, &c, None)),
             lookup_selectors: self
                 .cs
                 .lookup_selectors

--- a/dlog/kimchi/src/prover.rs
+++ b/dlog/kimchi/src/prover.rs
@@ -186,18 +186,22 @@ where
         let lookup_info = LookupInfo::<Fr<G>>::create();
         let lookup_used = lookup_info.lookup_used(&index.cs.gates);
 
-        let (runtime_table_evals, runtime_table_comm, runtime_table_poly, runtime_table8) = {
+        let (runtime_table_comm, runtime_table_poly, runtime_table8) = {
             match lookup_used.as_ref() {
-                None => (None, None, None, None),
+                None => (None, None, None),
                 Some(_) => {
-                    let evals = lookup::zk_patch(runtime_table, index.cs.domain.d1, rng);
+                    let evals = lookup::zk_patch(
+                        runtime_table.iter().map(|x| *x).rev().collect(),
+                        index.cs.domain.d1,
+                        rng,
+                    );
                     let comm = index
                         .srs
                         .commit_evaluations(index.cs.domain.d1, &evals, None, rng);
                     fq_sponge.absorb_g(&comm.0.unshifted);
                     let coeffs = evals.clone().interpolate();
                     let evals8 = coeffs.evaluate_over_domain_by_ref(index.cs.domain.d8);
-                    (Some(evals), Some(comm), Some(coeffs), Some(evals8))
+                    (Some(comm), Some(coeffs), Some(evals8))
                 }
             }
         };

--- a/dlog/kimchi/src/prover.rs
+++ b/dlog/kimchi/src/prover.rs
@@ -438,6 +438,7 @@ where
                 domain: index.cs.domain,
                 index: index_evals,
                 lookup: lookup_env,
+                indexer: &index.cs.indexer8,
             }
         };
 
@@ -565,6 +566,7 @@ where
             lookup: lookup_evals(zeta),
             generic_selector: index.cs.genericm.eval(zeta, index.max_poly_size),
             poseidon_selector: index.cs.psm.eval(zeta, index.max_poly_size),
+            indexer: index.cs.indexer.eval(zeta, index.max_poly_size),
         };
         let chunked_evals_zeta_omega = ProofEvaluations::<Vec<Fr<G>>> {
             s: array_init(|i| {
@@ -575,6 +577,7 @@ where
             lookup: lookup_evals(zeta_omega),
             generic_selector: index.cs.genericm.eval(zeta_omega, index.max_poly_size),
             poseidon_selector: index.cs.psm.eval(zeta_omega, index.max_poly_size),
+            indexer: index.cs.indexer.eval(zeta_omega, index.max_poly_size),
         };
 
         drop(lookup_aggreg_coeffs);
@@ -605,6 +608,7 @@ where
                 }),
                 generic_selector: DensePolynomial::eval_polynomial(&es.generic_selector, e1),
                 poseidon_selector: DensePolynomial::eval_polynomial(&es.poseidon_selector, e1),
+                indexer: DensePolynomial::eval_polynomial(&es.indexer, e1),
             })
             .collect::<Vec<_>>();
 

--- a/dlog/kimchi/src/prover.rs
+++ b/dlog/kimchi/src/prover.rs
@@ -275,24 +275,21 @@ where
             CombinedEntry(x)
         };
 
+        let iter_lookup_table = || {
+            (0..d1_size).map(|i| {
+                let table_id = 0;
+                let row = index.cs.lookup_tables8[table_id as usize]
+                    .iter()
+                    .map(|e| &e.evals[8 * i]);
+                combine_table_entry(joint_combiner, table_id, lookup_info.max_joint_size, row)
+            })
+        };
+
         let (lookup_sorted, lookup_sorted_coeffs, lookup_sorted_comm, lookup_sorted8) =
             match lookup_used.as_ref() {
                 None => (None, None, None, None),
                 Some(_) => {
-                    let iter_lookup_table = || {
-                        (0..d1_size).map(|i| {
-                            let table_id = 0;
-                            let row = index.cs.lookup_tables8[table_id as usize]
-                                .iter()
-                                .map(|e| &e.evals[8 * i]);
-                            CombinedEntry(combine_table_entry(
-                                joint_combiner,
-                                table_id,
-                                lookup_info.max_joint_size,
-                                row,
-                            ))
-                        })
-                    };
+                    let iter_lookup_table = || iter_lookup_table().map(|x| CombinedEntry(x));
 
                     // TODO: Once we switch to committing using lagrange commitments,
                     // `witness` will be consumed when we interpolate, so interpolation will
@@ -384,12 +381,6 @@ where
             match lookup_sorted {
                 None => (None, None, None),
                 Some(lookup_sorted) => {
-                    let iter_lookup_table = || (0..d1_size).map(|i| {
-                        let table_id = 0;
-                        let row = index.cs.lookup_tables8[table_id as usize].iter().map(|e| & e.evals[8 * i]);
-                        combine_table_entry(joint_combiner, table_id, lookup_info.max_joint_size, row)
-                    });
-
                     let aggreg =
                         lookup::aggregation::<_, Fr<G>, _>(
                             Box::new(iter_lookup_table()) as Box<dyn DoubleEndedIterator<Item = Fr<G>>>,

--- a/dlog/kimchi/src/verifier.rs
+++ b/dlog/kimchi/src/verifier.rs
@@ -145,6 +145,7 @@ where
         let gamma = fq_sponge.challenge();
 
         self.commitments.lookup.iter().for_each(|l| {
+            fq_sponge.absorb_g(&l.lookup_chunk.unshifted);
             fq_sponge.absorb_g(&l.aggreg.unshifted);
         });
 
@@ -525,6 +526,9 @@ where
                             }
                             RuntimeLookupTable => {
                                 panic!("TODO: RuntimeLookupTable");
+                            }
+                            LookupChunk => {
+                                panic!("TODO: LookupChunk");
                             }
                         }
                     }

--- a/dlog/kimchi/src/verifier.rs
+++ b/dlog/kimchi/src/verifier.rs
@@ -122,6 +122,10 @@ where
             .iter()
             .for_each(|c| fq_sponge.absorb_g(&c.unshifted));
 
+        self.commitments.lookup.iter().for_each(|l| {
+            fq_sponge.absorb_g(&l.runtime_table.unshifted);
+        });
+
         let joint_combiner = {
             let s = match index.lookup_used.as_ref() {
                 None | Some(LookupsUsed::Single) => ScalarChallenge(Fr::<G>::zero()),
@@ -517,7 +521,10 @@ where
                             }
                             Indexer => {
                                 scalars_part.push(e);
-                                commitments_part.push(&index.indexer_comm);
+                                commitments_part.push(&index.indexer_comm)
+                            }
+                            RuntimeLookupTable => {
+                                panic!("TODO: RuntimeLookupTable");
                             }
                         }
                     }

--- a/dlog/kimchi/src/verifier.rs
+++ b/dlog/kimchi/src/verifier.rs
@@ -510,6 +510,7 @@ where
                                     ChaCha1 => &index.chacha_comm.as_ref().unwrap()[1],
                                     ChaCha2 => &index.chacha_comm.as_ref().unwrap()[2],
                                     ChaChaFinal => &index.chacha_comm.as_ref().unwrap()[3],
+                                    Lookup => &index.lookup_comm.as_ref().unwrap(),
                                 };
                                 scalars_part.push(e);
                                 commitments_part.push(c);

--- a/dlog/kimchi/src/verifier.rs
+++ b/dlog/kimchi/src/verifier.rs
@@ -515,6 +515,10 @@ where
                                 scalars_part.push(e);
                                 commitments_part.push(c);
                             }
+                            Indexer => {
+                                scalars_part.push(e);
+                                commitments_part.push(&index.indexer_comm);
+                            }
                         }
                     }
                 }

--- a/dlog/kimchi/src/verifier.rs
+++ b/dlog/kimchi/src/verifier.rs
@@ -492,6 +492,10 @@ where
                                     scalars_part.push(e * j);
                                     commitments_part.push(t);
                                 }
+                                /* TODO: When multiple tables are supported, include the table ID commitment here */
+                                /*
+                                scalars_part.push(e * constants.joint_combiner.pow([index.max_joint_size as u64]));
+                                commitments_part.push(&index.table_ids[0]); */
                             }
                             Index(t) => {
                                 use GateType::*;

--- a/dlog/kimchi/tests/ec.rs
+++ b/dlog/kimchi/tests/ec.rs
@@ -183,9 +183,14 @@ fn ec_test() {
     index.cs.verify(&witness).unwrap();
 
     let start = Instant::now();
-    let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index, vec![])
-            .unwrap();
+    let proof = ProverProof::create::<BaseSponge, ScalarSponge>(
+        &group_map,
+        witness,
+        vec![],
+        &index,
+        vec![],
+    )
+    .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
     let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];

--- a/dlog/kimchi/tests/endomul_scalar.rs
+++ b/dlog/kimchi/tests/endomul_scalar.rs
@@ -95,9 +95,14 @@ fn endomul_scalar_test() {
     }
 
     let start = Instant::now();
-    let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index, vec![])
-            .unwrap();
+    let proof = ProverProof::create::<BaseSponge, ScalarSponge>(
+        &group_map,
+        witness,
+        vec![],
+        &index,
+        vec![],
+    )
+    .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
     let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];

--- a/dlog/kimchi/tests/generic.rs
+++ b/dlog/kimchi/tests/generic.rs
@@ -126,8 +126,14 @@ fn verify_proof(gates: Vec<CircuitGate<Fp>>, witness: [Vec<Fp>; COLUMNS], public
     // add the proof to the batch
     let mut batch = Vec::new();
     batch.push(
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index, vec![prev])
-            .unwrap(),
+        ProverProof::create::<BaseSponge, ScalarSponge>(
+            &group_map,
+            witness,
+            vec![],
+            &index,
+            vec![prev],
+        )
+        .unwrap(),
     );
 
     // verify the proof

--- a/dlog/tests/chacha_test.rs
+++ b/dlog/tests/chacha_test.rs
@@ -92,9 +92,14 @@ fn chacha_prover() {
     let group_map = <Affine as CommitmentCurve>::Map::setup();
 
     let start = Instant::now();
-    let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index, vec![])
-            .unwrap();
+    let proof = ProverProof::create::<BaseSponge, ScalarSponge>(
+        &group_map,
+        witness,
+        vec![],
+        &index,
+        vec![],
+    )
+    .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
     let start = Instant::now();

--- a/dlog/tests/endomul.rs
+++ b/dlog/tests/endomul.rs
@@ -145,9 +145,14 @@ fn endomul_test() {
     }
 
     let start = Instant::now();
-    let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index, vec![])
-            .unwrap();
+    let proof = ProverProof::create::<BaseSponge, ScalarSponge>(
+        &group_map,
+        witness,
+        vec![],
+        &index,
+        vec![],
+    )
+    .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
     let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];

--- a/dlog/tests/lookup_test.rs
+++ b/dlog/tests/lookup_test.rs
@@ -1,0 +1,106 @@
+use ark_ff::UniformRand;
+use ark_ff::Zero;
+use array_init::array_init;
+use colored::Colorize;
+use commitment_dlog::{
+    commitment::{ceil_log2, CommitmentCurve},
+    srs::{endos, SRS},
+};
+use groupmap::GroupMap;
+use kimchi::{index::Index, prover::ProverProof};
+use kimchi_circuits::wires::{Wire, COLUMNS};
+use kimchi_circuits::{
+    gate::{CircuitGate, GateType},
+    nolookup::constraints::ConstraintSystem,
+    polynomials::chacha,
+};
+use mina_curves::pasta::{
+    fp::Fp,
+    pallas::Affine as Other,
+    vesta::{Affine, VestaParameters},
+};
+use oracle::{
+    poseidon::PlonkSpongeConstants15W,
+    sponge::{DefaultFqSponge, DefaultFrSponge},
+};
+use std::cmp::min;
+use std::{sync::Arc, time::Instant};
+
+// aliases
+
+type SpongeParams = PlonkSpongeConstants15W;
+type BaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;
+type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
+
+const PUBLIC: usize = 0;
+
+#[test]
+fn lookup_prover() {
+    let num_lookups = 500;
+    let table_size = 500;
+    let max_size = 1 << ceil_log2(min(num_lookups, table_size));
+    let rng = &mut rand::rngs::OsRng;
+    let runtime_table: Vec<_> = (0..table_size).map(|_i| Fp::rand(rng)).collect();
+
+    let mut gates = Vec::with_capacity(num_lookups);
+    for i in 0..num_lookups {
+        gates.push(CircuitGate {
+            row: i,
+            typ: GateType::Lookup,
+            wires: array_init(|j| Wire { row: i, col: j }),
+            c: vec![],
+        });
+    }
+
+    let mut witness: [Vec<Fp>; COLUMNS] = array_init(|_| vec![]);
+    for _ in 0..num_lookups {
+        for i in 0..4 {
+            let idx = rand::random::<usize>() % table_size;
+            witness[i * 2].push(Into::into(idx as u64));
+            witness[i * 2 + 1].push(runtime_table[idx]);
+        }
+        for i in 8..COLUMNS {
+            witness[i].push(Fp::zero());
+        }
+    }
+
+    // create the index
+    let fp_sponge_params = oracle::pasta::fp::params();
+    let cs =
+        ConstraintSystem::<Fp>::create(gates, vec![chacha::xor_table()], fp_sponge_params, PUBLIC)
+            .unwrap();
+    let fq_sponge_params = oracle::pasta::fq::params();
+    let (endo_q, _endo_r) = endos::<Other>();
+    let mut srs = SRS::create(max_size);
+    srs.add_lagrange_basis(cs.domain.d1);
+    let srs = Arc::new(srs);
+
+    let index = Index::<Affine>::create(cs, fq_sponge_params, endo_q, srs);
+
+    let group_map = <Affine as CommitmentCurve>::Map::setup();
+
+    let start = Instant::now();
+    let proof = ProverProof::create::<BaseSponge, ScalarSponge>(
+        &group_map,
+        witness,
+        runtime_table,
+        &index,
+        vec![],
+    )
+    .unwrap();
+    println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
+
+    let start = Instant::now();
+    let verifier_index = index.verifier_index();
+    println!("{}{:?}", "Verifier index time: ".yellow(), start.elapsed());
+
+    let lgr_comms = vec![];
+    let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];
+    let start = Instant::now();
+    match ProverProof::verify::<BaseSponge, ScalarSponge>(&group_map, &batch) {
+        Err(error) => panic!("Failure verifying the prover's proofs in batch: {}", error),
+        Ok(_) => {
+            println!("{}{:?}", "Verifier time: ".yellow(), start.elapsed());
+        }
+    }
+}

--- a/dlog/tests/lookup_test.rs
+++ b/dlog/tests/lookup_test.rs
@@ -54,12 +54,12 @@ fn lookup_prover() {
 
     let mut witness: [Vec<Fp>; COLUMNS] = array_init(|_| vec![]);
     for _ in 0..num_lookups {
-        for i in 0..4 {
+        for i in 0..3 {
             let idx = rand::random::<usize>() % table_size;
             witness[i * 2].push(Into::into(idx as u64));
             witness[i * 2 + 1].push(runtime_table[idx]);
         }
-        for i in 8..COLUMNS {
+        for i in 6..COLUMNS {
             witness[i].push(Fp::zero());
         }
     }

--- a/dlog/tests/poseidon_vesta_15_wires.rs
+++ b/dlog/tests/poseidon_vesta_15_wires.rs
@@ -195,6 +195,7 @@ fn positive(index: &Index<Affine>) {
             ProverProof::create::<BaseSponge, ScalarSponge>(
                 &group_map,
                 witness_cols,
+                vec![],
                 index,
                 vec![prev],
             )

--- a/dlog/tests/varbasemul.rs
+++ b/dlog/tests/varbasemul.rs
@@ -122,9 +122,14 @@ fn varbase_mul_test() {
     );
 
     let start = Instant::now();
-    let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index, vec![])
-            .unwrap();
+    let proof = ProverProof::create::<BaseSponge, ScalarSponge>(
+        &group_map,
+        witness,
+        vec![],
+        &index,
+        vec![],
+    )
+    .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
     let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];


### PR DESCRIPTION
This PR adds support for a 'runtime' table, which we can use to model write-once memory.

This
* uses the `joint_combiner` to associate a table ID with looked-up values
  - this ensures that lookups for one table do not (negl. prob.) resolve to values in another table
* adds a commitment for `lookup_chunk`, which accumulates the values of all of the lookups that occur in each row
  - this is necessary to keep the degree of the lookup aggregation polynomial below n*8
* adds a 'runtime table', which is committed to at proving time (rather than index creation time)
* adds an 'indexer' polynomial, which attains each of the values `0..n-ZK_ROWS`
  - this is used as the 'address' of the memory to read/write in the runtime table
* increases the number of sorted columns in the lookup aggregation by 1, to account for the extra column of values in the runtime table

-----------------

#### Technical details

* The index's lookup table and the runtime table are combined by 'snakifying', like we were doing previously for the sorted columns
  - As there, this is necessary for us to associate the last value in one table and the first in the subsequent table, because the zk rows lie between the last and first values.
  - In practice, this means that the runtime table is reversed, and we treat the tables as the combined table formed by `runtime_table.rev().extend(lookup_table)`
* The initial value of the lookup aggregation column is modified to include the term `gamma * (beta+1) + runtime_table[n-ZK_ROWS] + beta * lookup_table[0]` in the numerator
  - This term performs the join between the (reversed) runtime table and the index table.
  - This is preferable to including the first value of the index table as the final value in the runtime table, because the values in each table are constructed differently (different numbers of joins, different table ID), and so building the correct term in combination with the joiners is significantly messier.
* The initial value of the lookup aggregation column is modified to include the term `gamma * (beta+1) + 0 + beta * 0 = gamma * (beta+1)` in the denominator
  - This term is needed to account for the final pair of (dummy) values of the index table, which is omitted from the sorted tables: the extra joiner term between the runtime and index tables above takes up a space within the sorted table, but was added by the initial condition in the unsorted table, so it shifts the final term `gamma * (beta+1) + lookup_table[n-ZK_ROWS-1] + beta * lookup_table[n-ZK_ROWS-1]` out of the available range.
  - Currently the final 2 entries in `lookup_table` are `0` due to padding; if we want to allow them to vary, we can add constants for these final two terms and use the full term instead.
* The `table_id` is included using `joint_combiner^max_joint_size`, where `max_joint_size` is the maximum number of vector entries in any vector table (currently 3 due to the XOR table).
  - This ensures that the table ID can't be confused with any part of the vector lookup data, but still generates distinct values for distinct tables.
* This explicitly adds the dummy values to the sorted tables, since the last table is now reversed.
  - Failure to do so adds the dummy values at the **start** of the table instead.
* The `Lookup` gate is structured as `[index_1; value_1; index_2; value_2; index_3; value_3; index_4; value_4]` where `runtime_table[index_i] = value_i`.
  - The remaining 9 fields are unused, as there currently doesn't seem to be much use to looking-up values into columns that don't participate in the permutation argument.
  - `value_4` is in a column that doesn't participate in the permutation argument, so the `index_4`/`value_4` pair will mostly be useless for lookups. However, `index_4` appears in the final permutation row, and thus can be used as a 'range check', giving us 4 ~10-bit range checks per gate (assuming d1 = 2^10).