### PR TITLE
[TO_DELETE][verifier] clean up the verifier API

### DIFF
--- a/kimchi/src/bench.rs
+++ b/kimchi/src/bench.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     index::{testing::new_index_for_test, Index, VerifierIndex},
     prover::ProverProof,
+    verifier::batch_verify,
 };
 use ark_ff::UniformRand;
 use ark_poly::{univariate::DensePolynomial, UVPolynomial};
@@ -106,12 +107,11 @@ impl BenchmarkCtx {
 
     pub fn batch_verification(&self, batch: Vec<ProverProof<Affine>>) {
         // verify the proof
-        let lgr_comms = vec![];
         let batch: Vec<_> = batch
             .iter()
-            .map(|proof| (&self.verifier_index, &lgr_comms, proof))
+            .map(|proof| (&self.verifier_index, proof))
             .collect();
-        ProverProof::verify::<BaseSponge, ScalarSponge>(&self.group_map, &batch).unwrap();
+        batch_verify::<Affine, BaseSponge, ScalarSponge>(&self.group_map, &batch).unwrap();
     }
 }
 

--- a/kimchi/src/tests/chacha.rs
+++ b/kimchi/src/tests/chacha.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     index::testing::new_index_for_test,
     prover::ProverProof,
+    verifier::batch_verify,
 };
 use array_init::array_init;
 use colored::Colorize;
@@ -90,10 +91,9 @@ fn chacha_prover() {
     let verifier_index = index.verifier_index();
     println!("{}{:?}", "Verifier index time: ".yellow(), start.elapsed());
 
-    let lgr_comms = vec![];
-    let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];
+    let batch: Vec<_> = vec![(&verifier_index, &proof)];
     let start = Instant::now();
