### PR TITLE
[verifier] reuse pre-computed lagrange bases we already have

### DIFF
--- a/kimchi/src/bench.rs
+++ b/kimchi/src/bench.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     index::{testing::new_index_for_test, Index, VerifierIndex},
     prover::ProverProof,
+    verifier::batch_verify,
 };
 use ark_ff::UniformRand;
 use ark_poly::{univariate::DensePolynomial, UVPolynomial};
@@ -106,12 +107,11 @@ impl BenchmarkCtx {
 
     pub fn batch_verification(&self, batch: Vec<ProverProof<Affine>>) {
         // verify the proof
-        let lgr_comms = vec![];
         let batch: Vec<_> = batch
             .iter()
-            .map(|proof| (&self.verifier_index, &lgr_comms, proof))
+            .map(|proof| (&self.verifier_index, proof))
             .collect();
-        ProverProof::verify::<BaseSponge, ScalarSponge>(&self.group_map, &batch).unwrap();
+        batch_verify::<Affine, BaseSponge, ScalarSponge>(&self.group_map, &batch).unwrap();
     }
 }
 

--- a/kimchi/src/tests/chacha.rs
+++ b/kimchi/src/tests/chacha.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     index::testing::new_index_for_test,
     prover::ProverProof,
+    verifier::batch_verify,
 };
 use array_init::array_init;
 use colored::Colorize;
@@ -90,10 +91,9 @@ fn chacha_prover() {
     let verifier_index = index.verifier_index();
     println!("{}{:?}", "Verifier index time: ".yellow(), start.elapsed());
 
-    let lgr_comms = vec![];
-    let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];
+    let batch: Vec<_> = vec![(&verifier_index, &proof)];
     let start = Instant::now();
