### PR TITLE
Remove orthogonal features "3", "3w" and "5w"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,11 +23,11 @@ jobs:
 
       - name: build
         run: |
-          cargo build
+          cargo check
 
-      - name: build ocaml types
+      - name: build all features (including ocaml_types)
         run: |
-          cargo build --features ocaml_types
+          cargo check --all-features
 
       - name: Run cargo fmt
         run: |

--- a/oracle/Cargo.toml
+++ b/oracle/Cargo.toml
@@ -25,22 +25,22 @@ ocaml-gen = { path = "../ocaml/ocaml-gen", optional = true }
 syn = { version = "1.0.76", optional = true }
 
 # for export_test_vectors
-num-bigint = "0.4.0"
-serde_json = "1.0"
-hex = "0.4"
-ark-serialize = "0.3.0"
+# maybe better to move the tool into a separate crate
+# to avoid polluting the dependency tree of this lib
+num-bigint = { version = "0.4.0", optional = true }
+serde_json = { version = "1.0", optional = true }
+hex = { version = "0.4", optional = true }
+ark-serialize = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 hex = "0.4"
+serde_json = "1.0"
+ark-serialize = "0.3.0"
 
 [features]
+default=[]
 ocaml_types = [ "ocaml", "ocaml-gen", "syn" ]
-
-# for test vectors
-default = ["3w"]
-3w = [ ]
-5w = [ ]
-3 = [ ]
+test_vectors = ["num-bigint", "serde_json", "hex", "ark-serialize"]
 
 [[bin]]
 name = "export_test_vectors"

--- a/oracle/tests/export_test_vectors/export_test_vectors.rs
+++ b/oracle/tests/export_test_vectors/export_test_vectors.rs
@@ -1,56 +1,96 @@
-use std::env;
-use std::fs::File;
-use std::io::{self, Write};
-use std::str::FromStr;
-
+#[cfg(feature = "test_vectors")]
 mod vectors;
+#[cfg(feature = "test_vectors")]
+use inner::*;
 
