### PR TITLE
add assert to test

### DIFF
--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -35,6 +35,7 @@ mod tests {
         for (d, expected_res) in tests.iter() {
             let res = ceil_log2(*d);
             println!("ceil(log2({})) = {}, expected = {}", d, res, expected_res);
+            assert!(res == *expected_res)
         }
     }
 }


### PR DESCRIPTION
unit test case for `ceil_log2` wasn't being asserted, only printed. Add `assert!(res == *expected)` to it