### PR TITLE
ROInput append_* fn chaining

### DIFF
--- a/hasher/README.md
+++ b/hasher/README.md
@@ -25,8 +25,7 @@ impl Hashable for Example {
 
     fn to_roinput(&self) -> ROInput {
         let mut roi = ROInput::new();
-        roi.append_u32(self.x);
-        roi.append_u64(self.y);
+        roi.append_u32(self.x).append_u64(self.y);
         roi
     }
 

--- a/hasher/src/lib.rs
+++ b/hasher/src/lib.rs
@@ -197,9 +197,7 @@ mod tests {
 
             fn to_roinput(&self) -> ROInput {
                 let mut roi = ROInput::new();
-                roi.append_u32(self.x);
-                roi.append_u64(self.y);
-
+                roi.append_u32(self.x).append_u64(self.y);
                 roi
             }
 

--- a/hasher/src/roinput.rs
+++ b/hasher/src/roinput.rs
@@ -73,47 +73,55 @@ impl ROInput {
     }
 
     /// Append a `Hashable` input
-    pub fn append_hashable(&mut self, input: impl Hashable) {
+    pub fn append_hashable(&mut self, input: impl Hashable) -> &mut Self {
         self.append_roinput(input.to_roinput());
+        self
     }
 
     /// Append another random oracle input
-    pub fn append_roinput(&mut self, roi: ROInput) {
+    pub fn append_roinput(&mut self, roi: ROInput) -> &mut Self {
         self.fields = [self.fields.clone(), roi.fields].concat();
         self.bits.extend(roi.bits);
+        self
     }
 
     /// Append a base field element
-    pub fn append_field(&mut self, f: Fp) {
+    pub fn append_field(&mut self, f: Fp) -> &mut Self {
         self.fields.push(f);
+        self
     }
 
     /// Append a scalar field element
-    pub fn append_scalar(&mut self, s: Fq) {
+    pub fn append_scalar(&mut self, s: Fq) -> &mut Self {
         // mina scalars are 255 bytes
         let bytes = s.to_bytes();
         let bits = &bytes.as_bits::<Lsb0>()[..Fq::size_in_bits()];
         self.bits.extend(bits);
+        self
     }
 
     /// Append a single bit
-    pub fn append_bool(&mut self, b: bool) {
+    pub fn append_bool(&mut self, b: bool) -> &mut Self {
         self.bits.push(b);
+        self
     }
 
     /// Append bytes
-    pub fn append_bytes(&mut self, bytes: &[u8]) {
+    pub fn append_bytes(&mut self, bytes: &[u8]) -> &mut Self {
         self.bits.extend_from_bitslice(bytes.as_bits::<Lsb0>());
+        self
     }
 
     /// Append a 32-bit unsigned integer
-    pub fn append_u32(&mut self, x: u32) {
+    pub fn append_u32(&mut self, x: u32) -> &mut Self {
         self.append_bytes(&x.to_le_bytes());
+        self
     }
 
     /// Append a 64-bit unsigned integer
-    pub fn append_u64(&mut self, x: u64) {
+    pub fn append_u64(&mut self, x: u64) -> &mut Self {
         self.append_bytes(&x.to_le_bytes());
+        self
     }
 
     /// Serialize random oracle input to bytes
@@ -198,11 +206,11 @@ mod tests {
     #[test]
     fn append_five_bits() {
         let mut roi: ROInput = ROInput::new();
-        roi.append_bool(false);
-        roi.append_bool(true);
-        roi.append_bool(false);
-        roi.append_bool(false);
-        roi.append_bool(true);
+        roi.append_bool(false)
+            .append_bool(true)
+            .append_bool(false)
+            .append_bool(false)
+            .append_bool(true);
         assert!(roi.bits.len() == 5);
         assert!(roi.bits.as_raw_slice() == [0x12]);
     }

--- a/hasher/tests/hasher.rs
+++ b/hasher/tests/hasher.rs
@@ -27,7 +27,7 @@ impl Hashable for TestVector {
         let mut roi = ROInput::new();
         // For hashing we only care about the input part
         for input in &self.input {
-            roi.append_field(Fp::from_hex(input).expect("failed to deserialize field element"))
+            roi.append_field(Fp::from_hex(input).expect("failed to deserialize field element"));
         }
         roi
     }


### PR DESCRIPTION
This PR allows chaining multiple `append_*` functions in `ROInput`.

@jspada  plz take a look and let me know your feedback, thx!

e.g.
```rust
let mut roi: ROInput = ROInput::new();
        roi.append_bool(false)
            .append_bool(true)
            .append_bool(false)
            .append_bool(false)
            .append_bool(true);
```