### PR TITLE
[easy][gates] remove Default implementation

### DIFF
--- a/kimchi/src/circuits/polynomials/chacha.rs
+++ b/kimchi/src/circuits/polynomials/chacha.rs
@@ -248,7 +248,6 @@ fn line<F: Field>(nybble_rotation: usize) -> Vec<E<F>> {
 //
 
 /// Implementation of the ChaCha0 gate
-#[derive(Default)]
 pub struct ChaCha0<F>(PhantomData<F>);
 
 impl<F> Argument<F> for ChaCha0<F>
@@ -265,8 +264,6 @@ where
 }
 
 /// Implementation of the ChaCha1 gate
-
-#[derive(Default)]
 pub struct ChaCha1<F>(PhantomData<F>);
 
 impl<F> Argument<F> for ChaCha1<F>
@@ -283,8 +280,6 @@ where
 }
 
 /// Implementation of the ChaCha2 gate
-
-#[derive(Default)]
 pub struct ChaCha2<F>(PhantomData<F>);
 
 impl<F> Argument<F> for ChaCha2<F>
@@ -301,8 +296,6 @@ where
 }
 
 /// Implementation of the ChaChaFinal gate
-
-#[derive(Default)]
 pub struct ChaChaFinal<F>(PhantomData<F>);
 
 impl<F> Argument<F> for ChaChaFinal<F>

--- a/kimchi/src/circuits/polynomials/complete_add.rs
+++ b/kimchi/src/circuits/polynomials/complete_add.rs
@@ -87,7 +87,6 @@ fn zero_check<F: Field>(z: E<F>, z_inv: E<F>, r: E<F>) -> Vec<E<F>> {
 /// for doubling.
 ///
 /// See [here](https://en.wikipedia.org/wiki/Elliptic_curve#The_group_law) for the formulas used.
-#[derive(Default)]
 pub struct CompleteAdd<F>(PhantomData<F>);
 
 impl<F> Argument<F> for CompleteAdd<F>

--- a/kimchi/src/circuits/polynomials/endomul_scalar.rs
+++ b/kimchi/src/circuits/polynomials/endomul_scalar.rs
@@ -116,7 +116,6 @@ fn polynomial<F: Field>(coeffs: &[F], x: &E<F>) -> E<F> {
 /// = x^4 - 6*x^3 + 11*x^2 - 6*x
 /// = x *(x^3 - 6*x^2 + 11*x - 6)
 /// ```
-#[derive(Default)]
 pub struct EndomulScalar<F>(PhantomData<F>);
 
 impl<F> Argument<F> for EndomulScalar<F>

--- a/kimchi/src/circuits/polynomials/endosclmul.rs
+++ b/kimchi/src/circuits/polynomials/endosclmul.rs
@@ -131,7 +131,6 @@ impl<F: FftField> CircuitGate<F> {
 }
 
 /// Implementation of the EndosclMul gate.
-#[derive(Default)]
 pub struct EndosclMul<F>(PhantomData<F>);
 
 impl<F> Argument<F> for EndosclMul<F>

--- a/kimchi/src/circuits/polynomials/poseidon.rs
+++ b/kimchi/src/circuits/polynomials/poseidon.rs
@@ -316,7 +316,6 @@ const ROUND_EQUATIONS: [RoundEquation; ROUNDS_PER_ROW] = [
 ///
 /// The rth position in this array contains the alphas used for the equations that
 /// constrain the values of the (r+1)th state.
-#[derive(Default)]
 pub struct Poseidon<F>(PhantomData<F>);
 
 impl<F> Poseidon<F> where F: Field {}

--- a/kimchi/src/circuits/polynomials/varbasemul.rs
+++ b/kimchi/src/circuits/polynomials/varbasemul.rs
@@ -326,7 +326,6 @@ pub fn witness<F: FftField + std::fmt::Display>(
 }
 
 /// Implementation of the VarbaseMul gate
-#[derive(Default)]
 pub struct VarbaseMul<F>(PhantomData<F>);
 
 impl<F> Argument<F> for VarbaseMul<F>


### PR DESCRIPTION
looks like we forgot to remove those when we moved away from using the `Argument` type for lookup.