### PR TITLE
[gate][chacha] refactor to distinguish the different subgates

### DIFF
--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1969,6 +1969,16 @@ impl<F: fmt::Display + Clone> fmt::Display for Expr<F> {
 /// An alias for the intended usage of the expression type in constructing constraints.
 pub type E<F> = Expr<ConstantExpr<F>>;
 
+/// Handy function to quickly create an expression for a witness.
+pub fn witness<F>(i: usize, r: CurrOrNext) -> E<F> {
+    E::<F>::cell(Column::Witness(i), r)
+}
+
+/// Handy function to quickly create an expression for a gate.
+pub fn index<F>(g: GateType, r: CurrOrNext) -> E<F> {
+    E::<F>::cell(Column::Index(g), r)
+}
+
 #[cfg(feature = "ocaml_types")]
 pub mod caml {
     use super::*;

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1979,6 +1979,11 @@ pub fn index<F>(g: GateType, r: CurrOrNext) -> E<F> {
     E::<F>::cell(Column::Index(g), r)
 }
 
+/// Creates a constraint to enforce that b is either 0 or 1.
+pub fn boolean<F: Field>(b: &E<F>) -> E<F> {
+    b.clone() * b.clone() - b.clone()
+}
+
 #[cfg(feature = "ocaml_types")]
 pub mod caml {
     use super::*;

--- a/kimchi/src/circuits/polynomials/chacha.rs
+++ b/kimchi/src/circuits/polynomials/chacha.rs
@@ -143,7 +143,7 @@
 //!
 
 use crate::circuits::{
-    expr::{index, witness, ConstantExpr as C, E},
+    expr::{boolean, index, witness, ConstantExpr as C, E},
     gate::{CurrOrNext, GateType},
 };
 use ark_ff::{FftField, Field, Zero};
@@ -195,11 +195,6 @@ fn chunks_over_2_rows<F>(col_offset: usize) -> Vec<E<F>> {
             witness(col_offset + (i % 4), r)
         })
         .collect()
-}
-
-/// Creates a constraint to enforce that b is either 0 or 1.
-fn boolean<F: Field>(b: &E<F>) -> E<F> {
-    b.clone() * b.clone() - b.clone()
 }
 
 fn combine_nybbles<F: Field>(ns: Vec<E<F>>) -> E<F> {

--- a/kimchi/src/index.rs
+++ b/kimchi/src/index.rs
@@ -174,8 +174,12 @@ pub fn constraints_expr<F: FftField + SquareRootField>(
             )
         }
     };
+
     if chacha {
-        expr + chacha::constraint(super::range::CHACHA.start)
+        let expr = expr + chacha::constraint_chacha0(super::range::CHACHA.start);
+        let expr = expr + chacha::constraint_chacha1(super::range::CHACHA.start);
+        let expr = expr + chacha::constraint_chacha2(super::range::CHACHA.start);
+        expr + chacha::constraint_chacha_final(super::range::CHACHA.start)
     } else {
         expr
     }

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -502,11 +502,42 @@ where
 
             // chacha
             if index.cs.chacha8.as_ref().is_some() {
-                let chacha = chacha::constraint(range::CHACHA.start).evaluations(&env);
-                t4 += &chacha;
+                let chacha0 = chacha::constraint_chacha0(range::CHACHA.start).evaluations(&env);
+                t4 += &chacha0;
+
+                let chacha1 = chacha::constraint_chacha1(range::CHACHA.start).evaluations(&env);
+                t4 += &chacha1;
+
+                let chacha2 = chacha::constraint_chacha2(range::CHACHA.start).evaluations(&env);
+                t4 += &chacha2;
+
+                let chacha_final =
+                    chacha::constraint_chacha_final(range::CHACHA.start).evaluations(&env);
+                t4 += &chacha_final;
 
                 if cfg!(test) {
-                    let (_, res) = chacha
+                    let (_, res) = chacha0
+                        .clone()
+                        .interpolate()
+                        .divide_by_vanishing_poly(index.cs.domain.d1)
+                        .unwrap();
+                    assert!(res.is_zero());
+
+                    let (_, res) = chacha1
+                        .clone()
+                        .interpolate()
+                        .divide_by_vanishing_poly(index.cs.domain.d1)
+                        .unwrap();
+                    assert!(res.is_zero());
+
+                    let (_, res) = chacha2
+                        .clone()
+                        .interpolate()
+                        .divide_by_vanishing_poly(index.cs.domain.d1)
+                        .unwrap();
+                    assert!(res.is_zero());
+
+                    let (_, res) = chacha_final
                         .clone()
                         .interpolate()
                         .divide_by_vanishing_poly(index.cs.domain.d1)

--- a/kimchi/src/tests/chacha.rs
+++ b/kimchi/src/tests/chacha.rs
@@ -52,12 +52,12 @@ fn chacha_prover() {
         0x3f5ec7b7, 0x335271c2, 0xf29489f3, 0xeabda8fc, 0x82e46ebd, 0xd19c12b4, 0xb04e16de,
         0x9e83d0cb, 0x4e3c50a2,
     ];
-    assert_eq!(expected_result, chacha::chacha20(s0.clone()));
+    assert_eq!(expected_result, chacha::testing::chacha20(s0.clone()));
 
     // circuit gates
     let mut gates = vec![];
     for _ in 0..num_chachas {
-        gates.extend(chacha::chacha20_gates())
+        gates.extend(chacha::testing::chacha20_gates())
     }
     let gates: Vec<CircuitGate<Fp>> = gates
         .into_iter()
@@ -84,7 +84,7 @@ fn chacha_prover() {
 
     let mut rows = vec![];
     for _ in 0..num_chachas {
-        rows.extend(chacha::chacha20_rows::<Fp>(s0.clone()))
+        rows.extend(chacha::testing::chacha20_rows::<Fp>(s0.clone()))
     }
     let mut witness: [Vec<Fp>; COLUMNS] = array_init(|_| vec![]);
     for r in rows.into_iter() {


### PR DESCRIPTION
I perform several changes to the chacha gate:

* separate the different chacha gates into different functions (the previous code wasn't making it clear that we're dealing with 4 gates)
* closures -> functions, this will facilitate changes when we use the alpha iterator later
* move functions for testing in a `testing` module