### PR TITLE
move horner schema to utils

### DIFF
--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -29,25 +29,38 @@ where
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
+    use mina_curves::pasta::Fp;
 
     #[test]
     fn test_eval() {
         /* [
             ([..coeffs..], (x, expected_y))
         ] */
-        let tests = [
-            (vec![5, 0, 7, 9], (2, 63)),
-            (vec![0, 0, 0, 3], (2, 3)),
-            (vec![16, 91, 23, 111], (32, 618_319)),
-            (vec![8, 0, 2, 0], (16, 32_800)),
-            (vec![3, 4, 1, -5], (3, 115)),
-            (vec![3, 4, 1, -5], (-6, -515)),
+        let test_set = [
+            ([5, 0, 7, 9], (2, 63)),
+            ([0, 0, 0, 3], (2, 3)),
+            ([16, 91, 23, 111], (32, 618_319)),
+            ([8, 0, 2, 0], (16, 32_800)),
+            ([0, 0, 0, 0], (11111, 0)),
         ];
 
-        for (coeffes, (x, expected)) in tests {
+        // runs the test_set as primitive i32 types
+        for (coeffes, (x, expected)) in test_set {
             let actual = evaluate_polynomial(coeffes.into_iter(), 0, x);
             assert!(actual == expected)
+        }
+
+        // transforms test_set into Field types and runs the test
+        for (coeffes, (x, expected)) in test_set {
+            let field_coeffes = coeffes.map(|i| Fp::from(i as u32));
+            let actual = evaluate_polynomial(
+                field_coeffes.into_iter(),
+                Fp::from(0u32),
+                Fp::from(x as u32),
+            );
+            assert!(actual == Fp::from(expected as u32));
         }
     }
 

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -35,9 +35,6 @@ mod tests {
 
     #[test]
     fn test_eval() {
-        /* [
-            ([..coeffs..], (x, expected_y))
-        ] */
         let test_set = [
             ([5, 0, 7, 9], (2, 63)),
             ([0, 0, 0, 3], (2, 3)),

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -19,6 +19,7 @@ pub fn ceil_log2(d: usize) -> usize {
     ceil_log2
 }
 
+/// Evaluates a polynomial's `coefficients` at a given point `x`, using [Horner's scheme](https://en.wikipedia.org/wiki/Horner%27s_method)
 pub fn evaluate_polynomial<F, I>(coefficients: I, zero: F, x: F) -> F
 where
     I: Iterator<Item = F>,

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -32,6 +32,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_eval() {
+        /* [
+            ([..coeffs..], (x, expected_y))
+        ] */
+        let tests = [
+            (vec![5, 0, 7, 9], (2, 63)),
+            (vec![0, 0, 0, 3], (2, 3)),
+            (vec![16, 91, 23, 111], (32, 618_319)),
+            (vec![8, 0, 2, 0], (16, 32_800)),
+            (vec![3, 4, 1, -5], (3, 115)),
+            (vec![3, 4, 1, -5], (-6, -515)),
+        ];
+
+        for (coeffes, (x, expected)) in tests {
+            let actual = evaluate_polynomial(coeffes.into_iter(), 0, x);
+            assert!(actual == expected)
+        }
+    }
+
+    #[test]
     fn test_log2() {
         let tests = [
             (1, 0),

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -46,20 +46,17 @@ mod tests {
             ([0, 0, 0, 0], (11111, 0)),
         ];
 
-        // runs the test_set as primitive i32 types
-        for (coeffes, (x, expected)) in test_set {
-            let actual = evaluate_polynomial(coeffes.into_iter(), 0, x);
+        // runs the test_set with primitive i32 types
+        for (coeffs, (x, expected)) in test_set {
+            let actual = evaluate_polynomial(coeffs.into_iter(), 0, x);
             assert!(actual == expected)
         }
 
-        // transforms test_set into Field types and runs the test
-        for (coeffes, (x, expected)) in test_set {
-            let field_coeffes = coeffes.map(|i| Fp::from(i as u32));
-            let actual = evaluate_polynomial(
-                field_coeffes.into_iter(),
-                Fp::from(0u32),
-                Fp::from(x as u32),
-            );
+        // transforms test_set into Field types and runs the test, making sure generics are set correctly
+        for (coeffs, (x, expected)) in test_set {
+            let field_coeffs = coeffs.map(|i| Fp::from(i as u32));
+            let actual =
+                evaluate_polynomial(field_coeffs.into_iter(), Fp::from(0u32), Fp::from(x as u32));
             assert!(actual == Fp::from(expected as u32));
         }
     }

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -19,7 +19,7 @@ pub fn ceil_log2(d: usize) -> usize {
     ceil_log2
 }
 
-fn evaluate_polynomial<F, I>(coefficients: I, zero: F, x: F) -> F
+pub fn evaluate_polynomial<F, I>(coefficients: I, zero: F, x: F) -> F
 where
     I: Iterator<Item = F>,
     F: Mul<F, Output = F> + Add<F, Output = F> + Copy,

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -1,5 +1,7 @@
 //! This modules implements some math helper functions.
 
+use std::ops::{Add, Mul};
+
 /// Returns ceil(log2(d)) but panics if d = 0.
 pub fn ceil_log2(d: usize) -> usize {
     // NOTE: should this really be usize, since usize is depended on the underlying system architecture?
@@ -15,6 +17,14 @@ pub fn ceil_log2(d: usize) -> usize {
         }
     }
     ceil_log2
+}
+
+fn evaluate_polynomial<F, I>(coefficients: I, zero: F, x: F) -> F
+where
+    I: Iterator<Item = F>,
+    F: Mul<F, Output = F> + Add<F, Output = F> + Copy,
+{
+    coefficients.fold(zero, |acc, coeff| x * acc + coeff)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
adds horner schema evaluation of polynomials to `o1_utils::math` plus tests - i went with the iterator-variant instead of passing a `DensePolynomial` directly to make it more "generic"

Not sure if its necessary to make Field-specific tests or if primitive integer tests are enough, i added them nonetheless 

i did not replace any implementations yet

would like to hear some thoughts about that

#437 