### PR TITLE
Removing field row from CircuitGate struct

### DIFF
--- a/circuits/kimchi/src/gate.rs
+++ b/circuits/kimchi/src/gate.rs
@@ -368,7 +368,7 @@ impl GateType {
 pub struct CircuitGate<F: FftField> {
     /// row position in the circuit
     // TODO(mimoo): shouldn't this be u32 since we serialize it as a u32?
-    pub row: usize,
+    //pub row: usize,
     /// type of the gate
     pub typ: GateType,
     /// gate wires
@@ -382,7 +382,6 @@ pub struct CircuitGate<F: FftField> {
 impl<F: FftField> ToBytes for CircuitGate<F> {
     #[inline]
     fn write<W: Write>(&self, mut w: W) -> IoResult<()> {
-        (self.row as u32).write(&mut w)?;
         let typ: u8 = ToPrimitive::to_u8(&self.typ).unwrap();
         typ.write(&mut w)?;
         for i in 0..COLUMNS {
@@ -399,9 +398,8 @@ impl<F: FftField> ToBytes for CircuitGate<F> {
 
 impl<F: FftField> CircuitGate<F> {
     /// this function creates "empty" circuit gate
-    pub fn zero(row: usize, wires: GateWires) -> Self {
+    pub fn zero(wires: GateWires) -> Self {
         CircuitGate {
-            row,
             typ: GateType::Zero,
             c: Vec::new(),
             wires,
@@ -412,18 +410,19 @@ impl<F: FftField> CircuitGate<F> {
     /// assignements (witness) against the constraints
     pub fn verify(
         &self,
+        row: usize,
         witness: &[Vec<F>; COLUMNS],
         cs: &ConstraintSystem<F>,
     ) -> Result<(), String> {
         use GateType::*;
         match self.typ {
             Zero => Ok(()),
-            Generic => self.verify_generic(witness),
-            Poseidon => self.verify_poseidon(witness, cs),
-            CompleteAdd => self.verify_complete_add(witness),
-            Vbmul => self.verify_vbmul(witness),
-            Endomul => self.verify_endomul(witness, cs),
-            EndomulScalar => self.verify_endomul_scalar(witness, cs),
+            Generic => self.verify_generic(row, witness),
+            Poseidon => self.verify_poseidon(row, witness, cs),
+            CompleteAdd => self.verify_complete_add(row, witness),
+            Vbmul => self.verify_vbmul(row, witness),
+            Endomul => self.verify_endomul(row, witness, cs),
+            EndomulScalar => self.verify_endomul_scalar(row, witness, cs),
             ChaCha0 | ChaCha1 | ChaCha2 | ChaChaFinal => panic!("todo"),
         }
     }
@@ -438,7 +437,6 @@ pub mod caml {
 
     #[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
     pub struct CamlCircuitGate<F> {
-        pub row: ocaml::Int,
         pub typ: GateType,
         pub wires: (
             CamlWire,
@@ -459,7 +457,6 @@ pub mod caml {
     {
         fn from(cg: CircuitGate<F>) -> Self {
             Self {
-                row: cg.row.try_into().expect("usize -> isize"),
                 typ: cg.typ,
                 wires: array_to_tuple(cg.wires),
                 c: cg.c.into_iter().map(Into::into).collect(),
@@ -474,7 +471,6 @@ pub mod caml {
     {
         fn from(cg: &CircuitGate<F>) -> Self {
             Self {
-                row: cg.row.try_into().expect("usize -> isize"),
                 typ: cg.typ,
                 wires: array_to_tuple(cg.wires),
                 c: cg.c.clone().into_iter().map(Into::into).collect(),
@@ -489,7 +485,6 @@ pub mod caml {
     {
         fn from(ccg: CamlCircuitGate<CamlF>) -> Self {
             Self {
-                row: ccg.row.try_into().expect("isize -> usize"),
                 typ: ccg.typ,
                 wires: tuple_to_array(ccg.wires),
                 c: ccg.c.into_iter().map(Into::into).collect(),
@@ -558,9 +553,8 @@ mod tests {
     }
 
     prop_compose! {
-        fn arb_circuit_gate()(row in any::<usize>(), typ: GateType, wires: GateWires, c in arb_fp_vec(25)) -> CircuitGate<Fp> {
+        fn arb_circuit_gate()(typ: GateType, wires: GateWires, c in arb_fp_vec(25)) -> CircuitGate<Fp> {
             CircuitGate {
-                row,
                 typ,
                 wires,
                 c,
@@ -577,7 +571,6 @@ mod tests {
             let decoded: CircuitGate<Fp> = rmp_serde::from_read_ref(&encoded).unwrap();
 
             println!("decoded gate: {:?}", decoded);
-            prop_assert_eq!(cg.row, decoded.row);
             prop_assert_eq!(cg.typ, decoded.typ);
             for i in 0..PERMUTS {
                 prop_assert_eq!(cg.wires[i], decoded.wires[i]);

--- a/circuits/kimchi/src/gate.rs
+++ b/circuits/kimchi/src/gate.rs
@@ -366,9 +366,6 @@ impl GateType {
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CircuitGate<F: FftField> {
-    /// row position in the circuit
-    // TODO(mimoo): shouldn't this be u32 since we serialize it as a u32?
-    //pub row: usize,
     /// type of the gate
     pub typ: GateType,
     /// gate wires

--- a/circuits/kimchi/src/gates/endosclmul.rs
+++ b/circuits/kimchi/src/gates/endosclmul.rs
@@ -37,9 +37,8 @@ use ark_ff::FftField;
 use array_init::array_init;
 
 impl<F: FftField> CircuitGate<F> {
-    pub fn create_endomul(row: usize, wires: GateWires) -> Self {
+    pub fn create_endomul(wires: GateWires) -> Self {
         CircuitGate {
-            row,
             typ: GateType::Endomul,
             wires,
             c: vec![],
@@ -48,11 +47,12 @@ impl<F: FftField> CircuitGate<F> {
 
     pub fn verify_endomul(
         &self,
+        row: usize,
         witness: &[Vec<F>; COLUMNS],
         cs: &ConstraintSystem<F>,
     ) -> Result<(), String> {
-        let this: [F; COLUMNS] = array_init(|i| witness[i][self.row]);
-        let next: [F; COLUMNS] = array_init(|i| witness[i][self.row + 1]);
+        let this: [F; COLUMNS] = array_init(|i| witness[i][row]);
+        let next: [F; COLUMNS] = array_init(|i| witness[i][row + 1]);
         let xq1 = (F::one() + ((cs.endo - F::one()) * next[12])) * this[0];
         let xq2 = (F::one() + ((cs.endo - F::one()) * next[14])) * this[0];
 
@@ -118,7 +118,7 @@ impl<F: FftField> CircuitGate<F> {
         );
         ensure_eq!(
             F::zero(),
-            (((witness[6][self.row + 1].double() + this[11]).double() + this[12]).double()
+            (((witness[6][row + 1].double() + this[11]).double() + this[12]).double()
                 + this[13])
                 .double()
                 + this[14]

--- a/circuits/kimchi/src/gates/endosclmul.rs
+++ b/circuits/kimchi/src/gates/endosclmul.rs
@@ -118,8 +118,7 @@ impl<F: FftField> CircuitGate<F> {
         );
         ensure_eq!(
             F::zero(),
-            (((witness[6][row + 1].double() + this[11]).double() + this[12]).double()
-                + this[13])
+            (((witness[6][row + 1].double() + this[11]).double() + this[12]).double() + this[13])
                 .double()
                 + this[14]
                 - this[6],

--- a/circuits/kimchi/src/gates/generic.rs
+++ b/circuits/kimchi/src/gates/generic.rs
@@ -14,7 +14,6 @@ pub const CONSTANT_COEFF: usize = GENERICS + 1;
 
 impl<F: FftField> CircuitGate<F> {
     pub fn create_generic(wires: GateWires, qw: [F; GENERICS], qm: F, qc: F) -> Self {
-
         let mut c = qw.to_vec();
         c.push(qm);
         c.push(qc);
@@ -31,7 +30,7 @@ impl<F: FftField> CircuitGate<F> {
         let on = F::one();
         let off = F::zero();
         let qw: [F; GENERICS] = [left_coeff, right_coeff, -on];
-        Self::create_generic( wires, qw, off, off)
+        Self::create_generic(wires, qw, off, off)
     }
 
     /// creates a multiplication gate

--- a/circuits/kimchi/src/gates/generic.rs
+++ b/circuits/kimchi/src/gates/generic.rs
@@ -13,13 +13,13 @@ pub const MUL_COEFF: usize = GENERICS;
 pub const CONSTANT_COEFF: usize = GENERICS + 1;
 
 impl<F: FftField> CircuitGate<F> {
-    pub fn create_generic(row: usize, wires: GateWires, qw: [F; GENERICS], qm: F, qc: F) -> Self {
+    pub fn create_generic(wires: GateWires, qw: [F; GENERICS], qm: F, qc: F) -> Self {
+
         let mut c = qw.to_vec();
         c.push(qm);
         c.push(qc);
 
         CircuitGate {
-            row,
             typ: GateType::Generic,
             wires,
             c,
@@ -27,42 +27,42 @@ impl<F: FftField> CircuitGate<F> {
     }
 
     /// creates an addition gate
-    pub fn create_generic_add(row: usize, wires: GateWires, left_coeff: F, right_coeff: F) -> Self {
+    pub fn create_generic_add(wires: GateWires, left_coeff: F, right_coeff: F) -> Self {
         let on = F::one();
         let off = F::zero();
         let qw: [F; GENERICS] = [left_coeff, right_coeff, -on];
-        Self::create_generic(row, wires, qw, off, off)
+        Self::create_generic( wires, qw, off, off)
     }
 
     /// creates a multiplication gate
-    pub fn create_generic_mul(row: usize, wires: GateWires) -> Self {
+    pub fn create_generic_mul(wires: GateWires) -> Self {
         let on = F::one();
         let off = F::zero();
         let qw: [F; GENERICS] = [off, off, -on];
-        Self::create_generic(row, wires, qw, on, off)
+        Self::create_generic(wires, qw, on, off)
     }
 
     /// creates a constant gate
-    pub fn create_generic_const(row: usize, wires: GateWires, constant: F) -> Self {
+    pub fn create_generic_const(wires: GateWires, constant: F) -> Self {
         let on = F::one();
         let off = F::zero();
         let qw: [F; GENERICS] = array_init(|col| if col == 0 { on } else { off });
-        Self::create_generic(row, wires, qw, off, -constant)
+        Self::create_generic(wires, qw, off, -constant)
     }
 
     /// creates a public input gate
-    pub fn create_generic_public(row: usize, wires: GateWires) -> Self {
+    pub fn create_generic_public(wires: GateWires) -> Self {
         let on = F::one();
         let off = F::zero();
         let qw: [F; GENERICS] = array_init(|col| if col == 0 { on } else { off });
-        Self::create_generic(row, wires, qw, off, off)
+        Self::create_generic(wires, qw, off, off)
     }
 
     /// verifies that the generic gate constraints are solved by the witness
     // TODO(mimoo): this is not going to work for public inputs no?
-    pub fn verify_generic(&self, witness: &[Vec<F>; COLUMNS]) -> Result<(), String> {
+    pub fn verify_generic(&self, row: usize, witness: &[Vec<F>; COLUMNS]) -> Result<(), String> {
         // assignments
-        let this: [F; COLUMNS] = array_init(|i| witness[i][self.row]);
+        let this: [F; COLUMNS] = array_init(|i| witness[i][row]);
         let left = this[0];
         let right = this[1];
 

--- a/circuits/kimchi/src/gates/varbasemul.rs
+++ b/circuits/kimchi/src/gates/varbasemul.rs
@@ -103,16 +103,14 @@ use ark_ff::FftField;
 use array_init::array_init;
 
 impl<F: FftField> CircuitGate<F> {
-    pub fn create_vbmul(row: usize, wires: &[GateWires; 2]) -> Vec<Self> {
+    pub fn create_vbmul(wires: &[GateWires; 2]) -> Vec<Self> {
         vec![
             CircuitGate {
-                row,
                 typ: GateType::Vbmul,
                 wires: wires[0],
                 c: vec![],
             },
             CircuitGate {
-                row: row + 1,
                 typ: GateType::Zero,
                 wires: wires[1],
                 c: vec![],
@@ -120,9 +118,9 @@ impl<F: FftField> CircuitGate<F> {
         ]
     }
 
-    pub fn verify_vbmul(&self, witness: &[Vec<F>; COLUMNS]) -> Result<(), String> {
-        let this: [F; COLUMNS] = array_init(|i| witness[i][self.row]);
-        let next: [F; COLUMNS] = array_init(|i| witness[i][self.row + 1]);
+    pub fn verify_vbmul(&self, row: usize, witness: &[Vec<F>; COLUMNS]) -> Result<(), String> {
+        let this: [F; COLUMNS] = array_init(|i| witness[i][row]);
+        let next: [F; COLUMNS] = array_init(|i| witness[i][row + 1]);
 
         //    0	1	2	3	4	5	6	7	8	9	10	11	12	13	14	Type
         //   xT	yT	xS	yS	xP	yP	n	xr	yr	s1	s2	b1	s3	s4	b2	VBSM

--- a/circuits/kimchi/src/nolookup/constraints.rs
+++ b/circuits/kimchi/src/nolookup/constraints.rs
@@ -354,7 +354,6 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
         let mut padding = (gates.len()..d1_size)
             .map(|i| {
                 CircuitGate::<F>::zero(
-                    i,
                     array_init(|j| Wire {
                         col: WIRES[j],
                         row: i,
@@ -655,7 +654,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
             }
 
             // check the gate's satisfiability
-            gate.verify(&witness, self)
+            gate.verify(row, &witness, self)
                 .map_err(|err| GateError::Custom { row, err })?;
         }
 

--- a/circuits/kimchi/src/nolookup/constraints.rs
+++ b/circuits/kimchi/src/nolookup/constraints.rs
@@ -353,12 +353,10 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
         let d1_size = domain.d1.size();
         let mut padding = (gates.len()..d1_size)
             .map(|i| {
-                CircuitGate::<F>::zero(
-                    array_init(|j| Wire {
-                        col: WIRES[j],
-                        row: i,
-                    }),
-                )
+                CircuitGate::<F>::zero(array_init(|j| Wire {
+                    col: WIRES[j],
+                    row: i,
+                }))
             })
             .collect();
         gates.append(&mut padding);

--- a/circuits/kimchi/src/polynomials/complete_add.rs
+++ b/circuits/kimchi/src/polynomials/complete_add.rs
@@ -170,8 +170,7 @@ pub fn constraint<F: Field>(alpha0: usize) -> (usize, E<F>) {
 
 impl<F: FftField> CircuitGate<F> {
     /// Check the correctness of witness values for a complete-add gate.
-    pub fn verify_complete_add(&self, witness: &[Vec<F>; COLUMNS]) -> Result<(), String> {
-        let row = self.row;
+    pub fn verify_complete_add(&self, row: usize, witness: &[Vec<F>; COLUMNS]) -> Result<(), String> {
         let x1 = witness[0][row];
         let y1 = witness[1][row];
         let x2 = witness[2][row];

--- a/circuits/kimchi/src/polynomials/complete_add.rs
+++ b/circuits/kimchi/src/polynomials/complete_add.rs
@@ -170,7 +170,11 @@ pub fn constraint<F: Field>(alpha0: usize) -> (usize, E<F>) {
 
 impl<F: FftField> CircuitGate<F> {
     /// Check the correctness of witness values for a complete-add gate.
-    pub fn verify_complete_add(&self, row: usize, witness: &[Vec<F>; COLUMNS]) -> Result<(), String> {
+    pub fn verify_complete_add(
+        &self,
+        row: usize,
+        witness: &[Vec<F>; COLUMNS],
+    ) -> Result<(), String> {
         let x1 = witness[0][row];
         let y1 = witness[1][row];
         let x2 = witness[2][row];

--- a/circuits/kimchi/src/polynomials/endomul_scalar.rs
+++ b/circuits/kimchi/src/polynomials/endomul_scalar.rs
@@ -7,6 +7,7 @@ use array_init::array_init;
 impl<F: FftField> CircuitGate<F> {
     pub fn verify_endomul_scalar(
         &self,
+        row: usize,
         witness: &[Vec<F>; COLUMNS],
         _cs: &ConstraintSystem<F>,
     ) -> Result<(), String> {
@@ -16,7 +17,6 @@ impl<F: FftField> CircuitGate<F> {
             "incorrect gate type (should be EndomulScalar)"
         );
 
-        let row = self.row;
         let n0 = witness[0][row];
         let n8 = witness[1][row];
         let a0 = witness[2][row];

--- a/circuits/kimchi/src/polynomials/generic.rs
+++ b/circuits/kimchi/src/polynomials/generic.rs
@@ -179,16 +179,14 @@ mod tests {
         let mut gates_row = iterate(0usize, |&i| i + 1);
         let r = gates_row.next().unwrap();
         gates.push(CircuitGate::create_generic_add(
-            r,
             Wire::new(r),
             Fp::one(),
             Fp::one(),
         )); // add
         let r = gates_row.next().unwrap();
-        gates.push(CircuitGate::create_generic_mul(r, Wire::new(r))); // mul
+        gates.push(CircuitGate::create_generic_mul(Wire::new(r))); // mul
         let r = gates_row.next().unwrap();
         gates.push(CircuitGate::create_generic_const(
-            r,
             Wire::new(r),
             19u32.into(),
         )); // const

--- a/dlog/kimchi/src/bench.rs
+++ b/dlog/kimchi/src/bench.rs
@@ -46,11 +46,7 @@ pub fn proof(num: usize) {
 
     for _ in 0..ADD_GATES {
         let wires = Wire::new(abs_row);
-        gates.push(CircuitGate::create_generic_add(
-            wires,
-            Fp::one(),
-            Fp::one(),
-        ));
+        gates.push(CircuitGate::create_generic_add(wires, Fp::one(), Fp::one()));
         abs_row += 1;
     }
 

--- a/dlog/kimchi/src/bench.rs
+++ b/dlog/kimchi/src/bench.rs
@@ -40,14 +40,13 @@ pub fn proof(num: usize) {
 
     for _ in 0..MUL_GATES {
         let wires = Wire::new(abs_row);
-        gates.push(CircuitGate::<Fp>::create_generic_mul(abs_row, wires));
+        gates.push(CircuitGate::<Fp>::create_generic_mul(wires));
         abs_row += 1;
     }
 
     for _ in 0..ADD_GATES {
         let wires = Wire::new(abs_row);
         gates.push(CircuitGate::create_generic_add(
-            abs_row,
             wires,
             Fp::one(),
             Fp::one(),

--- a/dlog/kimchi/tests/ec.rs
+++ b/dlog/kimchi/tests/ec.rs
@@ -44,7 +44,6 @@ fn ec_test() {
 
     for row in 0..(num_doubles + num_additions + num_infs) {
         gates.push(CircuitGate {
-            row,
             typ: GateType::CompleteAdd,
             wires: Wire::new(row),
             c: vec![],

--- a/dlog/kimchi/tests/endomul_scalar.rs
+++ b/dlog/kimchi/tests/endomul_scalar.rs
@@ -49,7 +49,6 @@ fn endomul_scalar_test() {
         for i in 0..rows_per_scalar {
             let row = rows_per_scalar * s + i;
             gates.push(CircuitGate {
-                row,
                 typ: GateType::EndomulScalar,
                 wires: Wire::new(row),
                 c: vec![],

--- a/dlog/kimchi/tests/generic.rs
+++ b/dlog/kimchi/tests/generic.rs
@@ -47,7 +47,6 @@ fn create_generic_circuit() -> Vec<CircuitGate<Fp>> {
     let multiplication = on;
     let constant = off;
     gates.push(CircuitGate::<Fp>::create_generic(
-        abs_row,
         wires,
         qw,
         multiplication,
@@ -57,7 +56,7 @@ fn create_generic_circuit() -> Vec<CircuitGate<Fp>> {
 
     // add a zero gate, just because
     let wires = Wire::new(abs_row);
-    gates.push(CircuitGate::<Fp>::zero(abs_row, wires));
+    gates.push(CircuitGate::<Fp>::zero(wires));
     //abs_row += 1;
 
     //

--- a/dlog/tests/chacha_test.rs
+++ b/dlog/tests/chacha_test.rs
@@ -59,7 +59,6 @@ fn chacha_prover() {
         .enumerate()
         .map(|(i, typ)| CircuitGate {
             typ,
-            row: i,
             c: vec![],
             wires: Wire::new(i),
         })

--- a/dlog/tests/endomul.rs
+++ b/dlog/tests/endomul.rs
@@ -52,7 +52,6 @@ fn endomul_test() {
         for i in 0..chunks {
             let row = rows_per_scalar * s + i;
             gates.push(CircuitGate {
-                row,
                 typ: GateType::Endomul,
                 wires: Wire::new(row),
                 c: vec![],
@@ -61,7 +60,6 @@ fn endomul_test() {
 
         let row = rows_per_scalar * s + chunks;
         gates.push(CircuitGate {
-            row,
             typ: GateType::Zero,
             wires: Wire::new(row),
             c: vec![],

--- a/dlog/tests/varbasemul.rs
+++ b/dlog/tests/varbasemul.rs
@@ -49,13 +49,11 @@ fn varbase_mul_test() {
     for i in 0..(chunks * num_scalars) {
         let row = 2 * i;
         gates.push(CircuitGate {
-            row,
             typ: GateType::Vbmul,
             wires: Wire::new(row),
             c: vec![],
         });
         gates.push(CircuitGate {
-            row: row + 1,
             typ: GateType::Zero,
             wires: Wire::new(row + 1),
             c: vec![],


### PR DESCRIPTION
I removed the field row from the CircuitGate struct. It was redundant information, as we are creating circuits by adding CircuitGate elements to an array (so their row is their position in that array). Apart from the definitions of the struct, there are changes in the verification functions for each CircuitGate, which now include a row parameter that is used to index the witness (as it was used before, but now the row is no longer a field in CircuitGate, but another parameter in those functions). This provides a less prone error instantiation of tests, as we don't need to keep track of the row index for each gate we create (in fact, I think we can still remove some variables such as first_row, last_row that appear in some tests, but I kept them for now until this change is accepted).