### PR TITLE
[esy][verifier] return () instead of bool

### DIFF
--- a/kimchi/src/tests/generic.rs
+++ b/kimchi/src/tests/generic.rs
@@ -4,11 +4,9 @@ use crate::index::testing::new_index_for_test;
 use crate::prover::ProverProof;
 use crate::verifier::batch_verify;
 use ark_ff::{UniformRand, Zero};
-use ark_poly::EvaluationDomain;
 use ark_poly::{univariate::DensePolynomial, UVPolynomial};
 use array_init::array_init;
 use commitment_dlog::commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve};
-use commitment_dlog::PolyComm;
 use groupmap::GroupMap;
 use mina_curves::pasta::{
     fp::Fp,

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -393,7 +393,7 @@ where
 pub fn batch_verify<G, EFqSponge, EFrSponge>(
     group_map: &G::Map,
     proofs: &[(&VerifierIndex<G>, &ProverProof<G>)],
-) -> Result<bool>
+) -> Result<()>
 where
     G: CommitmentCurve,
     G::BaseField: PrimeField,
@@ -402,7 +402,7 @@ where
 {
     // if there's no proof to verify, return early
     if proofs.is_empty() {
-        return Ok(true);
+        return Ok(());
     }
 
     // TODO: Account for the different SRS lengths
@@ -690,6 +690,6 @@ where
     // final check to verify the evaluation proofs
     match srs.verify::<EFqSponge, _>(group_map, &mut batch, &mut thread_rng()) {
         false => Err(ProofError::OpenProof),
-        true => Ok(true),
+        true => Ok(()),
     }
 }


### PR DESCRIPTION
no need to return a bool since it's always `true` anyway