### PR TITLE
Introduce a CryptoHash trait to easily hash types

### DIFF
--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -5,6 +5,7 @@ use ark_ff::bytes::ToBytes;
 use ark_ff::{FftField, Field};
 use ark_poly::{Evaluations as E, Radix2EvaluationDomain as D};
 use num_traits::cast::ToPrimitive;
+use o1_utils::hasher::CryptoDigest;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::collections::{hash_map::Entry, HashMap, HashSet};
@@ -446,6 +447,7 @@ impl GateType {
 
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
+/// A single gate in a circuit.
 pub struct CircuitGate<F: FftField> {
     /// type of the gate
     pub typ: GateType,
@@ -504,6 +506,16 @@ impl<F: FftField> CircuitGate<F> {
             ChaCha0 | ChaCha1 | ChaCha2 | ChaChaFinal => Ok(()),
         }
     }
+}
+
+/// A circuit is specified as a series of [CircuitGate].
+#[derive(Serialize)]
+pub struct Circuit<'a, F: FftField>(
+    #[serde(bound = "CircuitGate<F>: Serialize")] pub &'a [CircuitGate<F>],
+);
+
+impl<'a, F: FftField> CryptoDigest for Circuit<'a, F> {
+    const PREFIX: &'static [u8; 15] = b"kimchi-circuit0";
 }
 
 #[cfg(feature = "ocaml_types")]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,9 +8,9 @@ license = "Apache-2.0"
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-poly = { version = "0.3.0", features = [ "parallel" ] }
 ark-serialize = "0.3.0"
+bcs = "0.1.3"
 hex = "0.4"
 rayon = "1.3.0"
-rmp-serde = "1.0.0"
 serde = "1.0.130"
 serde_with = "1.10.0"
 sha2 = "0.10.2"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,12 +8,15 @@ license = "Apache-2.0"
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-poly = { version = "0.3.0", features = [ "parallel" ] }
 ark-serialize = "0.3.0"
+hex = "0.4"
 rayon = "1.3.0"
+rmp-serde = "1.0.0"
 serde = "1.0.130"
 serde_with = "1.10.0"
-hex = "0.4"
+sha2 = "0.10.2"
 thiserror = "1.0.30"
 
+
 [dev-dependencies]
-mina-curves = { path = "../curves" }
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
+mina-curves = { path = "../curves" }

--- a/utils/src/hasher.rs
+++ b/utils/src/hasher.rs
@@ -1,0 +1,56 @@
+//! This module includes the [CryptoDigest] trait,
+//! which provides a generic interface for hashing.
+//!
+//! To use it, simply implement [CryptoDigest] for your type:
+//!
+//! ```
+//! use o1_utils::hasher::CryptoDigest;
+//! use serde::Serialize;
+//!
+//! #[derive(Serialize)]
+//! struct A {
+//!     thing: u8,
+//! }
+//!
+//! impl CryptoDigest for A {
+//!     const PREFIX: &'static [u8; 15] = b"kimchi-circuit0";
+//! }
+//!
+//! let a = A { thing: 1 };
+//! let expected_result = [190, 149, 126, 83, 64, 202, 220, 210, 10, 145, 208, 164, 52, 140, 137, 120, 25, 116, 213, 144, 224, 43, 112, 166, 160, 157, 43, 125, 7, 174, 249, 230];
+//! assert_eq!(a.digest(), expected_result);
+//!
+//! let b = A { thing: 1 };
+//! assert_eq!(a.digest(), b.digest());
+//! ```
+//!
+//! Warning: make sure not to reuse the same `PREFIX`
+//! for different types. This prefix is here to semantically
+//! distinguish the hash of different types
+//! (and thus different use-case).
+//!
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+pub trait CryptoDigest: Serialize {
+    /// The domain separation string to use in the hash.
+    /// This is to distinguish hashes for different use-cases.
+    /// With this approach, a type is linked to a single usecase.
+    ///
+    /// Warning: careful not to use the same separation string with
+    /// two different types.
+    const PREFIX: &'static [u8; 15];
+
+    /// Returns the digest of `self`.
+    /// Note: this is implemented as the SHA-256 of a prefix
+    /// ("kimchi-circuit"), followed by the serialized gates.
+    /// The gates are serialized using messagepack.
+    fn digest(&self) -> [u8; 32] {
+        // compute the prefixed state lazily
+        let mut hasher = Sha256::new();
+        hasher.update(Self::PREFIX);
+        hasher.update(&rmp_serde::to_vec(self).expect("couldn't serialize the gate"));
+        hasher.finalize().into()
+    }
+}

--- a/utils/src/hasher.rs
+++ b/utils/src/hasher.rs
@@ -1,4 +1,4 @@
-//! This module includes the [CryptoDigest] trait,
+//! This module provides the [CryptoDigest] trait,
 //! which provides a generic interface for hashing.
 //!
 //! To use it, simply implement [CryptoDigest] for your type:

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod dense_polynomial;
 pub mod evaluations;
 pub mod field_helpers;
+pub mod hasher;
 pub mod serialization;
 
 pub use dense_polynomial::ExtendedDensePolynomial;


### PR DESCRIPTION
this introduces the CryptoHash trait, which you can implement for a type to get access to a `digest()` function:

```rust
#[derive(Serialize)]
struct A {
    thing: u8,
}
impl CryptoDigest for A {
    const PREFIX: &'static [u8; 15] = b"kimchi-circuit0";
}
println!("digest: {:?}", a.digest());
```

The `PREFIX` is a domain-separation string that is simply prepended to the real input.

Benefit of this approach:

* less error-prone since we generate the boilerplate by implementing the trait
* uses a domain-separation string by default

It would be nice if:

* we could just use a macro
    ```rust
    #[derive(Serialize, CryptoDigest("kimchi-circuit")]
    struct A { 
    ```
* we could make sure all types that implement CryptoDigest use different prefixes
* the hash state with the prefix is pre-computed (for example using [sha2-const](https://github.com/saleemrashid/sha2-const))

