### PR TITLE
Allow table to be set by coefficients in Lookup gate

### DIFF
--- a/circuits/kimchi/src/expr.rs
+++ b/circuits/kimchi/src/expr.rs
@@ -425,8 +425,8 @@ impl<F: Copy> VariableEvaluator<F> for ProofEvaluations<F> {
             _ => Err("Cannot get index evaluation (should have been linearized away)"),
         }
     }
-    fn coefficient<'b>(self: &Self, _i: usize) -> Result<F, &'b str> {
-        Err("Cannot get coefficient evaluation")
+    fn coefficient<'b>(self: &Self, i: usize) -> Result<F, &'b str> {
+        Ok(self.c[i])
     }
     fn lookup_kind_index<'b>(self: &Self, _i: usize) -> Result<F, &'b str> {
         Err("Cannot get lookup index evaluation")

--- a/circuits/kimchi/src/gate.rs
+++ b/circuits/kimchi/src/gate.rs
@@ -5,7 +5,7 @@ This source file implements Plonk constraint gate primitive.
 *****************************************************************************************************************/
 
 use crate::domains::EvaluationDomains;
-use crate::expr::E as Expr;
+use crate::expr::{Column, E as Expr};
 use crate::{nolookup::constraints::ConstraintSystem, wires::*};
 use ark_ff::bytes::ToBytes;
 use ark_ff::{FftField, Field};
@@ -328,7 +328,7 @@ impl GateType {
                 let index = curr_row(2 * i);
                 let value = curr_row(2 * i + 1);
                 JointLookup {
-                    table_id: -Expr::literal(F::from(1 as u64)),
+                    table_id: Expr::cell(Column::Coefficient(i), Curr),
                     entry: vec![l(index), l(value)],
                 }
             })

--- a/circuits/kimchi/src/gate.rs
+++ b/circuits/kimchi/src/gate.rs
@@ -329,7 +329,7 @@ impl GateType {
                 let value = curr_row(2 * i + 1);
                 JointLookup {
                     table_id: -Expr::literal(F::from(1 as u64)),
-                    entry: vec![l(value), l(index)],
+                    entry: vec![l(index), l(value)],
                 }
             })
             .collect();

--- a/circuits/kimchi/src/nolookup/scalars.rs
+++ b/circuits/kimchi/src/nolookup/scalars.rs
@@ -36,6 +36,8 @@ pub struct ProofEvaluations<Field> {
     /// permutation polynomials
     /// (PERMUTS-1 evaluations because the last permutation is only used in commitment form)
     pub s: [Field; PERMUTS - 1],
+    /// coefficient polynomials
+    pub c: [Field; COLUMNS],
     /// lookup-related evaluations
     pub lookup: Option<LookupEvaluations<Field>>,
     /// evaluation of the generic selector polynomial
@@ -63,6 +65,7 @@ impl<F: FftField> ProofEvaluations<Vec<F>> {
                 runtime_table: DensePolynomial::eval_polynomial(&l.runtime_table, pt),
                 lookup_chunk: DensePolynomial::eval_polynomial(&l.lookup_chunk, pt),
             }),
+            c: array_init(|i| DensePolynomial::eval_polynomial(&self.c[i], pt)),
             generic_selector: DensePolynomial::eval_polynomial(&self.generic_selector, pt),
             poseidon_selector: DensePolynomial::eval_polynomial(&self.poseidon_selector, pt),
             indexer: DensePolynomial::eval_polynomial(&self.indexer, pt),
@@ -197,6 +200,23 @@ pub mod caml {
             Vec<CamlF>,
             Vec<CamlF>,
         ),
+        pub c: (
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+            Vec<CamlF>,
+        ),
         pub generic_selector: Vec<CamlF>,
         pub poseidon_selector: Vec<CamlF>,
         pub indexer: Vec<CamlF>,
@@ -237,10 +257,28 @@ pub mod caml {
                 pe.s[4].iter().cloned().map(Into::into).collect(),
                 pe.s[5].iter().cloned().map(Into::into).collect(),
             );
