### PR TITLE
Re-export Hash type of the Hasher trait

### DIFF
--- a/hasher/Cargo.toml
+++ b/hasher/Cargo.toml
@@ -16,4 +16,6 @@ ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 
 bitvec = "1.0.0"
 serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
 serde_json = { version = "1.0" }

--- a/hasher/README.md
+++ b/hasher/README.md
@@ -1,13 +1,13 @@
 # Mina hasher
 
-This crate provides an API and framework for Mina hashing.  It is a safe wrapper around Mina's instances of the [Poseidon arithmetic sponge](https://github.com/o1-labs/cryptography-rfcs/blob/master/mina/001-poseidon-sponge.md) that converts it from a sponge into a hash interface.
+This crate provides an API and framework for Mina hashing. It is a safe wrapper around Mina's instances of the [Poseidon arithmetic sponge](https://github.com/o1-labs/cryptography-rfcs/blob/master/mina/001-poseidon-sponge.md) that converts it from a sponge into a hash interface.
 
 ## Hasher interface
 
 The `mina_hasher` crate currently supports creating both the legacy hasher and an experimental kimchi hasher.
 
-* [`create_legacy`] create a legacy hasher
-* [`create_kimchi`] create an experimental kimchi hasher
+- [`create_legacy`] create a legacy hasher
+- [`create_kimchi`] create an experimental kimchi hasher
 
 Here is an example of how to use the hasher interface.
 
@@ -62,7 +62,7 @@ let out = hasher.init_and_hash(1, &Example { x: 82, y: 834 });
 
 ## The `Hashable` trait
 
-In order to sign something it must be hashed.  This framework allows you to define how types are hashed by implementing the [`Hashable`] trait.
+In order to sign something it must be hashed. This framework allows you to define how types are hashed by implementing the [`Hashable`] trait.
 
 For example, if you wanted to create Mina signatures for a `Foo` structure you would do the following.
 