-    match ProverProof::verify::<BaseSponge, ScalarSponge>(&group_map, &batch) {
+    match batch_verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &batch) {
         Err(error) => panic!("Failure verifying the prover's proofs in batch: {}", error),
         Ok(_) => {
             println!("{}{:?}", "Verifier time: ".yellow(), start.elapsed());

--- a/kimchi/src/tests/ec.rs
+++ b/kimchi/src/tests/ec.rs
@@ -5,6 +5,7 @@ use crate::{
     },
     index::testing::new_index_for_test,
     prover::ProverProof,
+    verifier::batch_verify,
 };
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
@@ -54,7 +55,6 @@ fn ec_test() {
     let verifier_index = index.verifier_index();
     let group_map = <Affine as CommitmentCurve>::Map::setup();
 
-    let lgr_comms = vec![];
     let rng = &mut StdRng::from_seed([0; 32]);
 
     let ps = {
@@ -174,9 +174,9 @@ fn ec_test() {
             .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
-    let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];
+    let batch: Vec<_> = vec![(&verifier_index, &proof)];
     let start = Instant::now();
-    match ProverProof::verify::<BaseSponge, ScalarSponge>(&group_map, &batch) {
+    match batch_verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &batch) {
         Err(error) => panic!("Failure verifying the prover's proofs in batch: {}", error),
         Ok(_) => {
             println!("{}{:?}", "Verifier time: ".yellow(), start.elapsed());

--- a/kimchi/src/tests/endomul.rs
+++ b/kimchi/src/tests/endomul.rs
@@ -1,4 +1,5 @@
 use crate::prover::ProverProof;
+use crate::verifier::batch_verify;
 use crate::{
     circuits::{
         gate::{CircuitGate, GateType},
@@ -72,7 +73,6 @@ fn endomul_test() {
     let verifier_index = index.verifier_index();
     let group_map = <Affine as CommitmentCurve>::Map::setup();
 
-    let lgr_comms = vec![];
     let rng = &mut StdRng::from_seed([0; 32]);
 
     // let start = Instant::now();
@@ -137,9 +137,9 @@ fn endomul_test() {
             .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
-    let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];
+    let batch: Vec<_> = vec![(&verifier_index, &proof)];
     let start = Instant::now();
-    match ProverProof::verify::<BaseSponge, ScalarSponge>(&group_map, &batch) {
+    match batch_verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &batch) {
         Err(error) => panic!("Failure verifying the prover's proofs in batch: {}", error),
         Ok(_) => {
             println!("{}{:?}", "Verifier time: ".yellow(), start.elapsed());

--- a/kimchi/src/tests/endomul_scalar.rs
+++ b/kimchi/src/tests/endomul_scalar.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     index::testing::new_index_for_test,
     prover::ProverProof,
+    verifier::batch_verify,
 };
 use ark_ff::{BigInteger, BitIteratorLE, PrimeField, UniformRand};
 use array_init::array_init;
@@ -60,7 +61,6 @@ fn endomul_scalar_test() {
     let verifier_index = index.verifier_index();
     let group_map = <Affine as CommitmentCurve>::Map::setup();
 
-    let lgr_comms = vec![];
     let rng = &mut StdRng::from_seed([0; 32]);
 
     //let start = Instant::now();
@@ -84,9 +84,9 @@ fn endomul_scalar_test() {
             .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
-    let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];
+    let batch: Vec<_> = vec![(&verifier_index, &proof)];
     let start = Instant::now();
-    match ProverProof::verify::<BaseSponge, ScalarSponge>(&group_map, &batch) {
+    match batch_verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &batch) {
         Err(error) => panic!("Failure verifying the prover's proofs in batch: {}", error),
         Ok(_) => {
             println!("{}{:?}", "Verifier time: ".yellow(), start.elapsed());

--- a/kimchi/src/tests/generic.rs
+++ b/kimchi/src/tests/generic.rs
@@ -2,6 +2,7 @@ use crate::circuits::polynomials::generic::testing::{create_circuit, fill_in_wit
 use crate::circuits::{gate::CircuitGate, wires::COLUMNS};
 use crate::index::testing::new_index_for_test;
 use crate::prover::ProverProof;
+use crate::verifier::batch_verify;
 use ark_ff::{UniformRand, Zero};
 use ark_poly::{univariate::DensePolynomial, UVPolynomial};
 use array_init::array_init;
@@ -67,10 +68,6 @@ fn verify_proof(gates: Vec<CircuitGate<Fp>>, witness: [Vec<Fp>; COLUMNS], public
 
     // verify the proof
     let verifier_index = index.verifier_index();
-    let lgr_comms = vec![]; // why empty?
-    let batch: Vec<_> = batch
-        .iter()
-        .map(|proof| (&verifier_index, &lgr_comms, proof))
-        .collect();
-    ProverProof::verify::<BaseSponge, ScalarSponge>(&group_map, &batch).unwrap();
+    let batch: Vec<_> = batch.iter().map(|proof| (&verifier_index, proof)).collect();
+    batch_verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &batch).unwrap();
 }

--- a/kimchi/src/tests/poseidon.rs
+++ b/kimchi/src/tests/poseidon.rs
@@ -5,6 +5,7 @@ use crate::{
         wires::{Wire, COLUMNS},
     },
     index::testing::new_index_for_test,
+    verifier::batch_verify,
 };
 use crate::{index::Index, prover::ProverProof};
 use ark_ff::{UniformRand, Zero};
@@ -167,16 +168,12 @@ fn positive(index: &Index<Affine>) {
     // TODO: shouldn't verifier_index be part of ProverProof, not being passed in verify?
     let verifier_index = index.verifier_index();
 
-    let lgr_comms = vec![];
-    let batch: Vec<_> = batch
-        .iter()
-        .map(|proof| (&verifier_index, &lgr_comms, proof))
-        .collect();
+    let batch: Vec<_> = batch.iter().map(|proof| (&verifier_index, proof)).collect();
 
     // verify the proofs in batch
     println!("{}", "Verifier zk-proofs verification".green());
     start = Instant::now();
-    match ProverProof::verify::<BaseSponge, ScalarSponge>(&group_map, &batch) {
+    match batch_verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &batch) {
         Err(error) => panic!("Failure verifying the prover's proofs in batch: {}", error),
         Ok(_) => {
             println!("{}{:?}", "Execution time: ".yellow(), start.elapsed());

--- a/kimchi/src/tests/varbasemul.rs
+++ b/kimchi/src/tests/varbasemul.rs
@@ -1,4 +1,5 @@
 use crate::prover::ProverProof;
+use crate::verifier::batch_verify;
 use crate::{
     circuits::{
         gate::{CircuitGate, GateType},
@@ -65,7 +66,6 @@ fn varbase_mul_test() {
     let verifier_index = index.verifier_index();
     let group_map = <Affine as CommitmentCurve>::Map::setup();
 
-    let lgr_comms = vec![];
     let rng = &mut StdRng::from_seed([0; 32]);
 
     let start = Instant::now();
@@ -112,9 +112,9 @@ fn varbase_mul_test() {
             .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
-    let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];
+    let batch: Vec<_> = vec![(&verifier_index, &proof)];
     let start = Instant::now();
-    match ProverProof::verify::<BaseSponge, ScalarSponge>(&group_map, &batch) {
+    match batch_verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &batch) {
         Err(error) => panic!("Failure verifying the prover's proofs in batch: {}", error),
         Ok(_) => {
             println!("{}{:?}", "Verifier time: ".yellow(), start.elapsed());

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -57,17 +57,32 @@ where
     pub combined_inner_product: Fr<G>,
 }
 
-impl<G: CommitmentCurve> ProverProof<G>
+pub struct DefferedVerification<G, EFqSponge>
+where
+    G: CommitmentCurve,
+    EFqSponge: Clone + FqSponge<Fq<G>, G, Fr<G>>,
+{
+    p_eval: [Vec<Fr<G>>; 2],
+    p_comm: PolyComm<G>,
+    ft_comm: PolyComm<G>,
+    fq_sponge: EFqSponge,
+    oracles: RandomOracles<Fr<G>>,
+    ft_evals: [Fr<G>; 2],
+    polys: Vec<(PolyComm<G>, Vec<Vec<Fr<G>>>)>,
+}
+
+impl<G: CommitmentCurve> VerifierIndex<G>
 where
     G::BaseField: PrimeField,
 {
     pub fn prev_chal_evals(
         &self,
-        index: &VerifierIndex<G>,
+        proof: &ProverProof<G>,
         evaluation_points: &[Fr<G>],
         powers_of_eval_points_for_chunks: &[Fr<G>],
     ) -> Vec<Vec<Vec<Fr<G>>>> {
-        self.prev_challenges
+        proof
+            .prev_challenges
             .iter()
             .map(|(chals, _poly)| {
                 // No need to check the correctness of poly explicitly. Its correctness is assured by the
@@ -78,11 +93,11 @@ where
                 (0..2)
                     .map(|i| {
                         let full = b_poly(chals, evaluation_points[i]);
-                        if index.max_poly_size == b_len {
+                        if self.max_poly_size == b_len {
                             return vec![full];
                         }
                         let mut betaacc = Fr::<G>::one();
-                        let diff = (index.max_poly_size..b_len)
+                        let diff = (self.max_poly_size..b_len)
                             .map(|j| {
                                 let b_j = match &b {
                                     None => {
@@ -109,23 +124,24 @@ where
     /// This function runs the random oracle argument
     pub fn oracles<EFqSponge: Clone + FqSponge<Fq<G>, G, Fr<G>>, EFrSponge: FrSponge<Fr<G>>>(
         &self,
-        index: &VerifierIndex<G>,
+        proof: &ProverProof<G>,
         p_comm: &PolyComm<G>,
     ) -> OraclesResult<G, EFqSponge> {
-        let n = index.domain.size;
+        let n = self.domain.size;
 
         // Run random oracle argument to sample verifier oracles
-        let mut fq_sponge = EFqSponge::new(index.fq_sponge_params.clone());
+        let mut fq_sponge = EFqSponge::new(self.fq_sponge_params.clone());
 
         // absorb the public input, l, r, o polycommitments into the argument
         fq_sponge.absorb_g(&p_comm.unshifted);
-        self.commitments
+        proof
+            .commitments
             .w_comm
             .iter()
             .for_each(|c| fq_sponge.absorb_g(&c.unshifted));
 
         let joint_combiner = {
-            let s = match index.lookup_index {
+            let s = match self.lookup_index {
                 None
                 | Some(LookupVerifierIndex {
                     lookup_used: LookupsUsed::Single,
@@ -136,10 +152,10 @@ where
                     ..
                 }) => ScalarChallenge(fq_sponge.challenge()),
             };
-            (s, s.to_field(&index.srs.endo_r))
+            (s, s.to_field(&self.srs.endo_r))
         };
 
-        self.commitments.lookup.iter().for_each(|l| {
+        proof.commitments.lookup.iter().for_each(|l| {
             l.sorted
                 .iter()
                 .for_each(|c| fq_sponge.absorb_g(&c.unshifted));
@@ -149,109 +165,109 @@ where
         let beta = fq_sponge.challenge();
         let gamma = fq_sponge.challenge();
 
-        self.commitments.lookup.iter().for_each(|l| {
+        proof.commitments.lookup.iter().for_each(|l| {
             fq_sponge.absorb_g(&l.aggreg.unshifted);
         });
 
         // absorb the z commitment into the argument and query alpha
-        fq_sponge.absorb_g(&self.commitments.z_comm.unshifted);
+        fq_sponge.absorb_g(&proof.commitments.z_comm.unshifted);
         let alpha_chal = ScalarChallenge(fq_sponge.challenge());
-        let alpha = alpha_chal.to_field(&index.srs.endo_r);
+        let alpha = alpha_chal.to_field(&self.srs.endo_r);
 
         // absorb the polycommitments into the argument and sample zeta
         let expected_t_size = PERMUTS;
-        assert_eq!(expected_t_size, self.commitments.t_comm.unshifted.len());
-        fq_sponge.absorb_g(&self.commitments.t_comm.unshifted);
+        assert_eq!(expected_t_size, proof.commitments.t_comm.unshifted.len());
+        fq_sponge.absorb_g(&proof.commitments.t_comm.unshifted);
 
         let zeta_chal = ScalarChallenge(fq_sponge.challenge());
-        let zeta = zeta_chal.to_field(&index.srs.endo_r);
+        let zeta = zeta_chal.to_field(&self.srs.endo_r);
         let digest = fq_sponge.clone().digest();
         let mut fr_sponge = {
-            let mut s = EFrSponge::new(index.fr_sponge_params.clone());
+            let mut s = EFrSponge::new(self.fr_sponge_params.clone());
             s.absorb(&digest);
             s
         };
 
         // prepare some often used values
         let zeta1 = zeta.pow(&[n]);
-        let zetaw = zeta * index.domain.group_gen;
-        let mut all_alphas = index.powers_of_alpha.clone();
+        let zetaw = zeta * self.domain.group_gen;
+        let mut all_alphas = self.powers_of_alpha.clone();
         all_alphas.instantiate(alpha);
 
         // compute Lagrange base evaluation denominators
-        let w = (0..self.public.len())
-            .zip(index.domain.elements())
+        let w = (0..proof.public.len())
+            .zip(self.domain.elements())
             .map(|(_, w)| w)
             .collect::<Vec<_>>();
         let mut lagrange = w.iter().map(|w| zeta - w).collect::<Vec<_>>();
-        (0..self.public.len())
+        (0..proof.public.len())
             .zip(w.iter())
             .for_each(|(_, w)| lagrange.push(zetaw - w));
         ark_ff::fields::batch_inversion::<Fr<G>>(&mut lagrange);
 
         // evaluate public input polynomials
         // NOTE: this works only in the case when the poly segment size is not smaller than that of the domain
-        let p_eval = if !self.public.is_empty() {
+        let p_eval = if !proof.public.is_empty() {
             [
                 vec![
-                    (self
+                    (proof
                         .public
                         .iter()
                         .zip(lagrange.iter())
-                        .zip(index.domain.elements())
+                        .zip(self.domain.elements())
                         .map(|((p, l), w)| -*l * p * w)
                         .fold(Fr::<G>::zero(), |x, y| x + y))
                         * (zeta1 - Fr::<G>::one())
-                        * index.domain.size_inv,
+                        * self.domain.size_inv,
                 ],
                 vec![
-                    (self
+                    (proof
                         .public
                         .iter()
-                        .zip(lagrange[self.public.len()..].iter())
-                        .zip(index.domain.elements())
+                        .zip(lagrange[proof.public.len()..].iter())
+                        .zip(self.domain.elements())
                         .map(|((p, l), w)| -*l * p * w)
                         .fold(Fr::<G>::zero(), |x, y| x + y))
-                        * index.domain.size_inv
+                        * self.domain.size_inv
                         * (zetaw.pow(&[n as u64]) - Fr::<G>::one()),
                 ],
             ]
         } else {
             [Vec::<Fr<G>>::new(), Vec::<Fr<G>>::new()]
         };
-        for (p, e) in p_eval.iter().zip(&self.evals) {
+        for (p, e) in p_eval.iter().zip(&proof.evals) {
             fr_sponge.absorb_evaluations(p, e);
         }
-        fr_sponge.absorb(&self.ft_eval1);
+        fr_sponge.absorb(&proof.ft_eval1);
 
         // query opening scalar challenges
         let v_chal = fr_sponge.challenge();
-        let v = v_chal.to_field(&index.srs.endo_r);
+        let v = v_chal.to_field(&self.srs.endo_r);
         let u_chal = fr_sponge.challenge();
-        let u = u_chal.to_field(&index.srs.endo_r);
+        let u = u_chal.to_field(&self.srs.endo_r);
 
         let ep = [zeta, zetaw];
 
         let powers_of_eval_points_for_chunks = [
-            zeta.pow(&[index.max_poly_size as u64]),
-            zetaw.pow(&[index.max_poly_size as u64]),
+            zeta.pow(&[self.max_poly_size as u64]),
+            zetaw.pow(&[self.max_poly_size as u64]),
         ];
 
-        let polys: Vec<(PolyComm<G>, _)> = self
+        let polys: Vec<(PolyComm<G>, _)> = proof
             .prev_challenges
             .iter()
-            .zip(self.prev_chal_evals(index, &ep, &powers_of_eval_points_for_chunks))
+            .zip(self.prev_chal_evals(proof, &ep, &powers_of_eval_points_for_chunks))
             .map(|(c, e)| (c.1.clone(), e))
             .collect();
 
         let evals = vec![
-            self.evals[0].combine(powers_of_eval_points_for_chunks[0]),
-            self.evals[1].combine(powers_of_eval_points_for_chunks[1]),
+            proof.evals[0].combine(powers_of_eval_points_for_chunks[0]),
+            proof.evals[1].combine(powers_of_eval_points_for_chunks[1]),
         ];
 
         // compute evaluation of ft(zeta)
         let ft_eval0 = {
-            let zkp = index.zkpm.evaluate(&zeta);
+            let zkp = self.zkpm.evaluate(&zeta);
             let zeta1m1 = zeta1 - Fr::<G>::one();
 
             let mut alpha_powers =
@@ -283,15 +299,15 @@ where
             ft_eval0 -= evals[0]
                 .w
                 .iter()
-                .zip(index.shift.iter())
+                .zip(self.shift.iter())
                 .map(|(w, s)| gamma + (beta * zeta * s) + w)
                 .fold(alpha0 * zkp * evals[0].z, |x, y| x * y);
 
-            let nominator = ((zeta1m1 * alpha1 * (zeta - index.w))
+            let nominator = ((zeta1m1 * alpha1 * (zeta - self.w))
                 + (zeta1m1 * alpha2 * (zeta - Fr::<G>::one())))
                 * (Fr::<G>::one() - evals[0].z);
 
-            let denominator = (zeta - index.w) * (zeta - Fr::<G>::one());
+            let denominator = (zeta - self.w) * (zeta - Fr::<G>::one());
             let denominator = denominator.inverse().expect("negligible probability");
 
             ft_eval0 += nominator * denominator;
@@ -301,12 +317,12 @@ where
                 beta,
                 gamma,
                 joint_combiner: joint_combiner.1,
-                endo_coefficient: index.endo,
-                mds: index.fr_sponge_params.mds.clone(),
+                endo_coefficient: self.endo,
+                mds: self.fr_sponge_params.mds.clone(),
             };
             ft_eval0 -= PolishToken::evaluate(
-                &index.linearization.constant_term,
-                index.domain,
+                &self.linearization.constant_term,
+                self.domain,
                 zeta,
                 &evals,
                 &cs,
@@ -317,43 +333,38 @@ where
         };
 
         let combined_inner_product = {
-            let ft_eval0 = vec![ft_eval0];
-            let ft_eval1 = vec![self.ft_eval1];
+            let ft_evals = vec![vec![ft_eval0], vec![proof.ft_eval1]];
 
             #[allow(clippy::type_complexity)]
-            let mut es: Vec<(Vec<&Vec<Fr<G>>>, Option<usize>)> = polys
-                .iter()
-                .map(|(_, e)| (e.iter().collect(), None))
-                .collect();
-            es.push((p_eval.iter().collect::<Vec<_>>(), None));
-            es.push((vec![&ft_eval0, &ft_eval1], None));
-            es.push((self.evals.iter().map(|e| &e.z).collect::<Vec<_>>(), None));
+            let mut es: Vec<_> = polys.iter().map(|(_, e)| (e.clone(), None)).collect();
+            es.push((p_eval.clone().into(), None));
+            es.push((ft_evals, None));
+            es.push((proof.evals.iter().map(|e| e.z.clone()).collect(), None));
             es.push((
-                self.evals
+                proof
+                    .evals
                     .iter()
-                    .map(|e| &e.generic_selector)
-                    .collect::<Vec<_>>(),
+                    .map(|e| e.generic_selector.clone())
+                    .collect(),
                 None,
             ));
             es.push((
-                self.evals
+                proof
+                    .evals
                     .iter()
-                    .map(|e| &e.poseidon_selector)
-                    .collect::<Vec<_>>(),
+                    .map(|e| e.poseidon_selector.clone())
+                    .collect(),
                 None,
             ));
             es.extend(
-                (0..COLUMNS)
-                    .map(|c| (self.evals.iter().map(|e| &e.w[c]).collect::<Vec<_>>(), None))
-                    .collect::<Vec<_>>(),
+                (0..COLUMNS).map(|c| (proof.evals.iter().map(|e| e.w[c].clone()).collect(), None)),
             );
             es.extend(
                 (0..PERMUTS - 1)
-                    .map(|c| (self.evals.iter().map(|e| &e.s[c]).collect::<Vec<_>>(), None))
-                    .collect::<Vec<_>>(),
+                    .map(|c| (proof.evals.iter().map(|e| e.s[c].clone()).collect(), None)),
             );
 
-            combined_inner_product::<G>(&ep, &v, &u, &es, index.srs.g.len())
+            combined_inner_product::<G>(&ep, &v, &u, &es, self.srs.g.len())
         };
 
         let oracles = RandomOracles {
@@ -384,300 +395,335 @@ where
         }
     }
 
-    /// This function verifies the batch of zk-proofs
-    ///     proofs: vector of Plonk proofs
-    ///     index: VerifierIndex
-    ///     RETURN: verification status
-    #[allow(clippy::type_complexity)]
-    pub fn verify<EFqSponge: Clone + FqSponge<Fq<G>, G, Fr<G>>, EFrSponge: FrSponge<Fr<G>>>(
-        group_map: &G::Map,
-        proofs: &[(&VerifierIndex<G>, &Vec<PolyComm<G>>, &ProverProof<G>)],
-    ) -> Result<bool> {
-        // if there's no proof to verify, return early
-        if proofs.is_empty() {
-            return Ok(true);
-        }
+    pub fn deffered_verify<EFqSponge, EFrSponge>(
+        &self,
+        proof: &ProverProof<G>,
+    ) -> DefferedVerification<G, EFqSponge>
+    where
+        EFqSponge: Clone + FqSponge<Fq<G>, G, Fr<G>>,
+        EFrSponge: FrSponge<Fr<G>>,
+    {
+        // commit to public input polynomial
+        let lgr_comm = self
+            .srs
+            .lagrange_bases
+            .get(&self.domain.size())
+            .expect("pre-computed committed lagrange bases not found");
+        let com: Vec<_> = lgr_comm
+            .into_iter()
+            .map(|c| PolyComm {
+                unshifted: vec![*c],
+                shifted: None,
+            })
+            .take(proof.public.len())
+            .collect();
+        let com: Vec<_> = com.iter().collect();
+        let elm: Vec<_> = proof.public.iter().map(|s| -*s).collect();
+        let p_comm = PolyComm::<G>::multi_scalar_mul(&com, &elm);
 
-        // TODO: Account for the different SRS lengths
-        let srs = &proofs[0].0.srs;
-        for (index, _, _) in proofs.iter() {
-            assert_eq!(index.srs.g.len(), srs.g.len());
-        }
+        // run the oracles argument
+        let OraclesResult {
+            fq_sponge,
+            oracles,
+            all_alphas,
+            p_eval,
+            powers_of_eval_points_for_chunks,
+            polys,
+            zeta1: zeta_to_domain_size,
+            ft_eval0,
+            ..
+        } = self.oracles::<EFqSponge, EFrSponge>(&proof, &p_comm);
 
-        // Validate each proof separately (f(zeta) = t(zeta) * Z_H(zeta))
-        // + build objects required to batch verify all the evaluation proofs
-        let mut params = vec![];
-        for (index, lgr_comm, proof) in proofs {
-            // commit to public input polynomial
-            let com: Vec<_> = lgr_comm.iter().take(proof.public.len()).collect();
-            let elm: Vec<_> = proof.public.iter().map(|s| -*s).collect();
-            let p_comm = PolyComm::<G>::multi_scalar_mul(&com, &elm);
+        // combine the committed chunked polynomials
+        // with the right powers of zeta^n or (zeta * omega)^n
+        let evals = vec![
+            proof.evals[0].combine(powers_of_eval_points_for_chunks[0]),
+            proof.evals[1].combine(powers_of_eval_points_for_chunks[1]),
+        ];
 
-            // run the oracles argument
-            let OraclesResult {
-                fq_sponge,
-                oracles,
-                all_alphas,
-                p_eval,
-                powers_of_eval_points_for_chunks,
-                polys,
-                zeta1: zeta_to_domain_size,
-                ft_eval0,
-                ..
-            } = proof.oracles::<EFqSponge, EFrSponge>(index, &p_comm);
+        //
+        // compute the commitment to the linearized polynomial f
+        //
 
-            // combine the committed chunked polynomials
-            // with the right powers of zeta^n or (zeta * omega)^n
-            let evals = vec![
-                proof.evals[0].combine(powers_of_eval_points_for_chunks[0]),
-                proof.evals[1].combine(powers_of_eval_points_for_chunks[1]),
-            ];
+        let f_comm = {
+            // permutation
+            let zkp = self.zkpm.evaluate(&oracles.zeta);
 
-            //
-            // compute the commitment to the linearized polynomial f
-            //
+            let alphas = all_alphas.get_alphas(ArgumentType::Permutation, permutation::CONSTRAINTS);
 
-            let f_comm = {
-                // permutation
-                let zkp = index.zkpm.evaluate(&oracles.zeta);
+            let mut commitments = vec![&self.sigma_comm[PERMUTS - 1]];
+            let mut scalars = vec![ConstraintSystem::perm_scalars(
+                &evals,
+                oracles.beta,
+                oracles.gamma,
+                alphas,
+                zkp,
+            )];
 
-                let alphas =
-                    all_alphas.get_alphas(ArgumentType::Permutation, permutation::CONSTRAINTS);
+            // generic
+            {
+                let alphas = all_alphas
+                    .get_alphas(ArgumentType::Gate(GateType::Generic), generic::CONSTRAINTS);
 
-                let mut commitments = vec![&index.sigma_comm[PERMUTS - 1]];
-                let mut scalars = vec![ConstraintSystem::perm_scalars(
-                    &evals,
-                    oracles.beta,
-                    oracles.gamma,
-                    alphas,
-                    zkp,
-                )];
+                let generic_scalars =
+                    &ConstraintSystem::gnrc_scalars(alphas, &evals[0].w, evals[0].generic_selector);
 
-                // generic
-                {
-                    let alphas = all_alphas
-                        .get_alphas(ArgumentType::Gate(GateType::Generic), generic::CONSTRAINTS);
+                let generic_com = self.coefficients_comm.iter().take(generic_scalars.len());
 
-                    let generic_scalars = &ConstraintSystem::gnrc_scalars(
-                        alphas,
-                        &evals[0].w,
-                        evals[0].generic_selector,
-                    );
+                assert_eq!(generic_scalars.len(), generic_com.len());
 
-                    let generic_com = index.coefficients_comm.iter().take(generic_scalars.len());
+                scalars.extend(generic_scalars);
+                commitments.extend(generic_com);
+            }
 
-                    assert_eq!(generic_scalars.len(), generic_com.len());
+            // other gates are implemented using the expression framework
+            {
+                // TODO: Reuse constants from oracles function
+                let constants = Constants {
+                    alpha: oracles.alpha,
+                    beta: oracles.beta,
+                    gamma: oracles.gamma,
+                    joint_combiner: oracles.joint_combiner.1,
+                    endo_coefficient: self.endo,
+                    mds: self.fr_sponge_params.mds.clone(),
+                };
 
-                    scalars.extend(generic_scalars);
-                    commitments.extend(generic_com);
-                }
-
-                // other gates are implemented using the expression framework
-                {
-                    // TODO: Reuse constants from oracles function
-                    let constants = Constants {
-                        alpha: oracles.alpha,
-                        beta: oracles.beta,
-                        gamma: oracles.gamma,
-                        joint_combiner: oracles.joint_combiner.1,
-                        endo_coefficient: index.endo,
-                        mds: index.fr_sponge_params.mds.clone(),
-                    };
-
-                    for (col, tokens) in &index.linearization.index_terms {
-                        let scalar = PolishToken::evaluate(
-                            tokens,
-                            index.domain,
-                            oracles.zeta,
-                            &evals,
-                            &constants,
-                        )
-                        .expect("should evaluate");
-                        let l = proof.commitments.lookup.as_ref();
-                        use Column::*;
-                        match col {
-                            Witness(i) => {
-                                scalars.push(scalar);
-                                commitments.push(&proof.commitments.w_comm[*i])
+                for (col, tokens) in &self.linearization.index_terms {
+                    let scalar = PolishToken::evaluate(
+                        tokens,
+                        self.domain,
+                        oracles.zeta,
+                        &evals,
+                        &constants,
+                    )
+                    .expect("should evaluate");
+                    let l = proof.commitments.lookup.as_ref();
+                    use Column::*;
+                    match col {
+                        Witness(i) => {
+                            scalars.push(scalar);
+                            commitments.push(&proof.commitments.w_comm[*i])
+                        }
+                        Coefficient(i) => {
+                            scalars.push(scalar);
+                            commitments.push(&self.coefficients_comm[*i])
+                        }
+                        Z => {
+                            scalars.push(scalar);
+                            commitments.push(&proof.commitments.z_comm);
+                        }
+                        LookupSorted(i) => {
+                            scalars.push(scalar);
+                            commitments.push(&l.unwrap().sorted[*i])
+                        }
+                        LookupAggreg => {
+                            scalars.push(scalar);
+                            commitments.push(&l.unwrap().aggreg)
+                        }
+                        LookupKindIndex(i) => match self.lookup_index.as_ref() {
+                            None => {
+                                panic!("Attempted to use {:?}, but no lookup index was given", col)
                             }
-                            Coefficient(i) => {
+                            Some(lindex) => {
                                 scalars.push(scalar);
-                                commitments.push(&index.coefficients_comm[*i])
+                                commitments.push(&lindex.lookup_selectors[*i]);
                             }
-                            Z => {
+                        },
+                        LookupTable => match self.lookup_index.as_ref() {
+                            None => {
+                                panic!("Attempted to use {:?}, but no lookup index was given", col)
+                            }
+                            Some(lindex) => {
+                                let mut j = Fr::<G>::one();
                                 scalars.push(scalar);
-                                commitments.push(&proof.commitments.z_comm);
-                            }
-                            LookupSorted(i) => {
-                                scalars.push(scalar);
-                                commitments.push(&l.unwrap().sorted[*i])
-                            }
-                            LookupAggreg => {
-                                scalars.push(scalar);
-                                commitments.push(&l.unwrap().aggreg)
-                            }
-                            LookupKindIndex(i) => match index.lookup_index.as_ref() {
-                                None => panic!(
-                                    "Attempted to use {:?}, but no lookup index was given",
-                                    col
-                                ),
-                                Some(lindex) => {
-                                    scalars.push(scalar);
-                                    commitments.push(&lindex.lookup_selectors[*i]);
+                                commitments.push(&lindex.lookup_tables[0][0]);
+                                for t in lindex.lookup_tables[0].iter().skip(1) {
+                                    j *= constants.joint_combiner;
+                                    scalars.push(scalar * j);
+                                    commitments.push(t);
                                 }
-                            },
-                            LookupTable => match index.lookup_index.as_ref() {
-                                None => panic!(
-                                    "Attempted to use {:?}, but no lookup index was given",
-                                    col
-                                ),
-                                Some(lindex) => {
-                                    let mut j = Fr::<G>::one();
-                                    scalars.push(scalar);
-                                    commitments.push(&lindex.lookup_tables[0][0]);
-                                    for t in lindex.lookup_tables[0].iter().skip(1) {
-                                        j *= constants.joint_combiner;
-                                        scalars.push(scalar * j);
-                                        commitments.push(t);
-                                    }
-                                }
-                            },
-                            Index(t) => {
-                                use GateType::*;
-                                let c = match t {
-                                    Zero | Generic => panic!("Selector for {:?} not defined", t),
-                                    CompleteAdd => &index.complete_add_comm,
-                                    VarBaseMul => &index.mul_comm,
-                                    EndoMul => &index.emul_comm,
-                                    EndoMulScalar => &index.endomul_scalar_comm,
-                                    Poseidon => &index.psm_comm,
-                                    ChaCha0 => &index.chacha_comm.as_ref().unwrap()[0],
-                                    ChaCha1 => &index.chacha_comm.as_ref().unwrap()[1],
-                                    ChaCha2 => &index.chacha_comm.as_ref().unwrap()[2],
-                                    ChaChaFinal => &index.chacha_comm.as_ref().unwrap()[3],
-                                };
-                                scalars.push(scalar);
-                                commitments.push(c);
                             }
+                        },
+                        Index(t) => {
+                            use GateType::*;
+                            let c = match t {
+                                Zero | Generic => panic!("Selector for {:?} not defined", t),
+                                CompleteAdd => &self.complete_add_comm,
+                                VarBaseMul => &self.mul_comm,
+                                EndoMul => &self.emul_comm,
+                                EndoMulScalar => &self.endomul_scalar_comm,
+                                Poseidon => &self.psm_comm,
+                                ChaCha0 => &self.chacha_comm.as_ref().unwrap()[0],
+                                ChaCha1 => &self.chacha_comm.as_ref().unwrap()[1],
+                                ChaCha2 => &self.chacha_comm.as_ref().unwrap()[2],
+                                ChaChaFinal => &self.chacha_comm.as_ref().unwrap()[3],
+                            };
+                            scalars.push(scalar);
+                            commitments.push(c);
                         }
                     }
                 }
+            }
 
-                // MSM
-                PolyComm::multi_scalar_mul(&commitments, &scalars)
-            };
+            // MSM
+            PolyComm::multi_scalar_mul(&commitments, &scalars)
+        };
 
-            let zeta_to_srs_len = oracles.zeta.pow(&[index.max_poly_size as u64]);
-            // Maller's optimization (see https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html)
-            let chunked_f_comm = f_comm.chunk_commitment(zeta_to_srs_len);
-            let chunked_t_comm = &proof.commitments.t_comm.chunk_commitment(zeta_to_srs_len);
-            let ft_comm =
-                &chunked_f_comm - &chunked_t_comm.scale(zeta_to_domain_size - Fr::<G>::one());
+        let zeta_to_srs_len = oracles.zeta.pow(&[self.max_poly_size as u64]);
+        // Maller's optimization (see https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html)
+        let chunked_f_comm = f_comm.chunk_commitment(zeta_to_srs_len);
+        let chunked_t_comm = &proof.commitments.t_comm.chunk_commitment(zeta_to_srs_len);
+        let ft_comm = &chunked_f_comm - &chunked_t_comm.scale(zeta_to_domain_size - Fr::<G>::one());
 
-            params.push((
-                p_eval,
-                p_comm,
-                ft_comm,
-                fq_sponge,
-                oracles,
-                vec![ft_eval0],
-                vec![proof.ft_eval1],
-                polys,
-            ));
+        DefferedVerification {
+            p_eval,
+            p_comm,
+            ft_comm,
+            fq_sponge,
+            oracles,
+            ft_evals: [ft_eval0, proof.ft_eval1],
+            polys,
         }
+    }
+}
 
-        // batch verify all the evaluation proofs
-        let mut batch = vec![];
-        for (proof, params) in proofs.iter().zip(params.iter()) {
-            let (index, _lgr_comm, proof) = proof;
-            let (p_eval, p_comm, ft_comm, fq_sponge, oracles, ft_eval0, ft_eval1, polys) = params;
+/// This function verifies the batch of zk-proofs
+///     proofs: vector of Plonk proofs
+///     index: VerifierIndex
+///     RETURN: verification status
+#[allow(clippy::type_complexity)]
+pub fn batch_verify<G, EFqSponge, EFrSponge>(
+    group_map: &G::Map,
+    proofs: &[(&VerifierIndex<G>, &ProverProof<G>)],
+) -> Result<()>
+where
+    G: CommitmentCurve,
+    G::BaseField: PrimeField,
+    EFqSponge: Clone + FqSponge<Fq<G>, G, Fr<G>>,
+    EFrSponge: FrSponge<Fr<G>>,
+{
+    // if there's no proof to verify, return early
+    if proofs.is_empty() {
+        return Ok(());
+    }
 
-            // recursion stuff
-            let mut polynomials = polys
+    //~ 1. Ensure that all proofs use an SRS of the same length.
+    //~    (This does not work with SRSs of different lengths at the moment.)
+    //~    (TODO: does the SRSs have to be the same though?)
+    // TODO: Account for the different SRS lengths
+    let srs = &proofs[0].0.srs;
+    for (index, _) in proofs.iter() {
+        assert_eq!(index.srs.g.len(), srs.g.len());
+    }
+
+    // Validate each proof separately (f(zeta) = t(zeta) * Z_H(zeta))
+    // + build objects required to batch verify all the evaluation proofs
+    let mut params = vec![];
+    for (index, proof) in proofs {
+        let deffered_verification = index.deffered_verify::<EFqSponge, EFrSponge>(proof);
+        params.push(deffered_verification);
+    }
+
+    // batch verify all the evaluation proofs
+    let mut batch = vec![];
+    for (proof, params) in proofs.into_iter().zip(params.into_iter()) {
+        let (index, proof) = proof;
+        let DefferedVerification::<G, EFqSponge> {
+            p_eval,
+            p_comm,
+            ft_comm,
+            fq_sponge,
+            oracles,
+            ft_evals,
+            polys,
+        } = params;
+
+        // recursion stuff
+        let mut polynomials: Vec<_> = polys
+            .into_iter()
+            .map(|(comm, evals)| (comm, evals, None))
+            .collect();
+
+        // public input commitment
+        polynomials.push((p_comm, p_eval.into(), None));
+
+        // ft commitment (chunks of it)
+        let ft_evals = ft_evals.into_iter().map(|e| vec![e]).collect();
+        polynomials.push((ft_comm, ft_evals, None));
+
+        // permutation commitment
+        polynomials.push((
+            proof.commitments.z_comm.clone(),
+            proof.evals.iter().map(|e| e.z.clone()).collect(),
+            None,
+        ));
+
+        // index commitments that use the coefficients
+        polynomials.push((
+            index.generic_comm.clone(),
+            proof
+                .evals
                 .iter()
-                .map(|(comm, evals)| (comm, evals.iter().collect(), None))
-                .collect::<Vec<(&PolyComm<G>, Vec<&Vec<Fr<G>>>, Option<usize>)>>();
+                .map(|e| e.generic_selector.clone())
+                .collect(),
+            None,
+        ));
+        polynomials.push((
+            index.psm_comm.clone(),
+            proof
+                .evals
+                .iter()
+                .map(|e| e.poseidon_selector.clone())
+                .collect(),
+            None,
+        ));
 
-            // public input commitment
-            polynomials.push((p_comm, p_eval.iter().collect::<Vec<_>>(), None));
+        // witness commitments
+        polynomials.extend(
+            proof
+                .commitments
+                .w_comm
+                .iter()
+                .zip((0..COLUMNS).map(|i| {
+                    proof
+                        .evals
+                        .iter()
+                        .map(|e| e.w[i].clone())
+                        .collect::<Vec<Vec<_>>>()
+                }))
+                .map(|(c, e)| (c.clone(), e, None)),
+        );
 
-            // ft commitment (chunks of it)
-            polynomials.push((ft_comm, vec![ft_eval0, ft_eval1], None));
+        // sigma commitments
+        polynomials.extend(
+            index
+                .sigma_comm
+                .iter()
+                .zip((0..PERMUTS - 1).map(|i| {
+                    proof
+                        .evals
+                        .iter()
+                        .map(|e| e.s[i].clone())
+                        .collect::<Vec<Vec<_>>>()
+                }))
+                .map(|(c, e)| (c.clone(), e, None)),
+        );
 
-            // permutation commitment
-            polynomials.push((
-                &proof.commitments.z_comm,
-                proof.evals.iter().map(|e| &e.z).collect::<Vec<_>>(),
-                None,
-            ));
+        // prepare for the opening proof verification
+        let omega = index.domain.group_gen;
+        batch.push((
+            fq_sponge.clone(),
+            vec![oracles.zeta, oracles.zeta * omega],
+            oracles.v,
+            oracles.u,
+            polynomials,
+            &proof.proof,
+        ));
+    }
 
-            // index commitments that use the coefficients
-            polynomials.push((
-                &index.generic_comm,
-                proof
-                    .evals
-                    .iter()
-                    .map(|e| &e.generic_selector)
-                    .collect::<Vec<_>>(),
-                None,
-            ));
-            polynomials.push((
-                &index.psm_comm,
-                proof
-                    .evals
-                    .iter()
-                    .map(|e| &e.poseidon_selector)
-                    .collect::<Vec<_>>(),
-                None,
-            ));
-
-            // witness commitments
-            polynomials.extend(
-                proof
-                    .commitments
-                    .w_comm
-                    .iter()
-                    .zip(
-                        (0..COLUMNS)
-                            .map(|i| proof.evals.iter().map(|e| &e.w[i]).collect::<Vec<_>>())
-                            .collect::<Vec<_>>()
-                            .iter(),
-                    )
-                    .map(|(c, e)| (c, e.clone(), None))
-                    .collect::<Vec<_>>(),
-            );
-
-            // sigma commitments
-            polynomials.extend(
-                index
-                    .sigma_comm
-                    .iter()
-                    .zip(
-                        (0..PERMUTS - 1)
-                            .map(|i| proof.evals.iter().map(|e| &e.s[i]).collect::<Vec<_>>())
-                            .collect::<Vec<_>>()
-                            .iter(),
-                    )
-                    .map(|(c, e)| (c, e.clone(), None))
-                    .collect::<Vec<_>>(),
-            );
-
-            // prepare for the opening proof verification
-            let omega = index.domain.group_gen;
-            batch.push((
-                fq_sponge.clone(),
-                vec![oracles.zeta, oracles.zeta * omega],
-                oracles.v,
-                oracles.u,
-                polynomials,
-                &proof.proof,
-            ));
-        }
-
-        // final check to verify the evaluation proofs
-        match srs.verify::<EFqSponge, _>(group_map, &mut batch, &mut thread_rng()) {
-            false => Err(ProofError::OpenProof),
-            true => Ok(true),
-        }
+    // final check to verify the evaluation proofs
+    match srs.verify::<EFqSponge, _>(group_map, &mut batch, &mut thread_rng()) {
+        false => Err(ProofError::OpenProof),
+        true => Ok(()),
     }
 }

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -455,7 +455,7 @@ pub fn combined_inner_product<G: CommitmentCurve>(
     xi: &Fr<G>,
     r: &Fr<G>,
     // TODO(mimoo): needs a type that can get you evaluations or segments
-    polys: &[(Vec<&Vec<Fr<G>>>, Option<usize>)],
+    polys: &[(Vec<Vec<Fr<G>>>, Option<usize>)],
     srs_length: usize,
 ) -> Fr<G> {
     let mut res = Fr::<G>::zero();
@@ -952,9 +952,9 @@ impl<G: CommitmentCurve> SRS<G> {
             Fr<G>,      // scaling factor for polynomials
             Fr<G>,      // scaling factor for evaluation point powers
             Vec<(
-                &PolyComm<G>,     // polycommitment
-                Vec<&Vec<Fr<G>>>, // vector of evaluations
-                Option<usize>,    // optional degree bound
+                PolyComm<G>,     // polycommitment
+                Vec<Vec<Fr<G>>>, // vector of evaluations
+                Option<usize>,   // optional degree bound
             )>,
             &OpeningProof<G>, // batched opening proof
         )>,
@@ -1275,12 +1275,8 @@ mod tests {
             v,
             u,
             vec![
-                (&commitment.0, poly1_chunked_evals.iter().collect(), None),
-                (
-                    &bounded_commitment.0,
-                    poly2_chunked_evals.iter().collect(),
-                    Some(upperbound),
-                ),
+                (commitment.0, poly1_chunked_evals, None),
+                (bounded_commitment.0, poly2_chunked_evals, Some(upperbound)),
             ],
             &opening_proof,
         )];

--- a/poly-commitment/tests/batch_15_wires.rs
+++ b/poly-commitment/tests/batch_15_wires.rs
@@ -115,7 +115,13 @@ where
                 proof
                     .4
                     .iter()
-                    .map(|poly| (&(poly.0).0, poly.1.iter().collect::<Vec<_>>(), poly.2))
+                    .map(|poly| {
+                        (
+                            (poly.0).0.clone(),
+                            poly.1.iter().cloned().collect::<Vec<_>>(),
+                            poly.2,
+                        )
+                    })
                     .collect::<Vec<_>>(),
                 &proof.5,
             )

--- a/poly-commitment/tests/commitment.rs
+++ b/poly-commitment/tests/commitment.rs
@@ -50,9 +50,9 @@ mod verifier {
         Fp,      // scaling factor for polynoms
         Fp,      // scaling factor for evaluation point powers
         Vec<(
-            &'a PolyComm<Affine>, // polycommitment
-            Vec<&'a Vec<Fp>>,     // vector of evaluations
-            Option<usize>,        // optional degree bound
+            PolyComm<Affine>, // polycommitment
+            Vec<Vec<Fp>>,     // vector of evaluations
+            Option<usize>,    // optional degree bound
         )>,
         &'a OpeningProof<Affine>, // batched opening proof
     );
@@ -94,10 +94,9 @@ impl AggregatedEvaluationProof {
         let mut coms = vec![];
         for eval_com in &self.eval_commitments {
             assert_eq!(self.eval_points.len(), eval_com.chunked_evals.len());
-            let evaluations = eval_com.chunked_evals.iter().collect();
             coms.push((
-                &eval_com.commit.chunked_commitment,
-                evaluations,
+                eval_com.commit.chunked_commitment.clone(),
+                eval_com.chunked_evals.clone(),
                 eval_com.commit.bound,
             ));
         }


### PR DESCRIPTION
This PR is a bit of a mess, I'll try to split it into several PRs that:

* verify -> batch_verify https://github.com/o1-labs/proof-systems/pull/361
* extract the per-proof verification of batch_verify in its own function https://github.com/o1-labs/proof-systems/pull/366
* use the pre-computed lagrange bases we already have (which led me to change a bunch of the references and the code) https://github.com/o1-labs/proof-systems/pull/361

closes https://github.com/o1-labs/proof-systems/issues/355