### PR TITLE
Fix performance bug

### DIFF
--- a/circuits/kimchi/Cargo.toml
+++ b/circuits/kimchi/Cargo.toml
@@ -19,7 +19,7 @@ rand = "0.8.0"
 rand_core = "0.6.3"
 num-derive = "0.3"
 num-traits = "0.2"
-itertools = "0.10.1"
+itertools = "0.10.3"
 serde = "1.0.130"
 serde_with = "1.10.0"
 

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -486,6 +486,60 @@ enum OptShiftedPolynomial<P> {
     Shifted(P, usize),
 }
 
+/// A formal sum of the form
+/// `s_0 * p_0 + ... s_n * p_n`
+/// where each `s_i` is a scalar and each `p_i` is an optionally shifted polynomial.
+struct ChunkedPolynomial<F, P>(Vec<(F, OptShiftedPolynomial<P>)>);
+
+impl<F, P> Default for ChunkedPolynomial<F, P> {
+    fn default() -> ChunkedPolynomial<F, P> {
+        ChunkedPolynomial(vec![])
+    }
+}
+
+impl<F, P> ChunkedPolynomial<F, P> {
+    fn add_unshifted(&mut self, scale: F, p: P) {
+        self.0.push((scale, OptShiftedPolynomial::Unshifted(p)))
+    }
+
+    fn add_shifted(&mut self, scale: F, shift: usize, p: P) {
+        self.0
+            .push((scale, OptShiftedPolynomial::Shifted(p, shift)))
+    }
+}
+
+impl<'a, F: Field> ChunkedPolynomial<F, &'a [F]> {
+    fn to_dense_polynomial(&self) -> DensePolynomial<F> {
+        let mut res = DensePolynomial::<F>::zero();
+
+        let scaled: Vec<_> = self
+            .0
+            .par_iter()
+            .map(|(scale, segment)| {
+                let scale = *scale;
+                match segment {
+                    OptShiftedPolynomial::Unshifted(segment) => {
+                        let v = segment.par_iter().map(|x| scale * *x).collect();
+                        DensePolynomial::from_coefficients_vec(v)
+                    }
+                    OptShiftedPolynomial::Shifted(segment, shift) => {
+                        let mut v: Vec<_> = segment.par_iter().map(|x| scale * *x).collect();
+                        let mut res = vec![F::zero(); *shift];
+                        res.append(&mut v);
+                        DensePolynomial::from_coefficients_vec(res)
+                    }
+                }
+            })
+            .collect();
+
+        for p in scaled {
+            res += &p;
+        }
+
+        res
+    }
+}
+
 impl<G: CommitmentCurve> SRS<G>
 where
     G::ScalarField: CommitmentField,
@@ -666,7 +720,8 @@ where
         g.extend(vec![G::zero(); padding]);
 
         let (p, blinding_factor) = {
-            let mut plnm_chunks: Vec<(Fr<G>, OptShiftedPolynomial<_>)> = vec![];
+            let mut plnm = ChunkedPolynomial::<Fr<G>, &[Fr<G>]>::default();
+            // let mut plnm_chunks: Vec<(Fr<G>, OptShiftedPolynomial<_>)> = vec![];
 
             let mut omega = Fr::<G>::zero();
             let mut scale = Fr::<G>::one();
@@ -686,7 +741,7 @@ where
                                 offset + self.g.len()
                             }];
                         // always mixing in the unshifted segments
-                        plnm_chunks.push((scale, OptShiftedPolynomial::Unshifted(segment)));
+                        plnm.add_unshifted(scale, segment);
 
                         omega += &(omegas.unshifted[j] * scale);
                         j += 1;
@@ -694,13 +749,7 @@ where
                         offset += self.g.len();
                         if offset > *m {
                             // mixing in the shifted segment since degree is bounded
-                            plnm_chunks.push((
-                                scale,
-                                OptShiftedPolynomial::Shifted(
-                                    segment,
-                                    self.g.len() - m % self.g.len(),
-                                ),
-                            ));
+                            plnm.add_shifted(scale, self.g.len() - m % self.g.len(), segment);
                             omega += &(omegas.shifted.unwrap() * scale);
                             scale *= &polyscale;
                         }
