### PR TITLE
Add support for multiple lookup tables

### DIFF
--- a/circuits/kimchi/src/gate.rs
+++ b/circuits/kimchi/src/gate.rs
@@ -65,12 +65,12 @@ pub struct SingleLookup<F> {
 /// This function computes that combined value.
 pub fn combine_table_entry<'a, F: Field, I: DoubleEndedIterator<Item = &'a F>>(
     joint_combiner: F,
-    table_id: u32,
+    table_id: F,
     max_joint_size: usize,
     v: I,
 ) -> F {
     v.rev().fold(F::zero(), |acc, x| joint_combiner * acc + x)
-        + &(joint_combiner.pow([max_joint_size as u64]) * &table_id.into())
+        + &(joint_combiner.pow([max_joint_size as u64]) * &table_id)
 }
 
 impl<F: Field> SingleLookup<F> {

--- a/circuits/kimchi/src/gate.rs
+++ b/circuits/kimchi/src/gate.rs
@@ -45,7 +45,7 @@ pub struct LocalPosition {
 /// A lookup table representative.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LookupTable<F> {
-    pub table_id: u32,
+    pub table_id: i32,
     pub width: usize,
     pub values: Vec<Vec<F>>,
 }
@@ -93,7 +93,7 @@ impl<F: Field> SingleLookup<F> {
 /// A spec for checking that the given vector belongs to a vector-valued lookup table.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct JointLookup<F> {
-    pub table_id: u64,
+    pub table_id: i32,
     pub entry: Vec<SingleLookup<F>>,
 }
 
@@ -112,7 +112,14 @@ impl<F: Field> JointLookup<F> {
             res += c * s.evaluate(eval);
             c *= joint_combiner;
         }
-        res + F::from(self.table_id) * joint_combiner.pow([max_joint_size as u64])
+        let table_id = {
+            if self.table_id >= 0 {
+                F::from(self.table_id as u32)
+            } else {
+                -F::from((-self.table_id) as u32)
+            }
+        };
+        res + table_id * joint_combiner.pow([max_joint_size as u64])
     }
 }
 

--- a/circuits/kimchi/src/gate.rs
+++ b/circuits/kimchi/src/gate.rs
@@ -331,7 +331,7 @@ impl GateType {
                 let index = curr_row(2 * i);
                 let value = curr_row(2 * i + 1);
                 JointLookup {
-                    table_id: 1,
+                    table_id: -1,
                     entry: vec![l(value), l(index)],
                 }
             })

--- a/circuits/kimchi/src/gate.rs
+++ b/circuits/kimchi/src/gate.rs
@@ -42,6 +42,14 @@ pub struct LocalPosition {
     pub column: usize,
 }
 
+/// A lookup table representative.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LookupTable<F> {
+    pub table_id: u32,
+    pub width: usize,
+    pub values: Vec<Vec<F>>,
+}
+
 /// Look up a single value in a lookup table. The value may be computed as a linear
 /// combination of locally-accessible cells.
 #[derive(Clone, Serialize, Deserialize)]

--- a/circuits/kimchi/src/gate.rs
+++ b/circuits/kimchi/src/gate.rs
@@ -320,7 +320,7 @@ impl GateType {
                 let right = curr_row(7 + i);
                 let output = curr_row(11 + i);
                 JointLookup {
-                    table_id: 0,
+                    table_id: 1,
                     entry: vec![l(left), l(right), l(output)],
                 }
             })
@@ -361,7 +361,7 @@ impl GateType {
                     value: vec![(one_half, nybble), (neg_one_half, low_bit)],
                 };
                 JointLookup {
-                    table_id: 0,
+                    table_id: 1,
                     entry: vec![x.clone(), x, SingleLookup { value: vec![] }],
                 }
             })

--- a/circuits/kimchi/src/nolookup/constraints.rs
+++ b/circuits/kimchi/src/nolookup/constraints.rs
@@ -199,6 +199,7 @@ pub struct ConstraintSystem<F: FftField> {
     pub lookup_table_ids: DP<F>,
     #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub lookup_table_ids8: E<F, D<F>>,
+    pub lookup_max_width: usize,
 
     /// Lookup selectors:
     /// For each kind of lookup-pattern, we have a selector that's
@@ -672,6 +673,8 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
             vec![]
         };
 
+        let lookup_max_width = std::cmp::max(max_table_width, lookup_info.max_joint_size);
+
         //
         // return result
         //
