### PR TITLE
move ceil_log2 tests into math module

### DIFF
--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -911,23 +911,6 @@ mod tests {
     use rand::{rngs::StdRng, SeedableRng};
 
     #[test]
-    fn test_log2() {
-        let tests = [
-            (1, 0),
-            (2, 1),
-            (3, 2),
-            (9, 4),
-            (15, 4),
-            (15430, 14),
-            (usize::MAX, 64),
-        ];
-        for (d, expected_res) in tests.iter() {
-            let res = math::ceil_log2(*d);
-            println!("ceil(log2({})) = {}, expected = {}", d, res, expected_res);
-        }
-    }
-
-    #[test]
     fn test_lagrange_commitments() {
         let n = 64;
         let domain = D::<Fp>::new(n).unwrap();

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -16,3 +16,25 @@ pub fn ceil_log2(d: usize) -> usize {
     }
     ceil_log2
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_log2() {
+        let tests = [
+            (1, 0),
+            (2, 1),
+            (3, 2),
+            (9, 4),
+            (15, 4),
+            (15430, 14),
+            (usize::MAX, 64),
+        ];
+        for (d, expected_res) in tests.iter() {
+            let res = ceil_log2(*d);
+            println!("ceil(log2({})) = {}, expected = {}", d, res, expected_res);
+        }
+    }
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/o1-labs/proof-systems/pull/436 which moves the corresponding test case of `ceil_log2` into the newly created `math` module in order to keep the code and structure clean (forgot it with last PR)