### PR TITLE
Remove unnecessary lookup_table_lengths field in index

### DIFF
--- a/circuits/kimchi/src/nolookup/constraints.rs
+++ b/circuits/kimchi/src/nolookup/constraints.rs
@@ -179,8 +179,6 @@ pub struct ConstraintSystem<F: FftField> {
     pub lookup_tables: Vec<Vec<DP<F>>>,
     #[serde_as(as = "Vec<Vec<o1_utils::serialization::SerdeAs>>")]
     pub lookup_tables8: Vec<Vec<E<F, D<F>>>>,
-    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
-    pub lookup_table_lengths: Vec<usize>,
 
     /// Lookup selectors:
     /// For each kind of lookup-pattern, we have a selector that's
@@ -535,9 +533,6 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
         // Lookup
         //
 
-        // get the height of each lookup table
-        let lookup_table_lengths: Vec<_> = lookup_tables.iter().map(|v| v[0].len()).collect();
-
         // get the last entry in each column of each table
         let dummy_lookup_values: Vec<Vec<F>> = lookup_tables
             .iter()
@@ -580,7 +575,6 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
             chacha8,
             lookup_selectors,
             dummy_lookup_values,
-            lookup_table_lengths,
             lookup_tables8,
             lookup_tables: lookup_tables_polys,
             endomul_scalar8,

--- a/circuits/kimchi/src/polynomials/lookup.rs
+++ b/circuits/kimchi/src/polynomials/lookup.rs
@@ -336,7 +336,7 @@ pub fn sorted<
 
     let sorted = {
         let mut sorted: Vec<Vec<E>> =
-            vec![Vec::with_capacity(lookup_rows + 1); max_lookups_per_row];
+            vec![Vec::with_capacity(lookup_rows + 1); max_lookups_per_row + 1];
 
         let mut i = 0;
         for t in lookup_table().take(lookup_rows) {

--- a/circuits/kimchi/src/polynomials/lookup.rs
+++ b/circuits/kimchi/src/polynomials/lookup.rs
@@ -315,7 +315,9 @@ pub fn sorted<
 
     for t in lookup_table().take(lookup_rows) {
         // Don't multiply-count duplicate values in the table, or they'll be duplicated for each
-        // duplicate! E.g. 3 values the same would insert the value 3 times for each instance.
+        // duplicate!
+        // E.g. A value duplicated in the table 3 times would be entered into the sorted array 3
+        // times at its first occurrence, then a further 2 times as each duplicate is encountered.
         counts.entry(t).or_insert(1);
     }
 

--- a/circuits/kimchi/src/polynomials/lookup.rs
+++ b/circuits/kimchi/src/polynomials/lookup.rs
@@ -63,7 +63,7 @@
 //!   - when they are different, there is some `j` such that it equals `gamma * (1 + beta) +
 //!     lookup_table[i] + beta * lookup_table[i+1]`
 //!   - using the example above, this becomes
-//!     ```
+//!     ```ignore
 //!         gamma * (1 + beta) + 0 + beta * 0
 //!       * gamma * (1 + beta) + 0 + beta * 0
 //!       * gamma * (1 + beta) + 0 + beta * 0
@@ -77,7 +77,7 @@
 //!       * gamma * (1 + beta) + 4 + beta * 5
 //!     ```
 //!     which we can simplify to
-//!     ```
+//!     ```ignore
 //!         (gamma + 0) * (1 + beta)
 //!       * (gamma + 0) * (1 + beta)
 //!       * (gamma + 0) * (1 + beta)
@@ -96,7 +96,7 @@
 //!   the product of `(gamma + witness_table[i]) * (1 + beta)`, since each term individually
 //!   cancels out.
 //!   - using the example above, the `lookup_table` terms become
-//!     ```
+//!     ```ignore
 //!         gamma * (1 + beta) + 0 + beta * 1
 //!       * gamma * (1 + beta) + 1 + beta * 2
 //!       * gamma * (1 + beta) + 2 + beta * 3
@@ -104,7 +104,7 @@
 //!       * gamma * (1 + beta) + 4 + beta * 5
 //!     ```
 //!     and the `witness_table` terms become
-//!     ```
+//!     ```ignore
 //!         (gamma + 0) * (1 + beta)
 //!       * (gamma + 0) * (1 + beta)
 //!       * (gamma + 0) * (1 + beta)

--- a/circuits/kimchi/src/polynomials/lookup.rs
+++ b/circuits/kimchi/src/polynomials/lookup.rs
@@ -333,10 +333,8 @@ pub fn sorted<
     }
 
     let sorted = {
-        let mut sorted: Vec<Vec<E>> = vec![];
-        for _ in 0..max_lookups_per_row + 1 {
-            sorted.push(Vec::with_capacity(lookup_rows + 1))
-        }
+        let mut sorted: Vec<Vec<E>> =
+            vec![Vec::with_capacity(lookup_rows + 1); max_lookups_per_row];
 
         let mut i = 0;
         for t in lookup_table().take(lookup_rows) {

--- a/circuits/kimchi/src/polynomials/lookup.rs
+++ b/circuits/kimchi/src/polynomials/lookup.rs
@@ -294,8 +294,8 @@ pub fn verify<F: FftField, I: Iterator<Item = F>, G: Fn() -> I>(
             witness[pos.column][row]
         };
         for joint_lookup in spec.iter() {
-            let table_entry = joint_lookup.evaluate(joint_combiner, &eval);
-            *all_lookups.entry(table_entry).or_insert(0) += 1
+            let joint_lookup_evaluation = joint_lookup.evaluate(joint_combiner, &eval);
+            *all_lookups.entry(joint_lookup_evaluation).or_insert(0) += 1
         }
 
         *all_lookups.entry(dummy_lookup_value).or_insert(0) += lookup_info.max_per_row - spec.len()
@@ -419,8 +419,8 @@ pub fn sorted<
         let spec = row;
         let padding = max_lookups_per_row - spec.len();
         for joint_lookup in spec.iter() {
-            let table_entry = E::evaluate(&params, joint_lookup, witness, i);
-            match counts.get_mut(&table_entry) {
+            let joint_lookup_evaluation = E::evaluate(&params, joint_lookup, witness, i);
+            match counts.get_mut(&joint_lookup_evaluation) {
                 None => return Err(ProofError::ValueNotInTable),
                 Some(count) => *count += 1,
             }

--- a/dlog/kimchi/src/prover.rs
+++ b/dlog/kimchi/src/prover.rs
@@ -263,7 +263,6 @@ where
                     let lookup_sorted: Vec<Vec<CombinedEntry<Fr<G>>>> = lookup::sorted(
                         dummy_lookup_value,
                         iter_lookup_table,
-                        index.cs.lookup_table_lengths[0],
                         index.cs.domain.d1,
                         &index.cs.gates,
                         &witness,


### PR DESCRIPTION
This PR removes `lookup_table_lengths` from the index, and tweaks the construction of the sorted table so that it handles duplicate values correctly.

This PR also fixes the `ValueNotInTable` error: this error now triggers when a looked-up value is absent from the source table, where previously it only fired in an edge-case.