### PR TITLE
move ceil_log2 into o1_utils::math package

### DIFF
--- a/kimchi/src/bench.rs
+++ b/kimchi/src/bench.rs
@@ -12,7 +12,7 @@ use crate::{
 use ark_ff::UniformRand;
 use ark_poly::{univariate::DensePolynomial, UVPolynomial};
 use array_init::array_init;
-use commitment_dlog::commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve};
+use commitment_dlog::commitment::{b_poly_coefficients, CommitmentCurve};
 use groupmap::{BWParameters, GroupMap};
 use mina_curves::pasta::vesta::VestaParameters;
 use mina_curves::pasta::{fp::Fp, vesta::Affine};
@@ -21,6 +21,8 @@ use oracle::{
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use rand::{rngs::StdRng, SeedableRng};
+
+use o1_utils::math;
 
 type SpongeParams = PlonkSpongeConstantsKimchi;
 type BaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;
@@ -87,7 +89,7 @@ impl BenchmarkCtx {
 
         // previous opening for recursion
         let prev = {
-            let k = ceil_log2(self.index.srs.g.len());
+            let k = math::ceil_log2(self.index.srs.g.len());
             let chals: Vec<_> = (0..k).map(|_| Fp::rand(rng)).collect();
             let comm = {
                 let coeffs = b_poly_coefficients(&chals);

--- a/kimchi/src/tests/chacha.rs
+++ b/kimchi/src/tests/chacha.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use array_init::array_init;
 use colored::Colorize;
-use commitment_dlog::commitment::{ceil_log2, CommitmentCurve};
+use commitment_dlog::commitment::CommitmentCurve;
 use groupmap::GroupMap;
 use mina_curves::pasta::{
     fp::Fp,
@@ -21,6 +21,8 @@ use oracle::{
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use std::time::Instant;
+
+use o1_utils::math;
 
 // aliases
 
@@ -35,7 +37,7 @@ fn chacha_prover() {
     let num_chachas = 8;
     let rows_per_chacha = 20 * 4 * 10;
     let n_lower_bound = rows_per_chacha * num_chachas;
-    let max_size = 1 << ceil_log2(n_lower_bound);
+    let max_size = 1 << math::ceil_log2(n_lower_bound);
     println!("{} {}", n_lower_bound, max_size);
 
     let s0: Vec<u32> = vec![

--- a/kimchi/src/tests/generic.rs
+++ b/kimchi/src/tests/generic.rs
@@ -6,7 +6,7 @@ use crate::verifier::{batch_verify, verify};
 use ark_ff::{UniformRand, Zero};
 use ark_poly::{univariate::DensePolynomial, UVPolynomial};
 use array_init::array_init;
-use commitment_dlog::commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve};
+use commitment_dlog::commitment::{b_poly_coefficients, CommitmentCurve};
 use groupmap::GroupMap;
 use mina_curves::pasta::{
     fp::Fp,
@@ -17,6 +17,8 @@ use oracle::{
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use rand::{rngs::StdRng, SeedableRng};
+
+use o1_utils::math;
 
 // aliases
 
@@ -62,7 +64,7 @@ fn verify_proof(gates: Vec<CircuitGate<Fp>>, witness: [Vec<Fp>; COLUMNS], public
 
     // previous opening for recursion
     let prev = {
-        let k = ceil_log2(index.srs.g.len());
+        let k = math::ceil_log2(index.srs.g.len());
         let chals: Vec<_> = (0..k).map(|_| Fp::rand(rng)).collect();
         let comm = {
             let coeffs = b_poly_coefficients(&chals);

--- a/kimchi/src/tests/poseidon.rs
+++ b/kimchi/src/tests/poseidon.rs
@@ -5,7 +5,7 @@ use ark_ff::{UniformRand, Zero};
 use ark_poly::{univariate::DensePolynomial, UVPolynomial};
 use array_init::array_init;
 use colored::Colorize;
-use commitment_dlog::commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve};
+use commitment_dlog::commitment::{b_poly_coefficients, CommitmentCurve};
 use groupmap::GroupMap;
 use mina_curves::pasta::{
     fp::Fp,
@@ -29,6 +29,8 @@ use crate::{
 };
 use crate::{prover::ProverProof, prover_index::ProverIndex};
 
+use o1_utils::math;
+
 // aliases
 
 type SpongeParams = PlonkSpongeConstantsKimchi;
@@ -46,7 +48,7 @@ const N_LOWER_BOUND: usize = (POS_ROWS_PER_HASH + 1) * NUM_POS; // Plonk domain 
 
 #[test]
 fn test_poseidon() {
-    let max_size = 1 << ceil_log2(N_LOWER_BOUND);
+    let max_size = 1 << math::ceil_log2(N_LOWER_BOUND);
     println!("max_size = {}", max_size);
     println!("rounds per hash = {}", ROUNDS_PER_HASH);
     println!("rounds per row = {}", ROUNDS_PER_ROW);
@@ -85,7 +87,7 @@ fn test_poseidon() {
 /// creates a proof and verifies it
 fn positive(index: &ProverIndex<Affine>) {
     // constant
-    let max_size = 1 << ceil_log2(N_LOWER_BOUND);
+    let max_size = 1 << math::ceil_log2(N_LOWER_BOUND);
 
     // set up
     let rng = &mut StdRng::from_seed([0u8; 32]);
@@ -136,7 +138,7 @@ fn positive(index: &ProverIndex<Affine>) {
 
         //
         let prev = {
-            let k = ceil_log2(index.srs.g.len());
+            let k = math::ceil_log2(index.srs.g.len());
             let chals: Vec<_> = (0..k).map(|_| Fp::rand(rng)).collect();
             let comm = {
                 let coeffs = b_poly_coefficients(&chals);

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -21,6 +21,7 @@ use ark_poly::{
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use core::ops::{Add, Sub};
 use groupmap::{BWParameters, GroupMap};
+use o1_utils::math;
 use o1_utils::ExtendedDensePolynomial as _;
 use oracle::{sponge::ScalarChallenge, FqSponge};
 use rand_core::{CryptoRng, RngCore};
@@ -262,22 +263,6 @@ pub fn b_poly_coefficients<F: Field>(chals: &[F]) -> Vec<F> {
         s[i] = s[i - (pow >> 1)] * chals[rounds - 1 - (k - 1)];
     }
     s
-}
-
-// TODO: move to utils
-/// Returns ceil(log2(d)) but panics if d = 0.
-pub fn ceil_log2(d: usize) -> usize {
-    assert!(d != 0);
-    let mut pow2 = 1;
-    let mut ceil_log2 = 0;
-    while d > pow2 {
-        ceil_log2 += 1;
-        pow2 = match pow2.checked_mul(2) {
-            Some(x) => x,
-            None => break,
-        }
-    }
-    ceil_log2
 }
 
 /// `pows(d, x)` returns a vector containing the first `d` powers of the field element `x` (from `1` to `x^(d-1)`).
@@ -720,7 +705,7 @@ impl<G: CommitmentCurve> SRS<G> {
 
         let nonzero_length = self.g.len();
 
-        let max_rounds = ceil_log2(nonzero_length);
+        let max_rounds = math::ceil_log2(nonzero_length);
 
         let padded_length = 1 << max_rounds;
 
@@ -937,7 +922,7 @@ mod tests {
             (usize::MAX, 64),
         ];
         for (d, expected_res) in tests.iter() {
-            let res = ceil_log2(*d);
+            let res = math::ceil_log2(*d);
             println!("ceil(log2({})) = {}, expected = {}", d, res, expected_res);
         }
     }

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -3,6 +3,7 @@ use crate::srs::SRS;
 use ark_ec::{msm::VariableBaseMSM, AffineCurve, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
 use ark_poly::univariate::DensePolynomial;
+use o1_utils::math;
 use oracle::{sponge::ScalarChallenge, FqSponge};
 use rand_core::{CryptoRng, RngCore};
 use rayon::prelude::*;
@@ -38,7 +39,7 @@ impl<G: CommitmentCurve> SRS<G> {
         RNG: RngCore + CryptoRng,
         G::BaseField: PrimeField,
     {
-        let rounds = ceil_log2(self.g.len());
+        let rounds = math::ceil_log2(self.g.len());
         let padded_length = 1 << rounds;
 
         // TODO: Trim this to the degree of the largest polynomial
@@ -105,7 +106,7 @@ impl<G: CommitmentCurve> SRS<G> {
             (plnm.to_dense_polynomial(), omega)
         };
 
-        let rounds = ceil_log2(self.g.len());
+        let rounds = math::ceil_log2(self.g.len());
 
         // b_j = sum_i r^i elm_i^j
         let b_init = {

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -2,6 +2,7 @@ pub mod dense_polynomial;
 pub mod evaluations;
 pub mod field_helpers;
 pub mod hasher;
+pub mod math;
 pub mod serialization;
 
 pub use dense_polynomial::ExtendedDensePolynomial;

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -1,0 +1,15 @@
+/// Returns ceil(log2(d)) but panics if d = 0.
+
+pub fn ceil_log2(d: usize) -> usize {
+    assert!(d != 0);
+    let mut pow2 = 1;
+    let mut ceil_log2 = 0;
+    while d > pow2 {
+        ceil_log2 += 1;
+        pow2 = match pow2.checked_mul(2) {
+            Some(x) => x,
+            None => break,
+        }
+    }
+    ceil_log2
+}

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -1,5 +1,6 @@
 /// Returns ceil(log2(d)) but panics if d = 0.
 
+// NOTE: should this really be usize, since usize is depended on the underlying system architecture?
 pub fn ceil_log2(d: usize) -> usize {
     assert!(d != 0);
     let mut pow2 = 1;

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -1,7 +1,9 @@
-/// Returns ceil(log2(d)) but panics if d = 0.
+//! This modules implements some math helper functions.
 
-// NOTE: should this really be usize, since usize is depended on the underlying system architecture?
+/// Returns ceil(log2(d)) but panics if d = 0.
 pub fn ceil_log2(d: usize) -> usize {
+    // NOTE: should this really be usize, since usize is depended on the underlying system architecture?
+
     assert!(d != 0);
     let mut pow2 = 1;
     let mut ceil_log2 = 0;


### PR DESCRIPTION

moves `ceil_log2` into the package `o1_utils::math` under `utils/src/math.rs`

see https://github.com/o1-labs/proof-systems/issues/386