### PR TITLE
Split out non-table-specific parts of `LookupConstraintSystem`

### DIFF
--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -2,8 +2,9 @@
 
 use crate::circuits::{
     domains::EvaluationDomains,
-    gate::{self, CircuitGate, GateType, LookupInfo, LookupTable, LookupsUsed},
+    gate::{self, CircuitGate, GateType, LookupInfo, LookupTable},
     polynomial::{WitnessEvals, WitnessOverDomains, WitnessShifts},
+    polynomials::lookup::LookupConfiguration,
     wires::*,
 };
 use ark_ff::{FftField, SquareRootField, Zero};
@@ -34,9 +35,6 @@ pub const ZK_ROWS: u64 = 3;
 pub struct LookupConstraintSystem<F: FftField> {
     /// Lookup tables
     #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
-    pub dummy_lookup_value: Vec<F>,
-    pub dummy_lookup_table_id: i32,
-    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
     pub lookup_table: Vec<DP<F>>,
     #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
     pub lookup_table8: Vec<E<F, D<F>>>,
@@ -55,13 +53,9 @@ pub struct LookupConstraintSystem<F: FftField> {
     #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
     pub lookup_selectors: Vec<E<F, D<F>>>,
 
-    /// The kind of lookups used
-    pub lookup_used: LookupsUsed,
-
-    /// The maximum number of lookups per row
-    pub max_lookups_per_row: usize,
-    /// The maximum number of elements in a vector lookup
-    pub max_joint_size: u32,
+    /// Configuration for the lookup constraint.
+    #[serde(bound = "LookupConfiguration<F>: Serialize + DeserializeOwned")]
+    pub configuration: LookupConfiguration<F>,
 }
 
 #[serde_as]
@@ -438,15 +432,17 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
                 // generate the look up selector polynomials
                 Ok(Some(Self {
                     lookup_selectors,
-                    dummy_lookup_value,
-                    dummy_lookup_table_id,
                     lookup_table8,
                     lookup_table: lookup_table_polys,
                     table_ids,
                     table_ids8,
-                    lookup_used,
-                    max_lookups_per_row: lookup_info.max_per_row as usize,
-                    max_joint_size: lookup_info.max_joint_size,
+                    configuration: LookupConfiguration {
+                        lookup_used,
+                        max_lookups_per_row: lookup_info.max_per_row as usize,
+                        max_joint_size: lookup_info.max_joint_size,
+                        dummy_lookup_value,
+                        dummy_lookup_table_id,
+                    },
                 }))
             }
         }

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -6,12 +6,11 @@ use crate::circuits::polynomials::chacha::{ChaCha0, ChaCha1, ChaCha2, ChaChaFina
 use crate::circuits::polynomials::complete_add::CompleteAdd;
 use crate::circuits::polynomials::endomul_scalar::EndomulScalar;
 use crate::circuits::polynomials::endosclmul::EndosclMul;
-use crate::circuits::polynomials::lookup;
+use crate::circuits::polynomials::lookup::{self, LookupConfiguration};
 use crate::circuits::polynomials::permutation;
 use crate::circuits::polynomials::poseidon::Poseidon;
 use crate::circuits::polynomials::varbasemul::VarbaseMul;
 use crate::circuits::{
-    constraints::LookupConstraintSystem,
     expr::{Column, ConstantExpr, Expr, Linearization, PolishToken},
     gate::GateType,
     wires::*,
@@ -22,7 +21,7 @@ use ark_poly::Radix2EvaluationDomain as D;
 pub fn constraints_expr<F: FftField + SquareRootField>(
     domain: D<F>,
     chacha: bool,
-    lookup_constraint_system: &Option<LookupConstraintSystem<F>>,
+    lookup_constraint_system: Option<&LookupConfiguration<F>>,
 ) -> (Expr<ConstantExpr<F>>, Alphas<F>) {
     // register powers of alpha so that we don't reuse them across mutually inclusive constraints
     let mut powers_of_alpha = Alphas::<F>::default();
@@ -55,12 +54,7 @@ pub fn constraints_expr<F: FftField + SquareRootField>(
         powers_of_alpha.register(ArgumentType::Lookup, lookup::CONSTRAINTS);
         let alphas = powers_of_alpha.get_exponents(ArgumentType::Lookup, lookup::CONSTRAINTS);
 
-        let constraints = lookup::constraints(
-            &lcs.dummy_lookup_value,
-            lcs.dummy_lookup_table_id,
-            domain,
-            lcs.max_joint_size,
-        );
+        let constraints = lookup::constraints(lcs, domain);
         let combined = Expr::combine_constraints(alphas, constraints);
         expr += combined;
     }
@@ -70,7 +64,7 @@ pub fn constraints_expr<F: FftField + SquareRootField>(
 }
 
 pub fn linearization_columns<F: FftField + SquareRootField>(
-    lookup_constraint_system: &Option<LookupConstraintSystem<F>>,
+    lookup_constraint_system: Option<&LookupConfiguration<F>>,
 ) -> std::collections::HashSet<Column> {
     let mut h = std::collections::HashSet::new();
     use Column::*;
@@ -96,7 +90,7 @@ pub fn linearization_columns<F: FftField + SquareRootField>(
 pub fn expr_linearization<F: FftField + SquareRootField>(
     domain: D<F>,
     chacha: bool,
-    lookup_constraint_system: &Option<LookupConstraintSystem<F>>,
+    lookup_constraint_system: Option<&LookupConfiguration<F>>,
 ) -> (Linearization<Vec<PolishToken<F>>>, Alphas<F>) {
     let evaluated_cols = linearization_columns::<F>(lookup_constraint_system);
 

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -11,7 +11,9 @@ use crate::{
             complete_add::CompleteAdd,
             endomul_scalar::EndomulScalar,
             endosclmul::EndosclMul,
-            generic, lookup, permutation,
+            generic, lookup,
+            lookup::LookupConfiguration,
+            permutation,
             poseidon::Poseidon,
             varbasemul::VarbaseMul,
         },
@@ -190,11 +192,19 @@ where
             let s = match index.cs.lookup_constraint_system.as_ref() {
                 None
                 | Some(LookupConstraintSystem {
-                    lookup_used: LookupsUsed::Single,
+                    configuration:
+                        LookupConfiguration {
+                            lookup_used: LookupsUsed::Single,
+                            ..
+                        },
                     ..
                 }) => ScalarChallenge(Fr::<G>::zero()),
                 Some(LookupConstraintSystem {
-                    lookup_used: LookupsUsed::Joint,
+                    configuration:
+                        LookupConfiguration {
+                            lookup_used: LookupsUsed::Joint,
+                            ..
+                        },
                     ..
                 }) => ScalarChallenge(fq_sponge.challenge()),
             };
@@ -250,9 +260,9 @@ where
                 None => Fr::<G>::zero(),
                 Some(lcs) => combine_table_entry(
                     joint_combiner,
-                    i32_to_field(lcs.dummy_lookup_table_id),
-                    lcs.max_joint_size,
-                    lcs.dummy_lookup_value.iter(),
+                    i32_to_field(lcs.configuration.dummy_lookup_table_id),
+                    lcs.configuration.max_joint_size,
+                    lcs.configuration.dummy_lookup_value.iter(),
                 ),
             };
             CombinedEntry(x)
@@ -277,7 +287,7 @@ where
                             CombinedEntry(combine_table_entry(
                                 joint_combiner,
                                 table_id,
-                                lcs.max_joint_size,
+                                lcs.configuration.max_joint_size,
                                 row,
                             ))
                         })
@@ -287,13 +297,13 @@ where
                     // `witness` will be consumed when we interpolate, so interpolation will
                     // have to moved below this.
                     let lookup_sorted: Vec<Vec<CombinedEntry<Fr<G>>>> = lookup::sorted(
+                        &lcs.configuration,
                         dummy_lookup_value,
                         iter_lookup_table,
                         index.cs.domain.d1,
                         &index.cs.gates,
                         &witness,
                         joint_combiner,
-                        lcs.max_joint_size,
                     )?;
 
                     let lookup_sorted: Vec<_> = lookup_sorted
@@ -349,18 +359,18 @@ where
                                     // table ID is identically 0.
                                     Fr::<G>::zero(),
                             };
-                        combine_table_entry(joint_combiner, table_id, lcs.max_joint_size, row)
+                        combine_table_entry(joint_combiner, table_id, lcs.configuration.max_joint_size, row)
                     });
 
                     let aggreg =
                         lookup::aggregation::<_, Fr<G>, _>(
+                            &lcs.configuration,
                             dummy_lookup_value.0,
                             iter_lookup_table(),
                             index.cs.domain.d1,
                             &index.cs.gates,
                             &witness,
                             joint_combiner,
-                            lcs.max_joint_size,
                             beta, gamma,
                             &lookup_sorted,
                             rng)?;
