### PR TITLE
Split out non-table-specific parts of `LookupConstraintSystem` (redux)

### DIFF
--- a/kimchi/src/alphas.rs
+++ b/kimchi/src/alphas.rs
@@ -326,7 +326,11 @@ mod tests {
         let (_linearization, powers_of_alpha) = expr_linearization(
             index.cs.domain.d1,
             index.cs.chacha8.is_some(),
-            &index.cs.lookup_constraint_system,
+            index
+                .cs
+                .lookup_constraint_system
+                .as_ref()
+                .map(|lcs| &lcs.configuration),
         );
 
         // make sure this is present in the specification

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -168,7 +168,7 @@ pub struct LookupInfo<F> {
     /// The maximum length of an element of `kinds`. This can be computed from `kinds`.
     pub max_per_row: usize,
     /// The maximum joint size of any joint lookup in a constraint in `kinds`. This can be computed from `kinds`.
-    pub max_joint_size: usize,
+    pub max_joint_size: u32,
     /// An empty vector.
     empty: Vec<JointLookup<F>>,
 }
@@ -211,7 +211,7 @@ impl<F: FftField> LookupInfo<F> {
         LookupInfo {
             max_joint_size: kinds.iter().fold(0, |acc0, v| {
                 v.iter()
-                    .fold(acc0, |acc, j| std::cmp::max(acc, j.entry.len()))
+                    .fold(acc0, |acc, j| std::cmp::max(acc, j.entry.len() as u32))
             }),
 
             kinds_map,

--- a/kimchi/src/circuits/polynomials/lookup.rs
+++ b/kimchi/src/circuits/polynomials/lookup.rs
@@ -236,6 +236,10 @@ pub struct LookupConfiguration<F: FftField> {
     pub max_joint_size: u32,
 
     #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
+    /// A placeholder value that is known to appear in the lookup table.
+    /// This is used to pad the lookups to `max_lookups_per_row` when fewer lookups are used in a
+    /// particular row, so that we can treat each row uniformly as having the same number of
+    /// lookups.
     pub dummy_lookup_value: Vec<F>,
 }
 

--- a/kimchi/src/circuits/polynomials/lookup.rs
+++ b/kimchi/src/circuits/polynomials/lookup.rs
@@ -123,7 +123,10 @@
 use crate::{
     circuits::{
         expr::{prologue::*, Column, ConstantExpr, Variable},
-        gate::{CircuitGate, CurrOrNext, JointLookup, LocalPosition, LookupInfo, SingleLookup},
+        gate::{
+            CircuitGate, CurrOrNext, JointLookup, LocalPosition, LookupInfo, LookupsUsed,
+            SingleLookup,
+        },
         wires::COLUMNS,
     },
     error::{ProofError, Result},
@@ -131,6 +134,8 @@ use crate::{
 use ark_ff::{FftField, Field, One, Zero};
 use ark_poly::{Evaluations, Radix2EvaluationDomain as D};
 use rand::Rng;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use std::collections::HashMap;
 use CurrOrNext::*;
 
@@ -215,6 +220,23 @@ pub fn zk_patch<R: Rng + ?Sized, F: FftField>(
     e.extend((0..((n - ZK_ROWS) - k)).map(|_| F::zero()));
     e.extend((0..ZK_ROWS).map(|_| F::rand(rng)));
     Evaluations::<F, D<F>>::from_vec_and_domain(e, d)
+}
+
+/// Configuration for the lookup constraint.
+/// These values are independent of the choice of lookup values.
+#[serde_as]
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct LookupConfiguration<F: FftField> {
+    /// The kind of lookups used
+    pub lookup_used: LookupsUsed,
+
+    /// The maximum number of lookups per row
+    pub max_lookups_per_row: usize,
+    /// The maximum number of elements in a vector lookup
+    pub max_joint_size: u32,
+
+    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
+    pub dummy_lookup_value: Vec<F>,
 }
 
 /// Checks that all the lookup constraints are satisfied.
@@ -392,7 +414,6 @@ pub fn sorted<
     I: Iterator<Item = E>,
     G: Fn() -> I,
 >(
-    // TODO: Multiple tables
     dummy_lookup_value: E,
     lookup_table: G,
     d1: D<F>,
@@ -586,7 +607,7 @@ pub fn aggregation<R: Rng + ?Sized, F: FftField, I: Iterator<Item = F>>(
 }
 
 /// Specifies the lookup constraints as expressions.
-pub fn constraints<F: FftField>(dummy_lookup: &[F], d1: D<F>) -> Vec<E<F>> {
+pub fn constraints<F: FftField>(configuration: &LookupConfiguration<F>, d1: D<F>) -> Vec<E<F>> {
     // Something important to keep in mind is that the last 2 rows of
     // all columns will have random values in them to maintain zero-knowledge.
     //
@@ -614,7 +635,8 @@ pub fn constraints<F: FftField>(dummy_lookup: &[F], d1: D<F>) -> Vec<E<F>> {
     let one: E<F> = E::one();
     let non_lookup_indcator = one - lookup_indicator;
 
-    let dummy_lookup: ConstantExpr<F> = dummy_lookup
+    let dummy_lookup: ConstantExpr<F> = configuration
+        .dummy_lookup_value
         .iter()
         .rev()
         .fold(ConstantExpr::zero(), |acc, x| {

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -6,12 +6,11 @@ use crate::circuits::polynomials::chacha::{ChaCha0, ChaCha1, ChaCha2, ChaChaFina
 use crate::circuits::polynomials::complete_add::CompleteAdd;
 use crate::circuits::polynomials::endomul_scalar::EndomulScalar;
 use crate::circuits::polynomials::endosclmul::EndosclMul;
-use crate::circuits::polynomials::lookup;
+use crate::circuits::polynomials::lookup::{self, LookupConfiguration};
 use crate::circuits::polynomials::permutation;
 use crate::circuits::polynomials::poseidon::Poseidon;
 use crate::circuits::polynomials::varbasemul::VarbaseMul;
 use crate::circuits::{
-    constraints::LookupConstraintSystem,
     expr::{Column, ConstantExpr, Expr, Linearization, PolishToken},
     gate::GateType,
     wires::*,
@@ -22,7 +21,7 @@ use ark_poly::Radix2EvaluationDomain as D;
 pub fn constraints_expr<F: FftField + SquareRootField>(
     domain: D<F>,
     chacha: bool,
-    lookup_constraint_system: &Option<LookupConstraintSystem<F>>,
+    lookup_constraint_system: Option<&LookupConfiguration<F>>,
 ) -> (Expr<ConstantExpr<F>>, Alphas<F>) {
     // register powers of alpha so that we don't reuse them across mutually inclusive constraints
     let mut powers_of_alpha = Alphas::<F>::default();
@@ -55,7 +54,7 @@ pub fn constraints_expr<F: FftField + SquareRootField>(
         powers_of_alpha.register(ArgumentType::Lookup, lookup::CONSTRAINTS);
         let alphas = powers_of_alpha.get_exponents(ArgumentType::Lookup, lookup::CONSTRAINTS);
 
-        let constraints = lookup::constraints(&lcs.dummy_lookup_value, domain);
+        let constraints = lookup::constraints(lcs, domain);
         let combined = Expr::combine_constraints(alphas, constraints);
         expr += combined;
     }
@@ -65,7 +64,7 @@ pub fn constraints_expr<F: FftField + SquareRootField>(
 }
 
 pub fn linearization_columns<F: FftField + SquareRootField>(
-    lookup_constraint_system: &Option<LookupConstraintSystem<F>>,
+    lookup_constraint_system: Option<&LookupConfiguration<F>>,
 ) -> std::collections::HashSet<Column> {
     let mut h = std::collections::HashSet::new();
     use Column::*;
@@ -91,7 +90,7 @@ pub fn linearization_columns<F: FftField + SquareRootField>(
 pub fn expr_linearization<F: FftField + SquareRootField>(
     domain: D<F>,
     chacha: bool,
-    lookup_constraint_system: &Option<LookupConstraintSystem<F>>,
+    lookup_constraint_system: Option<&LookupConfiguration<F>>,
 ) -> (Linearization<Vec<PolishToken<F>>>, Alphas<F>) {
     let evaluated_cols = linearization_columns::<F>(lookup_constraint_system);
 

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -11,7 +11,9 @@ use crate::{
             complete_add::CompleteAdd,
             endomul_scalar::EndomulScalar,
             endosclmul::EndosclMul,
-            generic, lookup, permutation,
+            generic, lookup,
+            lookup::LookupConfiguration,
+            permutation,
             poseidon::Poseidon,
             varbasemul::VarbaseMul,
         },
@@ -199,11 +201,19 @@ where
             let s = match index.cs.lookup_constraint_system.as_ref() {
                 None
                 | Some(LookupConstraintSystem {
-                    lookup_used: LookupsUsed::Single,
+                    configuration:
+                        LookupConfiguration {
+                            lookup_used: LookupsUsed::Single,
+                            ..
+                        },
                     ..
                 }) => ScalarChallenge(Fr::<G>::zero()),
                 Some(LookupConstraintSystem {
-                    lookup_used: LookupsUsed::Joint,
+                    configuration:
+                        LookupConfiguration {
+                            lookup_used: LookupsUsed::Joint,
+                            ..
+                        },
                     ..
                 }) => ScalarChallenge(fq_sponge.challenge()),
             };
@@ -257,7 +267,9 @@ where
         let dummy_lookup_value = {
             let x = match index.cs.lookup_constraint_system.as_ref() {
                 None => Fr::<G>::zero(),
-                Some(lcs) => combine_table_entry(joint_combiner, lcs.dummy_lookup_value.iter()),
+                Some(lcs) => {
+                    combine_table_entry(joint_combiner, lcs.configuration.dummy_lookup_value.iter())
+                }
             };
             CombinedEntry(x)
         };
@@ -614,7 +626,7 @@ where
             if let Some(lcs) = index.cs.lookup_constraint_system.as_ref() {
                 let lookup_alphas =
                     all_alphas.get_alphas(ArgumentType::Lookup, lookup::CONSTRAINTS);
-                let constraints = lookup::constraints(&lcs.dummy_lookup_value, index.cs.domain.d1);
+                let constraints = lookup::constraints(&lcs.configuration, index.cs.domain.d1);
 
                 for (constraint, alpha_pow) in constraints.into_iter().zip_eq(lookup_alphas) {
                     let mut eval = constraint.evaluations(&env);

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -75,7 +75,9 @@ where
         let (linearization, powers_of_alpha) = expr_linearization(
             cs.domain.d1,
             cs.chacha8.is_some(),
-            &cs.lookup_constraint_system,
+            cs.lookup_constraint_system
+                .as_ref()
+                .map(|lcs| &lcs.configuration),
         );
 
         // set `max_quot_size` to the degree of the quotient polynomial,

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -133,7 +133,7 @@ where
                 .lookup_constraint_system
                 .as_ref()
                 .map(|cs| LookupVerifierIndex {
-                    lookup_used: cs.lookup_used,
+                    lookup_used: cs.configuration.lookup_used,
                     lookup_selectors: cs
                         .lookup_selectors
                         .iter()


### PR DESCRIPTION
This is PR #405 cherry-picked onto master. To quote from there:

> This PR builds upon https://github.com/o1-labs/proof-systems/pull/400, splitting out a LookupConfig structure from the rest of the LookupConstraintSystem. LookupConfig doesn't depend on the contents of the lookup tables, and so can be shared across multiple different constraint systems.

> In particular, this is useful for generating a linearisation in the OCaml bindings, since we can specify the 'shape' of lookup tables in the verifier, but we can't be confident of the table's contents.