### PR TITLE
Update OCamlgen test for mina compatibility

### DIFF
--- a/ocaml/tests/src/dune
+++ b/ocaml/tests/src/dune
@@ -36,7 +36,7 @@
    (run rm -rf ./Cargo.lock)
    (with-stdout-to
     bindings.ml
-    (run cargo +nightly run)))))
+    (run cargo run)))))
 
 ;; test library
 

--- a/ocaml/tests/src/dune
+++ b/ocaml/tests/src/dune
@@ -14,7 +14,7 @@
    (run rm -rf ./target)
    (run rm -rf ./Cargo.lock)
    (run sh -c "touch dllocamlgen_test_stubs.so")
-   (run cargo +nightly build --release)
+   (run cargo build --release)
    (run sh -c "cp ../target/release/libocamlgen_test_stubs.a ."))))
 
 ;; generate the OCaml bindings from rust code
@@ -61,6 +61,6 @@
 ;; rule for running the tests
 
 (rule
- (alias test)
+ (alias runtest)
  (action
   (run ./ocamlgen_test.exe)))

--- a/ocaml/tests/src/dune
+++ b/ocaml/tests/src/dune
@@ -38,15 +38,29 @@
     bindings.ml
     (run cargo +nightly run)))))
 
-;; library
+;; test library
 
 (library
- (name ocamlgen_test)
+ (name ocamlgen_test_lib)
  (public_name ocamlgen-test)
- (inline_tests)
+ (modules lib bindings)
  (preprocess
   (pps ppx_inline_test))
  (libraries unix)
  ; Link the Rust library
  (foreign_archives ocamlgen_test_stubs)
  (c_library_flags :standard "-lpthread"))
+
+;; test executable
+
+(executable
+ (name ocamlgen_test)
+ (modules ocamlgen_test)
+ (libraries ocamlgen_test_lib))
+
+;; rule for running the tests
+
+(rule
+ (alias test)
+ (action
+  (run ./ocamlgen_test.exe)))

--- a/ocaml/tests/src/lib.ml
+++ b/ocaml/tests/src/lib.ml
@@ -1,3 +1,5 @@
+let linkme = ()
+
 let () = 
   let b = Bindings.new_t () in  
   assert (b.inner = "Hello");

--- a/ocaml/tests/src/ocamlgen_test.ml
+++ b/ocaml/tests/src/ocamlgen_test.ml
@@ -1,0 +1,1 @@
+let () = Ocamlgen_test_lib.Lib.linkme


### PR DESCRIPTION
This PR
* removes the `+nightly` flag to `cargo build`, which is currently unsupported on mina's CI (and unneeded for these tests)
* removes the fake `inline_tests` stanza from the dune file, replaces it with an executable and a `runtest` rule.