@@ -411,7 +421,7 @@ where
                 res.evals.iter_mut().for_each(|e| *e *= joint_combiner);
                 res += col;
             }
-            let table_id_combiner = joint_combiner.pow([lcs.max_joint_size as u64]);
+            let table_id_combiner = joint_combiner.pow([lcs.configuration.max_joint_size as u64]);
             if let Some(table_ids8) = &lcs.table_ids8 {
                 for (x, table_id) in res.evals.iter_mut().zip(table_ids8.evals.iter()) {
                     *x += table_id_combiner * table_id;
@@ -640,12 +650,7 @@ where
             if let Some(lcs) = index.cs.lookup_constraint_system.as_ref() {
                 let lookup_alphas =
                     all_alphas.get_alphas(ArgumentType::Lookup, lookup::CONSTRAINTS);
-                let constraints = lookup::constraints(
-                    &lcs.dummy_lookup_value,
-                    lcs.dummy_lookup_table_id,
-                    index.cs.domain.d1,
-                    lcs.max_joint_size,
-                );
+                let constraints = lookup::constraints(&lcs.configuration, index.cs.domain.d1);
 
                 for (constraint, alpha_pow) in constraints.into_iter().zip_eq(lookup_alphas) {
                     let mut eval = constraint.evaluations(&env);
@@ -738,7 +743,7 @@ where
                             None => base_table,
                             Some(table_ids) => {
                                 let table_combiner =
-                                    joint_combiner.pow([lcs.max_joint_size as u64]);
+                                    joint_combiner.pow([lcs.configuration.max_joint_size as u64]);
                                 base_table
                                     .into_iter()
                                     .zip(table_ids.eval(e, index.max_poly_size))

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -79,7 +79,9 @@ where
         let (linearization, powers_of_alpha) = expr_linearization(
             cs.domain.d1,
             cs.chacha8.is_some(),
-            &cs.lookup_constraint_system,
+            cs.lookup_constraint_system
+                .as_ref()
+                .map(|lcs| &lcs.configuration),
         );
 
         //~ 2. set `max_quot_size` to the degree of the quotient polynomial,

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -141,7 +141,7 @@ where
                 .lookup_constraint_system
                 .as_ref()
                 .map(|cs| LookupVerifierIndex {
-                    lookup_used: cs.lookup_used,
+                    lookup_used: cs.configuration.lookup_used,
                     lookup_selectors: cs
                         .lookup_selectors
                         .iter()
@@ -156,7 +156,7 @@ where
                         self.srs
                             .commit_evaluations_non_hiding(domain, table_ids8, None)
                     }),
-                    max_joint_size: cs.max_joint_size,
+                    max_joint_size: cs.configuration.max_joint_size,
                 })
         };
 


### PR DESCRIPTION
This PR builds upon #400, splitting out a `LookupConfig` structure from the rest of the `LookupConstraintSystem`. `LookupConfig` doesn't depend on the contents of the lookup tables, and so can be shared across multiple different constraint systems.

In particular, this is useful for generating a linearisation in the OCaml bindings, since we can specify the 'shape' of lookup tables in the verifier, but we can't be confident of the table's contents.