-    match ProverProof::verify::<BaseSponge, ScalarSponge>(&group_map, &batch) {
+    match batch_verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &batch) {
         Err(error) => panic!("Failure verifying the prover's proofs in batch: {}", error),
         Ok(_) => {
             println!("{}{:?}", "Verifier time: ".yellow(), start.elapsed());

--- a/kimchi/src/tests/ec.rs
+++ b/kimchi/src/tests/ec.rs
@@ -5,6 +5,7 @@ use crate::{
     },
     index::testing::new_index_for_test,
     prover::ProverProof,
+    verifier::batch_verify,
 };
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
@@ -54,7 +55,6 @@ fn ec_test() {
     let verifier_index = index.verifier_index();
     let group_map = <Affine as CommitmentCurve>::Map::setup();
 
-    let lgr_comms = vec![];
     let rng = &mut StdRng::from_seed([0; 32]);
 
     let ps = {
@@ -174,9 +174,9 @@ fn ec_test() {
             .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
-    let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];
+    let batch: Vec<_> = vec![(&verifier_index, &proof)];
     let start = Instant::now();
-    match ProverProof::verify::<BaseSponge, ScalarSponge>(&group_map, &batch) {
+    match batch_verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &batch) {
         Err(error) => panic!("Failure verifying the prover's proofs in batch: {}", error),
         Ok(_) => {
             println!("{}{:?}", "Verifier time: ".yellow(), start.elapsed());

--- a/kimchi/src/tests/endomul.rs
+++ b/kimchi/src/tests/endomul.rs
@@ -1,4 +1,5 @@
 use crate::prover::ProverProof;
+use crate::verifier::batch_verify;
 use crate::{
     circuits::{
         gate::{CircuitGate, GateType},
@@ -72,7 +73,6 @@ fn endomul_test() {
     let verifier_index = index.verifier_index();
     let group_map = <Affine as CommitmentCurve>::Map::setup();
 
-    let lgr_comms = vec![];
     let rng = &mut StdRng::from_seed([0; 32]);
 
     // let start = Instant::now();
@@ -137,9 +137,9 @@ fn endomul_test() {
             .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
-    let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];
+    let batch: Vec<_> = vec![(&verifier_index, &proof)];
     let start = Instant::now();
-    match ProverProof::verify::<BaseSponge, ScalarSponge>(&group_map, &batch) {
+    match batch_verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &batch) {
         Err(error) => panic!("Failure verifying the prover's proofs in batch: {}", error),
         Ok(_) => {
             println!("{}{:?}", "Verifier time: ".yellow(), start.elapsed());

--- a/kimchi/src/tests/endomul_scalar.rs
+++ b/kimchi/src/tests/endomul_scalar.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     index::testing::new_index_for_test,
     prover::ProverProof,
+    verifier::batch_verify,
 };
 use ark_ff::{BigInteger, BitIteratorLE, PrimeField, UniformRand};
 use array_init::array_init;
@@ -60,7 +61,6 @@ fn endomul_scalar_test() {
     let verifier_index = index.verifier_index();
     let group_map = <Affine as CommitmentCurve>::Map::setup();
 
-    let lgr_comms = vec![];
     let rng = &mut StdRng::from_seed([0; 32]);
 
     //let start = Instant::now();
@@ -84,9 +84,9 @@ fn endomul_scalar_test() {
             .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
-    let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];
+    let batch: Vec<_> = vec![(&verifier_index, &proof)];
     let start = Instant::now();
-    match ProverProof::verify::<BaseSponge, ScalarSponge>(&group_map, &batch) {
+    match batch_verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &batch) {
         Err(error) => panic!("Failure verifying the prover's proofs in batch: {}", error),
         Ok(_) => {
             println!("{}{:?}", "Verifier time: ".yellow(), start.elapsed());

--- a/kimchi/src/tests/poseidon.rs
+++ b/kimchi/src/tests/poseidon.rs
@@ -5,6 +5,7 @@ use crate::{
         wires::{Wire, COLUMNS},
     },
     index::testing::new_index_for_test,
+    verifier::batch_verify,
 };
 use crate::{index::Index, prover::ProverProof};
 use ark_ff::{UniformRand, Zero};
@@ -167,16 +168,12 @@ fn positive(index: &Index<Affine>) {
     // TODO: shouldn't verifier_index be part of ProverProof, not being passed in verify?
     let verifier_index = index.verifier_index();
 
-    let lgr_comms = vec![];
-    let batch: Vec<_> = batch
-        .iter()
-        .map(|proof| (&verifier_index, &lgr_comms, proof))
-        .collect();
+    let batch: Vec<_> = batch.iter().map(|proof| (&verifier_index, proof)).collect();
 
     // verify the proofs in batch
     println!("{}", "Verifier zk-proofs verification".green());
     start = Instant::now();
-    match ProverProof::verify::<BaseSponge, ScalarSponge>(&group_map, &batch) {
+    match batch_verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &batch) {
         Err(error) => panic!("Failure verifying the prover's proofs in batch: {}", error),
         Ok(_) => {
             println!("{}{:?}", "Execution time: ".yellow(), start.elapsed());

--- a/kimchi/src/tests/varbasemul.rs
+++ b/kimchi/src/tests/varbasemul.rs
@@ -1,4 +1,5 @@
 use crate::prover::ProverProof;
+use crate::verifier::batch_verify;
 use crate::{
     circuits::{
         gate::{CircuitGate, GateType},
@@ -65,7 +66,6 @@ fn varbase_mul_test() {
     let verifier_index = index.verifier_index();
     let group_map = <Affine as CommitmentCurve>::Map::setup();
 
-    let lgr_comms = vec![];
     let rng = &mut StdRng::from_seed([0; 32]);
 
     let start = Instant::now();
@@ -112,9 +112,9 @@ fn varbase_mul_test() {
             .unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
-    let batch: Vec<_> = vec![(&verifier_index, &lgr_comms, &proof)];
+    let batch: Vec<_> = vec![(&verifier_index, &proof)];
     let start = Instant::now();
-    match ProverProof::verify::<BaseSponge, ScalarSponge>(&group_map, &batch) {
+    match batch_verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &batch) {
         Err(error) => panic!("Failure verifying the prover's proofs in batch: {}", error),
         Ok(_) => {
             println!("{}{:?}", "Verifier time: ".yellow(), start.elapsed());

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -422,7 +422,7 @@ where
             .get(&index.domain.size())
             .expect("pre-computed committed lagrange bases not found");
         let com: Vec<_> = lgr_comm
-            .into_iter()
+            .iter()
             .map(|c| PolyComm {
                 unshifted: vec![*c],
                 shifted: None,

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -383,301 +383,300 @@ where
             combined_inner_product,
         }
     }
+}
 
-    /// This function verifies the batch of zk-proofs
-    ///     proofs: vector of Plonk proofs
-    ///     index: VerifierIndex
-    ///     RETURN: verification status
-    #[allow(clippy::type_complexity)]
-    pub fn verify<EFqSponge: Clone + FqSponge<Fq<G>, G, Fr<G>>, EFrSponge: FrSponge<Fr<G>>>(
-        group_map: &G::Map,
-        proofs: &[(&VerifierIndex<G>, &Vec<PolyComm<G>>, &ProverProof<G>)],
-    ) -> Result<bool> {
-        // if there's no proof to verify, return early
-        if proofs.is_empty() {
-            return Ok(true);
-        }
+/// This function verifies the batch of zk-proofs
+///     proofs: vector of Plonk proofs
+///     index: VerifierIndex
+///     RETURN: verification status
+#[allow(clippy::type_complexity)]
+pub fn verify<G, EFqSponge, EFrSponge>(
+    group_map: &G::Map,
+    proofs: &[(&VerifierIndex<G>, &Vec<PolyComm<G>>, &ProverProof<G>)],
+) -> Result<bool>
+where
+    G: CommitmentCurve,
+    G::BaseField: PrimeField,
+    EFqSponge: Clone + FqSponge<Fq<G>, G, Fr<G>>,
+    EFrSponge: FrSponge<Fr<G>>,
+{
+    // if there's no proof to verify, return early
+    if proofs.is_empty() {
+        return Ok(true);
+    }
 
-        // TODO: Account for the different SRS lengths
-        let srs = &proofs[0].0.srs;
-        for (index, _, _) in proofs.iter() {
-            assert_eq!(index.srs.g.len(), srs.g.len());
-        }
+    // TODO: Account for the different SRS lengths
+    let srs = &proofs[0].0.srs;
+    for (index, _, _) in proofs.iter() {
+        assert_eq!(index.srs.g.len(), srs.g.len());
+    }
 
-        // Validate each proof separately (f(zeta) = t(zeta) * Z_H(zeta))
-        // + build objects required to batch verify all the evaluation proofs
-        let mut params = vec![];
-        for (index, lgr_comm, proof) in proofs {
-            // commit to public input polynomial
-            let com: Vec<_> = lgr_comm.iter().take(proof.public.len()).collect();
-            let elm: Vec<_> = proof.public.iter().map(|s| -*s).collect();
-            let p_comm = PolyComm::<G>::multi_scalar_mul(&com, &elm);
+    // Validate each proof separately (f(zeta) = t(zeta) * Z_H(zeta))
+    // + build objects required to batch verify all the evaluation proofs
+    let mut params = vec![];
+    for (index, lgr_comm, proof) in proofs {
+        // commit to public input polynomial
+        let com: Vec<_> = lgr_comm.iter().take(proof.public.len()).collect();
+        let elm: Vec<_> = proof.public.iter().map(|s| -*s).collect();
+        let p_comm = PolyComm::<G>::multi_scalar_mul(&com, &elm);
 
-            // run the oracles argument
-            let OraclesResult {
-                fq_sponge,
-                oracles,
-                all_alphas,
-                p_eval,
-                powers_of_eval_points_for_chunks,
-                polys,
-                zeta1: zeta_to_domain_size,
-                ft_eval0,
-                ..
-            } = proof.oracles::<EFqSponge, EFrSponge>(index, &p_comm);
+        // run the oracles argument
+        let OraclesResult {
+            fq_sponge,
+            oracles,
+            all_alphas,
+            p_eval,
+            powers_of_eval_points_for_chunks,
+            polys,
+            zeta1: zeta_to_domain_size,
+            ft_eval0,
+            ..
+        } = proof.oracles::<EFqSponge, EFrSponge>(index, &p_comm);
 
-            // combine the committed chunked polynomials
-            // with the right powers of zeta^n or (zeta * omega)^n
-            let evals = vec![
-                proof.evals[0].combine(powers_of_eval_points_for_chunks[0]),
-                proof.evals[1].combine(powers_of_eval_points_for_chunks[1]),
-            ];
+        // combine the committed chunked polynomials
+        // with the right powers of zeta^n or (zeta * omega)^n
+        let evals = vec![
+            proof.evals[0].combine(powers_of_eval_points_for_chunks[0]),
+            proof.evals[1].combine(powers_of_eval_points_for_chunks[1]),
+        ];
 
-            //
-            // compute the commitment to the linearized polynomial f
-            //
+        //
+        // compute the commitment to the linearized polynomial f
+        //
 
-            let f_comm = {
-                // permutation
-                let zkp = index.zkpm.evaluate(&oracles.zeta);
+        let f_comm = {
+            // permutation
+            let zkp = index.zkpm.evaluate(&oracles.zeta);
 
-                let alphas =
-                    all_alphas.get_alphas(ArgumentType::Permutation, permutation::CONSTRAINTS);
+            let alphas = all_alphas.get_alphas(ArgumentType::Permutation, permutation::CONSTRAINTS);
 
-                let mut commitments = vec![&index.sigma_comm[PERMUTS - 1]];
-                let mut scalars = vec![ConstraintSystem::perm_scalars(
-                    &evals,
-                    oracles.beta,
-                    oracles.gamma,
-                    alphas,
-                    zkp,
-                )];
+            let mut commitments = vec![&index.sigma_comm[PERMUTS - 1]];
+            let mut scalars = vec![ConstraintSystem::perm_scalars(
+                &evals,
+                oracles.beta,
+                oracles.gamma,
+                alphas,
+                zkp,
+            )];
 
-                // generic
-                {
-                    let alphas = all_alphas
-                        .get_alphas(ArgumentType::Gate(GateType::Generic), generic::CONSTRAINTS);
+            // generic
+            {
+                let alphas = all_alphas
+                    .get_alphas(ArgumentType::Gate(GateType::Generic), generic::CONSTRAINTS);
 
-                    let generic_scalars = &ConstraintSystem::gnrc_scalars(
-                        alphas,
-                        &evals[0].w,
-                        evals[0].generic_selector,
-                    );
+                let generic_scalars =
+                    &ConstraintSystem::gnrc_scalars(alphas, &evals[0].w, evals[0].generic_selector);
 
-                    let generic_com = index.coefficients_comm.iter().take(generic_scalars.len());
+                let generic_com = index.coefficients_comm.iter().take(generic_scalars.len());
 
-                    assert_eq!(generic_scalars.len(), generic_com.len());
+                assert_eq!(generic_scalars.len(), generic_com.len());
 
-                    scalars.extend(generic_scalars);
-                    commitments.extend(generic_com);
-                }
+                scalars.extend(generic_scalars);
+                commitments.extend(generic_com);
+            }
 
-                // other gates are implemented using the expression framework
-                {
-                    // TODO: Reuse constants from oracles function
-                    let constants = Constants {
-                        alpha: oracles.alpha,
-                        beta: oracles.beta,
-                        gamma: oracles.gamma,
-                        joint_combiner: oracles.joint_combiner.1,
-                        endo_coefficient: index.endo,
-                        mds: index.fr_sponge_params.mds.clone(),
-                    };
+            // other gates are implemented using the expression framework
+            {
+                // TODO: Reuse constants from oracles function
+                let constants = Constants {
+                    alpha: oracles.alpha,
+                    beta: oracles.beta,
+                    gamma: oracles.gamma,
+                    joint_combiner: oracles.joint_combiner.1,
+                    endo_coefficient: index.endo,
+                    mds: index.fr_sponge_params.mds.clone(),
+                };
 
-                    for (col, tokens) in &index.linearization.index_terms {
-                        let scalar = PolishToken::evaluate(
-                            tokens,
-                            index.domain,
-                            oracles.zeta,
-                            &evals,
-                            &constants,
-                        )
-                        .expect("should evaluate");
-                        let l = proof.commitments.lookup.as_ref();
-                        use Column::*;
-                        match col {
-                            Witness(i) => {
-                                scalars.push(scalar);
-                                commitments.push(&proof.commitments.w_comm[*i])
+                for (col, tokens) in &index.linearization.index_terms {
+                    let scalar = PolishToken::evaluate(
+                        tokens,
+                        index.domain,
+                        oracles.zeta,
+                        &evals,
+                        &constants,
+                    )
+                    .expect("should evaluate");
+                    let l = proof.commitments.lookup.as_ref();
+                    use Column::*;
+                    match col {
+                        Witness(i) => {
+                            scalars.push(scalar);
+                            commitments.push(&proof.commitments.w_comm[*i])
+                        }
+                        Coefficient(i) => {
+                            scalars.push(scalar);
+                            commitments.push(&index.coefficients_comm[*i])
+                        }
+                        Z => {
+                            scalars.push(scalar);
+                            commitments.push(&proof.commitments.z_comm);
+                        }
+                        LookupSorted(i) => {
+                            scalars.push(scalar);
+                            commitments.push(&l.unwrap().sorted[*i])
+                        }
+                        LookupAggreg => {
+                            scalars.push(scalar);
+                            commitments.push(&l.unwrap().aggreg)
+                        }
+                        LookupKindIndex(i) => match index.lookup_index.as_ref() {
+                            None => {
+                                panic!("Attempted to use {:?}, but no lookup index was given", col)
                             }
-                            Coefficient(i) => {
+                            Some(lindex) => {
                                 scalars.push(scalar);
-                                commitments.push(&index.coefficients_comm[*i])
+                                commitments.push(&lindex.lookup_selectors[*i]);
                             }
-                            Z => {
+                        },
+                        LookupTable => match index.lookup_index.as_ref() {
+                            None => {
+                                panic!("Attempted to use {:?}, but no lookup index was given", col)
+                            }
+                            Some(lindex) => {
+                                let mut j = Fr::<G>::one();
                                 scalars.push(scalar);
-                                commitments.push(&proof.commitments.z_comm);
-                            }
-                            LookupSorted(i) => {
-                                scalars.push(scalar);
-                                commitments.push(&l.unwrap().sorted[*i])
-                            }
-                            LookupAggreg => {
-                                scalars.push(scalar);
-                                commitments.push(&l.unwrap().aggreg)
-                            }
-                            LookupKindIndex(i) => match index.lookup_index.as_ref() {
-                                None => panic!(
-                                    "Attempted to use {:?}, but no lookup index was given",
-                                    col
-                                ),
-                                Some(lindex) => {
-                                    scalars.push(scalar);
-                                    commitments.push(&lindex.lookup_selectors[*i]);
+                                commitments.push(&lindex.lookup_tables[0][0]);
+                                for t in lindex.lookup_tables[0].iter().skip(1) {
+                                    j *= constants.joint_combiner;
+                                    scalars.push(scalar * j);
+                                    commitments.push(t);
                                 }
-                            },
-                            LookupTable => match index.lookup_index.as_ref() {
-                                None => panic!(
-                                    "Attempted to use {:?}, but no lookup index was given",
-                                    col
-                                ),
-                                Some(lindex) => {
-                                    let mut j = Fr::<G>::one();
-                                    scalars.push(scalar);
-                                    commitments.push(&lindex.lookup_tables[0][0]);
-                                    for t in lindex.lookup_tables[0].iter().skip(1) {
-                                        j *= constants.joint_combiner;
-                                        scalars.push(scalar * j);
-                                        commitments.push(t);
-                                    }
-                                }
-                            },
-                            Index(t) => {
-                                use GateType::*;
-                                let c = match t {
-                                    Zero | Generic => panic!("Selector for {:?} not defined", t),
-                                    CompleteAdd => &index.complete_add_comm,
-                                    VarBaseMul => &index.mul_comm,
-                                    EndoMul => &index.emul_comm,
-                                    EndoMulScalar => &index.endomul_scalar_comm,
-                                    Poseidon => &index.psm_comm,
-                                    ChaCha0 => &index.chacha_comm.as_ref().unwrap()[0],
-                                    ChaCha1 => &index.chacha_comm.as_ref().unwrap()[1],
-                                    ChaCha2 => &index.chacha_comm.as_ref().unwrap()[2],
-                                    ChaChaFinal => &index.chacha_comm.as_ref().unwrap()[3],
-                                };
-                                scalars.push(scalar);
-                                commitments.push(c);
                             }
+                        },
+                        Index(t) => {
+                            use GateType::*;
+                            let c = match t {
+                                Zero | Generic => panic!("Selector for {:?} not defined", t),
+                                CompleteAdd => &index.complete_add_comm,
+                                VarBaseMul => &index.mul_comm,
+                                EndoMul => &index.emul_comm,
+                                EndoMulScalar => &index.endomul_scalar_comm,
+                                Poseidon => &index.psm_comm,
+                                ChaCha0 => &index.chacha_comm.as_ref().unwrap()[0],
+                                ChaCha1 => &index.chacha_comm.as_ref().unwrap()[1],
+                                ChaCha2 => &index.chacha_comm.as_ref().unwrap()[2],
+                                ChaChaFinal => &index.chacha_comm.as_ref().unwrap()[3],
+                            };
+                            scalars.push(scalar);
+                            commitments.push(c);
                         }
                     }
                 }
+            }
 
-                // MSM
-                PolyComm::multi_scalar_mul(&commitments, &scalars)
-            };
+            // MSM
+            PolyComm::multi_scalar_mul(&commitments, &scalars)
+        };
 
-            let zeta_to_srs_len = oracles.zeta.pow(&[index.max_poly_size as u64]);
-            // Maller's optimization (see https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html)
-            let chunked_f_comm = f_comm.chunk_commitment(zeta_to_srs_len);
-            let chunked_t_comm = &proof.commitments.t_comm.chunk_commitment(zeta_to_srs_len);
-            let ft_comm =
-                &chunked_f_comm - &chunked_t_comm.scale(zeta_to_domain_size - Fr::<G>::one());
+        let zeta_to_srs_len = oracles.zeta.pow(&[index.max_poly_size as u64]);
+        // Maller's optimization (see https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html)
+        let chunked_f_comm = f_comm.chunk_commitment(zeta_to_srs_len);
+        let chunked_t_comm = &proof.commitments.t_comm.chunk_commitment(zeta_to_srs_len);
+        let ft_comm = &chunked_f_comm - &chunked_t_comm.scale(zeta_to_domain_size - Fr::<G>::one());
 
-            params.push((
-                p_eval,
-                p_comm,
-                ft_comm,
-                fq_sponge,
-                oracles,
-                vec![ft_eval0],
-                vec![proof.ft_eval1],
-                polys,
-            ));
-        }
+        params.push((
+            p_eval,
+            p_comm,
+            ft_comm,
+            fq_sponge,
+            oracles,
+            vec![ft_eval0],
+            vec![proof.ft_eval1],
+            polys,
+        ));
+    }
 
-        // batch verify all the evaluation proofs
-        let mut batch = vec![];
-        for (proof, params) in proofs.iter().zip(params.iter()) {
-            let (index, _lgr_comm, proof) = proof;
-            let (p_eval, p_comm, ft_comm, fq_sponge, oracles, ft_eval0, ft_eval1, polys) = params;
+    // batch verify all the evaluation proofs
+    let mut batch = vec![];
+    for (proof, params) in proofs.iter().zip(params.iter()) {
+        let (index, _lgr_comm, proof) = proof;
+        let (p_eval, p_comm, ft_comm, fq_sponge, oracles, ft_eval0, ft_eval1, polys) = params;
 
-            // recursion stuff
-            let mut polynomials = polys
+        // recursion stuff
+        let mut polynomials = polys
+            .iter()
+            .map(|(comm, evals)| (comm, evals.iter().collect(), None))
+            .collect::<Vec<(&PolyComm<G>, Vec<&Vec<Fr<G>>>, Option<usize>)>>();
+
+        // public input commitment
+        polynomials.push((p_comm, p_eval.iter().collect::<Vec<_>>(), None));
+
+        // ft commitment (chunks of it)
+        polynomials.push((ft_comm, vec![ft_eval0, ft_eval1], None));
+
+        // permutation commitment
+        polynomials.push((
+            &proof.commitments.z_comm,
+            proof.evals.iter().map(|e| &e.z).collect::<Vec<_>>(),
+            None,
+        ));
+
+        // index commitments that use the coefficients
+        polynomials.push((
+            &index.generic_comm,
+            proof
+                .evals
                 .iter()
-                .map(|(comm, evals)| (comm, evals.iter().collect(), None))
-                .collect::<Vec<(&PolyComm<G>, Vec<&Vec<Fr<G>>>, Option<usize>)>>();
+                .map(|e| &e.generic_selector)
+                .collect::<Vec<_>>(),
+            None,
+        ));
+        polynomials.push((
+            &index.psm_comm,
+            proof
+                .evals
+                .iter()
+                .map(|e| &e.poseidon_selector)
+                .collect::<Vec<_>>(),
+            None,
+        ));
 
-            // public input commitment
-            polynomials.push((p_comm, p_eval.iter().collect::<Vec<_>>(), None));
+        // witness commitments
+        polynomials.extend(
+            proof
+                .commitments
+                .w_comm
+                .iter()
+                .zip(
+                    (0..COLUMNS)
+                        .map(|i| proof.evals.iter().map(|e| &e.w[i]).collect::<Vec<_>>())
+                        .collect::<Vec<_>>()
+                        .iter(),
+                )
+                .map(|(c, e)| (c, e.clone(), None))
+                .collect::<Vec<_>>(),
+        );
 
-            // ft commitment (chunks of it)
-            polynomials.push((ft_comm, vec![ft_eval0, ft_eval1], None));
+        // sigma commitments
+        polynomials.extend(
+            index
+                .sigma_comm
+                .iter()
+                .zip(
+                    (0..PERMUTS - 1)
+                        .map(|i| proof.evals.iter().map(|e| &e.s[i]).collect::<Vec<_>>())
+                        .collect::<Vec<_>>()
+                        .iter(),
+                )
+                .map(|(c, e)| (c, e.clone(), None))
+                .collect::<Vec<_>>(),
+        );
 
-            // permutation commitment
-            polynomials.push((
-                &proof.commitments.z_comm,
-                proof.evals.iter().map(|e| &e.z).collect::<Vec<_>>(),
-                None,
-            ));
+        // prepare for the opening proof verification
+        let omega = index.domain.group_gen;
+        batch.push((
+            fq_sponge.clone(),
+            vec![oracles.zeta, oracles.zeta * omega],
+            oracles.v,
+            oracles.u,
+            polynomials,
+            &proof.proof,
+        ));
+    }
 
-            // index commitments that use the coefficients
-            polynomials.push((
-                &index.generic_comm,
-                proof
-                    .evals
-                    .iter()
-                    .map(|e| &e.generic_selector)
-                    .collect::<Vec<_>>(),
-                None,
-            ));
-            polynomials.push((
-                &index.psm_comm,
-                proof
-                    .evals
-                    .iter()
-                    .map(|e| &e.poseidon_selector)
-                    .collect::<Vec<_>>(),
-                None,
-            ));
-
-            // witness commitments
-            polynomials.extend(
-                proof
-                    .commitments
-                    .w_comm
-                    .iter()
-                    .zip(
-                        (0..COLUMNS)
-                            .map(|i| proof.evals.iter().map(|e| &e.w[i]).collect::<Vec<_>>())
-                            .collect::<Vec<_>>()
-                            .iter(),
-                    )
-                    .map(|(c, e)| (c, e.clone(), None))
-                    .collect::<Vec<_>>(),
-            );
-
-            // sigma commitments
-            polynomials.extend(
-                index
-                    .sigma_comm
-                    .iter()
-                    .zip(
-                        (0..PERMUTS - 1)
-                            .map(|i| proof.evals.iter().map(|e| &e.s[i]).collect::<Vec<_>>())
-                            .collect::<Vec<_>>()
-                            .iter(),
-                    )
-                    .map(|(c, e)| (c, e.clone(), None))
-                    .collect::<Vec<_>>(),
-            );
-
-            // prepare for the opening proof verification
-            let omega = index.domain.group_gen;
-            batch.push((
-                fq_sponge.clone(),
-                vec![oracles.zeta, oracles.zeta * omega],
-                oracles.v,
-                oracles.u,
-                polynomials,
-                &proof.proof,
-            ));
-        }
-
-        // final check to verify the evaluation proofs
-        match srs.verify::<EFqSponge, _>(group_map, &mut batch, &mut thread_rng()) {
-            false => Err(ProofError::OpenProof),
-            true => Ok(true),
-        }
+    // final check to verify the evaluation proofs
+    match srs.verify::<EFqSponge, _>(group_map, &mut batch, &mut thread_rng()) {
+        false => Err(ProofError::OpenProof),
+        true => Ok(true),
     }
 }


### PR DESCRIPTION
before:

* we expected the verifier to pass enough lagrange bases that we have public inputs
* verify was a batch verify function

after:

* we rely on the pre-computed lagrange bases we already have
* verify -> batch_verify