@@ -96,18 +96,17 @@ impl Hashable for Foo {
 **Example: `domain_string` parameterized by structure contents**
 
 Suppose you wanted to hash a non-leaf Merkle tree node, where the
-domain string depends on the height of the node.  This can be implemented like this.
+domain string depends on the height of the node. This can be implemented like this.
 
 ```rust
 use ark_ff::Zero;
-use mina_hasher::{create_legacy, Hashable, Hasher, ROInput};
-use mina_curves::pasta::Fp;
+use mina_hasher::{create_legacy, Hash, Hashable, Hasher, ROInput};
 
 #[derive(Clone)]
 struct ExampleMerkleNode {
     height: u64,
-    left: Fp,
-    right: Fp,
+    left: Hash,
+    right: Hash,
 }
 
 impl Hashable for ExampleMerkleNode {
@@ -134,8 +133,8 @@ impl Hashable for ExampleMerkleNode {
 let mut hasher = create_legacy::<ExampleMerkleNode>(());
 let node = ExampleMerkleNode {
     height: 3,
-    left: Fp::zero(),
-    right: Fp::zero(),
+    left: Hash::zero(),
+    right: Hash::zero(),
 };
 let out = hasher.hash(&node);
 // Or like this..
@@ -149,13 +148,12 @@ passed when hashing, then it can be implemented like this.
 
 ```rust
 use ark_ff::Zero;
-use mina_hasher::{create_legacy, Hashable, Hasher, ROInput};
-use mina_curves::pasta::Fp;
+use mina_hasher::{create_legacy, Hash, Hashable, Hasher, ROInput};
 
 #[derive(Clone)]
 struct ExampleMerkleNode {
-    left: Fp,
-    right: Fp,
+    left: Hash,
+    right: Hash,
 }
 
 impl Hashable for ExampleMerkleNode {
@@ -178,12 +176,12 @@ impl Hashable for ExampleMerkleNode {
 // Used like this
 let mut hasher = create_legacy::<ExampleMerkleNode>(0);
 let node1 = ExampleMerkleNode {
-    left: Fp::zero(),
-    right: Fp::zero(),
+    left: Hash::zero(),
+    right: Hash::zero(),
 };
 let node2 = ExampleMerkleNode {
-    left: Fp::zero(),
-    right: Fp::zero(),
+    left: Hash::zero(),
+    right: Hash::zero(),
 };
 let out = hasher.init_and_hash(3 /* height */, &node1);
 let out = hasher.init_and_hash(7 /* height */, &node2);

--- a/hasher/README.md
+++ b/hasher/README.md
@@ -100,13 +100,13 @@ domain string depends on the height of the node.  This can be implemented like t
 
 ```rust
 use ark_ff::Zero;
-use mina_hasher::{create_legacy, Hash, Hashable, Hasher, ROInput};
+use mina_hasher::{create_legacy, Fp, Hashable, Hasher, ROInput};
 
 #[derive(Clone)]
 struct ExampleMerkleNode {
     height: u64,
-    left: Hash,
-    right: Hash,
+    left: Fp,
+    right: Fp,
 }
 
 impl Hashable for ExampleMerkleNode {
@@ -133,8 +133,8 @@ impl Hashable for ExampleMerkleNode {
 let mut hasher = create_legacy::<ExampleMerkleNode>(());
 let node = ExampleMerkleNode {
     height: 3,
-    left: Hash::zero(),
-    right: Hash::zero(),
+    left: Fp::zero(),
+    right: Fp::zero(),
 };
 let out = hasher.hash(&node);
 // Or like this..
@@ -148,12 +148,12 @@ passed when hashing, then it can be implemented like this.
 
 ```rust
 use ark_ff::Zero;
-use mina_hasher::{create_legacy, Hash, Hashable, Hasher, ROInput};
+use mina_hasher::{create_legacy, Fp, Hashable, Hasher, ROInput};
 
 #[derive(Clone)]
 struct ExampleMerkleNode {
-    left: Hash,
-    right: Hash,
+    left: Fp,
+    right: Fp,
 }
 
 impl Hashable for ExampleMerkleNode {
@@ -176,12 +176,12 @@ impl Hashable for ExampleMerkleNode {
 // Used like this
 let mut hasher = create_legacy::<ExampleMerkleNode>(0);
 let node1 = ExampleMerkleNode {
-    left: Hash::zero(),
-    right: Hash::zero(),
+    left: Fp::zero(),
+    right: Fp::zero(),
 };
 let node2 = ExampleMerkleNode {
-    left: Hash::zero(),
-    right: Hash::zero(),
+    left: Fp::zero(),
+    right: Fp::zero(),
 };
 let out = hasher.init_and_hash(3 /* height */, &node1);
 let out = hasher.init_and_hash(7 /* height */, &node2);

--- a/hasher/README.md
+++ b/hasher/README.md
@@ -1,13 +1,13 @@
 # Mina hasher
 
-This crate provides an API and framework for Mina hashing. It is a safe wrapper around Mina's instances of the [Poseidon arithmetic sponge](https://github.com/o1-labs/cryptography-rfcs/blob/master/mina/001-poseidon-sponge.md) that converts it from a sponge into a hash interface.
+This crate provides an API and framework for Mina hashing.  It is a safe wrapper around Mina's instances of the [Poseidon arithmetic sponge](https://github.com/o1-labs/cryptography-rfcs/blob/master/mina/001-poseidon-sponge.md) that converts it from a sponge into a hash interface.
 
 ## Hasher interface
 
 The `mina_hasher` crate currently supports creating both the legacy hasher and an experimental kimchi hasher.
 
-- [`create_legacy`] create a legacy hasher
-- [`create_kimchi`] create an experimental kimchi hasher
+* [`create_legacy`] create a legacy hasher
+* [`create_kimchi`] create an experimental kimchi hasher
 
 Here is an example of how to use the hasher interface.
 
@@ -62,7 +62,7 @@ let out = hasher.init_and_hash(1, &Example { x: 82, y: 834 });
 
 ## The `Hashable` trait
 
-In order to sign something it must be hashed. This framework allows you to define how types are hashed by implementing the [`Hashable`] trait.
+In order to sign something it must be hashed.  This framework allows you to define how types are hashed by implementing the [`Hashable`] trait.
 
 For example, if you wanted to create Mina signatures for a `Foo` structure you would do the following.
 
@@ -96,7 +96,7 @@ impl Hashable for Foo {
 **Example: `domain_string` parameterized by structure contents**
 
 Suppose you wanted to hash a non-leaf Merkle tree node, where the
-domain string depends on the height of the node. This can be implemented like this.
+domain string depends on the height of the node.  This can be implemented like this.
 
 ```rust
 use ark_ff::Zero;

--- a/hasher/src/lib.rs
+++ b/hasher/src/lib.rs
@@ -5,7 +5,7 @@ pub mod poseidon;
 pub mod roinput;
 
 use ark_ff::PrimeField;
-use mina_curves::pasta::Fp;
+pub use mina_curves::pasta::Fp as Hash;
 use o1_utils::FieldHelpers;
 pub use roinput::ROInput;
 
@@ -95,8 +95,7 @@ pub trait Hashable: Clone {
 /// Example usage
 ///
 /// ```rust
-/// use mina_hasher::{create_legacy, Hashable, Hasher, ROInput};
-/// use mina_curves::pasta::Fp;
+/// use mina_hasher::{create_legacy, Hash, Hashable, Hasher, ROInput};
 ///
 /// #[derive(Clone)]
 /// struct Something;
@@ -116,7 +115,7 @@ pub trait Hashable: Clone {
 /// }
 ///
 /// let mut hasher = create_legacy::<Something>(123);
-/// let output: Fp = hasher.hash(&Something { });
+/// let output: Hash = hasher.hash(&Something { });
 /// ```
 ///
 pub trait Hasher<H: Hashable> {
@@ -131,10 +130,10 @@ pub trait Hasher<H: Hashable> {
     fn update(&mut self, input: &H) -> &mut dyn Hasher<H>;
 
     /// Obtain has result output
-    fn digest(&mut self) -> Fp;
+    fn digest(&mut self) -> Hash;
 
     /// Hash input and obtain result output
-    fn hash(&mut self, input: &H) -> Fp {
+    fn hash(&mut self, input: &H) -> Hash {
         self.reset();
         self.update(input);
         let output = self.digest();
@@ -143,7 +142,7 @@ pub trait Hasher<H: Hashable> {
     }
 
     /// Initialize state, hash input and obtain result output
-    fn init_and_hash(&mut self, domain_param: H::D, input: &H) -> Fp {
+    fn init_and_hash(&mut self, domain_param: H::D, input: &H) -> Hash {
         self.init(domain_param);
         self.update(input);
         let output = self.digest();

--- a/hasher/src/lib.rs
+++ b/hasher/src/lib.rs
@@ -3,11 +3,11 @@
 
 pub mod poseidon;
 pub mod roinput;
+pub use mina_curves::pasta::Fp;
+pub use roinput::ROInput;
 
 use ark_ff::PrimeField;
-pub use mina_curves::pasta::Fp as Hash;
 use o1_utils::FieldHelpers;
-pub use roinput::ROInput;
 
 /// The domain parameter trait is used during hashing to convey extra
 /// arguments to domain string generation.  It is also used by generic signing code.
@@ -95,7 +95,7 @@ pub trait Hashable: Clone {
 /// Example usage
 ///
 /// ```rust
-/// use mina_hasher::{create_legacy, Hash, Hashable, Hasher, ROInput};
+/// use mina_hasher::{create_legacy, Fp, Hashable, Hasher, ROInput};
 ///
 /// #[derive(Clone)]
 /// struct Something;
@@ -115,7 +115,7 @@ pub trait Hashable: Clone {
 /// }
 ///
 /// let mut hasher = create_legacy::<Something>(123);
-/// let output: Hash = hasher.hash(&Something { });
+/// let output: Fp = hasher.hash(&Something { });
 /// ```
 ///
 pub trait Hasher<H: Hashable> {
@@ -130,10 +130,10 @@ pub trait Hasher<H: Hashable> {
     fn update(&mut self, input: &H) -> &mut dyn Hasher<H>;
 
     /// Obtain has result output
-    fn digest(&mut self) -> Hash;
+    fn digest(&mut self) -> Fp;
 
     /// Hash input and obtain result output
-    fn hash(&mut self, input: &H) -> Hash {
+    fn hash(&mut self, input: &H) -> Fp {
         self.reset();
         self.update(input);
         let output = self.digest();
@@ -142,7 +142,7 @@ pub trait Hasher<H: Hashable> {
     }
 
     /// Initialize state, hash input and obtain result output
-    fn init_and_hash(&mut self, domain_param: H::D, input: &H) -> Hash {
+    fn init_and_hash(&mut self, domain_param: H::D, input: &H) -> Fp {
         self.init(domain_param);
         self.update(input);
         let output = self.digest();

--- a/hasher/tests/hasher.rs
+++ b/hasher/tests/hasher.rs
@@ -1,4 +1,4 @@
-use mina_hasher::{Hash, Hashable, Hasher, ROInput};
+use mina_hasher::{Fp, Hashable, Hasher, ROInput};
 use o1_utils::FieldHelpers;
 use serde::Deserialize;
 use std::fs::File;
@@ -26,7 +26,7 @@ impl Hashable for TestVector {
         let mut roi = ROInput::new();
         // For hashing we only care about the input part
         for input in &self.input {
-            roi.append_field(Hash::from_hex(input).expect("failed to deserialize field element"))
+            roi.append_field(Fp::from_hex(input).expect("failed to deserialize field element"))
         }
         roi
     }
@@ -49,7 +49,7 @@ fn test_vectors(test_vector_file: &str, hasher: &mut dyn Hasher<TestVector>) {
     // execute test vectors
     for test_vector in test_vectors.test_vectors {
         let expected_output =
-            Hash::from_hex(&test_vector.output).expect("failed to deserialize field element");
+            Fp::from_hex(&test_vector.output).expect("failed to deserialize field element");
 
         // hash & check against expect output
         let output = hasher.hash(&test_vector);

--- a/hasher/tests/hasher.rs
+++ b/hasher/tests/hasher.rs
@@ -1,5 +1,4 @@
-use mina_curves::pasta::Fp;
-use mina_hasher::{Hashable, Hasher, ROInput};
+use mina_hasher::{Hash, Hashable, Hasher, ROInput};
 use o1_utils::FieldHelpers;
 use serde::Deserialize;
 use std::fs::File;
@@ -27,7 +26,7 @@ impl Hashable for TestVector {
         let mut roi = ROInput::new();
         // For hashing we only care about the input part
         for input in &self.input {
-            roi.append_field(Fp::from_hex(input).expect("failed to deserialize field element"))
+            roi.append_field(Hash::from_hex(input).expect("failed to deserialize field element"))
         }
         roi
     }
@@ -50,7 +49,7 @@ fn test_vectors(test_vector_file: &str, hasher: &mut dyn Hasher<TestVector>) {
     // execute test vectors
     for test_vector in test_vectors.test_vectors {
         let expected_output =
-            Fp::from_hex(&test_vector.output).expect("failed to deserialize field element");
+            Hash::from_hex(&test_vector.output).expect("failed to deserialize field element");
 
         // hash & check against expect output
         let output = hasher.hash(&test_vector);


### PR DESCRIPTION
This PR re-exports the Hash type (`Fp`) of the `Hasher<H: Hashable>` trait, so that the caller doesn't need to explicitly depend on the `mina-curves` crate to use this Hash type. 

@jspada plz take a look and let me know your feedback, thx!

