### PR TITLE
Use a single implementation for `combine_table_entry`

### DIFF
--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1925,7 +1925,7 @@ impl<F: Field> Mul<F> for Expr<ConstantExpr<F>> {
     type Output = Expr<ConstantExpr<F>>;
 
     fn mul(self, y: F) -> Self::Output {
-        Expr::Constant(ConstantExpr::Literal(F::from(y))) * self
+        Expr::Constant(ConstantExpr::Literal(y)) * self
     }
 }
 

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1921,6 +1921,14 @@ impl<F: Field> From<u64> for Expr<ConstantExpr<F>> {
     }
 }
 
+impl<F: Field> Mul<F> for Expr<ConstantExpr<F>> {
+    type Output = Expr<ConstantExpr<F>>;
+
+    fn mul(self, y: F) -> Self::Output {
+        Expr::Constant(ConstantExpr::Literal(F::from(y))) * self
+    }
+}
+
 //
 // Display
 //

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -99,6 +99,8 @@ pub struct JointLookup<SingleLookup> {
     pub entry: Vec<SingleLookup>,
 }
 
+/// A spec for checking that the given vector belongs to a vector-valued lookup table, where the
+/// components of the vector are computed from a linear combination of locally-accessible cells.
 pub type JointLookupSpec<F> = JointLookup<SingleLookup<F>>;
 
 impl<F: Zero + One + Clone> JointLookup<F> {
@@ -110,6 +112,8 @@ impl<F: Zero + One + Clone> JointLookup<F> {
 }
 
 impl<F: Copy> JointLookup<SingleLookup<F>> {
+    /// Reduce linear combinations in the lookup entries to a single value, resolving local
+    /// positions using the given function.
     pub fn reduce<K, G: Fn(LocalPosition) -> K>(&self, eval: &G) -> JointLookup<K>
     where
         K: Zero,
@@ -121,6 +125,8 @@ impl<F: Copy> JointLookup<SingleLookup<F>> {
         }
     }
 
+    /// Evaluate the combined value of a joint-lookup, resolving local positions using the given
+    /// function.
     pub fn evaluate<K, G: Fn(LocalPosition) -> K>(&self, joint_combiner: K, eval: &G) -> K
     where
         K: Zero + One + Clone,

--- a/kimchi/src/circuits/polynomials/lookup.rs
+++ b/kimchi/src/circuits/polynomials/lookup.rs
@@ -122,7 +122,7 @@
 
 use crate::{
     circuits::{
-        expr::{prologue::*, Column, ConstantExpr, Variable},
+        expr::{prologue::*, Column, ConstantExpr},
         gate::{CircuitGate, CurrOrNext, JointLookupSpec, LocalPosition, LookupInfo, LookupsUsed},
         wires::COLUMNS,
     },
@@ -635,12 +635,7 @@ pub fn constraints<F: FftField>(configuration: &LookupConfiguration<F>, d1: D<F>
             .collect()
     };
 
-    let eval = |pos: LocalPosition| {
-        E::Cell(Variable {
-            col: Column::Witness(pos.column),
-            row: pos.row,
-        })
-    };
+    let eval = |pos: LocalPosition| witness(pos.column, pos.row);
 
     // This is set up so that on rows that have lookups, chunk will be equal
     // to the product over all lookups `f` in that row of `gamma + f`

--- a/kimchi/src/circuits/polynomials/lookup.rs
+++ b/kimchi/src/circuits/polynomials/lookup.rs
@@ -298,7 +298,7 @@ pub fn verify<F: FftField, I: Iterator<Item = F>, G: Fn() -> I>(
             witness[pos.column][row]
         };
         for joint_lookup in spec.iter() {
-            let joint_lookup_evaluation = joint_lookup.reduce(&eval).evaluate(joint_combiner);
+            let joint_lookup_evaluation = joint_lookup.evaluate(joint_combiner, &eval);
             *all_lookups.entry(joint_lookup_evaluation).or_insert(0) += 1
         }
 
@@ -356,7 +356,7 @@ impl<F: Field> Entry for CombinedEntry<F> {
             witness[pos.column][row]
         };
 
-        CombinedEntry(j.reduce(&eval).evaluate(*joint_combiner))
+        CombinedEntry(j.evaluate(*joint_combiner, &eval))
     }
 }
 
@@ -567,7 +567,7 @@ pub fn aggregation<R: Rng + ?Sized, F: FftField, I: Iterator<Item = F>>(
                 // `max_lookups_per_row (=4) * n` field elements of
                 // memory.
                 spec.iter().fold(padding, |acc, j| {
-                    acc * (gamma + j.reduce(&eval).evaluate(joint_combiner))
+                    acc * (gamma + j.evaluate(joint_combiner, &eval))
                 })
             };
 
@@ -653,8 +653,7 @@ pub fn constraints<F: FftField>(configuration: &LookupConfiguration<F>, d1: D<F>
         spec.iter()
             .map(|j| {
                 E::Constant(ConstantExpr::Gamma)
-                    + j.reduce(&eval)
-                        .evaluate(E::constant(ConstantExpr::JointCombiner))
+                    + j.evaluate(E::constant(ConstantExpr::JointCombiner), &eval)
             })
             .fold(E::Constant(padding), |acc: E<F>, x| acc * x)
     };

--- a/kimchi/src/circuits/polynomials/lookup.rs
+++ b/kimchi/src/circuits/polynomials/lookup.rs
@@ -123,9 +123,7 @@
 use crate::{
     circuits::{
         expr::{prologue::*, Column, ConstantExpr, Variable},
-        gate::{
-            CircuitGate, CurrOrNext, JointLookupSpec, LocalPosition, LookupInfo, LookupsUsed,
-        },
+        gate::{CircuitGate, CurrOrNext, JointLookupSpec, LocalPosition, LookupInfo, LookupsUsed},
         wires::COLUMNS,
     },
     error::ProofError,


### PR DESCRIPTION
This PR generalises `JointLookup` so that it can handle `SingleLookup<F>`s, `F`s, or `Expr<ConstantExpr<F>>`s as arguments, and relaxes the constraints on `combine_table_entry`.

This allows us to
* store the 'dummy' lookup value as a `JointLookup` in the constraint system, rather than unpacking and re-packing it
  - not done here; this will be in a follow-up PR
* unify the 3 different implementations of `combine_table_entry` into one
  - happily, the 'fold' implementation in `combine_table_entry` minimises the number of multiplications compared to the others, so this is also an efficiency gain
* have a single point to change when we add `table_id`s