### PR TITLE
2x-ish speedup from endomorphism

### DIFF
--- a/circuits/kimchi/Cargo.toml
+++ b/circuits/kimchi/Cargo.toml
@@ -19,7 +19,7 @@ rand = "0.8.0"
 rand_core = "0.6.3"
 num-derive = "0.3"
 num-traits = "0.2"
-itertools = "0.10.1"
+itertools = "0.10.3"
 serde = "1.0.130"
 serde_with = "1.10.0"
 

--- a/dlog/commitment/src/combine.rs
+++ b/dlog/commitment/src/combine.rs
@@ -311,14 +311,14 @@ fn affine_window_combine_one_endo_base<P: SWModelParameters>(
     // acc = 2 (phi(g2) + g2)
     let mut points = g2.to_vec();
     batch_endo_in_place(endo_coeff, &mut points);
-    batch_add_assign_no_branch(&mut denominators, &mut points, &g2);
+    batch_add_assign_no_branch(&mut denominators, &mut points, g2);
     batch_double_in_place(&mut denominators, &mut points);
 
     let mut tmp_s = g2.to_vec();
     let mut tmp_acc = g2.to_vec();
     for i in (0..(128 / 2)).rev() {
         // s = g2
-        assign(&mut tmp_s, &g2);
+        assign(&mut tmp_s, g2);
         // tmp = acc
         assign(&mut tmp_acc, &points);
 
@@ -335,7 +335,7 @@ fn affine_window_combine_one_endo_base<P: SWModelParameters>(
         batch_add_assign_no_branch(&mut denominators, &mut points, &tmp_acc);
     }
     // acc += g1
-    batch_add_assign(&mut denominators, &mut points, &g1);
+    batch_add_assign(&mut denominators, &mut points, g1);
     points
 }
 

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -382,6 +382,17 @@ pub trait CommitmentCurve: AffineCurve {
         crate::combine::window_combine(g1, g2, Self::ScalarField::one(), x2)
     }
 
+    // Combine where x1 = one
+    fn combine_one_endo(
+        endo_r: Self::ScalarField,
+        _endo_q: Self::BaseField,
+        g1: &[Self],
+        g2: &[Self],
+        x2: ScalarChallenge<Self::ScalarField>,
+    ) -> Vec<Self> {
+        crate::combine::window_combine(g1, g2, Self::ScalarField::one(), x2.to_field(&endo_r))
+    }
+
     fn combine(
         g1: &[Self],
         g2: &[Self],
@@ -413,6 +424,16 @@ where
 
     fn combine_one(g1: &[Self], g2: &[Self], x2: Self::ScalarField) -> Vec<Self> {
         crate::combine::affine_window_combine_one(g1, g2, x2)
+    }
+
+    fn combine_one_endo(
+        _endo_r: Self::ScalarField,
+        endo_q: Self::BaseField,
+        g1: &[Self],
+        g2: &[Self],
+        x2: ScalarChallenge<Self::ScalarField>,
+    ) -> Vec<Self> {
+        crate::combine::affine_window_combine_one_endo(endo_q, g1, g2, x2)
     }
 
     fn combine(
@@ -830,7 +851,8 @@ where
             sponge.absorb_g(&[l]);
             sponge.absorb_g(&[r]);
 
-            let u = squeeze_challenge(&self.endo_r, &mut sponge);
+            let u_pre = squeeze_prechallenge(&mut sponge);
+            let u = u_pre.to_field(&self.endo_r);
             let u_inv = u.inverse().unwrap();
 
             chals.push(u);
@@ -860,7 +882,7 @@ where
                 })
                 .collect();
 
-            g = G::combine_one(&g_lo, &g_hi, u);
+            g = G::combine_one_endo(self.endo_r, self.endo_q, &g_lo, &g_hi, u_pre);
         }
 
         assert!(g.len() == 1);


### PR DESCRIPTION
This PR uses the endomorphism to compute the `g1 + x * g2` step of the commitment opener. The result is a roughly 2x overall speedup in prover time. E.g., with domain size 2^14, prover time has gone from 2.830285628s to 1.440663255s.

Algorithm 1 of https://eprint.iacr.org/2019/1021.pdf (on page 19) was used as a reference.