### PR TITLE
Move LookupConstraintSystem creation to its own function

### DIFF
--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -319,6 +319,60 @@ pub enum GateError {
     Custom { row: usize, err: String },
 }
 
+impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
+    pub fn create(
+        gates: &Vec<CircuitGate<F>>,
+        lookup_tables: Vec<Vec<Vec<F>>>,
+        domain: &EvaluationDomains<F>,
+    ) -> Option<Self> {
+        let lookup_info = LookupInfo::<F>::create();
+        match lookup_info.lookup_used(gates) {
+            None => None,
+            Some(lookup_used) => {
+                let d1_size = domain.d1.size();
+
+                // get the last entry in each column of each table
+                let dummy_lookup_values: Vec<Vec<F>> = lookup_tables
+                    .iter()
+                    .map(|table| table.iter().map(|col| col[col.len() - 1]).collect())
+                    .collect();
+
+                // pre-compute polynomial and evaluation form for the look up tables
+                let mut lookup_tables_polys: Vec<Vec<DP<F>>> = vec![];
+                let mut lookup_tables8: Vec<Vec<E<F, D<F>>>> = vec![];
+
+                for (table, dummies) in lookup_tables.into_iter().zip(&dummy_lookup_values) {
+                    let mut table_poly = vec![];
+                    let mut table_eval = vec![];
+                    for (mut col, dummy) in table.into_iter().zip(dummies) {
+                        // pad each column to the size of the domain
+                        let padding = (0..(d1_size - col.len())).map(|_| dummy);
+                        col.extend(padding);
+                        let poly = E::<F, D<F>>::from_vec_and_domain(col, domain.d1).interpolate();
+                        let eval = poly.evaluate_over_domain_by_ref(domain.d8);
+                        table_poly.push(poly);
+                        table_eval.push(eval);
+                    }
+                    lookup_tables_polys.push(table_poly);
+                    lookup_tables8.push(table_eval);
+                }
+
+                // generate the look up selector polynomials
+                let lookup_selectors = lookup_info.selector_polynomials(domain, gates);
+                Some(LookupConstraintSystem {
+                    lookup_selectors,
+                    dummy_lookup_values,
+                    lookup_tables8,
+                    lookup_tables: lookup_tables_polys,
+                    lookup_used,
+                    max_lookups_per_row: lookup_info.max_per_row,
+                    max_joint_size: lookup_info.max_joint_size,
+                })
+            }
+        }
+    }
+}
+
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {
     /// creates a constraint system from a vector of gates ([CircuitGate]), some sponge parameters ([ArithmeticSpongeParams]), and the number of public inputs.
     pub fn create(
@@ -518,52 +572,8 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
         // Lookup
         //
 
-        let lookup_constraint_system = {
-            let lookup_info = LookupInfo::<F>::create();
-            match lookup_info.lookup_used(&gates) {
-                None => None,
-                Some(lookup_used) => {
-                    // get the last entry in each column of each table
-                    let dummy_lookup_values: Vec<Vec<F>> = lookup_tables
-                        .iter()
-                        .map(|table| table.iter().map(|col| col[col.len() - 1]).collect())
-                        .collect();
-
-                    // pre-compute polynomial and evaluation form for the look up tables
-                    let mut lookup_tables_polys: Vec<Vec<DP<F>>> = vec![];
-                    let mut lookup_tables8: Vec<Vec<E<F, D<F>>>> = vec![];
-
-                    for (table, dummies) in lookup_tables.into_iter().zip(&dummy_lookup_values) {
-                        let mut table_poly = vec![];
-                        let mut table_eval = vec![];
-                        for (mut col, dummy) in table.into_iter().zip(dummies) {
-                            // pad each column to the size of the domain
-                            let padding = (0..(d1_size - col.len())).map(|_| dummy);
-                            col.extend(padding);
-                            let poly =
-                                E::<F, D<F>>::from_vec_and_domain(col, domain.d1).interpolate();
-                            let eval = poly.evaluate_over_domain_by_ref(domain.d8);
-                            table_poly.push(poly);
-                            table_eval.push(eval);
-                        }
-                        lookup_tables_polys.push(table_poly);
-                        lookup_tables8.push(table_eval);
-                    }
-
-                    // generate the look up selector polynomials
-                    let lookup_selectors = lookup_info.selector_polynomials(domain, &gates);
-                    Some(LookupConstraintSystem {
-                        lookup_selectors,
-                        dummy_lookup_values,
-                        lookup_tables8,
-                        lookup_tables: lookup_tables_polys,
-                        lookup_used,
-                        max_lookups_per_row: lookup_info.max_per_row,
-                        max_joint_size: lookup_info.max_joint_size,
-                    })
-                }
-            }
-        };
+        let lookup_constraint_system =
+            LookupConstraintSystem::create(&gates, lookup_tables, &domain);
 
         //
         // return result

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -227,7 +227,7 @@ impl<F: FftField> LookupInfo<F> {
     /// lookup kind should be enforced at a given row. This computes those selector polynomials.
     pub fn selector_polynomials(
         &self,
-        domain: EvaluationDomains<F>,
+        domain: &EvaluationDomains<F>,
         gates: &[CircuitGate<F>],
     ) -> Vec<E<F, D<F>>> {
         let n = domain.d1.size as usize;


### PR DESCRIPTION
This PR adds a `LookupConstraintSystem::create` function, which abstracts out the logic for creating a `LookupConstraintSystem`. This will allow us to call this function as part of generating the linearisation when we want to implement plookup in pickles.