### PR TITLE
Add from_bytes_unstrict to FieldHelpers

### DIFF
--- a/signer/src/keypair.rs
+++ b/signer/src/keypair.rs
@@ -43,7 +43,8 @@ impl Keypair {
         let mut bytes: Vec<u8> = hex::decode(secret_hex).map_err(|_| "Invalid secret key hex")?;
         bytes.reverse(); // mina scalars hex format is in big-endian order
 
-        let secret = ScalarField::from_bytes(&bytes).map_err(|_| "Invalid secret key hex")?;
+        let secret =
+            ScalarField::from_bytes(bytes.as_slice()).map_err(|_| "Invalid secret key hex")?;
         let public: CurvePoint = CurvePoint::prime_subgroup_generator()
             .mul(secret)
             .into_affine();

--- a/signer/src/roinput.rs
+++ b/signer/src/roinput.rs
@@ -136,7 +136,7 @@ impl ROInput {
                 bv.resize(BaseField::size_in_bits(), false);
 
                 acc.push(
-                    BaseField::from_bytes(&bv.into_vec())
+                    BaseField::from_bytes(bv.into_vec().as_slice())
                         .expect("failed to create base field element"),
                 );
 

--- a/signer/src/schnorr.rs
+++ b/signer/src/schnorr.rs
@@ -137,11 +137,10 @@ impl<SC: SpongeConstants> Schnorr<SC> {
         // Set sponge initial state (explicitly init state so signer context can be reused)
         // N.B. Mina sets the sponge's initial state by hashing the input's domain bytes
         self.sponge.reset();
-        self.sponge
-            .absorb(&[
-                BaseField::from_bytes(&Schnorr::<SC>::domain_bytes::<S>(self.network_id))
-                    .expect("invalid domain bytes"),
-            ]);
+        self.sponge.absorb(&[BaseField::from_bytes(
+            Schnorr::<SC>::domain_bytes::<S>(self.network_id).as_slice(),
+        )
+        .expect("invalid domain bytes")]);
         self.sponge.squeeze();
 
         // Absorb random oracle input

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -16,3 +16,4 @@ hex = "0.4"
 [dev-dependencies]
 mina-curves = { path = "../curves" }
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
+num-bigint = "0.4"

--- a/utils/src/field_helpers.rs
+++ b/utils/src/field_helpers.rs
@@ -1,10 +1,10 @@
 use ark_ff::FftField;
-use ark_serialize::Read;
+use ark_serialize::Read as ArkRead;
 
 /// Field element helpers
 pub trait FieldHelpers<F: FftField> {
     /// Deserialize from bytes
-    fn from_bytes(bytes: impl Read) -> Result<F, &'static str>;
+    fn from_bytes(bytes: impl ArkRead) -> Result<F, &'static str>;
 
     /// Deserialize from bytes
     /// length of the input bytes can be arbitrary
@@ -28,7 +28,7 @@ pub trait FieldHelpers<F: FftField> {
 }
 
 impl<F: FftField> FieldHelpers<F> for F {
-    fn from_bytes(bytes: impl Read) -> Result<F, &'static str> {
+    fn from_bytes(bytes: impl ArkRead) -> Result<F, &'static str> {
         F::deserialize(bytes).map_err(|_| "Failed to deserialize field bytes")
     }
 
@@ -223,8 +223,6 @@ mod tests {
         test_prefix_to_field!(b"12", "12849");
         // Printf.printf "%s" ("123" |> prefix_to_field |> Field.to_string) ;
         test_prefix_to_field!(b"123", "3355185");
-        // Printf.printf "%s" ("AbC" |> prefix_to_field |> Field.to_string) ;
-        test_prefix_to_field!(b"AbC", "4416065");
         // Printf.printf "%s" ("AbC" |> prefix_to_field |> Field.to_string) ;
         test_prefix_to_field!(b"AbC", "4416065");
         // Printf.printf "%s" ("CodaMklTree003******" |> prefix_to_field |> Field.to_string) ;


### PR DESCRIPTION
Changes:
- Add `from_bytes_unstrict` function to FieldHelpers, which performs padding / trimming to the given input string
The logic is equivalent to [prefix_to_field](https://github.com/MinaProtocol/mina/blob/58eea687b9c85b6b71cb447ba8a6646b818ac214/src/lib/random_oracle/random_oracle.ml#L161), except the field type is generic here.
- Unit tests for from_bytes_unstrict that are generated from OCaml code
- Change signature of `from_bytes` to support use case that the caller function returns owned field by providing a local variable, this did not work before because the old fn signature breaks borrow checker rule for this use case.