### PR TITLE
Field aliases

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -552,16 +552,16 @@ These pre-computations are optimizations, in the context of normal proofs, but t
 ```rs
 pub struct ProverIndex<G: CommitmentCurve> {
     /// constraints system polynomials
-    #[serde(bound = "ConstraintSystem<Fr<G>>: Serialize + DeserializeOwned")]
-    pub cs: ConstraintSystem<Fr<G>>,
+    #[serde(bound = "ConstraintSystem<ScalarField<G>>: Serialize + DeserializeOwned")]
+    pub cs: ConstraintSystem<ScalarField<G>>,
 
     /// The symbolic linearization of our circuit, which can compile to concrete types once certain values are learned in the protocol.
     #[serde(skip)]
-    pub linearization: Linearization<Vec<PolishToken<Fr<G>>>>,
+    pub linearization: Linearization<Vec<PolishToken<ScalarField<G>>>>,
 
     /// The mapping between powers of alpha and constraints
     #[serde(skip)]
-    pub powers_of_alpha: Alphas<Fr<G>>,
+    pub powers_of_alpha: Alphas<ScalarField<G>>,
 
     /// polynomial commitment keys
     #[serde(skip)]
@@ -575,7 +575,7 @@ pub struct ProverIndex<G: CommitmentCurve> {
 
     /// random oracle argument parameters
     #[serde(skip)]
-    pub fq_sponge_params: ArithmeticSpongeParams<Fq<G>>,
+    pub fq_sponge_params: ArithmeticSpongeParams<BaseField<G>>,
 }
 ```
 
