### PR TITLE
[CI] only bench if the label benchmark is applied

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -2,13 +2,14 @@ name: Benchmarks
 
 on:
   pull_request:
-    branches:
-      - master
+    types:
+      - labeled
 
 jobs:
-  run_checks:
+  bench:
     runs-on: ubuntu-latest
     name: Run some basic checks
+    if: github.event.label.name == 'benchmark'
     steps:
       - name: Install dependencies
         run: |


### PR DESCRIPTION
benching is a bit noisy at the moment, it writes a comment on a PR (any PR) every time there's a change there. I change the behavior so that it only benches if we apply the benchmark label. Testing in this PR (actually not sure if I can properly test this before it gets checked in).