@@ -716,7 +765,7 @@ where
                             }];
 
                         // always mixing in the unshifted segments
-                        plnm_chunks.push((scale, OptShiftedPolynomial::Unshifted(segment)));
+                        plnm.add_unshifted(scale, segment);
                         omega += &(omegas.unshifted[j] * scale);
                         j += 1;
                         scale *= &polyscale;
@@ -726,32 +775,7 @@ where
                 assert_eq!(j, omegas.unshifted.len());
             }
 
-            let mut res = DensePolynomial::<Fr<G>>::zero();
-
-            let scaled: Vec<_> = plnm_chunks
-                .par_iter()
-                .map(|(scale, segment)| {
-                    let scale = *scale;
-                    match segment {
-                        OptShiftedPolynomial::Unshifted(segment) => {
-                            let v = segment.par_iter().map(|x| scale * *x).collect();
-                            DensePolynomial::from_coefficients_vec(v)
-                        }
-                        OptShiftedPolynomial::Shifted(segment, shift) => {
-                            let mut v: Vec<_> = segment.par_iter().map(|x| scale * *x).collect();
-                            let mut res = vec![Fr::<G>::zero(); *shift];
-                            res.append(&mut v);
-                            DensePolynomial::from_coefficients_vec(res)
-                        }
-                    }
-                })
-                .collect();
-
-            for p in scaled {
-                res += &p;
-            }
-
-            (res, omega)
+            (plnm.to_dense_polynomial(), omega)
         };
 
         let rounds = ceil_log2(self.g.len());

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -666,7 +666,7 @@ where
         g.extend(vec![G::zero(); padding]);
 
         let (p, blinding_factor) = {
-            let mut plnm_chunks : Vec<(Fr::<G>, OptShiftedPolynomial<_>)> = vec![];
+            let mut plnm_chunks: Vec<(Fr<G>, OptShiftedPolynomial<_>)> = vec![];
 
             let mut omega = Fr::<G>::zero();
             let mut scale = Fr::<G>::one();
@@ -679,8 +679,8 @@ where
                 if let Some(m) = degree_bound {
                     assert!(p_i.coeffs.len() <= m + 1);
                     while j < omegas.unshifted.len() {
-                        let segment =
-                            &p_i.coeffs[offset..if offset + self.g.len() > p_i.coeffs.len() {
+                        let segment = &p_i.coeffs[offset
+                            ..if offset + self.g.len() > p_i.coeffs.len() {
                                 p_i.coeffs.len()
                             } else {
                                 offset + self.g.len()
@@ -694,7 +694,13 @@ where
                         offset += self.g.len();
                         if offset > *m {
                             // mixing in the shifted segment since degree is bounded
-                            plnm_chunks.push((scale, OptShiftedPolynomial::Shifted(segment, self.g.len() - m % self.g.len())));
+                            plnm_chunks.push((
+                                scale,
+                                OptShiftedPolynomial::Shifted(
+                                    segment,
+                                    self.g.len() - m % self.g.len(),
+                                ),
+                            ));
                             omega += &(omegas.shifted.unwrap() * scale);
                             scale *= &polyscale;
                         }
@@ -702,8 +708,8 @@ where
                 } else {
                     assert!(omegas.shifted.is_none());
                     while j < omegas.unshifted.len() {
-                        let segment =
-                            &p_i.coeffs[offset..if offset + self.g.len() > p_i.coeffs.len() {
+                        let segment = &p_i.coeffs[offset
+                            ..if offset + self.g.len() > p_i.coeffs.len() {
                                 p_i.coeffs.len()
                             } else {
                                 offset + self.g.len()
@@ -722,21 +728,24 @@ where
 
             let mut res = DensePolynomial::<Fr<G>>::zero();
 
-            let scaled: Vec<_> = plnm_chunks.par_iter().map(|(scale, segment)| {
-                let scale = *scale;
-                match segment {
-                    OptShiftedPolynomial::Unshifted(segment) => {
-                        let v = segment.par_iter().map(|x| scale * *x).collect();
-                        DensePolynomial::from_coefficients_vec(v)
-                    },
-                    OptShiftedPolynomial::Shifted(segment, shift) => {
-                        let mut v: Vec<_> = segment.par_iter().map(|x| scale * *x).collect();
-                        let mut res = vec![Fr::<G>::zero(); *shift];
-                        res.append(&mut v);
-                        DensePolynomial::from_coefficients_vec(res)
-                    },
-                }
-            }).collect();
+            let scaled: Vec<_> = plnm_chunks
+                .par_iter()
+                .map(|(scale, segment)| {
+                    let scale = *scale;
+                    match segment {
+                        OptShiftedPolynomial::Unshifted(segment) => {
+                            let v = segment.par_iter().map(|x| scale * *x).collect();
+                            DensePolynomial::from_coefficients_vec(v)
+                        }
+                        OptShiftedPolynomial::Shifted(segment, shift) => {
+                            let mut v: Vec<_> = segment.par_iter().map(|x| scale * *x).collect();
+                            let mut res = vec![Fr::<G>::zero(); *shift];
+                            res.append(&mut v);
+                            DensePolynomial::from_coefficients_vec(res)
+                        }
+                    }
+                })
+                .collect();
 
             for p in scaled {
                 res += &p;

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -666,10 +666,12 @@ where
         g.extend(vec![G::zero(); padding]);
 
         let (p, blinding_factor) = {
-            let start = std::time::Instant::now();
-            let mut scale = Fr::<G>::one();
-            let mut omega = Fr::<G>::zero();
             let mut plnm_chunks : Vec<(Fr::<G>, OptShiftedPolynomial<_>)> = vec![];
+
+            let mut omega = Fr::<G>::zero();
+            let mut scale = Fr::<G>::one();
+
+            // iterating over polynomials in the batch
             for (p_i, degree_bound, omegas) in plnms.iter().filter(|p| !p.0.is_zero()) {
                 let mut offset = 0;
                 let mut j = 0;
@@ -740,12 +742,8 @@ where
                 res += &p;
             }
 
-            println!("palt {:?}", start.elapsed());
             (res, omega)
         };
-
-        let start = std::time::Instant::now();
-        // scale the polynoms in accumulator shifted, if bounded, to the end of SRS
 
         let rounds = ceil_log2(self.g.len());
 

--- a/utils/src/dense_polynomial.rs
+++ b/utils/src/dense_polynomial.rs
@@ -29,9 +29,10 @@ pub trait ExtendedDensePolynomial<F: Field> {
 impl<F: Field> ExtendedDensePolynomial<F> for DensePolynomial<F> {
     fn scale(&self, elm: F) -> Self {
         let mut result = self.clone();
-        result.coeffs.par_iter_mut().for_each(|coeff| {
-            *coeff *= &elm
-        });
+        result
+            .coeffs
+            .par_iter_mut()
+            .for_each(|coeff| *coeff *= &elm);
         result
     }
 

--- a/utils/src/dense_polynomial.rs
+++ b/utils/src/dense_polynomial.rs
@@ -2,6 +2,7 @@
 
 use ark_ff::Field;
 use ark_poly::{univariate::DensePolynomial, Polynomial, UVPolynomial};
+use rayon::prelude::*;
 
 //
 // ExtendedDensePolynomial trait
@@ -28,9 +29,9 @@ pub trait ExtendedDensePolynomial<F: Field> {
 impl<F: Field> ExtendedDensePolynomial<F> for DensePolynomial<F> {
     fn scale(&self, elm: F) -> Self {
         let mut result = self.clone();
-        for coeff in &mut result.coeffs {
+        result.coeffs.par_iter_mut().for_each(|coeff| {
             *coeff *= &elm
-        }
+        });
         result
     }
 


### PR DESCRIPTION
I accidentally committed some debug lines which were computing completely unused polynomial commitments inside the opening function. This removes that and also optimizes the code for combining polynomials to an improved version. In testing this improved prover performance by about 15-20% :sweat_smile: 