@@ -685,6 +688,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
             lookup_tables: lookup_table_polys,
             lookup_table_ids: lookup_table_id_polys,
             lookup_table_ids8,
+            lookup_max_width,
             endomul_scalar8,
             endomul_scalarm,
             domain,

--- a/circuits/kimchi/src/nolookup/constraints.rs
+++ b/circuits/kimchi/src/nolookup/constraints.rs
@@ -599,12 +599,19 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
         let mut lookup_table = vec![Vec::with_capacity(d1_size); max_table_width];
         let mut lookup_table_ids = Vec::with_capacity(d1_size);
         for table in lookup_tables.iter() {
+            let table_id = {
+                if table.table_id >= 0 {
+                    F::from(table.table_id as u32)
+                } else {
+                    -F::from((-table.table_id) as u32)
+                }
+            };
             for row in table.values.iter() {
                 if row.len() != table.width {
                     // Malformed table, widths do not match
                     None?;
                 }
-                lookup_table_ids.push(table.table_id.into());
+                lookup_table_ids.push(table_id);
                 for (i, value) in row.iter().enumerate() {
                     lookup_table[i].push(*value);
                 }

--- a/circuits/kimchi/src/nolookup/constraints.rs
+++ b/circuits/kimchi/src/nolookup/constraints.rs
@@ -611,7 +611,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
                     // Malformed table, widths do not match
                     None?;
                 }
-                lookup_table_ids.push(table_id);
+                lookup_table_ids.push(table_id.into());
                 for (i, value) in row.iter().enumerate() {
                     lookup_table[i].push(*value);
                 }

--- a/circuits/kimchi/src/nolookup/constraints.rs
+++ b/circuits/kimchi/src/nolookup/constraints.rs
@@ -196,6 +196,10 @@ pub struct ConstraintSystem<F: FftField> {
     pub lookup_tables8: Vec<Vec<E<F, D<F>>>>,
     #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub lookup_table_lengths: Vec<usize>,
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
+    pub lookup_table_ids: DP<F>,
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
+    pub lookup_table_ids8: E<F, D<F>>,
 
     /// Lookup selectors:
     /// For each kind of lookup-pattern, we have a selector that's
@@ -616,6 +620,11 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
             lookup_tables8.push(table_eval);
         }
 
+        let lookup_table_ids = vec![F::zero(); d1_size - ZK_ROWS as usize];
+        let lookup_table_id_polys =
+            E::<F, D<F>>::from_vec_and_domain(lookup_table_ids, domain.d1).interpolate();
+        let lookup_table_ids8 = lookup_table_id_polys.evaluate_over_domain_by_ref(domain.d8);
+
         // generate the look up selector polynomials if any lookup-based gate is being used in the circuit
         let lookup_info = LookupInfo::<F>::create();
         let lookup_selectors = if lookup_info.lookup_used(&gates).is_some() {
@@ -635,6 +644,8 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
             lookup_table_lengths,
             lookup_tables8,
             lookup_tables: lookup_tables_polys,
+            lookup_table_ids: lookup_table_id_polys,
+            lookup_table_ids8,
             endomul_scalar8,
             endomul_scalarm,
             domain,

--- a/circuits/kimchi/src/nolookup/constraints.rs
+++ b/circuits/kimchi/src/nolookup/constraints.rs
@@ -620,7 +620,10 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
             lookup_tables8.push(table_eval);
         }
 
-        let lookup_table_ids = vec![F::zero(); d1_size - ZK_ROWS as usize];
+        let mut lookup_table_ids = vec![F::zero(); d1_size];
+        for i in (d1_size - ZK_ROWS as usize)..d1_size {
+            lookup_table_ids[i] = F::one();
+        }
         let lookup_table_id_polys =
             E::<F, D<F>>::from_vec_and_domain(lookup_table_ids, domain.d1).interpolate();
         let lookup_table_ids8 = lookup_table_id_polys.evaluate_over_domain_by_ref(domain.d8);

--- a/circuits/kimchi/src/polynomials/chacha.rs
+++ b/circuits/kimchi/src/polynomials/chacha.rs
@@ -157,7 +157,7 @@ pub fn xor_table<F: Field>() -> LookupTable<F> {
     values[0].iter().fold((), |(), x| assert!(x.is_zero()));
 
     LookupTable {
-        table_id: 0,
+        table_id: 1,
         width: 3,
         values,
     }
@@ -165,7 +165,7 @@ pub fn xor_table<F: Field>() -> LookupTable<F> {
 
 pub fn dummy_xor_table<F: Field>() -> LookupTable<F> {
     LookupTable {
-        table_id: 0,
+        table_id: 1,
         width: 3,
         values: vec![],
     }

--- a/circuits/kimchi/src/polynomials/lookup.rs
+++ b/circuits/kimchi/src/polynomials/lookup.rs
@@ -651,7 +651,7 @@ pub fn constraints<F: FftField>(
     let runtime_table_entry = |curr_or_next| -> E<F> {
         E::cell(Column::RuntimeLookupTable, curr_or_next)
             + E::cell(Column::Indexer, curr_or_next) * E::constant(ConstantExpr::JointCombiner)
-            + E::constant(ConstantExpr::JointCombiner).pow(lookup_info.max_joint_size)
+            - E::constant(ConstantExpr::JointCombiner).pow(lookup_info.max_joint_size)
     };
 
     let rt_chunk = ft_chunk

--- a/circuits/kimchi/src/polynomials/lookup.rs
+++ b/circuits/kimchi/src/polynomials/lookup.rs
@@ -55,14 +55,20 @@ fn single_lookup<F: FftField>(s: &SingleLookup<F>) -> E<F> {
 }
 
 fn joint_lookup<F: FftField>(j: &JointLookup<F>, max_joint_size: usize) -> E<F> {
+    let table_id = {
+        if j.table_id >= 0 {
+            F::from(j.table_id as u32)
+        } else {
+            -F::from((-j.table_id) as u32)
+        }
+    };
     j.entry
         .iter()
         .enumerate()
         .map(|(i, s)| E::constant(ConstantExpr::JointCombiner.pow(i)) * single_lookup(s))
         .fold(E::zero(), |acc, x| acc + x)
         + E::constant(
-            ConstantExpr::JointCombiner.pow(max_joint_size)
-                * ConstantExpr::Literal(j.table_id.into()),
+            ConstantExpr::JointCombiner.pow(max_joint_size) * ConstantExpr::Literal(table_id),
         )
 }
 

--- a/dlog/kimchi/src/index.rs
+++ b/dlog/kimchi/src/index.rs
@@ -141,7 +141,7 @@ pub struct VerifierIndex<G: CommitmentCurve> {
 
     pub lookup_used: Option<LookupsUsed>,
     #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
-    pub lookup_tables: Vec<Vec<PolyComm<G>>>,
+    pub lookup_tables: Vec<PolyComm<G>>,
     #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
     pub lookup_table_ids: PolyComm<G>,
     #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
@@ -205,11 +205,7 @@ where
                 .cs
                 .lookup_tables8
                 .iter()
-                .map(|v| {
-                    v.iter()
-                        .map(|e| self.srs.commit_evaluations_non_hiding(domain, e, None))
-                        .collect()
-                })
+                .map(|e| self.srs.commit_evaluations_non_hiding(domain, e, None))
                 .collect(),
             lookup_table_ids: self.srs.commit_evaluations_non_hiding(
                 domain,
@@ -283,7 +279,7 @@ where
             let expr = if lookup_used.is_some() {
                 expr + Expr::combine_constraints(
                     2 + super::range::CHACHA.end,
-                    lookup::constraints(&cs.dummy_lookup_values[0], 0, cs.domain.d1),
+                    lookup::constraints(&cs.dummy_lookup_values, 0, cs.domain.d1),
                 )
             } else {
                 expr

--- a/dlog/kimchi/src/index.rs
+++ b/dlog/kimchi/src/index.rs
@@ -143,6 +143,8 @@ pub struct VerifierIndex<G: CommitmentCurve> {
     #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
     pub lookup_tables: Vec<Vec<PolyComm<G>>>,
     #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
+    pub lookup_table_ids: PolyComm<G>,
+    #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
     pub lookup_selectors: Vec<PolyComm<G>>,
     #[serde(skip)]
     pub linearization: Linearization<Vec<PolishToken<Fr<G>>>>,
@@ -209,6 +211,11 @@ where
                         .collect()
                 })
                 .collect(),
+            lookup_table_ids: self.srs.commit_evaluations_non_hiding(
+                domain,
+                &self.cs.lookup_table_ids8,
+                None,
+            ),
 
             max_joint_size: self.max_joint_size,
 

--- a/dlog/kimchi/src/index.rs
+++ b/dlog/kimchi/src/index.rs
@@ -61,8 +61,6 @@ where
     /// maximal size of the quotient polynomial according to the supported constraints
     pub max_quot_size: usize,
 
-    pub max_joint_size: usize,
-
     /// random oracle argument parameters
     #[serde(skip)]
     pub fq_sponge_params: ArithmeticSpongeParams<Fq<G>>,
@@ -137,7 +135,7 @@ pub struct VerifierIndex<G: CommitmentCurve> {
     #[serde(skip)]
     pub endo: Fr<G>,
 
-    pub max_joint_size: usize,
+    pub lookup_max_width: usize,
 
     pub lookup_used: Option<LookupsUsed>,
     #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
@@ -213,7 +211,7 @@ where
                 None,
             ),
 
-            max_joint_size: self.max_joint_size,
+            lookup_max_width: self.cs.lookup_max_width,
 
             w: zk_w3(self.cs.domain.d1),
             fr_sponge_params: self.cs.fr_sponge_params.clone(),
@@ -279,7 +277,12 @@ where
             let expr = if lookup_used.is_some() {
                 expr + Expr::combine_constraints(
                     2 + super::range::CHACHA.end,
-                    lookup::constraints(&cs.dummy_lookup_values, 0, cs.domain.d1),
+                    lookup::constraints(
+                        &cs.dummy_lookup_values,
+                        0,
+                        cs.domain.d1,
+                        cs.lookup_max_width,
+                    ),
                 )
             } else {
                 expr
@@ -299,7 +302,6 @@ where
             max_quot_size: cs.domain.d8.size as usize - 7,
             fq_sponge_params,
             max_poly_size,
-            max_joint_size: lookup_info.max_joint_size,
             srs,
             cs,
             lookup_used,

--- a/dlog/kimchi/src/prover.rs
+++ b/dlog/kimchi/src/prover.rs
@@ -294,7 +294,7 @@ where
                         let value = &runtime_table8.evals[8 * i];
                         combine_table_entry(
                             joint_combiner,
-                            Fr::<G>::one(), // Table ID 1
+                            -Fr::<G>::one(), // Table ID -1
                             lookup_info.max_joint_size,
                             [value, index].into_iter(),
                         )

--- a/dlog/kimchi/src/prover.rs
+++ b/dlog/kimchi/src/prover.rs
@@ -271,7 +271,7 @@ where
                     combine_table_entry(
                         joint_combiner,
                         Fr::<G>::zero(), // Table ID 0 for dummy value
-                        lookup_info.max_joint_size,
+                        index.cs.lookup_max_width,
                         index.cs.dummy_lookup_values.iter(),
                     )
                 }
@@ -283,20 +283,20 @@ where
             (0..d1_size).map(|i| {
                 let row = index.cs.lookup_tables8.iter().map(|e| &e.evals[8 * i]);
                 let table_id = index.cs.lookup_table_ids8.evals[8 * i];
-                combine_table_entry(joint_combiner, table_id, lookup_info.max_joint_size, row)
+                combine_table_entry(joint_combiner, table_id, index.cs.lookup_max_width, row)
             })
         };
         let iter_runtime_table = || {
             (0..d1_size).map(|i| {
                 match &runtime_table8 {
                     Some(runtime_table8) => {
-                        let index = &index.cs.indexer8.evals[8 * i];
+                        let idx = &index.cs.indexer8.evals[8 * i];
                         let value = &runtime_table8.evals[8 * i];
                         combine_table_entry(
                             joint_combiner,
                             -Fr::<G>::one(), // Table ID -1
-                            lookup_info.max_joint_size,
-                            [value, index].into_iter(),
+                            index.cs.lookup_max_width,
+                            [value, idx].into_iter(),
                         )
                     }
                     None => Fr::<G>::zero(),
@@ -319,7 +319,7 @@ where
                         iter_lookup_table,
                         index.cs.lookup_table_length,
                         iter_runtime_table,
-                        lookup_info.max_joint_size,
+                        index.cs.lookup_max_width,
                         index.cs.domain.d1,
                         &index.cs.gates,
                         &witness,
@@ -373,6 +373,7 @@ where
                             &index.cs.gates,
                             &witness,
                             joint_combiner,
+                            index.cs.lookup_max_width,
                             beta, gamma,
                             rng,
                         );
@@ -452,7 +453,7 @@ where
                 res += col;
             }
             let mut table_id_eval = index.cs.lookup_table_ids8.clone();
-            let table_combiner = joint_combiner.pow([lookup_info.max_joint_size as u64]);
+            let table_combiner = joint_combiner.pow([index.cs.lookup_max_width as u64]);
             table_id_eval
                 .evals
                 .iter_mut()
@@ -573,10 +574,15 @@ where
                 (t4, t8),
                 alpha,
                 alphas[alphas.len() - 1],
-                lookup::constraints(&index.cs.dummy_lookup_values, 0, index.cs.domain.d1)
-                    .iter()
-                    .map(|e| e.evaluations(&env))
-                    .collect(),
+                lookup::constraints(
+                    &index.cs.dummy_lookup_values,
+                    0,
+                    index.cs.domain.d1,
+                    index.cs.lookup_max_width,
+                )
+                .iter()
+                .map(|e| e.evaluations(&env))
+                .collect(),
             ),
         };
 
@@ -619,7 +625,7 @@ where
                             .collect(),
                         table: {
                             let table_combiner =
-                                joint_combiner.pow([lookup_info.max_joint_size as u64]);
+                                joint_combiner.pow([index.cs.lookup_max_width as u64]);
                             index
                                 .cs
                                 .lookup_tables

--- a/dlog/kimchi/src/prover.rs
+++ b/dlog/kimchi/src/prover.rs
@@ -271,7 +271,7 @@ where
                     let table_id = 0;
                     combine_table_entry(
                         joint_combiner,
-                        table_id,
+                        Fr::<G>::zero(), // Table ID 0 for dummy value
                         lookup_info.max_joint_size,
                         index.cs.dummy_lookup_values[table_id as usize].iter(),
                     )
@@ -283,26 +283,28 @@ where
         let iter_lookup_table = || {
             (0..d1_size).map(|i| {
                 let table_id = 0;
-                let row = index.cs.lookup_tables8[table_id as usize]
-                    .iter()
-                    .map(|e| &e.evals[8 * i]);
-                combine_table_entry(joint_combiner, table_id, lookup_info.max_joint_size, row)
+                let row = index.cs.lookup_tables8[table_id as usize].iter().map(|e| &e.evals[8 * i]);
+                combine_table_entry(
+                    joint_combiner,
+                    Fr::<G>::zero(), // Table ID 0
+                    lookup_info.max_joint_size,
+                    row)
             })
         };
         let iter_runtime_table = || {
-            (0..d1_size).map(|i| match &runtime_table8 {
-                Some(runtime_table8) => {
-                    let table_id = 1;
-                    let index = &index.cs.indexer8.evals[8 * i];
-                    let value = &runtime_table8.evals[8 * i];
-                    combine_table_entry(
-                        joint_combiner,
-                        table_id,
-                        lookup_info.max_joint_size,
-                        [value, index].into_iter(),
-                    )
+            (0..d1_size).map(|i| {
+                match &runtime_table8 {
+                    Some(runtime_table8) => {
+                        let index = &index.cs.indexer8.evals[8 * i];
+                        let value = &runtime_table8.evals[8 * i];
+                        combine_table_entry(
+                            joint_combiner,
+                            Fr::<G>::one(), // Table ID 1
+                            lookup_info.max_joint_size,
+                            [value, index].into_iter())
+                    },
+                    None => Fr::<G>::zero(),
                 }
-                None => Fr::<G>::zero(),
             })
         };
 

--- a/dlog/kimchi/src/prover.rs
+++ b/dlog/kimchi/src/prover.rs
@@ -283,12 +283,15 @@ where
         let iter_lookup_table = || {
             (0..d1_size).map(|i| {
                 let table_id = 0;
-                let row = index.cs.lookup_tables8[table_id as usize].iter().map(|e| &e.evals[8 * i]);
+                let row = index.cs.lookup_tables8[table_id as usize]
+                    .iter()
+                    .map(|e| &e.evals[8 * i]);
                 combine_table_entry(
                     joint_combiner,
                     Fr::<G>::zero(), // Table ID 0
                     lookup_info.max_joint_size,
-                    row)
+                    row,
+                )
             })
         };
         let iter_runtime_table = || {
@@ -301,8 +304,9 @@ where
                             joint_combiner,
                             Fr::<G>::one(), // Table ID 1
                             lookup_info.max_joint_size,
-                            [value, index].into_iter())
-                    },
+                            [value, index].into_iter(),
+                        )
+                    }
                     None => Fr::<G>::zero(),
                 }
             })

--- a/dlog/kimchi/src/prover.rs
+++ b/dlog/kimchi/src/prover.rs
@@ -286,12 +286,8 @@ where
                 let row = index.cs.lookup_tables8[table_id as usize]
                     .iter()
                     .map(|e| &e.evals[8 * i]);
-                combine_table_entry(
-                    joint_combiner,
-                    Fr::<G>::zero(), // Table ID 0
-                    lookup_info.max_joint_size,
-                    row,
-                )
+                let table_id = index.cs.lookup_table_ids8.evals[8 * i];
+                combine_table_entry(joint_combiner, table_id, lookup_info.max_joint_size, row)
             })
         };
         let iter_runtime_table = || {
@@ -460,10 +456,12 @@ where
                 res.evals.iter_mut().for_each(|e| *e *= joint_combiner);
                 res += col;
             }
