### PR TITLE
[WIP][argument] use argument trait for lookup

### DIFF
--- a/kimchi/src/circuits/argument.rs
+++ b/kimchi/src/circuits/argument.rs
@@ -38,11 +38,11 @@ pub trait Argument {
 
     /// Returns the set of constraints required to prove this argument.
     // TODO: return a [_; Self::CONSTRAINTS] once generic consts are stable
-    fn constraints() -> Vec<E<Self::Field>>;
+    fn constraints(&self) -> Vec<E<Self::Field>>;
 
     /// Returns constraints safely combined via the passed combinator.
-    fn combined_constraints(alphas: &Alphas<Self::Field>) -> E<Self::Field> {
-        let constraints = Self::constraints();
+    fn combined_constraints(&self, alphas: &Alphas<Self::Field>) -> E<Self::Field> {
+        let constraints = self.constraints();
         assert!(constraints.len() == Self::CONSTRAINTS);
         let alphas = alphas.get_exponents(Self::ARGUMENT_TYPE, Self::CONSTRAINTS);
         let combined_constraints = E::combine_constraints(alphas, constraints);

--- a/kimchi/src/circuits/gates/endosclmul.rs
+++ b/kimchi/src/circuits/gates/endosclmul.rs
@@ -73,7 +73,7 @@ impl<F: FftField> CircuitGate<F> {
             ProofEvaluations::dummy_with_witness_evaluations(next),
         ];
 
-        let constraints = EndosclMul::constraints();
+        let constraints = EndosclMul::default().constraints();
         for (i, c) in constraints.iter().enumerate() {
             match c.evaluate_(cs.domain.d1, pt, &evals, &constants) {
                 Ok(x) => {

--- a/kimchi/src/circuits/polynomials/chacha.rs
+++ b/kimchi/src/circuits/polynomials/chacha.rs
@@ -257,7 +257,7 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::ChaCha0);
     const CONSTRAINTS: usize = 5;
 
-    fn constraints() -> Vec<E<F>> {
+    fn constraints(&self) -> Vec<E<F>> {
         // a += b; d ^= a; d <<<= 16 (=4*4)
         line(4)
     }
@@ -276,7 +276,7 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::ChaCha1);
     const CONSTRAINTS: usize = 5;
 
-    fn constraints() -> Vec<E<F>> {
+    fn constraints(&self) -> Vec<E<F>> {
         // c += d; b ^= c; b <<<= 12 (=3*4)
         line(3)
     }
@@ -295,7 +295,7 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::ChaCha2);
     const CONSTRAINTS: usize = 5;
 
-    fn constraints() -> Vec<E<F>> {
+    fn constraints(&self) -> Vec<E<F>> {
         // a += b; d ^= a; d <<<= 8  (=2*4)
         line(2)
     }
@@ -314,7 +314,7 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::ChaChaFinal);
     const CONSTRAINTS: usize = 9;
 
-    fn constraints() -> Vec<E<F>> {
+    fn constraints(&self) -> Vec<E<F>> {
         // The last line, namely,
         // c += d; b ^= c; b <<<= 7;
         // is special.
@@ -572,10 +572,10 @@ mod tests {
             ArgumentType::Gate(GateType::ChaChaFinal),
             ChaChaFinal::<F>::CONSTRAINTS,
         );
-        let mut expr = ChaCha0::combined_constraints(&alphas);
-        expr += ChaCha1::combined_constraints(&alphas);
-        expr += ChaCha2::combined_constraints(&alphas);
-        expr += ChaChaFinal::combined_constraints(&alphas);
+        let mut expr = ChaCha0::default().combined_constraints(&alphas);
+        expr += ChaCha1::default().combined_constraints(&alphas);
+        expr += ChaCha2::default().combined_constraints(&alphas);
+        expr += ChaChaFinal::default().combined_constraints(&alphas);
         let linearized = expr.linearize(evaluated_cols).unwrap();
         let _expr_polish = expr.to_polish();
         let linearized_polish = linearized.map(|e| e.to_polish());

--- a/kimchi/src/circuits/polynomials/complete_add.rs
+++ b/kimchi/src/circuits/polynomials/complete_add.rs
@@ -57,7 +57,7 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::CompleteAdd);
     const CONSTRAINTS: usize = 7;
 
-    fn constraints() -> Vec<E<F>> {
+    fn constraints(&self) -> Vec<E<F>> {
         // This function makes 2 + 1 + 1 + 1 + 2 = 7 constraints
         let x1 = witness_curr(0);
         let y1 = witness_curr(1);

--- a/kimchi/src/circuits/polynomials/endomul_scalar.rs
+++ b/kimchi/src/circuits/polynomials/endomul_scalar.rs
@@ -127,7 +127,7 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::EndoMulScalar);
     const CONSTRAINTS: usize = 11;
 
-    fn constraints() -> Vec<E<F>> {
+    fn constraints(&self) -> Vec<E<F>> {
         let n0 = witness_curr(0);
         let n8 = witness_curr(1);
         let a0 = witness_curr(2);

--- a/kimchi/src/circuits/polynomials/endosclmul.rs
+++ b/kimchi/src/circuits/polynomials/endosclmul.rs
@@ -50,7 +50,7 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::EndoMul);
     const CONSTRAINTS: usize = 11;
 
-    fn constraints() -> Vec<E<F>> {
+    fn constraints(&self) -> Vec<E<F>> {
         let b1 = witness_curr(11);
         let b2 = witness_curr(12);
         let b3 = witness_curr(13);

--- a/kimchi/src/circuits/polynomials/lookup.rs
+++ b/kimchi/src/circuits/polynomials/lookup.rs
@@ -1,4 +1,4 @@
-//! This source file implements the arithmetization of plookup constraints
+//! This module implements the arithmetization of plookup constraints
 //!
 //! Because of our ZK-rows, we can't do the trick in the plookup paper of
 //! wrapping around to enforce consistency between the sorted lookup columns.
@@ -120,21 +120,18 @@
 //! snakifying on `witness_table`, because its contribution above only uses a single term rather
 //! than a pair of terms.
 
-use ark_poly::{Evaluations, Radix2EvaluationDomain as D};
-
+use crate::circuits::argument::{Argument, ArgumentType};
 use crate::circuits::expr::{prologue::*, Column, ConstantExpr, Variable};
 use crate::circuits::{
     gate::{CircuitGate, CurrOrNext, JointLookup, LocalPosition, LookupInfo, SingleLookup},
     wires::COLUMNS,
 };
 use ark_ff::{FftField, Field, One, Zero};
+use ark_poly::{Evaluations, Radix2EvaluationDomain as D};
 use oracle::rndoracle::ProofError;
 use rand::Rng;
 use std::collections::HashMap;
 use CurrOrNext::*;
-
-/// Number of constraints produced by the argument.
-pub const CONSTRAINTS: usize = 7;
 
 // TODO: Update for multiple tables
 fn single_lookup<F: FftField>(s: &SingleLookup<F>) -> E<F> {
@@ -584,168 +581,199 @@ pub fn aggregation<R: Rng + ?Sized, F: FftField, I: Iterator<Item = F>>(
     Ok(zk_patch(lookup_aggreg, d1, rng))
 }
 
-/// Specifies the lookup constraints as expressions.
-pub fn constraints<F: FftField>(dummy_lookup: &[F], d1: D<F>) -> Vec<E<F>> {
-    // Something important to keep in mind is that the last 2 rows of
-    // all columns will have random values in them to maintain zero-knowledge.
-    //
-    // Another important thing to note is that there are no lookups permitted
-    // in the 3rd to last row.
-    //
-    // This is because computing the lookup-product requires
-    // num_lookup_rows + 1
-    // rows, so we need to have
-    // num_lookup_rows + 1 = n - 2 (the last 2 being reserved for the zero-knowledge random
-    // values) and thus
-    //
-    // num_lookup_rows = n - 3
-    let lookup_info = LookupInfo::<F>::create();
+/// Implementation of the lookup argument
+pub struct Lookup<'a, F>
+where
+    F: FftField,
+{
+    dummy_lookup_values: &'a [F],
+    domain: D<F>,
+}
 
-    let column = |col: Column| E::cell(col, Curr);
-
-    let lookup_indicator = lookup_info
-        .kinds
-        .iter()
-        .enumerate()
-        .map(|(i, _)| column(Column::LookupKindIndex(i)))
-        .fold(E::zero(), |acc: E<F>, x| acc + x);
-
-    let one: E<F> = E::one();
-    let non_lookup_indcator = one - lookup_indicator;
-
-    let dummy_lookup: ConstantExpr<F> = dummy_lookup
-        .iter()
-        .rev()
-        .fold(ConstantExpr::zero(), |acc, x| {
-            ConstantExpr::JointCombiner * acc + ConstantExpr::Literal(*x)
-        });
-
-    let complements_with_beta_term: Vec<ConstantExpr<F>> = {
-        let mut v = vec![ConstantExpr::one()];
-        let x = ConstantExpr::Gamma + dummy_lookup;
-        for i in 1..(lookup_info.max_per_row + 1) {
-            v.push(v[i - 1].clone() * x.clone())
+impl<'a, F> Lookup<'a, F>
+where
+    F: FftField,
+{
+    /// Creates a new [Lookup] from a list of dummy lookup values and a domain.
+    pub fn new(dummy_lookup_values: &'a [F], domain: D<F>) -> Self {
+        Self {
+            dummy_lookup_values,
+            domain,
         }
+    }
+}
 
-        let beta1_per_row: ConstantExpr<F> =
-            (ConstantExpr::one() + ConstantExpr::Beta).pow(lookup_info.max_per_row);
-        v.iter()
-            .map(|x| x.clone() * beta1_per_row.clone())
-            .collect()
-    };
+impl<'a, F> Argument for Lookup<'a, F>
+where
+    F: FftField,
+{
+    type Field = F;
+    const ARGUMENT_TYPE: ArgumentType = ArgumentType::Lookup;
+    const CONSTRAINTS: usize = 7;
 
-    // This is set up so that on rows that have lookups, chunk will be equal
-    // to the product over all lookups `f` in that row of `gamma + f`
-    // and
-    // on non-lookup rows, will be equal to 1.
-    let f_term = |spec: &Vec<_>| {
-        assert!(spec.len() <= lookup_info.max_per_row);
-        let padding = complements_with_beta_term[lookup_info.max_per_row - spec.len()].clone();
+    fn constraints(&self) -> Vec<E<F>> {
+        // Something important to keep in mind is that the last 2 rows of
+        // all columns will have random values in them to maintain zero-knowledge.
+        //
+        // Another important thing to note is that there are no lookups permitted
+        // in the 3rd to last row.
+        //
+        // This is because computing the lookup-product requires
+        // num_lookup_rows + 1
+        // rows, so we need to have
+        // num_lookup_rows + 1 = n - 2 (the last 2 being reserved for the zero-knowledge random
+        // values) and thus
+        //
+        // num_lookup_rows = n - 3
+        let lookup_info = LookupInfo::<F>::create();
 
-        spec.iter()
-            .map(|j| E::Constant(ConstantExpr::Gamma) + joint_lookup(j))
-            .fold(E::Constant(padding), |acc: E<F>, x| acc * x)
-    };
-    let f_chunk = lookup_info
-        .kinds
-        .iter()
-        .enumerate()
-        .map(|(i, spec)| column(Column::LookupKindIndex(i)) * f_term(spec))
-        .fold(non_lookup_indcator * f_term(&vec![]), |acc, x| acc + x);
-    let gammabeta1 =
-        || E::<F>::Constant(ConstantExpr::Gamma * (ConstantExpr::Beta + ConstantExpr::one()));
-    let ft_chunk = f_chunk
-        * (gammabeta1()
-            + E::cell(Column::LookupTable, Curr)
-            + E::beta() * E::cell(Column::LookupTable, Next));
+        let column = |col: Column| E::cell(col, Curr);
 
-    let num_rows = d1.size as usize;
+        let lookup_indicator = lookup_info
+            .kinds
+            .iter()
+            .enumerate()
+            .map(|(i, _)| column(Column::LookupKindIndex(i)))
+            .fold(E::zero(), |acc: E<F>, x| acc + x);
 
-    let num_lookup_rows = num_rows - ZK_ROWS - 1;
+        let one: E<F> = E::one();
+        let non_lookup_indcator = one - lookup_indicator;
 
-    // Because of our ZK-rows, we can't do the trick in the plookup paper of
-    // wrapping around to enforce consistency between the sorted lookup columns.
-    //
-    // Instead, we arrange the LookupSorted table into columns in a snake-shape.
-    //
-    // Like so,
-    //    _   _
-    // | | | | |
-    // | | | | |
-    // |_| |_| |
-    //
-    // or, imagining the full sorted array is [ s0, ..., s8 ], like
-    //
-    // s0 s4 s4 s8
-    // s1 s3 s5 s7
-    // s2 s2 s6 s6
-    //
-    // So the direction ("increasing" or "decreasing" (relative to LookupTable)
-    // is
-    // if i % 2 = 0 { Increasing } else { Decreasing }
-    //
-    // Then, for each i < max_lookups_per_row, if i % 2 = 0, we enforce that the
-    // last element of LookupSorted(i) = last element of LookupSorted(i + 1),
-    // and if i % 2 = 1, we enforce that the
-    // first element of LookupSorted(i) = first element of LookupSorted(i + 1)
+        let dummy_lookup: ConstantExpr<F> = self
+            .dummy_lookup_values
+            .iter()
+            .rev()
+            .fold(ConstantExpr::zero(), |acc, x| {
+                ConstantExpr::JointCombiner * acc + ConstantExpr::Literal(*x)
+            });
 
-    let s_chunk = (0..(lookup_info.max_per_row + 1))
-        .map(|i| {
-            let (s1, s2) = if i % 2 == 0 {
-                (Curr, Next)
-            } else {
-                (Next, Curr)
-            };
+        let complements_with_beta_term: Vec<ConstantExpr<F>> = {
+            let mut v = vec![ConstantExpr::one()];
+            let x = ConstantExpr::Gamma + dummy_lookup;
+            for i in 1..(lookup_info.max_per_row + 1) {
+                v.push(v[i - 1].clone() * x.clone())
+            }
 
-            gammabeta1()
-                + E::cell(Column::LookupSorted(i), s1)
-                + E::beta() * E::cell(Column::LookupSorted(i), s2)
-        })
-        .fold(E::one(), |acc: E<F>, x| acc * x);
+            let beta1_per_row: ConstantExpr<F> =
+                (ConstantExpr::one() + ConstantExpr::Beta).pow(lookup_info.max_per_row);
+            v.iter()
+                .map(|x| x.clone() * beta1_per_row.clone())
+                .collect()
+        };
 
-    let compatibility_checks: Vec<_> = (0..lookup_info.max_per_row)
-        .map(|i| {
-            let first_or_last = if i % 2 == 0 {
-                // Check compatibility of the last elements
-                num_lookup_rows
-            } else {
-                // Check compatibility of the first elements
-                0
-            };
-            E::UnnormalizedLagrangeBasis(first_or_last)
-                * (column(Column::LookupSorted(i)) - column(Column::LookupSorted(i + 1)))
-        })
-        .collect();
+        // This is set up so that on rows that have lookups, chunk will be equal
+        // to the product over all lookups `f` in that row of `gamma + f`
+        // and
+        // on non-lookup rows, will be equal to 1.
+        let f_term = |spec: &Vec<_>| {
+            assert!(spec.len() <= lookup_info.max_per_row);
+            let padding = complements_with_beta_term[lookup_info.max_per_row - spec.len()].clone();
 
-    let aggreg_equation = E::cell(Column::LookupAggreg, Next) * s_chunk
-        - E::cell(Column::LookupAggreg, Curr) * ft_chunk;
+            spec.iter()
+                .map(|j| E::Constant(ConstantExpr::Gamma) + joint_lookup(j))
+                .fold(E::Constant(padding), |acc: E<F>, x| acc * x)
+        };
+        let f_chunk = lookup_info
+            .kinds
+            .iter()
+            .enumerate()
+            .map(|(i, spec)| column(Column::LookupKindIndex(i)) * f_term(spec))
+            .fold(non_lookup_indcator * f_term(&vec![]), |acc, x| acc + x);
+        let gammabeta1 =
+            || E::<F>::Constant(ConstantExpr::Gamma * (ConstantExpr::Beta + ConstantExpr::one()));
+        let ft_chunk = f_chunk
+            * (gammabeta1()
+                + E::cell(Column::LookupTable, Curr)
+                + E::beta() * E::cell(Column::LookupTable, Next));
 
-    /*
-        aggreg.next =
-        aggreg.curr
-        * f_chunk
-        * (gammabeta1 + index.lookup_tables[0][i] + beta * index.lookup_tables[0][i+1];)
-        / (\prod_i (gammabeta1 + lookup_sorted_i.curr + beta * lookup_sorted_i.next))
+        let num_rows = self.domain.size as usize;
 
-        rearranging,
+        let num_lookup_rows = num_rows - ZK_ROWS - 1;
 
-        aggreg.next
-        * (\prod_i (gammabeta1 + lookup_sorted_i.curr + beta * lookup_sorted_i.next))
-        =
-        aggreg.curr
-        * f_chunk
-        * (gammabeta1 + index.lookup_tables[0][i] + beta * index.lookup_tables[0][i+1];)
+        // Because of our ZK-rows, we can't do the trick in the plookup paper of
+        // wrapping around to enforce consistency between the sorted lookup columns.
+        //
+        // Instead, we arrange the LookupSorted table into columns in a snake-shape.
+        //
+        // Like so,
+        //    _   _
+        // | | | | |
+        // | | | | |
+        // |_| |_| |
+        //
+        // or, imagining the full sorted array is [ s0, ..., s8 ], like
+        //
+        // s0 s4 s4 s8
+        // s1 s3 s5 s7
+        // s2 s2 s6 s6
+        //
+        // So the direction ("increasing" or "decreasing" (relative to LookupTable)
+        // is
+        // if i % 2 = 0 { Increasing } else { Decreasing }
+        //
+        // Then, for each i < max_lookups_per_row, if i % 2 = 0, we enforce that the
+        // last element of LookupSorted(i) = last element of LookupSorted(i + 1),
+        // and if i % 2 = 1, we enforce that the
+        // first element of LookupSorted(i) = first element of LookupSorted(i + 1)
 
-    */
+        let s_chunk = (0..(lookup_info.max_per_row + 1))
+            .map(|i| {
+                let (s1, s2) = if i % 2 == 0 {
+                    (Curr, Next)
+                } else {
+                    (Next, Curr)
+                };
 
-    let mut res = vec![
-        E::VanishesOnLast4Rows * aggreg_equation,
-        E::UnnormalizedLagrangeBasis(0) * (E::cell(Column::LookupAggreg, Curr) - E::one()),
-        // Check that the 3rd to last row (index = num_rows - 3), which
-        // contains the full product, equals 1
-        E::UnnormalizedLagrangeBasis(num_lookup_rows)
-            * (E::cell(Column::LookupAggreg, Curr) - E::one()),
-    ];
-    res.extend(compatibility_checks);
-    res
+                gammabeta1()
+                    + E::cell(Column::LookupSorted(i), s1)
+                    + E::beta() * E::cell(Column::LookupSorted(i), s2)
+            })
+            .fold(E::one(), |acc: E<F>, x| acc * x);
+
+        let compatibility_checks: Vec<_> = (0..lookup_info.max_per_row)
+            .map(|i| {
+                let first_or_last = if i % 2 == 0 {
+                    // Check compatibility of the last elements
+                    num_lookup_rows
+                } else {
+                    // Check compatibility of the first elements
+                    0
+                };
+                E::UnnormalizedLagrangeBasis(first_or_last)
+                    * (column(Column::LookupSorted(i)) - column(Column::LookupSorted(i + 1)))
+            })
+            .collect();
+
+        let aggreg_equation = E::cell(Column::LookupAggreg, Next) * s_chunk
+            - E::cell(Column::LookupAggreg, Curr) * ft_chunk;
+
+        /*
+            aggreg.next =
+            aggreg.curr
+            * f_chunk
+            * (gammabeta1 + index.lookup_tables[0][i] + beta * index.lookup_tables[0][i+1];)
+            / (\prod_i (gammabeta1 + lookup_sorted_i.curr + beta * lookup_sorted_i.next))
+
+            rearranging,
+
+            aggreg.next
+            * (\prod_i (gammabeta1 + lookup_sorted_i.curr + beta * lookup_sorted_i.next))
+            =
+            aggreg.curr
+            * f_chunk
+            * (gammabeta1 + index.lookup_tables[0][i] + beta * index.lookup_tables[0][i+1];)
+
+        */
+
+        let mut res = vec![
+            E::VanishesOnLast4Rows * aggreg_equation,
+            E::UnnormalizedLagrangeBasis(0) * (E::cell(Column::LookupAggreg, Curr) - E::one()),
+            // Check that the 3rd to last row (index = num_rows - 3), which
+            // contains the full product, equals 1
+            E::UnnormalizedLagrangeBasis(num_lookup_rows)
+                * (E::cell(Column::LookupAggreg, Curr) - E::one()),
+        ];
+        res.extend(compatibility_checks);
+        res
+    }
 }

--- a/kimchi/src/circuits/polynomials/poseidon.rs
+++ b/kimchi/src/circuits/polynomials/poseidon.rs
@@ -74,7 +74,7 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::Poseidon);
     const CONSTRAINTS: usize = 15;
 
-    fn constraints() -> Vec<E<F>> {
+    fn constraints(&self) -> Vec<E<F>> {
         let mut res = vec![];
         let mut cache = Cache::default();
 

--- a/kimchi/src/circuits/polynomials/varbasemul.rs
+++ b/kimchi/src/circuits/polynomials/varbasemul.rs
@@ -209,7 +209,7 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::VarBaseMul);
     const CONSTRAINTS: usize = 21;
 
-    fn constraints() -> Vec<E<F>> {
+    fn constraints(&self) -> Vec<E<F>> {
         let Layout {
             base,
             accs,

--- a/kimchi/src/index.rs
+++ b/kimchi/src/index.rs
@@ -6,7 +6,7 @@ use crate::circuits::polynomials::chacha::{ChaCha0, ChaCha1, ChaCha2, ChaChaFina
 use crate::circuits::polynomials::complete_add::CompleteAdd;
 use crate::circuits::polynomials::endomul_scalar::EndomulScalar;
 use crate::circuits::polynomials::endosclmul::EndosclMul;
-use crate::circuits::polynomials::lookup;
+use crate::circuits::polynomials::lookup::Lookup;
 use crate::circuits::polynomials::permutation;
 use crate::circuits::polynomials::poseidon::Poseidon;
 use crate::circuits::polynomials::varbasemul::VarbaseMul;
@@ -175,17 +175,17 @@ pub fn constraints_expr<F: FftField + SquareRootField>(
         highest_constraints,
     );
 
-    let mut expr = Poseidon::combined_constraints(&powers_of_alpha);
-    expr += VarbaseMul::combined_constraints(&powers_of_alpha);
-    expr += CompleteAdd::combined_constraints(&powers_of_alpha);
-    expr += EndosclMul::combined_constraints(&powers_of_alpha);
-    expr += EndomulScalar::combined_constraints(&powers_of_alpha);
+    let mut expr = Poseidon::default().combined_constraints(&powers_of_alpha);
+    expr += VarbaseMul::default().combined_constraints(&powers_of_alpha);
+    expr += CompleteAdd::default().combined_constraints(&powers_of_alpha);
+    expr += EndosclMul::default().combined_constraints(&powers_of_alpha);
+    expr += EndomulScalar::default().combined_constraints(&powers_of_alpha);
 
     if chacha {
-        expr += ChaCha0::combined_constraints(&powers_of_alpha);
-        expr += ChaCha1::combined_constraints(&powers_of_alpha);
-        expr += ChaCha2::combined_constraints(&powers_of_alpha);
-        expr += ChaChaFinal::combined_constraints(&powers_of_alpha);
+        expr += ChaCha0::default().combined_constraints(&powers_of_alpha);
+        expr += ChaCha1::default().combined_constraints(&powers_of_alpha);
+        expr += ChaCha2::default().combined_constraints(&powers_of_alpha);
+        expr += ChaChaFinal::default().combined_constraints(&powers_of_alpha);
     }
 
     // permutation
@@ -193,12 +193,9 @@ pub fn constraints_expr<F: FftField + SquareRootField>(
 
     // lookup
     if let Some(lcs) = lookup_constraint_system.as_ref() {
-        powers_of_alpha.register(ArgumentType::Lookup, lookup::CONSTRAINTS);
-        let alphas = powers_of_alpha.get_exponents(ArgumentType::Lookup, lookup::CONSTRAINTS);
-
-        let constraints = lookup::constraints(&lcs.dummy_lookup_values[0], domain);
-        let combined = Expr::combine_constraints(alphas, constraints);
-        expr += combined;
+        let lookup = Lookup::new(&lcs.dummy_lookup_values[0], domain);
+        powers_of_alpha.register(ArgumentType::Lookup, Lookup::<F>::CONSTRAINTS);
+        expr += lookup.combined_constraints(&powers_of_alpha);
     }
 
     // return the expression


### PR DESCRIPTION
originally part of https://github.com/o1-labs/proof-systems/pull/295, but now part of its own PR: it implements the `Argument` trait for lookup. Since lookup needs access to some dynamic data to build the constraints, we change the API slightly to allow that.