### PR TITLE
rename Index to ProverIndex

### DIFF
--- a/kimchi/src/bench.rs
+++ b/kimchi/src/bench.rs
@@ -5,7 +5,7 @@ use crate::{
         wires::{Wire, COLUMNS},
     },
     prover::ProverProof,
-    prover_index::{testing::new_index_for_test, Index},
+    prover_index::{testing::new_index_for_test, ProverIndex},
     verifier::batch_verify,
     verifier_index::VerifierIndex,
 };
@@ -32,7 +32,7 @@ pub const CIRCUIT_SIZE: usize = 27164;
 
 pub struct BenchmarkCtx {
     group_map: BWParameters<VestaParameters>,
-    index: Index<Affine>,
+    index: ProverIndex<Affine>,
     verifier_index: VerifierIndex<Affine>,
 }
 

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     error::{ProofError, Result},
     plonk_sponge::FrSponge,
-    prover_index::Index,
+    prover_index::ProverIndex,
 };
 use ark_ec::AffineCurve;
 use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
@@ -82,14 +82,14 @@ impl<G: CommitmentCurve> ProverProof<G>
 where
     G::BaseField: PrimeField,
 {
-    /// This function constructs prover's zk-proof from the witness & the Index against SRS instance
+    /// This function constructs prover's zk-proof from the witness & the ProverIndex against SRS instance
     ///     witness: computation witness
-    ///     index: Index
+    ///     index: ProverIndex
     ///     RETURN: prover's zk-proof
     pub fn create<EFqSponge: Clone + FqSponge<Fq<G>, G, Fr<G>>, EFrSponge: FrSponge<Fr<G>>>(
         group_map: &G::Map,
         mut witness: [Vec<Fr<G>>; COLUMNS],
-        index: &Index<G>,
+        index: &ProverIndex<G>,
         prev_challenges: Vec<(Vec<Fr<G>>, PolyComm<G>)>,
     ) -> Result<Self> {
         let d1_size = index.cs.domain.d1.size as usize;

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -19,7 +19,7 @@ type Fr<G> = <G as AffineCurve>::ScalarField;
 type Fq<G> = <G as AffineCurve>::BaseField;
 
 //~
-//~ ### The prover ProverIndex
+//~ ### The prover Index
 //~
 
 /// The index used by the prover

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -1,4 +1,4 @@
-//! This module implements the prover index as [Index].
+//! This module implements the prover index as [ProverIndex].
 
 use crate::alphas::Alphas;
 use crate::circuits::{
@@ -19,14 +19,13 @@ type Fr<G> = <G as AffineCurve>::ScalarField;
 type Fq<G> = <G as AffineCurve>::BaseField;
 
 //~
-//~ ### The prover Index
+//~ ### The prover ProverIndex
 //~
 
 /// The index used by the prover
-// TODO: rename as ProverIndex
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Index<G: CommitmentCurve> {
+pub struct ProverIndex<G: CommitmentCurve> {
     /// constraints system polynomials
     #[serde(bound = "ConstraintSystem<Fr<G>>: Serialize + DeserializeOwned")]
     pub cs: ConstraintSystem<Fr<G>>,
@@ -54,7 +53,7 @@ pub struct Index<G: CommitmentCurve> {
     pub fq_sponge_params: ArithmeticSpongeParams<Fq<G>>,
 }
 
-impl<'a, G: CommitmentCurve> Index<G>
+impl<'a, G: CommitmentCurve> ProverIndex<G>
 where
     G::BaseField: PrimeField,
 {
@@ -87,7 +86,7 @@ where
         //~    where the $w_i(x)$ are of degree the size of the domain.
         let max_quot_size = PERMUTS * cs.domain.d1.size as usize;
 
-        Index {
+        ProverIndex {
             cs,
             linearization,
             powers_of_alpha,
@@ -105,7 +104,7 @@ pub mod testing {
     use commitment_dlog::srs::endos;
     use mina_curves::pasta::{pallas::Affine as Other, vesta::Affine, Fp};
 
-    pub fn new_index_for_test(gates: Vec<CircuitGate<Fp>>, public: usize) -> Index<Affine> {
+    pub fn new_index_for_test(gates: Vec<CircuitGate<Fp>>, public: usize) -> ProverIndex<Affine> {
         let fp_sponge_params = oracle::pasta::fp_kimchi::params();
         let cs = ConstraintSystem::<Fp>::create(gates, vec![], fp_sponge_params, public).unwrap();
 
@@ -115,6 +114,6 @@ pub mod testing {
 
         let fq_sponge_params = oracle::pasta::fq_kimchi::params();
         let (endo_q, _endo_r) = endos::<Other>();
-        Index::<Affine>::create(cs, fq_sponge_params, endo_q, srs)
+        ProverIndex::<Affine>::create(cs, fq_sponge_params, endo_q, srs)
     }
 }

--- a/kimchi/src/tests/poseidon.rs
+++ b/kimchi/src/tests/poseidon.rs
@@ -7,7 +7,7 @@ use crate::{
     prover_index::testing::new_index_for_test,
     verifier::batch_verify,
 };
-use crate::{prover::ProverProof, prover_index::Index};
+use crate::{prover::ProverProof, prover_index::ProverIndex};
 use ark_ff::{UniformRand, Zero};
 use ark_poly::{univariate::DensePolynomial, UVPolynomial};
 use array_init::array_init;
@@ -80,7 +80,7 @@ fn test_poseidon() {
 }
 
 /// creates a proof and verifies it
-fn positive(index: &Index<Affine>) {
+fn positive(index: &ProverIndex<Affine>) {
     // constant
     let max_size = 1 << ceil_log2(N_LOWER_BOUND);
 

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -1,5 +1,5 @@
 //! This module implements the verifier index as [VerifierIndex].
-//! You can derive this struct from the [Index] struct.
+//! You can derive this struct from the [ProverIndex] struct.
 
 use crate::alphas::Alphas;
 use crate::circuits::{
@@ -8,7 +8,7 @@ use crate::circuits::{
     gate::LookupsUsed,
     wires::*,
 };
-use crate::prover_index::Index;
+use crate::prover_index::ProverIndex;
 use ark_ec::AffineCurve;
 use ark_ff::PrimeField;
 use ark_poly::{univariate::DensePolynomial, Radix2EvaluationDomain as D};
@@ -119,11 +119,11 @@ pub struct VerifierIndex<G: CommitmentCurve> {
     pub fq_sponge_params: ArithmeticSpongeParams<Fq<G>>,
 }
 
-impl<'a, G: CommitmentCurve> Index<G>
+impl<'a, G: CommitmentCurve> ProverIndex<G>
 where
     G::BaseField: PrimeField,
 {
-    /// Produces the [VerifierIndex] from the prover's [Index].
+    /// Produces the [VerifierIndex] from the prover's [ProverIndex].
     pub fn verifier_index(&self) -> VerifierIndex<G> {
         let domain = self.cs.domain.d1;
         let lookup_index = {

--- a/tools/kimchi-visu/src/lib.rs
+++ b/tools/kimchi-visu/src/lib.rs
@@ -15,7 +15,7 @@ use kimchi::{
             varbasemul::VarbaseMul,
         },
     },
-    prover_index::Index,
+    prover_index::ProverIndex,
 };
 use serde::Serialize;
 use std::{
@@ -77,7 +77,7 @@ where
 }
 
 /// Produces a `circuit.html` in the current folder.
-pub fn visu<G>(index: &Index<G>, witness: Option<Witness<Fr<G>>>)
+pub fn visu<G>(index: &ProverIndex<G>, witness: Option<Witness<Fr<G>>>)
 where
     G: CommitmentCurve,
 {


### PR DESCRIPTION
refactors `Index` to `ProverIndex` as mentioned in #379
`cargo test`, `cargo check` and `cargo build` all run successfully

closes #379 