-            let mut table_id_eval = index.cs.l08.clone();
-            table_id_eval.evals.iter_mut().for_each(|e| {
-                *e *= joint_combiner.pow([lookup_info.max_joint_size as u64]) * &table_id.into()
-            });
+            let mut table_id_eval = index.cs.lookup_table_ids8.clone();
+            let table_combiner = joint_combiner.pow([lookup_info.max_joint_size as u64]);
+            table_id_eval
+                .evals
+                .iter_mut()
+                .for_each(|e| *e *= table_combiner);
             res += &table_id_eval;
             res
         });

--- a/dlog/kimchi/src/verifier.rs
+++ b/dlog/kimchi/src/verifier.rs
@@ -498,7 +498,9 @@ where
                                     commitments_part.push(t);
                                 }
                                 scalars_part.push(
-                                    e * constants.joint_combiner.pow([index.max_joint_size as u64]),
+                                    e * constants
+                                        .joint_combiner
+                                        .pow([index.lookup_max_width as u64]),
                                 );
                                 commitments_part.push(&index.lookup_table_ids);
                             }

--- a/dlog/kimchi/src/verifier.rs
+++ b/dlog/kimchi/src/verifier.rs
@@ -497,10 +497,10 @@ where
                                     scalars_part.push(e * j);
                                     commitments_part.push(t);
                                 }