+            let c = (
+                pe.c[0].iter().cloned().map(Into::into).collect(),
+                pe.c[1].iter().cloned().map(Into::into).collect(),
+                pe.c[2].iter().cloned().map(Into::into).collect(),
+                pe.c[3].iter().cloned().map(Into::into).collect(),
+                pe.c[4].iter().cloned().map(Into::into).collect(),
+                pe.c[5].iter().cloned().map(Into::into).collect(),
+                pe.c[6].iter().cloned().map(Into::into).collect(),
+                pe.c[7].iter().cloned().map(Into::into).collect(),
+                pe.c[8].iter().cloned().map(Into::into).collect(),
+                pe.c[9].iter().cloned().map(Into::into).collect(),
+                pe.c[10].iter().cloned().map(Into::into).collect(),
+                pe.c[11].iter().cloned().map(Into::into).collect(),
+                pe.c[12].iter().cloned().map(Into::into).collect(),
+                pe.c[13].iter().cloned().map(Into::into).collect(),
+                pe.c[14].iter().cloned().map(Into::into).collect(),
+            );
             Self {
                 w,
                 z: pe.z.into_iter().map(Into::into).collect(),
                 s,
+                c,
                 generic_selector: pe.generic_selector.into_iter().map(Into::into).collect(),
                 poseidon_selector: pe.poseidon_selector.into_iter().map(Into::into).collect(),
                 indexer: pe.indexer.into_iter().map(Into::into).collect(),
@@ -279,11 +317,29 @@ pub mod caml {
                 cpe.s.4.into_iter().map(Into::into).collect(),
                 cpe.s.5.into_iter().map(Into::into).collect(),
             ];
+            let c = [
+                cpe.c.0.into_iter().map(Into::into).collect(),
+                cpe.c.1.into_iter().map(Into::into).collect(),
+                cpe.c.2.into_iter().map(Into::into).collect(),
+                cpe.c.3.into_iter().map(Into::into).collect(),
+                cpe.c.4.into_iter().map(Into::into).collect(),
+                cpe.c.5.into_iter().map(Into::into).collect(),
+                cpe.c.6.into_iter().map(Into::into).collect(),
+                cpe.c.7.into_iter().map(Into::into).collect(),
+                cpe.c.8.into_iter().map(Into::into).collect(),
+                cpe.c.9.into_iter().map(Into::into).collect(),
+                cpe.c.10.into_iter().map(Into::into).collect(),
+                cpe.c.11.into_iter().map(Into::into).collect(),
+                cpe.c.12.into_iter().map(Into::into).collect(),
+                cpe.c.13.into_iter().map(Into::into).collect(),
+                cpe.c.14.into_iter().map(Into::into).collect(),
+            ];
 
             Self {
                 w,
                 z: cpe.z.into_iter().map(Into::into).collect(),
                 s,
+                c,
                 lookup: None,
                 generic_selector: cpe.generic_selector.into_iter().map(Into::into).collect(),
                 poseidon_selector: cpe.poseidon_selector.into_iter().map(Into::into).collect(),

--- a/circuits/kimchi/src/polynomials/chacha.rs
+++ b/circuits/kimchi/src/polynomials/chacha.rs
@@ -507,6 +507,7 @@ mod tests {
             w: array_init(|_| F::rand(rng)),
             z: F::rand(rng),
             s: array_init(|_| F::rand(rng)),
+            c: array_init(|_| F::rand(rng)),
             generic_selector: F::zero(),
             poseidon_selector: F::zero(),
             lookup: Some(LookupEvaluations {

--- a/circuits/kimchi/src/polynomials/lookup.rs
+++ b/circuits/kimchi/src/polynomials/lookup.rs
@@ -457,34 +457,34 @@ impl<'a, F: Copy> VariableEvaluator<F> for LookupChunkVariableEvaluator<'a, F> {
         Ok(self.witness[i][self.row])
     }
     fn z<'b>(self: &Self) -> Result<F, &'b str> {
-        panic!("Not implemented");
+        Err("LookupChunkVariableEvaluator z: Not implemented")
     }
     fn lookup_sorted<'b>(self: &Self, _i: usize) -> Result<F, &'b str> {
-        panic!("Not implemented");
+        Err("LookupChunkVariableEvaluator lookup_sorted: Not implemented")
     }
     fn lookup_aggreg<'b>(self: &Self) -> Result<F, &'b str> {
-        panic!("Not implemented");
+        Err("LookupChunkVariableEvaluator lookup_aggreg: Not implemented")
     }
     fn lookup_table<'b>(self: &Self) -> Result<F, &'b str> {
-        panic!("Not implemented");
+        Err("LookupChunkVariableEvaluator lookup_table: Not implemented")
     }
     fn lookup_chunk<'b>(self: &Self) -> Result<F, &'b str> {
-        panic!("Not implemented");
+        Err("LookupChunkVariableEvaluator lookup_chunk: Not implemented")
     }
     fn runtime_lookup_table<'b>(self: &Self) -> Result<F, &'b str> {
-        panic!("Not implemented");
+        Err("LookupChunkVariableEvaluator runtime_lookup_table: Not implemented")
     }
     fn index<'b>(self: &Self, _kind: crate::gate::GateType) -> Result<F, &'b str> {
-        panic!("Not implemented");
+        Err("LookupChunkVariableEvaluator index: Not implemented")
     }
     fn coefficient<'b>(self: &Self, _i: usize) -> Result<F, &'b str> {
-        panic!("Not implemented");
+        Err("LookupChunkVariableEvaluator coefficient: Not implemented")
     }
     fn lookup_kind_index<'b>(self: &Self, _i: usize) -> Result<F, &'b str> {
-        panic!("Not implemented");
+        Err("LookupChunkVariableEvaluator lookup_kind_index: Not implemented")
     }
     fn indexer<'b>(self: &Self) -> Result<F, &'b str> {
-        panic!("Not implemented");
+        Err("LookupChunkVariableEvaluator indexer: Not implemented")
     }
 }
 

--- a/circuits/kimchi/src/polynomials/lookup.rs
+++ b/circuits/kimchi/src/polynomials/lookup.rs
@@ -738,8 +738,8 @@ pub fn constraints<F: FftField>(
             + E::beta() * E::cell(Column::LookupTable, Next));
 
     let runtime_table_entry = |curr_or_next| -> E<F> {
-        E::cell(Column::RuntimeLookupTable, curr_or_next)
-            + E::cell(Column::Indexer, curr_or_next) * E::constant(ConstantExpr::JointCombiner)
+        E::cell(Column::RuntimeLookupTable, curr_or_next) * E::constant(ConstantExpr::JointCombiner)
+            + E::cell(Column::Indexer, curr_or_next)
             - E::constant(ConstantExpr::JointCombiner).pow(lookup_info.max_joint_size)
     };
 

--- a/dlog/kimchi/src/index.rs
+++ b/dlog/kimchi/src/index.rs
@@ -254,6 +254,7 @@ where
                 use Column::*;
                 for i in 0..COLUMNS {
                     h.insert(Witness(i));
+                    h.insert(Coefficient(i));
                 }
                 for i in 0..(lookup_info.max_per_row + 2) {
                     h.insert(LookupSorted(i));

--- a/dlog/kimchi/src/prover.rs
+++ b/dlog/kimchi/src/prover.rs
@@ -323,6 +323,7 @@ where
                         index.cs.domain.d1,
                         &index.cs.gates,
                         &witness,
+                        &array_init(|i| &index.cs.coefficients8[i].evals),
                         joint_combiner,
                     )?;
 
@@ -372,6 +373,7 @@ where
                             index.cs.domain.d1,
                             &index.cs.gates,
                             &witness,
+                            &array_init(|i| &index.cs.coefficients8[i].evals),
                             joint_combiner,
                             beta, gamma,
                             rng,
@@ -648,6 +650,7 @@ where
             s: array_init(|i| index.cs.sigmam[0..PERMUTS - 1][i].eval(zeta, index.max_poly_size)),
             w: array_init(|i| witness_poly[i].eval(zeta, index.max_poly_size)),
             z: z_poly.eval(zeta, index.max_poly_size),
+            c: array_init(|i| index.cs.coefficientsm[i].eval(zeta, index.max_poly_size)),
             lookup: lookup_evals(zeta),
             generic_selector: index.cs.genericm.eval(zeta, index.max_poly_size),
             poseidon_selector: index.cs.psm.eval(zeta, index.max_poly_size),
@@ -659,6 +662,7 @@ where
             }),
             w: array_init(|i| witness_poly[i].eval(zeta_omega, index.max_poly_size)),
             z: z_poly.eval(zeta_omega, index.max_poly_size),
+            c: array_init(|i| index.cs.coefficientsm[i].eval(zeta_omega, index.max_poly_size)),
             lookup: lookup_evals(zeta_omega),
             generic_selector: index.cs.genericm.eval(zeta_omega, index.max_poly_size),
             poseidon_selector: index.cs.psm.eval(zeta_omega, index.max_poly_size),
@@ -682,6 +686,7 @@ where
                 s: array_init(|i| DensePolynomial::eval_polynomial(&es.s[i], e1)),
                 w: array_init(|i| DensePolynomial::eval_polynomial(&es.w[i], e1)),
                 z: DensePolynomial::eval_polynomial(&es.z, e1),
+                c: array_init(|i| DensePolynomial::eval_polynomial(&es.c[i], e1)),
                 lookup: es.lookup.as_ref().map(|l| LookupEvaluations {
                     table: DensePolynomial::eval_polynomial(&l.table, e1),
                     aggreg: DensePolynomial::eval_polynomial(&l.aggreg, e1),

--- a/dlog/kimchi/src/prover.rs
+++ b/dlog/kimchi/src/prover.rs
@@ -296,7 +296,7 @@ where
                             joint_combiner,
                             -Fr::<G>::one(), // Table ID -1
                             lookup_info.max_joint_size,
-                            [value, index].into_iter(),
+                            [index, value].into_iter(),
                         )
                     }
                     None => Fr::<G>::zero(),


### PR DESCRIPTION
This PR builds upon #235, which adds support for multiple lookup tables.

This PR
* adds a new `VariableEvaluator` trait, to allow evaluating an `expr::E` with partial evaluations different from `ProofEvaluations`
* replaces the constant `table_id` in `JointLookup` with an arbitrary `expr::E`
* adds evaluations for the coefficients row to `ProofEvaluations`
* modifies the `table_id` for `Lookup` gate lookups to use values from the coefficients row
* updates the `lookup_prover` test to use different tables based on the given parameters
* adds additional index-time tables to the `lookup_prover` test and adds a row that looks up values inside them.

This allows us to make use of the multiple table support provided by #235, by using the `Lookup` gate with the desired table.