@@ -588,7 +588,7 @@ Same as the prover index, we have a number of pre-computations as part of the ve
 pub struct VerifierIndex<G: CommitmentCurve> {
     /// evaluation domain
     #[serde_as(as = "o1_utils::serialization::SerdeAs")]
-    pub domain: D<Fr<G>>,
+    pub domain: D<ScalarField<G>>,
     /// maximal size of polynomial section
     pub max_poly_size: usize,
     /// maximal size of the quotient polynomial according to the supported constraints
@@ -633,32 +633,32 @@ pub struct VerifierIndex<G: CommitmentCurve> {
 
     /// wire coordinate shifts
     #[serde_as(as = "[o1_utils::serialization::SerdeAs; PERMUTS]")]
-    pub shift: [Fr<G>; PERMUTS],
+    pub shift: [ScalarField<G>; PERMUTS],
     /// zero-knowledge polynomial
     #[serde(skip)]
-    pub zkpm: DensePolynomial<Fr<G>>,
+    pub zkpm: DensePolynomial<ScalarField<G>>,
     // TODO(mimoo): isn't this redundant with domain.d1.group_gen ?
     /// domain offset for zero-knowledge
     #[serde(skip)]
-    pub w: Fr<G>,
+    pub w: ScalarField<G>,
     /// endoscalar coefficient
     #[serde(skip)]
-    pub endo: Fr<G>,
+    pub endo: ScalarField<G>,
 
     #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
     pub lookup_index: Option<LookupVerifierIndex<G>>,
 
     #[serde(skip)]
-    pub linearization: Linearization<Vec<PolishToken<Fr<G>>>>,
+    pub linearization: Linearization<Vec<PolishToken<ScalarField<G>>>>,
     /// The mapping between powers of alpha and constraints
     #[serde(skip)]
-    pub powers_of_alpha: Alphas<Fr<G>>,
+    pub powers_of_alpha: Alphas<ScalarField<G>>,
 
     // random oracle argument parameters
     #[serde(skip)]
-    pub fr_sponge_params: ArithmeticSpongeParams<Fr<G>>,
+    pub fr_sponge_params: ArithmeticSpongeParams<ScalarField<G>>,
     #[serde(skip)]
-    pub fq_sponge_params: ArithmeticSpongeParams<Fq<G>>,
+    pub fq_sponge_params: ArithmeticSpongeParams<BaseField<G>>,
 }
 ```
 

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -39,15 +39,9 @@ use commitment_dlog::{
     evaluation_proof::OpeningProof,
 };
 use itertools::Itertools;
-use o1_utils::ExtendedDensePolynomial;
+use o1_utils::{types::fields::*, ExtendedDensePolynomial};
 use oracle::{sponge::ScalarChallenge, FqSponge};
 use std::collections::HashMap;
-
-/// Alias to refer to the scalar field of a curve.
-type Fr<G> = <G as AffineCurve>::ScalarField;
-
-/// Alias to refer to the base field of a curve.
-type Fq<G> = <G as AffineCurve>::BaseField;
 
 /// The result of a proof creation or verification.
 pub type Result<T> = std::result::Result<T, ProofError>;
@@ -82,16 +76,16 @@ pub struct ProverProof<G: AffineCurve> {
 
     /// Two evaluations over a number of committed polynomials
     // TODO(mimoo): that really should be a type Evals { z: PE, zw: PE }
-    pub evals: [ProofEvaluations<Vec<Fr<G>>>; 2],
+    pub evals: [ProofEvaluations<Vec<ScalarField<G>>>; 2],
 
     /// Required evaluation for [Maller's optimization](https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html#the-evaluation-of-l)
-    pub ft_eval1: Fr<G>,
+    pub ft_eval1: ScalarField<G>,
 
     /// The public input
-    pub public: Vec<Fr<G>>,
+    pub public: Vec<ScalarField<G>>,
 
     /// The challenges underlying the optional polynomials folded into the proof
-    pub prev_challenges: Vec<(Vec<Fr<G>>, PolyComm<G>)>,
+    pub prev_challenges: Vec<(Vec<ScalarField<G>>, PolyComm<G>)>,
 }
 
 impl<G: CommitmentCurve> ProverProof<G>
@@ -99,9 +93,12 @@ where
     G::BaseField: PrimeField,
 {
     /// This function constructs prover's zk-proof from the witness & the ProverIndex against SRS instance
-    pub fn create<EFqSponge: Clone + FqSponge<Fq<G>, G, Fr<G>>, EFrSponge: FrSponge<Fr<G>>>(
+    pub fn create<
+        EFqSponge: Clone + FqSponge<BaseField<G>, G, ScalarField<G>>,
+        EFrSponge: FrSponge<ScalarField<G>>,
+    >(
         groupmap: &G::Map,
-        witness: [Vec<Fr<G>>; COLUMNS],
+        witness: [Vec<ScalarField<G>>; COLUMNS],
         index: &ProverIndex<G>,
     ) -> Result<Self> {
         Self::create_recursive::<EFqSponge, EFrSponge>(groupmap, witness, index, Vec::new())
@@ -109,13 +106,13 @@ where
 
     /// This function constructs prover's recursive zk-proof from the witness & the ProverIndex against SRS instance
     pub fn create_recursive<
-        EFqSponge: Clone + FqSponge<Fq<G>, G, Fr<G>>,
-        EFrSponge: FrSponge<Fr<G>>,
+        EFqSponge: Clone + FqSponge<BaseField<G>, G, ScalarField<G>>,
+        EFrSponge: FrSponge<ScalarField<G>>,
     >(
         group_map: &G::Map,
-        mut witness: [Vec<Fr<G>>; COLUMNS],
+        mut witness: [Vec<ScalarField<G>>; COLUMNS],
         index: &ProverIndex<G>,
-        prev_challenges: Vec<(Vec<Fr<G>>, PolyComm<G>)>,
+        prev_challenges: Vec<(Vec<ScalarField<G>>, PolyComm<G>)>,
     ) -> Result<Self> {
         let d1_size = index.cs.domain.d1.size as usize;
         // TODO: rng should be passed as arg
@@ -151,11 +148,11 @@ where
             }
 
             // padding
-            w.extend(std::iter::repeat(Fr::<G>::zero()).take(length_padding));
+            w.extend(std::iter::repeat(ScalarField::<G>::zero()).take(length_padding));
 
             // zk-rows
             for row in w.iter_mut().rev().take(ZK_ROWS as usize) {
-                *row = Fr::<G>::rand(rng);
+                *row = ScalarField::<G>::rand(rng);
             }
         }
 
@@ -166,7 +163,7 @@ where
         //~    the polynomial that evaluates to $-p_i$ for the first `public_input_size` values of the domain,
         //~    and $0$ for the rest.
         let public = witness[0][0..index.cs.public].to_vec();
-        let public_poly = -Evaluations::<Fr<G>, D<Fr<G>>>::from_vec_and_domain(
+        let public_poly = -Evaluations::<ScalarField<G>, D<ScalarField<G>>>::from_vec_and_domain(
             public.clone(),
             index.cs.domain.d1,
         )
@@ -181,8 +178,8 @@ where
         //~ 7. Commit to the witness columns by creating `COLUMNS` hidding commitments.
         //~    Note: since the witness is in evaluation form,
         //~    we can use the `commit_evaluation` optimization.
-        let w_comm: [(PolyComm<G>, PolyComm<Fr<G>>); COLUMNS] = array_init(|i| {
-            let e = Evaluations::<Fr<G>, D<Fr<G>>>::from_vec_and_domain(
+        let w_comm: [(PolyComm<G>, PolyComm<ScalarField<G>>); COLUMNS] = array_init(|i| {
+            let e = Evaluations::<ScalarField<G>, D<ScalarField<G>>>::from_vec_and_domain(
                 witness[i].clone(),
                 index.cs.domain.d1,
             );
@@ -198,8 +195,8 @@ where
 
         //~ 9. Compute the witness polynomials by interpolating each `COLUMNS` of the witness.
         //~    TODO: why not do this first, and then commit? Why commit from evaluation directly?
-        let witness_poly: [DensePolynomial<Fr<G>>; COLUMNS] = array_init(|i| {
-            Evaluations::<Fr<G>, D<Fr<G>>>::from_vec_and_domain(
+        let witness_poly: [DensePolynomial<ScalarField<G>>; COLUMNS] = array_init(|i| {
+            Evaluations::<ScalarField<G>, D<ScalarField<G>>>::from_vec_and_domain(
                 witness[i].clone(),
                 index.cs.domain.d1,
             )
@@ -218,7 +215,7 @@ where
                             ..
                         },
                     ..
-                }) => ScalarChallenge(Fr::<G>::zero()),
+                }) => ScalarChallenge(ScalarField::<G>::zero()),
                 Some(LookupConstraintSystem {
                     configuration:
                         LookupConfiguration {
@@ -232,7 +229,7 @@ where
         };
 
         // TODO: that seems like an unecessary line
-        let joint_combiner: Fr<G> = joint_combiner_.1;
+        let joint_combiner: ScalarField<G> = joint_combiner_.1;
 
         // TODO: Looking-up a tuple (f_0, f_1, ..., f_{m-1}) in a tuple of tables (T_0, ..., T_{m-1}) is
         // reduced to a single lookup
@@ -277,7 +274,7 @@ where
 
         let dummy_lookup_value = {
             let x = match index.cs.lookup_constraint_system.as_ref() {
-                None => Fr::<G>::zero(),
+                None => ScalarField::<G>::zero(),
                 Some(lcs) => {
                     combine_table_entry(joint_combiner, lcs.configuration.dummy_lookup_value.iter())
                 }
@@ -299,7 +296,7 @@ where
                     // TODO: Once we switch to committing using lagrange commitments,
                     // `witness` will be consumed when we interpolate, so interpolation will
                     // have to moved below this.
-                    let lookup_sorted: Vec<Vec<CombinedEntry<Fr<G>>>> =
+                    let lookup_sorted: Vec<Vec<CombinedEntry<ScalarField<G>>>> =
                         lookup::constraints::sorted(
                             dummy_lookup_value,
                             iter_lookup_table,
@@ -358,7 +355,7 @@ where
                     });
 
                     let aggreg =
-                        lookup::constraints::aggregation::<_, Fr<G>, _>(
+                        lookup::constraints::aggregation::<_, ScalarField<G>, _>(
                             dummy_lookup_value.0,
                             iter_lookup_table(),
                             index.cs.domain.d1,
@@ -369,7 +366,7 @@ where
                             &lookup_sorted,
                             rng)?;
 
-                    if aggreg.evals[d1_size - (ZK_ROWS as usize + 1)] != Fr::<G>::one() {
+                    if aggreg.evals[d1_size - (ZK_ROWS as usize + 1)] != ScalarField::<G>::one() {
                         panic!("aggregation incorrect: {}", aggreg.evals[d1_size-(ZK_ROWS as usize + 1)]);
                     }
 
@@ -685,7 +682,7 @@ where
             // the higher degree coefficients of `t` are 0.
             for _ in 0..dummies {
                 use ark_ec::ProjectiveCurve;
-                let w = Fr::<G>::rand(rng);
+                let w = ScalarField::<G>::rand(rng);
                 t_comm.unshifted.push(index.srs.h.mul(w).into_affine());
                 omega_t.unshifted.push(w);
             }
@@ -705,7 +702,7 @@ where
         let zeta_omega = zeta * omega;
 
         //~ 28. TODO: lookup
-        let lookup_evals = |e: Fr<G>| {
+        let lookup_evals = |e: ScalarField<G>| {
             lookup_aggreg_coeffs
                 .as_ref()
                 .zip(lookup_sorted_coeffs.as_ref())
@@ -721,7 +718,7 @@ where
                         .iter()
                         .map(|p| p.eval(e, index.max_poly_size))
                         .rev()
-                        .fold(vec![Fr::<G>::zero()], |acc, x| {
+                        .fold(vec![ScalarField::<G>::zero()], |acc, x| {
                             acc.into_iter()
                                 .zip(x.iter())
                                 .map(|(acc, x)| acc * joint_combiner + x)
@@ -749,7 +746,7 @@ where
         //~
         //~      TODO: do we want to specify more on that? It seems unecessary except for the t polynomial (or if for some reason someone sets that to a low value)
         let chunked_evals = {
-            let chunked_evals_zeta = ProofEvaluations::<Vec<Fr<G>>> {
+            let chunked_evals_zeta = ProofEvaluations::<Vec<ScalarField<G>>> {
                 s: array_init(|i| {
                     index.cs.sigmam[0..PERMUTS - 1][i].eval(zeta, index.max_poly_size)
                 }),
@@ -759,7 +756,7 @@ where
                 generic_selector: index.cs.genericm.eval(zeta, index.max_poly_size),
                 poseidon_selector: index.cs.psm.eval(zeta, index.max_poly_size),
             };
-            let chunked_evals_zeta_omega = ProofEvaluations::<Vec<Fr<G>>> {
+            let chunked_evals_zeta_omega = ProofEvaluations::<Vec<ScalarField<G>>> {
                 s: array_init(|i| {
                     index.cs.sigmam[0..PERMUTS - 1][i].eval(zeta_omega, index.max_poly_size)
                 }),
@@ -787,7 +784,7 @@ where
             &chunked_evals
                 .iter()
                 .zip(power_of_eval_points_for_chunks.iter())
-                .map(|(es, &e1)| ProofEvaluations::<Fr<G>> {
+                .map(|(es, &e1)| ProofEvaluations::<ScalarField<G>> {
                     s: array_init(|i| DensePolynomial::eval_polynomial(&es.s[i], e1)),
                     w: array_init(|i| DensePolynomial::eval_polynomial(&es.w[i], e1)),
                     z: DensePolynomial::eval_polynomial(&es.z, e1),
@@ -808,7 +805,7 @@ where
 
         //~ 31. Compute the ft polynomial.
         //~     This is to implement [Maller's optimization](https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html).
-        let ft: DensePolynomial<Fr<G>> = {
+        let ft: DensePolynomial<ScalarField<G>> = {
             let f_chunked = {
                 // TODO: compute the linearization polynomial in evaluation form so
                 // that we can drop the coefficient forms of the index polynomials from
@@ -844,18 +841,20 @@ where
 
             let t_chunked = quotient_poly.chunk_polynomial(zeta_to_srs_len, index.max_poly_size);
 
-            &f_chunked - &t_chunked.scale(zeta_to_domain_size - Fr::<G>::one())
+            &f_chunked - &t_chunked.scale(zeta_to_domain_size - ScalarField::<G>::one())
         };
 
         //~ 32. construct the blinding part of the ft polynomial commitment
         //~     see https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html#evaluation-proof-and-blinding-factors
         let blinding_ft = {
             let blinding_t = t_comm.1.chunk_blinding(zeta_to_srs_len);
-            let blinding_f = Fr::<G>::zero();
+            let blinding_f = ScalarField::<G>::zero();
 
             PolyComm {
                 // blinding_f - Z_H(zeta) * blinding_t
-                unshifted: vec![blinding_f - (zeta_to_domain_size - Fr::<G>::one()) * blinding_t],
+                unshifted: vec![
+                    blinding_f - (zeta_to_domain_size - ScalarField::<G>::one()) * blinding_t,
+                ],
                 shifted: None,
             }
         };
@@ -910,7 +909,7 @@ where
         //~     (and evaluation proofs) in the protocol.
         //~     First, include the previous challenges, in case we are in a recursive prover.
         let non_hiding = |d1_size: usize| PolyComm {
-            unshifted: vec![Fr::<G>::zero(); d1_size],
+            unshifted: vec![ScalarField::<G>::zero(); d1_size],
             shifted: None,
         };
 

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -395,7 +395,7 @@ where
         let alpha_chal = ScalarChallenge(fq_sponge.challenge());
 
         //~ 18. Derive $\alpha$ from $\alpha'$ using the endomorphism (TODO: details)
-        let alpha = alpha_chal.to_field(&index.srs.endo_r);
+        let alpha: ScalarField<G> = alpha_chal.to_field(&index.srs.endo_r);
 
         //~ 19. TODO: instantiate alpha?
         let mut all_alphas = index.powers_of_alpha.clone();

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -7,16 +7,13 @@ use crate::circuits::{
     wires::*,
 };
 use crate::linearization::expr_linearization;
-use ark_ec::AffineCurve;
 use ark_ff::PrimeField;
 use commitment_dlog::{commitment::CommitmentCurve, srs::SRS};
+use o1_utils::types::fields::*;
 use oracle::poseidon::ArithmeticSpongeParams;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
 use std::sync::Arc;
-
-type Fr<G> = <G as AffineCurve>::ScalarField;
-type Fq<G> = <G as AffineCurve>::BaseField;
 
 /// The index used by the prover
 #[serde_as]
@@ -24,16 +21,16 @@ type Fq<G> = <G as AffineCurve>::BaseField;
 //~spec:startcode
 pub struct ProverIndex<G: CommitmentCurve> {
     /// constraints system polynomials
-    #[serde(bound = "ConstraintSystem<Fr<G>>: Serialize + DeserializeOwned")]
-    pub cs: ConstraintSystem<Fr<G>>,
+    #[serde(bound = "ConstraintSystem<ScalarField<G>>: Serialize + DeserializeOwned")]
+    pub cs: ConstraintSystem<ScalarField<G>>,
 
     /// The symbolic linearization of our circuit, which can compile to concrete types once certain values are learned in the protocol.
     #[serde(skip)]
-    pub linearization: Linearization<Vec<PolishToken<Fr<G>>>>,
+    pub linearization: Linearization<Vec<PolishToken<ScalarField<G>>>>,
 
     /// The mapping between powers of alpha and constraints
     #[serde(skip)]
-    pub powers_of_alpha: Alphas<Fr<G>>,
+    pub powers_of_alpha: Alphas<ScalarField<G>>,
 
     /// polynomial commitment keys
     #[serde(skip)]
@@ -47,7 +44,7 @@ pub struct ProverIndex<G: CommitmentCurve> {
 
     /// random oracle argument parameters
     #[serde(skip)]
-    pub fq_sponge_params: ArithmeticSpongeParams<Fq<G>>,
+    pub fq_sponge_params: ArithmeticSpongeParams<BaseField<G>>,
 }
 //~spec:endcode
 
@@ -57,9 +54,9 @@ where
 {
     /// this function compiles the index from constraints
     pub fn create(
-        mut cs: ConstraintSystem<Fr<G>>,
-        fq_sponge_params: ArithmeticSpongeParams<Fq<G>>,
-        endo_q: Fr<G>,
+        mut cs: ConstraintSystem<ScalarField<G>>,
+        fq_sponge_params: ArithmeticSpongeParams<BaseField<G>>,
+        endo_q: ScalarField<G>,
         srs: Arc<SRS<G>>,
     ) -> Self {
         let max_poly_size = srs.g.len();

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -9,7 +9,6 @@ use crate::circuits::{
     wires::*,
 };
 use crate::prover_index::ProverIndex;
-use ark_ec::AffineCurve;
 use ark_ff::PrimeField;
 use ark_poly::{univariate::DensePolynomial, Radix2EvaluationDomain as D};
 use array_init::array_init;
@@ -17,6 +16,7 @@ use commitment_dlog::{
     commitment::{CommitmentCurve, PolyComm},
     srs::SRS,
 };
+use o1_utils::types::fields::*;
 use oracle::poseidon::ArithmeticSpongeParams;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
@@ -27,9 +27,6 @@ use std::{
     path::Path,
     sync::Arc,
 };
-
-type Fr<G> = <G as AffineCurve>::ScalarField;
-type Fq<G> = <G as AffineCurve>::BaseField;
 
 #[serde_as]
 #[derive(Serialize, Deserialize)]
@@ -47,7 +44,7 @@ pub struct LookupVerifierIndex<G: CommitmentCurve> {
 pub struct VerifierIndex<G: CommitmentCurve> {
     /// evaluation domain
     #[serde_as(as = "o1_utils::serialization::SerdeAs")]
-    pub domain: D<Fr<G>>,
+    pub domain: D<ScalarField<G>>,
     /// maximal size of polynomial section
     pub max_poly_size: usize,
     /// maximal size of the quotient polynomial according to the supported constraints
@@ -92,32 +89,32 @@ pub struct VerifierIndex<G: CommitmentCurve> {
 
     /// wire coordinate shifts
     #[serde_as(as = "[o1_utils::serialization::SerdeAs; PERMUTS]")]
-    pub shift: [Fr<G>; PERMUTS],
+    pub shift: [ScalarField<G>; PERMUTS],
     /// zero-knowledge polynomial
     #[serde(skip)]
-    pub zkpm: DensePolynomial<Fr<G>>,
+    pub zkpm: DensePolynomial<ScalarField<G>>,
     // TODO(mimoo): isn't this redundant with domain.d1.group_gen ?
     /// domain offset for zero-knowledge
     #[serde(skip)]
-    pub w: Fr<G>,
+    pub w: ScalarField<G>,
     /// endoscalar coefficient
     #[serde(skip)]
-    pub endo: Fr<G>,
+    pub endo: ScalarField<G>,
 
     #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
     pub lookup_index: Option<LookupVerifierIndex<G>>,
 
     #[serde(skip)]
-    pub linearization: Linearization<Vec<PolishToken<Fr<G>>>>,
+    pub linearization: Linearization<Vec<PolishToken<ScalarField<G>>>>,
     /// The mapping between powers of alpha and constraints
     #[serde(skip)]
-    pub powers_of_alpha: Alphas<Fr<G>>,
+    pub powers_of_alpha: Alphas<ScalarField<G>>,
 
     // random oracle argument parameters
     #[serde(skip)]
-    pub fr_sponge_params: ArithmeticSpongeParams<Fr<G>>,
+    pub fr_sponge_params: ArithmeticSpongeParams<ScalarField<G>>,
     #[serde(skip)]
-    pub fq_sponge_params: ArithmeticSpongeParams<Fq<G>>,
+    pub fq_sponge_params: ArithmeticSpongeParams<BaseField<G>>,
 }
 //~spec:endcode
 
@@ -209,8 +206,8 @@ where
         offset: Option<u64>,
         // TODO: we shouldn't have to pass these
         endo: G::ScalarField,
-        fq_sponge_params: ArithmeticSpongeParams<Fq<G>>,
-        fr_sponge_params: ArithmeticSpongeParams<Fr<G>>,
+        fq_sponge_params: ArithmeticSpongeParams<BaseField<G>>,
+        fr_sponge_params: ArithmeticSpongeParams<ScalarField<G>>,
     ) -> Result<Self, String> {
         // open file
         let file = File::open(path).map_err(|e| e.to_string())?;

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -22,6 +22,7 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use core::ops::{Add, Sub};
 use groupmap::{BWParameters, GroupMap};
 use o1_utils::math;
+use o1_utils::types::fields::*;
 use o1_utils::ExtendedDensePolynomial as _;
 use oracle::{sponge::ScalarChallenge, FqSponge};
 use rand_core::{CryptoRng, RngCore};
@@ -31,9 +32,6 @@ use serde_with::serde_as;
 use std::iter::Iterator;
 
 use super::evaluation_proof::*;
-
-type Fr<G> = <G as AffineCurve>::ScalarField;
-type Fq<G> = <G as AffineCurve>::BaseField;
 
 /// A polynomial commitment.
 #[serde_as]
@@ -382,15 +380,15 @@ pub fn to_group<G: CommitmentCurve>(m: &G::Map, t: <G as AffineCurve>::BaseField
 /// the evaluation for the last segment is potentially shifted to meet the proof.
 #[allow(clippy::type_complexity)]
 pub fn combined_inner_product<G: CommitmentCurve>(
-    evaluation_points: &[Fr<G>],
-    xi: &Fr<G>,
-    r: &Fr<G>,
+    evaluation_points: &[ScalarField<G>],
+    xi: &ScalarField<G>,
+    r: &ScalarField<G>,
     // TODO(mimoo): needs a type that can get you evaluations or segments
-    polys: &[(Vec<Vec<Fr<G>>>, Option<usize>)],
+    polys: &[(Vec<Vec<ScalarField<G>>>, Option<usize>)],
     srs_length: usize,
-) -> Fr<G> {
-    let mut res = Fr::<G>::zero();
-    let mut xi_i = Fr::<G>::one();
+) -> ScalarField<G> {
+    let mut res = ScalarField::<G>::zero();
+    let mut xi_i = ScalarField::<G>::one();
 
     for (evals_tr, shifted) in polys.iter().filter(|(evals_tr, _)| !evals_tr[0].is_empty()) {
         // transpose the evaluations
@@ -400,7 +398,7 @@ pub fn combined_inner_product<G: CommitmentCurve>(
 
         // iterating over the polynomial segments
         for eval in evals.iter() {
-            let term = DensePolynomial::<Fr<G>>::eval_polynomial(eval, *r);
+            let term = DensePolynomial::<ScalarField<G>>::eval_polynomial(eval, *r);
 
             res += &(xi_i * term);
             xi_i *= xi;
@@ -409,7 +407,7 @@ pub fn combined_inner_product<G: CommitmentCurve>(
         if let Some(m) = shifted {
             // xi^i sum_j r^j elm_j^{N - m} f(elm_j)
             let last_evals = if *m > evals.len() * srs_length {
-                vec![Fr::<G>::zero(); evaluation_points.len()]
+                vec![ScalarField::<G>::zero(); evaluation_points.len()]
             } else {
                 evals[evals.len() - 1].clone()
             };
@@ -419,7 +417,7 @@ pub fn combined_inner_product<G: CommitmentCurve>(
                 .map(|(elm, f_elm)| elm.pow(&[(srs_length - (*m) % srs_length) as u64]) * f_elm)
                 .collect();
 
-            res += &(xi_i * DensePolynomial::<Fr<G>>::eval_polynomial(&shifted_evals, *r));
+            res += &(xi_i * DensePolynomial::<ScalarField<G>>::eval_polynomial(&shifted_evals, *r));
             xi_i *= xi;
         }
     }
@@ -494,7 +492,7 @@ where
     pub commitment: PolyComm<G>,
 
     /// Contains an evaluation table
-    pub evaluations: Vec<Vec<Fr<G>>>,
+    pub evaluations: Vec<Vec<ScalarField<G>>>,
 
     /// optional degree bound
     pub degree_bound: Option<usize>,
@@ -505,16 +503,16 @@ where
 pub struct BatchEvaluationProof<'a, G, EFqSponge>
 where
     G: AffineCurve,
-    EFqSponge: FqSponge<Fq<G>, G, Fr<G>>,
+    EFqSponge: FqSponge<BaseField<G>, G, ScalarField<G>>,
 {
     pub sponge: EFqSponge,
     pub evaluations: Vec<Evaluation<G>>,
     /// vector of evaluation points
-    pub evaluation_points: Vec<Fr<G>>,
+    pub evaluation_points: Vec<ScalarField<G>>,
     /// scaling factor for evaluation point powers
-    pub xi: Fr<G>,
+    pub xi: ScalarField<G>,
     /// scaling factor for polynomials
-    pub r: Fr<G>,
+    pub r: ScalarField<G>,
     /// batched opening proof
     pub opening: &'a OpeningProof<G>,
 }
@@ -523,10 +521,10 @@ impl<G: CommitmentCurve> SRS<G> {
     /// Commits a polynomial, potentially splitting the result in multiple commitments.
     pub fn commit(
         &self,
-        plnm: &DensePolynomial<Fr<G>>,
+        plnm: &DensePolynomial<ScalarField<G>>,
         max: Option<usize>,
         rng: &mut (impl RngCore + CryptoRng),
-    ) -> (PolyComm<G>, PolyComm<Fr<G>>) {
+    ) -> (PolyComm<G>, PolyComm<ScalarField<G>>) {
         self.mask(self.commit_non_hiding(plnm, max), rng)
     }
 
@@ -535,14 +533,14 @@ impl<G: CommitmentCurve> SRS<G> {
         &self,
         c: PolyComm<G>,
         rng: &mut (impl RngCore + CryptoRng),
-    ) -> (PolyComm<G>, PolyComm<Fr<G>>) {
+    ) -> (PolyComm<G>, PolyComm<ScalarField<G>>) {
         c.map(|g: G| {
             if g.is_zero() {
                 // TODO: This leaks information when g is the identity!
                 // We should change this so that we still mask in this case
-                (g, Fr::<G>::zero())
+                (g, ScalarField::<G>::zero())
             } else {
-                let w = Fr::<G>::rand(rng);
+                let w = ScalarField::<G>::rand(rng);
                 let mut g_masked = self.h.mul(w);
                 g_masked.add_assign_mixed(&g);
                 (g_masked.into_affine(), w)
@@ -559,14 +557,14 @@ impl<G: CommitmentCurve> SRS<G> {
     /// Note that a maximum degree cannot (and doesn't need to) be enforced via a shift if `max` is a multiple of `n`.
     pub fn commit_non_hiding(
         &self,
-        plnm: &DensePolynomial<Fr<G>>,
+        plnm: &DensePolynomial<ScalarField<G>>,
         max: Option<usize>,
     ) -> PolyComm<G> {
         Self::commit_helper(&plnm.coeffs[..], &self.g[..], None, plnm.is_zero(), max)
     }
 
     pub fn commit_helper(
-        scalars: &[Fr<G>],
+        scalars: &[ScalarField<G>],
         basis: &[G],
         n: Option<usize>,
         is_zero: bool,
@@ -625,8 +623,8 @@ impl<G: CommitmentCurve> SRS<G> {
 
     pub fn commit_evaluations_non_hiding(
         &self,
-        domain: D<Fr<G>>,
-        plnm: &Evaluations<Fr<G>, D<Fr<G>>>,
+        domain: D<ScalarField<G>>,
+        plnm: &Evaluations<ScalarField<G>, D<ScalarField<G>>>,
         max: Option<usize>,
     ) -> PolyComm<G> {
         let is_zero = plnm.evals.iter().all(|x| x.is_zero());
@@ -653,11 +651,11 @@ impl<G: CommitmentCurve> SRS<G> {
 
     pub fn commit_evaluations(
         &self,
-        domain: D<Fr<G>>,
-        plnm: &Evaluations<Fr<G>, D<Fr<G>>>,
+        domain: D<ScalarField<G>>,
+        plnm: &Evaluations<ScalarField<G>, D<ScalarField<G>>>,
         max: Option<usize>,
         rng: &mut (impl RngCore + CryptoRng),
-    ) -> (PolyComm<G>, PolyComm<Fr<G>>) {
+    ) -> (PolyComm<G>, PolyComm<ScalarField<G>>) {
         self.mask(self.commit_evaluations_non_hiding(domain, plnm, max), rng)
     }
 
@@ -679,7 +677,7 @@ impl<G: CommitmentCurve> SRS<G> {
         rng: &mut RNG,
     ) -> bool
     where
-        EFqSponge: FqSponge<Fq<G>, G, Fr<G>>,
+        EFqSponge: FqSponge<BaseField<G>, G, ScalarField<G>>,
         RNG: RngCore + CryptoRng,
         G::BaseField: PrimeField,
     {
@@ -715,15 +713,15 @@ impl<G: CommitmentCurve> SRS<G> {
         points.extend(self.g.clone());
         points.extend(vec![G::zero(); padding]);
 
-        let mut scalars = vec![Fr::<G>::zero(); padded_length + 1];
+        let mut scalars = vec![ScalarField::<G>::zero(); padded_length + 1];
         assert_eq!(scalars.len(), points.len());
 
         // sample randomiser to scale the proofs with
-        let rand_base = Fr::<G>::rand(rng);
-        let sg_rand_base = Fr::<G>::rand(rng);
+        let rand_base = ScalarField::<G>::rand(rng);
+        let sg_rand_base = ScalarField::<G>::rand(rng);
 
-        let mut rand_base_i = Fr::<G>::one();
-        let mut sg_rand_base_i = Fr::<G>::one();
+        let mut rand_base_i = ScalarField::<G>::one();
+        let mut sg_rand_base_i = ScalarField::<G>::one();
 
         for BatchEvaluationProof {
             sponge,
@@ -775,8 +773,8 @@ impl<G: CommitmentCurve> SRS<G> {
             // ==
             // sum_i r^i < s, pows(evaluation_point[i]) >
             let b0 = {
-                let mut scale = Fr::<G>::one();
-                let mut res = Fr::<G>::zero();
+                let mut scale = ScalarField::<G>::one();
+                let mut res = ScalarField::<G>::zero();
                 for &e in evaluation_points.iter() {
                     let term = b_poly(&chal, e);
                     res += &(scale * term);
@@ -838,7 +836,7 @@ impl<G: CommitmentCurve> SRS<G> {
             // == sum_j sum_i r^j xi^i f_i(elm_j)
             // == sum_i xi^i sum_j r^j f_i(elm_j)
             {
-                let mut xi_i = Fr::<G>::one();
+                let mut xi_i = ScalarField::<G>::one();
 
                 for Evaluation {
                     commitment,

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -3,14 +3,14 @@ use crate::srs::SRS;
 use ark_ec::{msm::VariableBaseMSM, AffineCurve, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
 use ark_poly::univariate::DensePolynomial;
-use o1_utils::math;
+use o1_utils::{
+    math,
+    types::{BaseField, ScalarField},
+};
 use oracle::{sponge::ScalarChallenge, FqSponge};
 use rand_core::{CryptoRng, RngCore};
 use rayon::prelude::*;
 use std::iter::Iterator;
-
-type Fr<G> = <G as AffineCurve>::ScalarField;
-type Fq<G> = <G as AffineCurve>::BaseField;
 
 impl<G: CommitmentCurve> SRS<G> {
     /// This function opens polynomial commitments in batch
@@ -27,15 +27,19 @@ impl<G: CommitmentCurve> SRS<G> {
         &self,
         group_map: &G::Map,
         // TODO(mimoo): create a type for that entry
-        plnms: &[(&DensePolynomial<Fr<G>>, Option<usize>, PolyComm<Fr<G>>)], // vector of polynomial with optional degree bound and commitment randomness
-        elm: &[Fr<G>],         // vector of evaluation points
-        polyscale: Fr<G>,      // scaling factor for polynoms
-        evalscale: Fr<G>,      // scaling factor for evaluation point powers
-        mut sponge: EFqSponge, // sponge
+        plnms: &[(
+            &DensePolynomial<ScalarField<G>>,
+            Option<usize>,
+            PolyComm<ScalarField<G>>,
+        )], // vector of polynomial with optional degree bound and commitment randomness
+        elm: &[ScalarField<G>],    // vector of evaluation points
+        polyscale: ScalarField<G>, // scaling factor for polynoms
+        evalscale: ScalarField<G>, // scaling factor for evaluation point powers
+        mut sponge: EFqSponge,     // sponge
         rng: &mut RNG,
     ) -> OpeningProof<G>
     where
-        EFqSponge: Clone + FqSponge<Fq<G>, G, Fr<G>>,
+        EFqSponge: Clone + FqSponge<BaseField<G>, G, ScalarField<G>>,
         RNG: RngCore + CryptoRng,
         G::BaseField: PrimeField,
     {
@@ -48,11 +52,11 @@ impl<G: CommitmentCurve> SRS<G> {
         g.extend(vec![G::zero(); padding]);
 
         let (p, blinding_factor) = {
-            let mut plnm = ChunkedPolynomial::<Fr<G>, &[Fr<G>]>::default();
-            // let mut plnm_chunks: Vec<(Fr<G>, OptShiftedPolynomial<_>)> = vec![];
+            let mut plnm = ChunkedPolynomial::<ScalarField<G>, &[ScalarField<G>]>::default();
+            // let mut plnm_chunks: Vec<(ScalarField<G>, OptShiftedPolynomial<_>)> = vec![];
 
-            let mut omega = Fr::<G>::zero();
-            let mut scale = Fr::<G>::one();
+            let mut omega = ScalarField::<G>::zero();
+            let mut scale = ScalarField::<G>::one();
 
             // iterating over polynomials in the batch
             for (p_i, degree_bound, omegas) in plnms.iter().filter(|p| !p.0.is_zero()) {
@@ -111,8 +115,10 @@ impl<G: CommitmentCurve> SRS<G> {
         // b_j = sum_i r^i elm_i^j
         let b_init = {
             // randomise/scale the eval powers
-            let mut scale = Fr::<G>::one();
-            let mut res: Vec<Fr<G>> = (0..padded_length).map(|_| Fr::<G>::zero()).collect();
+            let mut scale = ScalarField::<G>::one();
+            let mut res: Vec<ScalarField<G>> = (0..padded_length)
+                .map(|_| ScalarField::<G>::zero())
+                .collect();
             for e in elm {
                 for (i, t) in pows(padded_length, *e).iter().enumerate() {
                     res[i] += &(scale * t);
@@ -127,7 +133,7 @@ impl<G: CommitmentCurve> SRS<G> {
             .iter()
             .zip(b_init.iter())
             .map(|(a, b)| *a * b)
-            .fold(Fr::<G>::zero(), |acc, x| acc + x);
+            .fold(ScalarField::<G>::zero(), |acc, x| acc + x);
 
         sponge.absorb_fr(&[shift_scalar::<G>(combined_inner_product)]);
 
@@ -136,7 +142,7 @@ impl<G: CommitmentCurve> SRS<G> {
 
         let mut a = p.coeffs;
         assert!(padded_length >= a.len());
-        a.extend(vec![Fr::<G>::zero(); padded_length - a.len()]);
+        a.extend(vec![ScalarField::<G>::zero(); padded_length - a.len()]);
 
         let mut b = b_init;
 
@@ -153,8 +159,8 @@ impl<G: CommitmentCurve> SRS<G> {
             let (a_lo, a_hi) = (&a[0..n], &a[n..]);
             let (b_lo, b_hi) = (&b[0..n], &b[n..]);
 
-            let rand_l = Fr::<G>::rand(rng);
-            let rand_r = Fr::<G>::rand(rng);
+            let rand_l = ScalarField::<G>::rand(rng);
+            let rand_r = ScalarField::<G>::rand(rng);
 
             let l = VariableBaseMSM::multi_scalar_mul(
                 &[&g[0..n], &[self.h, u]].concat(),
@@ -227,8 +233,8 @@ impl<G: CommitmentCurve> SRS<G> {
             .map(|((l, r), (u, u_inv))| ((*l) * u_inv) + (*r * u))
             .fold(blinding_factor, |acc, x| acc + x);
 
-        let d = Fr::<G>::rand(rng);
-        let r_delta = Fr::<G>::rand(rng);
+        let d = ScalarField::<G>::rand(rng);
+        let r_delta = ScalarField::<G>::rand(rng);
 
         let delta = ((g0.into_projective() + (u.mul(b0))).into_affine().mul(d)
             + self.h.mul(r_delta))
@@ -266,10 +272,10 @@ pub struct Challenges<F> {
 }
 
 impl<G: AffineCurve> OpeningProof<G> {
-    pub fn prechallenges<EFqSponge: FqSponge<Fq<G>, G, Fr<G>>>(
+    pub fn prechallenges<EFqSponge: FqSponge<BaseField<G>, G, ScalarField<G>>>(
         &self,
         sponge: &mut EFqSponge,
-    ) -> Vec<ScalarChallenge<Fr<G>>> {
+    ) -> Vec<ScalarChallenge<ScalarField<G>>> {
         let _t = sponge.challenge_fq();
         self.lr
             .iter()
@@ -281,11 +287,11 @@ impl<G: AffineCurve> OpeningProof<G> {
             .collect()
     }
 
-    pub fn challenges<EFqSponge: FqSponge<Fq<G>, G, Fr<G>>>(
+    pub fn challenges<EFqSponge: FqSponge<BaseField<G>, G, ScalarField<G>>>(
         &self,
-        endo_r: &Fr<G>,
+        endo_r: &ScalarField<G>,
         sponge: &mut EFqSponge,
-    ) -> Challenges<Fr<G>> {
+    ) -> Challenges<ScalarField<G>> {
         let chal: Vec<_> = self
             .lr
             .iter()

--- a/tools/kimchi-visu/src/lib.rs
+++ b/tools/kimchi-visu/src/lib.rs
@@ -1,6 +1,5 @@
 //! Implements a tool to visualize a circuit as an HTML page.
 
-use ark_ec::AffineCurve;
 use ark_ff::PrimeField;
 use commitment_dlog::commitment::CommitmentCurve;
 use kimchi::{
@@ -17,6 +16,7 @@ use kimchi::{
     },
     prover_index::ProverIndex,
 };
+use o1_utils::types::fields::*;
 use serde::Serialize;
 use std::{
     collections::HashMap,
@@ -37,8 +37,6 @@ struct Context {
     js: String,
     data: String,
 }
-
-type Fr<G> = <G as AffineCurve>::ScalarField;
 
 /// Allows us to quickly implement a LaTeX encoder for each gate
 trait LaTeX<F>: Argument<F>
@@ -64,20 +62,20 @@ where
     G: CommitmentCurve,
 {
     let mut map = HashMap::new();
-    map.insert("Poseidon", Poseidon::<Fr<G>>::latex());
-    map.insert("CompleteAdd", CompleteAdd::<Fr<G>>::latex());
-    map.insert("VarBaseMul", VarbaseMul::<Fr<G>>::latex());
-    map.insert("EndoMul", EndosclMul::<Fr<G>>::latex());
-    map.insert("EndoMulScalar", EndomulScalar::<Fr<G>>::latex());
-    map.insert("ChaCha0", ChaCha0::<Fr<G>>::latex());
-    map.insert("ChaCha1", ChaCha1::<Fr<G>>::latex());
-    map.insert("ChaCha2", ChaCha2::<Fr<G>>::latex());
-    map.insert("ChaChaFinal", ChaChaFinal::<Fr<G>>::latex());
+    map.insert("Poseidon", Poseidon::<ScalarField<G>>::latex());
+    map.insert("CompleteAdd", CompleteAdd::<ScalarField<G>>::latex());
+    map.insert("VarBaseMul", VarbaseMul::<ScalarField<G>>::latex());
+    map.insert("EndoMul", EndosclMul::<ScalarField<G>>::latex());
+    map.insert("EndoMulScalar", EndomulScalar::<ScalarField<G>>::latex());
+    map.insert("ChaCha0", ChaCha0::<ScalarField<G>>::latex());
+    map.insert("ChaCha1", ChaCha1::<ScalarField<G>>::latex());
+    map.insert("ChaCha2", ChaCha2::<ScalarField<G>>::latex());
+    map.insert("ChaChaFinal", ChaChaFinal::<ScalarField<G>>::latex());
     map
 }
 
 /// Produces a `circuit.html` in the current folder.
-pub fn visu<G>(index: &ProverIndex<G>, witness: Option<Witness<Fr<G>>>)
+pub fn visu<G>(index: &ProverIndex<G>, witness: Option<Witness<ScalarField<G>>>)
 where
     G: CommitmentCurve,
 {

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
+ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-poly = { version = "0.3.0", features = [ "parallel" ] }
 ark-serialize = "0.3.0"

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -4,6 +4,7 @@ pub mod field_helpers;
 pub mod hasher;
 pub mod math;
 pub mod serialization;
+pub mod types;
 
 pub use dense_polynomial::ExtendedDensePolynomial;
 pub use evaluations::ExtendedEvaluations;

--- a/utils/src/types.rs
+++ b/utils/src/types.rs
@@ -1,3 +1,5 @@
+//! This is used to define common types and associated prologues
+
 use ark_ec::AffineCurve;
 
 /// Alias to refer to the scalar field of a curve.
@@ -6,6 +8,7 @@ pub type ScalarField<G> = <G as AffineCurve>::ScalarField;
 /// Alias to refer to the base field of a curve.
 pub type BaseField<G> = <G as AffineCurve>::BaseField;
 
+/// Fields prologue
 pub mod fields {
     pub use super::{BaseField, ScalarField};
 }

--- a/utils/src/types.rs
+++ b/utils/src/types.rs
@@ -1,0 +1,11 @@
+use ark_ec::AffineCurve;
+
+/// Alias to refer to the scalar field of a curve.
+pub type ScalarField<G> = <G as AffineCurve>::ScalarField;
+
+/// Alias to refer to the base field of a curve.
+pub type BaseField<G> = <G as AffineCurve>::BaseField;
+
+pub mod fields {
+    pub use super::{BaseField, ScalarField};
+}


### PR DESCRIPTION
This PR renames and migrates commonly used field types.  The types have been renamed from `Fr` and `Fq` to `ScalarField` and `BaseField`.  They have been migrated to `o1_utils::types::fields::*` where they can be used across crates.  I have added explicit type declaration for:
```
//~ 18. Derive $\alpha$ from $\alpha'$ using the endomorphism (TODO: details)
- let alpha = alpha_chal.to_field(&index.srs.endo_r);
+ let alpha: ScalarField<F> = alpha_chal.to_field(&index.srs.endo_r);
```
but received a compilation error when applying the following change so it has not been included:
```
- let alpha_chal = ScalarChallenge(fq_sponge.challenge());
+ let alpha_chal: BaseField<F> = ScalarChallenge(fq_sponge.challenge());
```

It should be noted that this PR also includes changes to the kimchi book (`kimchi.md`)

closes: #426 