-                                /* TODO: When multiple tables are supported, include the table ID commitment here */
-                                /*
-                                scalars_part.push(e * constants.joint_combiner.pow([index.max_joint_size as u64]));
-                                commitments_part.push(&index.table_ids[0]); */
+                                scalars_part.push(
+                                    e * constants.joint_combiner.pow([index.max_joint_size as u64]),
+                                );
+                                commitments_part.push(&index.lookup_table_ids);
                             }
                             Index(t) => {
                                 use GateType::*;

--- a/dlog/kimchi/src/verifier.rs
+++ b/dlog/kimchi/src/verifier.rs
@@ -491,8 +491,8 @@ where
                             LookupTable => {
                                 let mut j = Fr::<G>::one();
                                 scalars_part.push(e);
-                                commitments_part.push(&index.lookup_tables[0][0]);
-                                for t in index.lookup_tables[0].iter().skip(1) {
+                                commitments_part.push(&index.lookup_tables[0]);
+                                for t in index.lookup_tables.iter().skip(1) {
                                     j *= constants.joint_combiner;
                                     scalars_part.push(e * j);
                                     commitments_part.push(t);


### PR DESCRIPTION
This PR builds upon #232, which added identification for tables using the `joint_combiner`.

This
* adds a `LookupTable` struct, which defines the width and table ID for tables
  - the width is added so that we can omit the values from an unused table, but still ensure that the table has the right 'shape'. (See e.g. `dummy_xor_table`.)
  - for ease of use, the values in this table are now represented as `Vec<row>` instead of `Vec<column>` (both are `Vec<Vec<F>>` in rust types), so that each entry in the table is represented by a corresponding entry in the vector
* increases the number of the `xor` table from 0 to 1, to ensure that the dummy padding value (using table ID 0) doesn't insert an extra value into the table
  - this isn't an actual concern while the dummy is 0, since `0, 0, 0` is both the dummy and a valid entry in the xor table
  - the intention is that all tables committed to in the index take some positive value
* decreases the number of the 'runtime' table from 1 to -1
  - the intention is for all 'runtime' tables to use a negative table ID, so that there aren't table ID collisions that would allow injecting values into the constraint system's tables at runtime
  - this is currently still hardcoded, we only support a single runtime table for now
* combines all input lookup tables into a single table of size `d1.size`, using their table IDs to keep domain separation
  - the table IDs are now encoded in a separate row in the constraint system, alongside the rows for the values in the tables
  - any tables that are narrower than the combined table are padded with 0s. We multiply these by the joint combiner and then add them, so using 0s removes any contribution from these terms.

This capability is currently unused. However, the lookup prover test has been modified to integrate multiple tables, to ensure that it works as intended.