-#[derive(Debug)]
-pub enum Mode {
-    Hex,
-    B10,
+/// "Usage: cargo run --all-features --bin export_test_vectors -- [hex|b10] [3|3w|5w] <OUTPUT_FILE>",
+fn main() {
+    #[cfg(feature = "test_vectors")]
+    inner::main();
+    #[cfg(not(feature = "test_vectors"))]
+    println!("Error: this tool should be compiled with feature 'test_vectors'");
 }
 
-impl FromStr for Mode {
-    type Err = ();
+#[cfg(feature = "test_vectors")]
+mod inner {
+    use super::vectors;
+    use std::env;
+    use std::fs::File;
+    use std::io::{self, Write};
+    use std::str::FromStr;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        match input {
-            "B10" => Ok(Mode::B10),
-            _ => Ok(Mode::Hex),
+    #[derive(Debug)]
+    pub enum Mode {
+        Hex,
+        B10,
+    }
+
+    impl FromStr for Mode {
+        type Err = ();
+
+        fn from_str(input: &str) -> Result<Self, Self::Err> {
+            match input.to_lowercase().as_str() {
+                "b10" => Ok(Mode::B10),
+                "hex" => Ok(Mode::Hex),
+                _ => Err(()),
+            }
         }
     }
-}
 
-fn main() {
-    let args: Vec<String> = env::args().collect();
+    #[derive(Debug)]
+    pub enum ParamType {
+        P3,
+        P3w,
+        P5w,
+    }
 
-    match args.len() {
-        3 => {
-            // parse command-line args
-            let mode: Mode = args
-                .get(1)
-                .expect("missing mode")
-                .parse()
-                .expect("invalid mode");
-            let output_file = args.get(2).expect("missing file");
+    impl FromStr for ParamType {
+        type Err = ();
 
-            // generate vectors
-            let vectors = vectors::generate(mode);
-
-            // save to output file
-            let writer: Box<dyn Write> = match output_file.as_str() {
-                "-" => Box::new(io::stdout()),
-                _ => Box::new(File::create(output_file).expect("could not create file")),
-            };
-            serde_json::to_writer_pretty(writer, &vectors).expect("could not write to file");
+        fn from_str(input: &str) -> Result<Self, Self::Err> {
+            match input.to_lowercase().as_str() {
+                "3" => Ok(ParamType::P3),
+                "3w" => Ok(ParamType::P3w),
+                "5w" => Ok(ParamType::P5w),
+                _ => Err(()),
+            }
         }
-        _ => {
-            println!(
-                "usage: cargo run --bin export_test_vectors --no-default-features --features [3w|5w|3] -- [{:?}|{:?}] <OUTPUT_FILE>",
+    }
+
+    pub(crate) fn main() {
+        let args: Vec<String> = env::args().collect();
+        match args.len() {
+            4 => {
+                // parse command-line args
+                let mode: Mode = args
+                    .get(1)
+                    .expect("missing mode")
+                    .parse()
+                    .expect("invalid mode");
+                let param_type: ParamType = args
+                    .get(2)
+                    .expect("missing param type")
+                    .parse()
+                    .expect("invalid param type");
+                let output_file = args.get(3).expect("missing file");
+
+                // generate vectors
+                let vectors = vectors::generate(mode, param_type);
+
+                // save to output file
+                let writer: Box<dyn Write> = match output_file.as_str() {
+                    "-" => Box::new(io::stdout()),
+                    _ => Box::new(File::create(output_file).expect("could not create file")),
+                };
+                serde_json::to_writer_pretty(writer, &vectors).expect("could not write to file");
+            }
+            _ => {
+                println!(
+                "usage: cargo run --all-features --bin export_test_vectors -- [{:?}|{:?}] [3|3w|5w] <OUTPUT_FILE>",
                 Mode::Hex,
-                Mode::B10
+                Mode::B10,
             );
+            }
         }
     }
 }

--- a/oracle/tests/export_test_vectors/vectors.rs
+++ b/oracle/tests/export_test_vectors/vectors.rs
@@ -1,26 +1,16 @@
-use super::Mode;
+use super::{Mode, ParamType};
 use ark_ff::{fields::PrimeField as _, UniformRand as _};
 use ark_serialize::CanonicalSerialize as _;
 use mina_curves::pasta::Fp;
 use num_bigint::BigUint;
-use oracle::poseidon::ArithmeticSponge as Poseidon;
-use oracle::poseidon::Sponge as _;
-use rand::prelude::*;
-use rand::Rng;
+use oracle::{
+    pasta,
+    poseidon::{
+        self, ArithmeticSponge as Poseidon, ArithmeticSpongeParams, Sponge as _, SpongeConstants,
+    },
+};
+use rand::{prelude::*, Rng};
 use serde::Serialize;
-
-//
-// generate different test vectors depending on features
-//
-
-#[cfg(feature = "3w")]
-use oracle::{pasta::fp as Parameters, poseidon::PlonkSpongeConstantsBasic};
-
-#[cfg(feature = "5w")]
-use oracle::{pasta::fp5 as Parameters, poseidon::PlonkSpongeConstants5W as PlonkSpongeConstants};
-
-#[cfg(feature = "3")]
-use oracle::{pasta::fp_3 as Parameters, poseidon::PlonkSpongeConstants3W as PlonkSpongeConstants};
 
 //
 // structs
@@ -44,10 +34,9 @@ pub struct TestVector {
 
 /// Computes the poseidon hash of several field elements.
 /// Uses the 'basic' configuration with N states and M rounds.
-fn poseidon(input: &[Fp]) -> Fp {
-    let mut s = Poseidon::<Fp, PlonkSpongeConstantsBasic>::new(Parameters::params());
+fn poseidon<SC: SpongeConstants>(input: &[Fp], params: ArithmeticSpongeParams<Fp>) -> Fp {
+    let mut s = Poseidon::<Fp, SC>::new(params);
     s.absorb(input);
-
     s.squeeze()
 }
 
@@ -62,7 +51,7 @@ fn rand_fields(rng: &mut impl Rng, length: u8) -> Vec<Fp> {
 }
 
 /// creates a set of test vectors
-pub fn generate(mode: Mode) -> TestVectors {
+pub fn generate(mode: Mode, param_type: ParamType) -> TestVectors {
     let mut rng = &mut rand::rngs::StdRng::from_seed([0u8; 32]);
     let mut test_vectors = vec![];
 
@@ -70,7 +59,17 @@ pub fn generate(mode: Mode) -> TestVectors {
     for length in 0..6 {
         // generate input & hash
         let input = rand_fields(&mut rng, length);
-        let output = poseidon(&input);
+        let output = match param_type {
+            ParamType::P3 => {
+                poseidon::<poseidon::PlonkSpongeConstantsBasic>(&input, pasta::fp::params())
+            }
+            ParamType::P3w => {
+                poseidon::<poseidon::PlonkSpongeConstants3W>(&input, pasta::fp_3::params())
+            }
+            ParamType::P5w => {
+                poseidon::<poseidon::PlonkSpongeConstants5W>(&input, pasta::fp5::params())
+            }
+        };
 
         // serialize input & output
         let input = input
@@ -99,15 +98,12 @@ pub fn generate(mode: Mode) -> TestVectors {
         })
     }
 
-    let name = if cfg!(feature = "3w") {
-        "3w".to_string()
-    } else if cfg!(feature = "3") {
-        "3".to_string()
-    } else if cfg!(feature = "5w") {
-        "5w".to_string()
-    } else {
-        panic!("test vector feature not recognized");
-    };
+    let name = match param_type {
+        ParamType::P3 => "3",
+        ParamType::P3w => "3w",
+        ParamType::P5w => "5w",
+    }
+    .into();
 
     //
     TestVectors { name, test_vectors }


### PR DESCRIPTION
As follow-up of [this comment](https://github.com/o1-labs/proof-systems/pull/323#discussion_r816414141)

- Remove orthogonal features "3", "3w" and "5w" under `oracle` crate to allow `cargo build/test --all-features`
- Remove `export_test_vectors` only deps from dependency tree when the crate is used as lib
- Make  "3", "3w" and "5w" the 2nd positional parameter of the `export_test_vectors` tool