### PR TITLE
Poseidon constants moved to a separate constants module #388

### DIFF
--- a/kimchi/src/bench.rs
+++ b/kimchi/src/bench.rs
@@ -17,7 +17,7 @@ use groupmap::{BWParameters, GroupMap};
 use mina_curves::pasta::vesta::VestaParameters;
 use mina_curves::pasta::{fp::Fp, vesta::Affine};
 use oracle::{
-    poseidon::PlonkSpongeConstantsKimchi,
+    constants::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use rand::{rngs::StdRng, SeedableRng};

--- a/kimchi/src/circuits/gates/poseidon.rs
+++ b/kimchi/src/circuits/gates/poseidon.rs
@@ -7,9 +7,11 @@ use crate::circuits::{
 };
 use ark_ff::{FftField, Field};
 use array_init::array_init;
-use oracle::poseidon::{
-    sbox, ArithmeticSponge, ArithmeticSpongeParams, PlonkSpongeConstantsKimchi, Sponge,
-    SpongeConstants,
+use oracle::{
+    poseidon::{
+    sbox, ArithmeticSponge, ArithmeticSpongeParams, Sponge,
+    },
+    constants::{PlonkSpongeConstantsKimchi, SpongeConstants}
 };
 use std::ops::Range;
 

--- a/kimchi/src/circuits/polynomials/poseidon.rs
+++ b/kimchi/src/circuits/polynomials/poseidon.rs
@@ -30,7 +30,7 @@ use crate::circuits::expr::{prologue::*, Cache, ConstantExpr};
 use crate::circuits::gate::{CurrOrNext, GateType};
 use crate::circuits::gates::poseidon::*;
 use ark_ff::{FftField, Field};
-use oracle::poseidon::{PlonkSpongeConstantsKimchi, SpongeConstants};
+use oracle::constants::{PlonkSpongeConstantsKimchi, SpongeConstants};
 use std::marker::PhantomData;
 use CurrOrNext::*;
 

--- a/kimchi/src/plonk_sponge.rs
+++ b/kimchi/src/plonk_sponge.rs
@@ -1,7 +1,10 @@
 use crate::circuits::scalars::ProofEvaluations;
 use ark_ff::{Field, PrimeField};
-use oracle::poseidon::{
-    ArithmeticSponge, ArithmeticSpongeParams, PlonkSpongeConstantsKimchi as SC, Sponge,
+use oracle::{
+    poseidon::{
+    ArithmeticSponge, ArithmeticSpongeParams, Sponge
+    },
+    constants::{PlonkSpongeConstantsKimchi as SC}
 };
 use oracle::sponge::{DefaultFrSponge, ScalarChallenge};
 

--- a/kimchi/src/tests/chacha.rs
+++ b/kimchi/src/tests/chacha.rs
@@ -17,7 +17,7 @@ use mina_curves::pasta::{
     vesta::{Affine, VestaParameters},
 };
 use oracle::{
-    poseidon::PlonkSpongeConstantsKimchi,
+    constants::{PlonkSpongeConstantsKimchi},
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use std::time::Instant;

--- a/kimchi/src/tests/ec.rs
+++ b/kimchi/src/tests/ec.rs
@@ -19,7 +19,7 @@ use mina_curves::pasta::{
     vesta::{Affine, VestaParameters},
 };
 use oracle::{
-    poseidon::PlonkSpongeConstantsKimchi,
+    constants::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use rand::{rngs::StdRng, SeedableRng};

--- a/kimchi/src/tests/endomul.rs
+++ b/kimchi/src/tests/endomul.rs
@@ -20,7 +20,7 @@ use mina_curves::pasta::{
     vesta::{Affine, VestaParameters},
 };
 use oracle::{
-    poseidon::PlonkSpongeConstantsKimchi,
+    constants::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge, ScalarChallenge},
 };
 use rand::{rngs::StdRng, SeedableRng};

--- a/kimchi/src/tests/endomul_scalar.rs
+++ b/kimchi/src/tests/endomul_scalar.rs
@@ -18,7 +18,7 @@ use mina_curves::pasta::{
     vesta::{Affine, VestaParameters},
 };
 use oracle::{
-    poseidon::PlonkSpongeConstantsKimchi,
+    constants::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge, ScalarChallenge},
 };
 use rand::{rngs::StdRng, SeedableRng};

--- a/kimchi/src/tests/generic.rs
+++ b/kimchi/src/tests/generic.rs
@@ -13,7 +13,7 @@ use mina_curves::pasta::{
     vesta::{Affine, VestaParameters},
 };
 use oracle::{
-    poseidon::PlonkSpongeConstantsKimchi,
+    constants::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use rand::{rngs::StdRng, SeedableRng};

--- a/kimchi/src/tests/poseidon.rs
+++ b/kimchi/src/tests/poseidon.rs
@@ -19,7 +19,7 @@ use mina_curves::pasta::{
     vesta::{Affine, VestaParameters},
 };
 use oracle::{
-    poseidon::{PlonkSpongeConstantsKimchi, SpongeConstants},
+    constants::{PlonkSpongeConstantsKimchi, SpongeConstants},
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use rand::{rngs::StdRng, SeedableRng};

--- a/kimchi/src/tests/varbasemul.rs
+++ b/kimchi/src/tests/varbasemul.rs
@@ -20,7 +20,7 @@ use mina_curves::pasta::{
     vesta::{Affine, VestaParameters},
 };
 use oracle::{
-    poseidon::PlonkSpongeConstantsKimchi,
+    constants::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use rand::{rngs::StdRng, SeedableRng};

--- a/oracle/export_test_vectors/src/vectors.rs
+++ b/oracle/export_test_vectors/src/vectors.rs
@@ -6,8 +6,9 @@ use num_bigint::BigUint;
 use oracle::{
     pasta,
     poseidon::{
-        self, ArithmeticSponge as Poseidon, ArithmeticSpongeParams, Sponge as _, SpongeConstants,
+        self, ArithmeticSponge as Poseidon, ArithmeticSpongeParams, Sponge as _
     },
+    constants::{SpongeConstants, self}
 };
 use rand::{prelude::*, Rng};
 use serde::Serialize;
@@ -65,10 +66,10 @@ pub fn generate(mode: Mode, param_type: ParamType) -> TestVectors {
         let input = rand_fields(&mut rng, length);
         let output = match param_type {
             ParamType::Legacy => {
-                poseidon::<poseidon::PlonkSpongeConstantsLegacy>(&input, pasta::fp_legacy::params())
+                poseidon::<constants::PlonkSpongeConstantsLegacy>(&input, pasta::fp_legacy::params())
             }
             ParamType::Kimchi => {
-                poseidon::<poseidon::PlonkSpongeConstantsKimchi>(&input, pasta::fp_kimchi::params())
+                poseidon::<constants::PlonkSpongeConstantsKimchi>(&input, pasta::fp_kimchi::params())
             }
         };
 

--- a/oracle/src/constants.rs
+++ b/oracle/src/constants.rs
@@ -1,0 +1,41 @@
+pub trait SpongeConstants {
+    const SPONGE_CAPACITY: usize = 1;
+    const SPONGE_WIDTH: usize = 3;
+    const SPONGE_RATE: usize = 2;
+    const PERM_ROUNDS_FULL: usize;
+    const PERM_ROUNDS_PARTIAL: usize;
+    const PERM_HALF_ROUNDS_FULL: usize;
+    const PERM_SBOX: u32;
+    const PERM_FULL_MDS: bool;
+    const PERM_INITIAL_ARK: bool;
+}
+
+#[derive(Clone)]
+pub struct PlonkSpongeConstantsLegacy {}
+
+impl SpongeConstants for PlonkSpongeConstantsLegacy {
+    const SPONGE_CAPACITY: usize = 1;
+    const SPONGE_WIDTH: usize = 3;
+    const SPONGE_RATE: usize = 2;
+    const PERM_ROUNDS_FULL: usize = 63;
+    const PERM_ROUNDS_PARTIAL: usize = 0;
+    const PERM_HALF_ROUNDS_FULL: usize = 0;
+    const PERM_SBOX: u32 = 5;
+    const PERM_FULL_MDS: bool = true;
+    const PERM_INITIAL_ARK: bool = true;
+}
+
+#[derive(Clone)]
+pub struct PlonkSpongeConstantsKimchi {}
+
+impl SpongeConstants for PlonkSpongeConstantsKimchi {
+    const SPONGE_CAPACITY: usize = 1;
+    const SPONGE_WIDTH: usize = 3;
+    const SPONGE_RATE: usize = 2;
+    const PERM_ROUNDS_FULL: usize = 55;
+    const PERM_ROUNDS_PARTIAL: usize = 0;
+    const PERM_HALF_ROUNDS_FULL: usize = 0;
+    const PERM_SBOX: u32 = 7;
+    const PERM_FULL_MDS: bool = true;
+    const PERM_INITIAL_ARK: bool = false;
+}

--- a/oracle/src/lib.rs
+++ b/oracle/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod constants;
 pub mod pasta;
 pub mod poseidon;
 pub mod sponge;

--- a/oracle/src/poseidon.rs
+++ b/oracle/src/poseidon.rs
@@ -1,50 +1,9 @@
 //! This module implements Poseidon Hash Function primitive
 
+use crate::constants::SpongeConstants;
 use ark_ff::Field;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-
-pub trait SpongeConstants {
-    const SPONGE_CAPACITY: usize = 1;
-    const SPONGE_WIDTH: usize = 3;
-    const SPONGE_RATE: usize = 2;
-    const PERM_ROUNDS_FULL: usize;
-    const PERM_ROUNDS_PARTIAL: usize;
-    const PERM_HALF_ROUNDS_FULL: usize;
-    const PERM_SBOX: u32;
-    const PERM_FULL_MDS: bool;
-    const PERM_INITIAL_ARK: bool;
-}
-
-#[derive(Clone)]
-pub struct PlonkSpongeConstantsLegacy {}
-
-impl SpongeConstants for PlonkSpongeConstantsLegacy {
-    const SPONGE_CAPACITY: usize = 1;
-    const SPONGE_WIDTH: usize = 3;
-    const SPONGE_RATE: usize = 2;
-    const PERM_ROUNDS_FULL: usize = 63;
-    const PERM_ROUNDS_PARTIAL: usize = 0;
-    const PERM_HALF_ROUNDS_FULL: usize = 0;
-    const PERM_SBOX: u32 = 5;
-    const PERM_FULL_MDS: bool = true;
-    const PERM_INITIAL_ARK: bool = true;
-}
-
-#[derive(Clone)]
-pub struct PlonkSpongeConstantsKimchi {}
-
-impl SpongeConstants for PlonkSpongeConstantsKimchi {
-    const SPONGE_CAPACITY: usize = 1;
-    const SPONGE_WIDTH: usize = 3;
-    const SPONGE_RATE: usize = 2;
-    const PERM_ROUNDS_FULL: usize = 55;
-    const PERM_ROUNDS_PARTIAL: usize = 0;
-    const PERM_HALF_ROUNDS_FULL: usize = 0;
-    const PERM_SBOX: u32 = 7;
-    const PERM_FULL_MDS: bool = true;
-    const PERM_INITIAL_ARK: bool = false;
-}
 
 /// Cryptographic sponge interface - for hashing an arbitrary amount of
 /// data into one or more field elements

--- a/oracle/src/sponge.rs
+++ b/oracle/src/sponge.rs
@@ -1,4 +1,5 @@
-use crate::poseidon::{ArithmeticSponge, ArithmeticSpongeParams, Sponge, SpongeConstants};
+use crate::constants::SpongeConstants;
+use crate::poseidon::{ArithmeticSponge, ArithmeticSpongeParams, Sponge};
 use ark_ec::{short_weierstrass_jacobian::GroupAffine, SWModelParameters};
 use ark_ff::{BigInteger, Field, FpParameters, One, PrimeField, Zero};
 

--- a/oracle/tests/poseidon_tests.rs
+++ b/oracle/tests/poseidon_tests.rs
@@ -8,10 +8,10 @@ use std::path::PathBuf; // needed for ::new() sponge
 
 use oracle::poseidon::ArithmeticSponge as Poseidon;
 
+use oracle::constants::PlonkSpongeConstantsKimchi;
+use oracle::constants::PlonkSpongeConstantsLegacy;
 use oracle::pasta::fp_kimchi as SpongeParametersKimchi;
 use oracle::pasta::fp_legacy as SpongeParametersLegacy;
-use oracle::poseidon::PlonkSpongeConstantsKimchi;
-use oracle::poseidon::PlonkSpongeConstantsLegacy;
 
 //
 // Helpers for test vectors

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -920,7 +920,7 @@ mod tests {
     use ark_poly::Polynomial;
     use array_init::array_init;
     use mina_curves::pasta::{fp::Fp, vesta::Affine as VestaG};
-    use oracle::poseidon::PlonkSpongeConstantsKimchi as SC;
+    use oracle::constants::PlonkSpongeConstantsKimchi as SC;
     use oracle::{pasta::fq_kimchi::params as spongeFqParams, sponge::DefaultFqSponge};
     use rand::{rngs::StdRng, SeedableRng};
 

--- a/poly-commitment/tests/batch_15_wires.rs
+++ b/poly-commitment/tests/batch_15_wires.rs
@@ -12,7 +12,7 @@ use mina_curves::pasta::{
 };
 use o1_utils::ExtendedDensePolynomial;
 
-use oracle::poseidon::PlonkSpongeConstantsKimchi as SC;
+use oracle::constants::PlonkSpongeConstantsKimchi as SC;
 use oracle::sponge::DefaultFqSponge;
 use oracle::FqSponge;
 

--- a/poly-commitment/tests/commitment.rs
+++ b/poly-commitment/tests/commitment.rs
@@ -12,7 +12,7 @@ use mina_curves::pasta::{
     Fp,
 };
 use o1_utils::ExtendedDensePolynomial as _;
-use oracle::poseidon::PlonkSpongeConstantsKimchi as SC;
+use oracle::constants::PlonkSpongeConstantsKimchi as SC;
 use oracle::sponge::DefaultFqSponge;
 use oracle::FqSponge as _;
 use rand::Rng;

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -20,9 +20,9 @@ pub use signature::Signature;
 use oracle::{
     pasta,
     poseidon::{
-        ArithmeticSponge, ArithmeticSpongeParams, PlonkSpongeConstantsLegacy, Sponge,
-        SpongeConstants,
+        ArithmeticSponge, ArithmeticSpongeParams, Sponge
     },
+    constants::{PlonkSpongeConstantsLegacy, SpongeConstants}
 };
 
 use ark_ec::AffineCurve;

--- a/signer/src/schnorr.rs
+++ b/signer/src/schnorr.rs
@@ -18,7 +18,10 @@ use blake2::{
     digest::{Update, VariableOutput},
     Blake2bVar,
 };
-use oracle::poseidon::{ArithmeticSponge, Sponge, SpongeConstants};
+use oracle:: {
+    poseidon::{ArithmeticSponge, Sponge},
+    constants::{SpongeConstants}
+};
 use std::ops::Neg;
 
 use crate::{

--- a/signer/tests/tests.rs
+++ b/signer/tests/tests.rs
@@ -259,10 +259,10 @@ fn sign_delegation_test_4() {
 
 #[test]
 fn custom_signer_test() {
-    use oracle::{pasta, poseidon};
+    use oracle::{pasta, constants};
 
     let kp = Keypair::rand(&mut rand::rngs::OsRng);
-    let mut ctx = mina_signer::custom::<poseidon::PlonkSpongeConstantsKimchi>(
+    let mut ctx = mina_signer::custom::<constants::PlonkSpongeConstantsKimchi>(
         pasta::fp_kimchi::params(),
         NetworkId::MAINNET,
     );


### PR DESCRIPTION
Created a separate module `constants` under oracle which now hosts the following constants structs
- PlonkSpongeConstantsLegacy
- PlonkSpongeConstantsKimchi