### PR TITLE
Fix 32-bit arch expr::pow by using the correct number of bits

### DIFF
--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -891,7 +891,7 @@ impl<'a, F: FftField> EvalResult<'a, F> {
 
     fn pow<'b>(self, d: usize, res_domain: (Domain, D<F>)) -> EvalResult<'b, F> {
         let mut acc = EvalResult::Constant(F::one());
-        for i in (0..64).rev() {
+        for i in (0..std::mem::size_of::<usize>() * 8).rev() {
             acc = acc.square(res_domain);
 
             if (d >> i) & 1 == 1 {
@@ -1573,7 +1573,7 @@ impl<F: Neg<Output = F> + Clone + One + Zero + PartialEq> Expr<F> {
                 let mut acc_is_one = true;
                 let x = x.monomials(ev);
 
-                for i in (0..64).rev() {
+                for i in (0..std::mem::size_of::<usize>() * 8).rev() {
                     if !acc_is_one {
                         let acc2 = mul_monomials(&acc, &acc);
                         acc = acc2;


### PR DESCRIPTION
This PR is the minimal possible fix for the poseidon failure in the WASM version of the code.

This was caused by the assumption that `usize` is always 64-bit -- where it's 32-bit under WASM -- and is a symptom of misusing `usize` for unsigned integers that aren't related to memory accesses.