### PR TITLE
add license identifier to Cargo.toml

### DIFF
--- a/dlog/Cargo.toml
+++ b/dlog/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dlog"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [dev-dependencies]
 rand_core = { version = "0.5" }

--- a/dlog/commitment/Cargo.toml
+++ b/dlog/commitment/Cargo.toml
@@ -2,6 +2,7 @@
 name = "commitment_dlog"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }

--- a/dlog/kimchi/Cargo.toml
+++ b/dlog/kimchi/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kimchi"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 path = "src/lib.rs"

--- a/dlog/plonk/Cargo.toml
+++ b/dlog/plonk/Cargo.toml
@@ -2,6 +2,7 @@
 name = "plonk_protocol_dlog"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 path = "src/lib.rs"

--- a/groupmap/Cargo.toml
+++ b/groupmap/Cargo.toml
@@ -3,6 +3,7 @@ name = "groupmap"
 version = "0.1.0"
 authors = ["Rebekah Mercer <github@rbkhmrcr.com>", "Izaak Meckler <izaak@o1labs.org>"]
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Part of #230 

Hi @mimoo thanks for adding the license file in #230. However, our linter depends on license identifier too in `Cargo.toml`. This PR adds the license identifier for the required crates in this repository.

cc @willemolding