### PR TITLE
Automatically infer and expose used tables from used gates

### DIFF
--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -331,9 +331,13 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
             Some(lookup_used) => {
                 let d1_size = domain.d1.size();
 
+                let (lookup_selectors, gate_lookup_tables) =
+                    lookup_info.selector_polynomials_and_tables(domain, gates);
+
                 // get the last entry in each column of each table
-                let dummy_lookup_values: Vec<Vec<F>> = lookup_tables
+                let dummy_lookup_values: Vec<Vec<F>> = gate_lookup_tables
                     .iter()
+                    .chain(lookup_tables.iter())
                     .map(|table| table.iter().map(|col| col[col.len() - 1]).collect())
                     .collect();
 
@@ -341,7 +345,11 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
                 let mut lookup_tables_polys: Vec<Vec<DP<F>>> = vec![];
                 let mut lookup_tables8: Vec<Vec<E<F, D<F>>>> = vec![];
 
-                for (table, dummies) in lookup_tables.into_iter().zip(&dummy_lookup_values) {
+                for (table, dummies) in gate_lookup_tables
+                    .into_iter()
+                    .chain(lookup_tables.into_iter())
+                    .zip(&dummy_lookup_values)
+                {
                     let mut table_poly = vec![];
                     let mut table_eval = vec![];
                     for (mut col, dummy) in table.into_iter().zip(dummies) {
@@ -358,7 +366,6 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
                 }
 
                 // generate the look up selector polynomials
-                let lookup_selectors = lookup_info.selector_polynomials(domain, gates);
                 Some(LookupConstraintSystem {
                     lookup_selectors,
                     dummy_lookup_values,

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -208,7 +208,7 @@ impl<F: FftField> LookupInfo<F> {
 
             kinds_map,
             kinds_tables,
-            kinds: kinds,
+            kinds,
             max_per_row,
             empty: vec![],
         }
@@ -235,6 +235,7 @@ impl<F: FftField> LookupInfo<F> {
 
     /// Each entry in `kinds` has a corresponding selector polynomial that controls whether that
     /// lookup kind should be enforced at a given row. This computes those selector polynomials.
+    #[allow(clippy::type_complexity)]
     pub fn selector_polynomials_and_tables(
         &self,
         domain: &EvaluationDomains<F>,
@@ -387,6 +388,7 @@ impl GateType {
         }
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn lookup_kinds_map<F: Field>(
         locations_with_tables: Vec<(HashSet<(GateType, CurrOrNext)>, Option<GateLookupTable>)>,
     ) -> (

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -7,7 +7,7 @@ use ark_poly::{Evaluations as E, Radix2EvaluationDomain as D};
 use num_traits::cast::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::collections::{HashMap, HashSet};
+use std::collections::{hash_map::Entry, HashMap, HashSet};
 use std::io::{Result as IoResult, Write};
 
 /// A row accessible from a given row, corresponds to the fact that we open all polynomials
@@ -423,14 +423,13 @@ impl GateType {
         ) in locations_with_tables.into_iter().enumerate()
         {
             for location in locs {
-                if let std::collections::hash_map::Entry::Vacant(e) = index_map.entry(location) {
+                if let Entry::Vacant(e) = index_map.entry(location) {
                     e.insert(i);
                 } else {
                     panic!("Multiple lookup patterns asserted on same row.")
                 }
                 if let Some(table_kind) = table_kind {
-                    if let std::collections::hash_map::Entry::Vacant(e) = table_map.entry(location)
-                    {
+                    if let Entry::Vacant(e) = table_map.entry(location) {
                         e.insert(table_kind);
                     }
                 }

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -10,6 +10,8 @@ use serde_with::serde_as;
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 use std::io::{Result as IoResult, Write};
 
+type Evaluations<Field> = E<Field, D<Field>>;
+
 /// A row accessible from a given row, corresponds to the fact that we open all polynomials
 /// at `zeta` **and** `omega * zeta`.
 #[repr(C)]
@@ -244,7 +246,7 @@ impl<F: FftField> LookupInfo<F> {
         &self,
         domain: &EvaluationDomains<F>,
         gates: &[CircuitGate<F>],
-    ) -> (Vec<E<F, D<F>>>, Vec<LookupTable<F>>) {
+    ) -> (Vec<Evaluations<F>>, Vec<LookupTable<F>>) {
         let n = domain.d1.size as usize;
         let mut selector_values: Vec<_> = self.kinds.iter().map(|_| vec![F::zero(); n]).collect();
         let mut gate_tables = HashSet::new();

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -188,7 +188,9 @@ pub enum GateLookupTable {
     Xor,
 }
 
-pub fn get_table<F: FftField>(table_name: GateLookupTable) -> Vec<Vec<F>> {
+pub type LookupTable<F> = Vec<Vec<F>>;
+
+pub fn get_table<F: FftField>(table_name: GateLookupTable) -> LookupTable<F> {
     match table_name {
         GateLookupTable::Xor => crate::circuits::polynomials::chacha::xor_table(),
     }
@@ -238,12 +240,11 @@ impl<F: FftField> LookupInfo<F> {
 
     /// Each entry in `kinds` has a corresponding selector polynomial that controls whether that
     /// lookup kind should be enforced at a given row. This computes those selector polynomials.
-    #[allow(clippy::type_complexity)]
     pub fn selector_polynomials_and_tables(
         &self,
         domain: &EvaluationDomains<F>,
         gates: &[CircuitGate<F>],
-    ) -> (Vec<E<F, D<F>>>, Vec<Vec<Vec<F>>>) {
+    ) -> (Vec<E<F, D<F>>>, Vec<LookupTable<F>>) {
         let n = domain.d1.size as usize;
         let mut selector_values: Vec<_> = self.kinds.iter().map(|_| vec![F::zero(); n]).collect();
         let mut gate_tables = HashSet::new();

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -323,7 +323,6 @@ impl GateType {
     ///
     /// See circuits/kimchi/src/polynomials/chacha.rs for an explanation of
     /// how these work.
-    #[allow(clippy::type_complexity)]
     pub fn lookup_kinds<F: Field>() -> (Vec<Vec<JointLookup<F>>>, Vec<GatesLookupSpec>) {
         let curr_row = |column| LocalPosition {
             row: CurrOrNext::Curr,
@@ -409,7 +408,6 @@ impl GateType {
         }
     }
 
-    #[allow(clippy::type_complexity)]
     pub fn lookup_kinds_map<F: Field>(
         locations_with_tables: Vec<GatesLookupSpec>,
     ) -> GatesLookupMaps {

--- a/kimchi/src/tests/chacha.rs
+++ b/kimchi/src/tests/chacha.rs
@@ -71,9 +71,7 @@ fn chacha_prover() {
 
     // create the index
     let fp_sponge_params = oracle::pasta::fp::params();
-    let cs =
-        ConstraintSystem::<Fp>::create(gates, vec![chacha::xor_table()], fp_sponge_params, PUBLIC)
-            .unwrap();
+    let cs = ConstraintSystem::<Fp>::create(gates, vec![], fp_sponge_params, PUBLIC).unwrap();
     let fq_sponge_params = oracle::pasta::fq::params();
     let (endo_q, _endo_r) = endos::<Other>();
     let mut srs = SRS::create(max_size);


### PR DESCRIPTION
This PR
* tracks the table associated with each gate that uses lookups
* generates the table when used, automatically inserting it into the list of tables considered when creating the proof
* removes the explicit use of `xor_table` in the chacha test