### PR TITLE
refactor ChunkedPolynomials

### DIFF
--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -748,23 +748,71 @@ where
         let chunked_evals = {
             let chunked_evals_zeta = ProofEvaluations::<Vec<ScalarField<G>>> {
                 s: array_init(|i| {
-                    index.cs.sigmam[0..PERMUTS - 1][i].eval(zeta, index.max_poly_size)
+                    //index.cs.sigmam[0..PERMUTS - 1][i].eval(zeta, index.max_poly_size)
+                    index.cs.sigmam[0..PERMUTS - 1][i]
+                        .to_chunked_polynomials(index.max_poly_size)
+                        .eval(zeta)
                 }),
-                w: array_init(|i| witness_poly[i].eval(zeta, index.max_poly_size)),
-                z: z_poly.eval(zeta, index.max_poly_size),
+                //w: array_init(|i| witness_poly[i].eval(zeta, index.max_poly_size)),
+                w: array_init(|i| {
+                    witness_poly[i]
+                        .to_chunked_polynomials(index.max_poly_size)
+                        .eval(zeta)
+                }),
+
+                //z: z_poly.eval(zeta, index.max_poly_size),
+                z: z_poly
+                    .to_chunked_polynomials(index.max_poly_size)
+                    .eval(zeta),
+                //eval(zeta, index.max_poly_size),
                 lookup: lookup_evals(zeta),
-                generic_selector: index.cs.genericm.eval(zeta, index.max_poly_size),
-                poseidon_selector: index.cs.psm.eval(zeta, index.max_poly_size),
+                //generic_selector: index.cs.genericm.eval(zeta, index.max_poly_size),
+                generic_selector: index
+                    .cs
+                    .genericm
+                    .to_chunked_polynomials(index.max_poly_size)
+                    .eval(zeta),
+
+                //poseidon_selector: index.cs.psm.eval(zeta, index.max_poly_size),
+                poseidon_selector: index
+                    .cs
+                    .psm
+                    .to_chunked_polynomials(index.max_poly_size)
+                    .eval(zeta),
             };
             let chunked_evals_zeta_omega = ProofEvaluations::<Vec<ScalarField<G>>> {
                 s: array_init(|i| {
-                    index.cs.sigmam[0..PERMUTS - 1][i].eval(zeta_omega, index.max_poly_size)
+                    //    index.cs.sigmam[0..PERMUTS - 1][i].eval(zeta_omega, index.max_poly_size)
+                    index.cs.sigmam[0..PERMUTS - 1][i]
+                        .to_chunked_polynomials(index.max_poly_size)
+                        .eval(zeta_omega)
                 }),
-                w: array_init(|i| witness_poly[i].eval(zeta_omega, index.max_poly_size)),
-                z: z_poly.eval(zeta_omega, index.max_poly_size),
+                //w: array_init(|i| witness_poly[i].eval(zeta_omega, index.max_poly_size)),
+                w: array_init(|i| {
+                    witness_poly[i]
+                        .to_chunked_polynomials(index.max_poly_size)
+                        .eval(zeta_omega)
+                }),
+
+                //z: z_poly.eval(zeta_omega, index.max_poly_size),
+                z: z_poly
+                    .to_chunked_polynomials(index.max_poly_size)
+                    .eval(zeta_omega),
+
                 lookup: lookup_evals(zeta_omega),
-                generic_selector: index.cs.genericm.eval(zeta_omega, index.max_poly_size),
-                poseidon_selector: index.cs.psm.eval(zeta_omega, index.max_poly_size),
+                //generic_selector: index.cs.genericm.eval(zeta_omega, index.max_poly_size),
+                generic_selector: index
+                    .cs
+                    .genericm
+                    .to_chunked_polynomials(index.max_poly_size)
+                    .eval(zeta_omega),
+
+                //poseidon_selector: index.cs.psm.eval(zeta_omega, index.max_poly_size),
+                poseidon_selector: index
+                    .cs
+                    .psm
+                    .to_chunked_polynomials(index.max_poly_size)
+                    .eval(zeta_omega),
             };
 
             [chunked_evals_zeta, chunked_evals_zeta_omega]
@@ -836,10 +884,15 @@ where
                 drop(lookup_table_combined);
 
                 // see https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html#the-prover-side
-                f.chunk_polynomial(zeta_to_srs_len, index.max_poly_size)
+                //f.chunk_polynomial(zeta_to_srs_len, index.max_poly_size)
+                f.to_chunked_polynomials(index.max_poly_size)
+                    .compress_polynomial(zeta_to_srs_len)
             };
 
-            let t_chunked = quotient_poly.chunk_polynomial(zeta_to_srs_len, index.max_poly_size);
+            //let t_chunked = quotient_poly.chunk_polynomial(zeta_to_srs_len, index.max_poly_size);
+            let t_chunked = quotient_poly
+                .to_chunked_polynomials(index.max_poly_size)
+                .compress_polynomial(zeta_to_srs_len);
 
             &f_chunked - &t_chunked.scale(zeta_to_domain_size - ScalarField::<G>::one())
         };

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -708,15 +708,17 @@ where
                 .zip(lookup_sorted_coeffs.as_ref())
                 .zip(index.cs.lookup_constraint_system.as_ref())
                 .map(|((aggreg, sorted), lcs)| LookupEvaluations {
-                    aggreg: aggreg.eval(e, index.max_poly_size),
+                    aggreg: aggreg
+                        .to_chunked_polynomials(index.max_poly_size)
+                        .linearize(e),
                     sorted: sorted
                         .iter()
-                        .map(|c| c.eval(e, index.max_poly_size))
+                        .map(|c| c.to_chunked_polynomials(index.max_poly_size).linearize(e))
                         .collect(),
                     table: lcs
                         .lookup_table
                         .iter()
-                        .map(|p| p.eval(e, index.max_poly_size))
+                        .map(|p| p.to_chunked_polynomials(index.max_poly_size).linearize(e))
                         .rev()
                         .fold(vec![ScalarField::<G>::zero()], |acc, x| {
                             acc.into_iter()
@@ -750,17 +752,17 @@ where
                 s: array_init(|i| {
                     index.cs.sigmam[0..PERMUTS - 1][i]
                         .to_chunked_polynomials(index.max_poly_size)
-                        .eval(zeta)
+                        .linearize(zeta)
                 }),
                 w: array_init(|i| {
                     witness_poly[i]
                         .to_chunked_polynomials(index.max_poly_size)
-                        .eval(zeta)
+                        .linearize(zeta)
                 }),
 
                 z: z_poly
                     .to_chunked_polynomials(index.max_poly_size)
-                    .eval(zeta),
+                    .linearize(zeta),
 
                 lookup: lookup_evals(zeta),
 
@@ -768,30 +770,30 @@ where
                     .cs
                     .genericm
                     .to_chunked_polynomials(index.max_poly_size)
-                    .eval(zeta),
+                    .linearize(zeta),
 
                 poseidon_selector: index
                     .cs
                     .psm
                     .to_chunked_polynomials(index.max_poly_size)
-                    .eval(zeta),
+                    .linearize(zeta),
             };
             let chunked_evals_zeta_omega = ProofEvaluations::<Vec<ScalarField<G>>> {
                 s: array_init(|i| {
                     index.cs.sigmam[0..PERMUTS - 1][i]
                         .to_chunked_polynomials(index.max_poly_size)
-                        .eval(zeta_omega)
+                        .linearize(zeta_omega)
                 }),
 
                 w: array_init(|i| {
                     witness_poly[i]
                         .to_chunked_polynomials(index.max_poly_size)
-                        .eval(zeta_omega)
+                        .linearize(zeta_omega)
                 }),
 
                 z: z_poly
                     .to_chunked_polynomials(index.max_poly_size)
-                    .eval(zeta_omega),
+                    .linearize(zeta_omega),
 
                 lookup: lookup_evals(zeta_omega),
 
@@ -799,13 +801,13 @@ where
                     .cs
                     .genericm
                     .to_chunked_polynomials(index.max_poly_size)
-                    .eval(zeta_omega),
+                    .linearize(zeta_omega),
 
                 poseidon_selector: index
                     .cs
                     .psm
                     .to_chunked_polynomials(index.max_poly_size)
-                    .eval(zeta_omega),
+                    .linearize(zeta_omega),
             };
 
             [chunked_evals_zeta, chunked_evals_zeta_omega]

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -709,16 +709,16 @@ where
                 .zip(index.cs.lookup_constraint_system.as_ref())
                 .map(|((aggreg, sorted), lcs)| LookupEvaluations {
                     aggreg: aggreg
-                        .to_chunked_polynomials(index.max_poly_size)
-                        .linearize(e),
+                        .to_chunked_polynomial(index.max_poly_size)
+                        .evaluate_chunks(e),
                     sorted: sorted
                         .iter()
-                        .map(|c| c.to_chunked_polynomials(index.max_poly_size).linearize(e))
+                        .map(|c| c.to_chunked_polynomial(index.max_poly_size).evaluate_chunks(e))
                         .collect(),
                     table: lcs
                         .lookup_table
                         .iter()
-                        .map(|p| p.to_chunked_polynomials(index.max_poly_size).linearize(e))
+                        .map(|p| p.to_chunked_polynomial(index.max_poly_size).evaluate_chunks(e))
                         .rev()
                         .fold(vec![ScalarField::<G>::zero()], |acc, x| {
                             acc.into_iter()
@@ -751,63 +751,63 @@ where
             let chunked_evals_zeta = ProofEvaluations::<Vec<ScalarField<G>>> {
                 s: array_init(|i| {
                     index.cs.sigmam[0..PERMUTS - 1][i]
-                        .to_chunked_polynomials(index.max_poly_size)
-                        .linearize(zeta)
+                        .to_chunked_polynomial(index.max_poly_size)
+                        .evaluate_chunks(zeta)
                 }),
                 w: array_init(|i| {
                     witness_poly[i]
-                        .to_chunked_polynomials(index.max_poly_size)
-                        .linearize(zeta)
+                        .to_chunked_polynomial(index.max_poly_size)
+                        .evaluate_chunks(zeta)
                 }),
 
                 z: z_poly
-                    .to_chunked_polynomials(index.max_poly_size)
-                    .linearize(zeta),
+                    .to_chunked_polynomial(index.max_poly_size)
+                    .evaluate_chunks(zeta),
 
                 lookup: lookup_evals(zeta),
 
                 generic_selector: index
                     .cs
                     .genericm
-                    .to_chunked_polynomials(index.max_poly_size)
-                    .linearize(zeta),
+                    .to_chunked_polynomial(index.max_poly_size)
+                    .evaluate_chunks(zeta),
 
                 poseidon_selector: index
                     .cs
                     .psm
-                    .to_chunked_polynomials(index.max_poly_size)
-                    .linearize(zeta),
+                    .to_chunked_polynomial(index.max_poly_size)
+                    .evaluate_chunks(zeta),
             };
             let chunked_evals_zeta_omega = ProofEvaluations::<Vec<ScalarField<G>>> {
                 s: array_init(|i| {
                     index.cs.sigmam[0..PERMUTS - 1][i]
-                        .to_chunked_polynomials(index.max_poly_size)
-                        .linearize(zeta_omega)
+                        .to_chunked_polynomial(index.max_poly_size)
+                        .evaluate_chunks(zeta_omega)
                 }),
 
                 w: array_init(|i| {
                     witness_poly[i]
-                        .to_chunked_polynomials(index.max_poly_size)
-                        .linearize(zeta_omega)
+                        .to_chunked_polynomial(index.max_poly_size)
+                        .evaluate_chunks(zeta_omega)
                 }),
 
                 z: z_poly
-                    .to_chunked_polynomials(index.max_poly_size)
-                    .linearize(zeta_omega),
+                    .to_chunked_polynomial(index.max_poly_size)
+                    .evaluate_chunks(zeta_omega),
 
                 lookup: lookup_evals(zeta_omega),
 
                 generic_selector: index
                     .cs
                     .genericm
-                    .to_chunked_polynomials(index.max_poly_size)
-                    .linearize(zeta_omega),
+                    .to_chunked_polynomial(index.max_poly_size)
+                    .evaluate_chunks(zeta_omega),
 
                 poseidon_selector: index
                     .cs
                     .psm
-                    .to_chunked_polynomials(index.max_poly_size)
-                    .linearize(zeta_omega),
+                    .to_chunked_polynomial(index.max_poly_size)
+                    .evaluate_chunks(zeta_omega),
             };
 
             [chunked_evals_zeta, chunked_evals_zeta_omega]
@@ -879,13 +879,13 @@ where
                 drop(lookup_table_combined);
 
                 // see https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html#the-prover-side
-                f.to_chunked_polynomials(index.max_poly_size)
-                    .compress_polynomial(zeta_to_srs_len)
+                f.to_chunked_polynomial(index.max_poly_size)
+                    .linearize(zeta_to_srs_len)
             };
 
             let t_chunked = quotient_poly
-                .to_chunked_polynomials(index.max_poly_size)
-                .compress_polynomial(zeta_to_srs_len);
+                .to_chunked_polynomial(index.max_poly_size)
+                .linearize(zeta_to_srs_len);
 
             &f_chunked - &t_chunked.scale(zeta_to_domain_size - ScalarField::<G>::one())
         };

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -713,12 +713,18 @@ where
                         .evaluate_chunks(e),
                     sorted: sorted
                         .iter()
-                        .map(|c| c.to_chunked_polynomial(index.max_poly_size).evaluate_chunks(e))
+                        .map(|c| {
+                            c.to_chunked_polynomial(index.max_poly_size)
+                                .evaluate_chunks(e)
+                        })
                         .collect(),
                     table: lcs
                         .lookup_table
                         .iter()
-                        .map(|p| p.to_chunked_polynomial(index.max_poly_size).evaluate_chunks(e))
+                        .map(|p| {
+                            p.to_chunked_polynomial(index.max_poly_size)
+                                .evaluate_chunks(e)
+                        })
                         .rev()
                         .fold(vec![ScalarField::<G>::zero()], |acc, x| {
                             acc.into_iter()

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -748,32 +748,28 @@ where
         let chunked_evals = {
             let chunked_evals_zeta = ProofEvaluations::<Vec<ScalarField<G>>> {
                 s: array_init(|i| {
-                    //index.cs.sigmam[0..PERMUTS - 1][i].eval(zeta, index.max_poly_size)
                     index.cs.sigmam[0..PERMUTS - 1][i]
                         .to_chunked_polynomials(index.max_poly_size)
                         .eval(zeta)
                 }),
-                //w: array_init(|i| witness_poly[i].eval(zeta, index.max_poly_size)),
                 w: array_init(|i| {
                     witness_poly[i]
                         .to_chunked_polynomials(index.max_poly_size)
                         .eval(zeta)
                 }),
 
-                //z: z_poly.eval(zeta, index.max_poly_size),
                 z: z_poly
                     .to_chunked_polynomials(index.max_poly_size)
                     .eval(zeta),
-                //eval(zeta, index.max_poly_size),
+
                 lookup: lookup_evals(zeta),
-                //generic_selector: index.cs.genericm.eval(zeta, index.max_poly_size),
+
                 generic_selector: index
                     .cs
                     .genericm
                     .to_chunked_polynomials(index.max_poly_size)
                     .eval(zeta),
 
-                //poseidon_selector: index.cs.psm.eval(zeta, index.max_poly_size),
                 poseidon_selector: index
                     .cs
                     .psm
@@ -782,32 +778,29 @@ where
             };
             let chunked_evals_zeta_omega = ProofEvaluations::<Vec<ScalarField<G>>> {
                 s: array_init(|i| {
-                    //    index.cs.sigmam[0..PERMUTS - 1][i].eval(zeta_omega, index.max_poly_size)
                     index.cs.sigmam[0..PERMUTS - 1][i]
                         .to_chunked_polynomials(index.max_poly_size)
                         .eval(zeta_omega)
                 }),
-                //w: array_init(|i| witness_poly[i].eval(zeta_omega, index.max_poly_size)),
+
                 w: array_init(|i| {
                     witness_poly[i]
                         .to_chunked_polynomials(index.max_poly_size)
                         .eval(zeta_omega)
                 }),
 
-                //z: z_poly.eval(zeta_omega, index.max_poly_size),
                 z: z_poly
                     .to_chunked_polynomials(index.max_poly_size)
                     .eval(zeta_omega),
 
                 lookup: lookup_evals(zeta_omega),
-                //generic_selector: index.cs.genericm.eval(zeta_omega, index.max_poly_size),
+
                 generic_selector: index
                     .cs
                     .genericm
                     .to_chunked_polynomials(index.max_poly_size)
                     .eval(zeta_omega),
 
-                //poseidon_selector: index.cs.psm.eval(zeta_omega, index.max_poly_size),
                 poseidon_selector: index
                     .cs
                     .psm
@@ -884,12 +877,10 @@ where
                 drop(lookup_table_combined);
 
                 // see https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html#the-prover-side
-                //f.chunk_polynomial(zeta_to_srs_len, index.max_poly_size)
                 f.to_chunked_polynomials(index.max_poly_size)
                     .compress_polynomial(zeta_to_srs_len)
             };
 
-            //let t_chunked = quotient_poly.chunk_polynomial(zeta_to_srs_len, index.max_poly_size);
             let t_chunked = quotient_poly
                 .to_chunked_polynomials(index.max_poly_size)
                 .compress_polynomial(zeta_to_srs_len);

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -908,8 +908,12 @@ mod tests {
 
         // evaluate the polynomials at these two points
         let poly1_chunked_evals = vec![
-            poly1.to_chunked_polynomial(srs.g.len()).evaluate_chunks(elm[0]),
-            poly1.to_chunked_polynomial(srs.g.len()).evaluate_chunks(elm[1]),
+            poly1
+                .to_chunked_polynomial(srs.g.len())
+                .evaluate_chunks(elm[0]),
+            poly1
+                .to_chunked_polynomial(srs.g.len())
+                .evaluate_chunks(elm[1]),
         ];
 
         fn sum(c: &[Fp]) -> Fp {
@@ -920,8 +924,12 @@ mod tests {
         assert_eq!(sum(&poly1_chunked_evals[1]), poly1.evaluate(&elm[1]));
 
         let poly2_chunked_evals = vec![
-            poly2.to_chunked_polynomial(srs.g.len()).evaluate_chunks(elm[0]),
-            poly2.to_chunked_polynomial(srs.g.len()).evaluate_chunks(elm[1]),
+            poly2
+                .to_chunked_polynomial(srs.g.len())
+                .evaluate_chunks(elm[0]),
+            poly2
+                .to_chunked_polynomial(srs.g.len())
+                .evaluate_chunks(elm[1]),
         ];
 
         assert_eq!(sum(&poly2_chunked_evals[0]), poly2.evaluate(&elm[0]));

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -908,8 +908,8 @@ mod tests {
 
         // evaluate the polynomials at these two points
         let poly1_chunked_evals = vec![
-            poly1.eval(elm[0], srs.g.len()),
-            poly1.eval(elm[1], srs.g.len()),
+            poly1.to_chunked_polynomials(srs.g.len()).linearize(elm[0]),
+            poly1.to_chunked_polynomials(srs.g.len()).linearize(elm[1]),
         ];
 
         fn sum(c: &[Fp]) -> Fp {
@@ -920,8 +920,8 @@ mod tests {
         assert_eq!(sum(&poly1_chunked_evals[1]), poly1.evaluate(&elm[1]));
 
         let poly2_chunked_evals = vec![
-            poly2.eval(elm[0], srs.g.len()),
-            poly2.eval(elm[1], srs.g.len()),
+            poly2.to_chunked_polynomials(srs.g.len()).linearize(elm[0]),
+            poly2.to_chunked_polynomials(srs.g.len()).linearize(elm[1]),
         ];
 
         assert_eq!(sum(&poly2_chunked_evals[0]), poly2.evaluate(&elm[0]));

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -908,8 +908,8 @@ mod tests {
 
         // evaluate the polynomials at these two points
         let poly1_chunked_evals = vec![
-            poly1.to_chunked_polynomials(srs.g.len()).linearize(elm[0]),
-            poly1.to_chunked_polynomials(srs.g.len()).linearize(elm[1]),
+            poly1.to_chunked_polynomial(srs.g.len()).evaluate_chunks(elm[0]),
+            poly1.to_chunked_polynomial(srs.g.len()).evaluate_chunks(elm[1]),
         ];
 
         fn sum(c: &[Fp]) -> Fp {
@@ -920,8 +920,8 @@ mod tests {
         assert_eq!(sum(&poly1_chunked_evals[1]), poly1.evaluate(&elm[1]));
 
         let poly2_chunked_evals = vec![
-            poly2.to_chunked_polynomials(srs.g.len()).linearize(elm[0]),
-            poly2.to_chunked_polynomials(srs.g.len()).linearize(elm[1]),
+            poly2.to_chunked_polynomial(srs.g.len()).evaluate_chunks(elm[0]),
+            poly2.to_chunked_polynomial(srs.g.len()).evaluate_chunks(elm[1]),
         ];
 
         assert_eq!(sum(&poly2_chunked_evals[0]), poly2.evaluate(&elm[0]));

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -4,6 +4,7 @@ use ark_ec::{msm::VariableBaseMSM, AffineCurve, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
 use ark_poly::univariate::DensePolynomial;
 use o1_utils::{
+    chunked_polynomial::ScaledChunkedPolynomials,
     math,
     types::{BaseField, ScalarField},
 };
@@ -52,7 +53,7 @@ impl<G: CommitmentCurve> SRS<G> {
         g.extend(vec![G::zero(); padding]);
 
         let (p, blinding_factor) = {
-            let mut plnm = ChunkedPolynomial::<ScalarField<G>, &[ScalarField<G>]>::default();
+            let mut plnm = ScaledChunkedPolynomials::<ScalarField<G>, &[ScalarField<G>]>::default();
             // let mut plnm_chunks: Vec<(ScalarField<G>, OptShiftedPolynomial<_>)> = vec![];
 
             let mut omega = ScalarField::<G>::zero();

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -2,9 +2,8 @@ use crate::commitment::*;
 use crate::srs::SRS;
 use ark_ec::{msm::VariableBaseMSM, AffineCurve, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
-use ark_poly::univariate::DensePolynomial;
+use ark_poly::{univariate::DensePolynomial, UVPolynomial};
 use o1_utils::{
-    chunked_polynomial::ScaledChunkedPolynomials,
     math,
     types::{BaseField, ScalarField},
 };
@@ -12,6 +11,61 @@ use oracle::{sponge::ScalarChallenge, FqSponge};
 use rand_core::{CryptoRng, RngCore};
 use rayon::prelude::*;
 use std::iter::Iterator;
+
+enum OptShiftedPolynomial<P> {
+    Unshifted(P),
+    Shifted(P, usize),
+}
+
+// A formal sum of the form
+// `s_0 * p_0 + ... s_n * p_n`
+// where each `s_i` is a scalar and each `p_i` is an optionally shifted polynomial.
+
+#[derive(Default)]
+struct ScaledChunkedPolynomial<F, P>(Vec<(F, OptShiftedPolynomial<P>)>);
+
+impl<F, P> ScaledChunkedPolynomial<F, P> {
+    fn add_unshifted(&mut self, scale: F, p: P) {
+        self.0.push((scale, OptShiftedPolynomial::Unshifted(p)))
+    }
+
+    fn add_shifted(&mut self, scale: F, shift: usize, p: P) {
+        self.0
+            .push((scale, OptShiftedPolynomial::Shifted(p, shift)))
+    }
+}
+
+impl<'a, F: Field> ScaledChunkedPolynomial<F, &'a [F]> {
+    fn to_dense_polynomial(&self) -> DensePolynomial<F> {
+        let mut res = DensePolynomial::<F>::zero();
+
+        let scaled: Vec<_> = self
+            .0
+            .par_iter()
+            .map(|(scale, segment)| {
+                let scale = *scale;
+                match segment {
+                    OptShiftedPolynomial::Unshifted(segment) => {
+                        let v = segment.par_iter().map(|x| scale * *x).collect();
+                        DensePolynomial::from_coefficients_vec(v)
+                    }
+                    OptShiftedPolynomial::Shifted(segment, shift) => {
+                        let mut v: Vec<_> = segment.par_iter().map(|x| scale * *x).collect();
+                        let mut res = vec![F::zero(); *shift];
+                        res.append(&mut v);
+                        DensePolynomial::from_coefficients_vec(res)
+                    }
+                }
+            })
+            .collect();
+
+        for p in scaled {
+            res += &p;
+        }
+
+        res
+    }
+}
 
 impl<G: CommitmentCurve> SRS<G> {
     /// This function opens polynomial commitments in batch
@@ -53,7 +107,7 @@ impl<G: CommitmentCurve> SRS<G> {
         g.extend(vec![G::zero(); padding]);
 
         let (p, blinding_factor) = {
-            let mut plnm = ScaledChunkedPolynomials::<ScalarField<G>, &[ScalarField<G>]>::default();
+            let mut plnm = ScaledChunkedPolynomial::<ScalarField<G>, &[ScalarField<G>]>::default();
             // let mut plnm_chunks: Vec<(ScalarField<G>, OptShiftedPolynomial<_>)> = vec![];
 
             let mut omega = ScalarField::<G>::zero();

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -20,7 +20,6 @@ enum OptShiftedPolynomial<P> {
 // A formal sum of the form
 // `s_0 * p_0 + ... s_n * p_n`
 // where each `s_i` is a scalar and each `p_i` is an optionally shifted polynomial.
-
 #[derive(Default)]
 struct ScaledChunkedPolynomial<F, P>(Vec<(F, OptShiftedPolynomial<P>)>);
 

--- a/poly-commitment/tests/batch_15_wires.rs
+++ b/poly-commitment/tests/batch_15_wires.rs
@@ -82,7 +82,7 @@ where
                     (
                         srs.commit(&a[i].clone(), bounds[i], rng),
                         x.iter()
-                            .map(|xx| a[i].to_chunked_polynomials(size).linearize(*xx))
+                            .map(|xx| a[i].to_chunked_polynomial(size).evaluate_chunks(*xx))
                             .collect::<Vec<_>>(),
                         bounds[i],
                     )

--- a/poly-commitment/tests/batch_15_wires.rs
+++ b/poly-commitment/tests/batch_15_wires.rs
@@ -81,7 +81,9 @@ where
                 .map(|i| {
                     (
                         srs.commit(&a[i].clone(), bounds[i], rng),
-                        x.iter().map(|xx| a[i].eval(*xx, size)).collect::<Vec<_>>(),
+                        x.iter()
+                            .map(|xx| a[i].to_chunked_polynomials(size).linearize(*xx))
+                            .collect::<Vec<_>>(),
                         bounds[i],
                     )
                 })

--- a/poly-commitment/tests/commitment.rs
+++ b/poly-commitment/tests/commitment.rs
@@ -148,7 +148,7 @@ where
 
             let mut chunked_evals = vec![];
             for point in eval_points.clone() {
-                chunked_evals.push(poly.eval(point, srs.g.len()));
+                chunked_evals.push(poly.to_chunked_polynomials(srs.g.len()).linearize(point));
             }
 
             let commit = Commitment {

--- a/poly-commitment/tests/commitment.rs
+++ b/poly-commitment/tests/commitment.rs
@@ -148,7 +148,10 @@ where
 
             let mut chunked_evals = vec![];
             for point in eval_points.clone() {
-                chunked_evals.push(poly.to_chunked_polynomial(srs.g.len()).evaluate_chunks(point));
+                chunked_evals.push(
+                    poly.to_chunked_polynomial(srs.g.len())
+                        .evaluate_chunks(point),
+                );
             }
 
             let commit = Commitment {

--- a/poly-commitment/tests/commitment.rs
+++ b/poly-commitment/tests/commitment.rs
@@ -148,7 +148,7 @@ where
 
             let mut chunked_evals = vec![];
             for point in eval_points.clone() {
-                chunked_evals.push(poly.to_chunked_polynomials(srs.g.len()).linearize(point));
+                chunked_evals.push(poly.to_chunked_polynomial(srs.g.len()).evaluate_chunks(point));
             }
 
             let commit = Commitment {

--- a/utils/src/chunked_polynomial.rs
+++ b/utils/src/chunked_polynomial.rs
@@ -26,7 +26,7 @@ impl<P> ChunkedPolynomials<P> {
 
 impl<F: Field> ChunkedPolynomials<DensePolynomial<F>> {
     /// This function evaluates polynomial in chunks.
-    pub fn eval(&self, elm: F) -> Vec<F> {
+    pub fn linearize(&self, elm: F) -> Vec<F> {
         let mut res: Vec<F> = vec![];
         for poly in self.polys.iter() {
             let eval = poly.evaluate(&elm);

--- a/utils/src/chunked_polynomial.rs
+++ b/utils/src/chunked_polynomial.rs
@@ -1,0 +1,164 @@
+use ark_ff::{Field, Zero};
+use ark_poly::polynomial::{univariate::DensePolynomial, Polynomial, UVPolynomial};
+
+use rayon::prelude::*;
+
+#[derive(Clone)]
+pub struct ChunkedPolynomials<P> {
+    pub polys: Vec<P>,
+    pub degree: usize,
+}
+
+impl<P> Default for ChunkedPolynomials<P> {
+    fn default() -> ChunkedPolynomials<P> {
+        ChunkedPolynomials {
+            polys: vec![],
+            degree: 0,
+        }
+    }
+}
+
+impl<P> ChunkedPolynomials<P> {
+    pub fn add_chunk(&mut self, p: P) {
+        self.polys.push(p)
+    }
+}
+
+impl<F: Field> ChunkedPolynomials<DensePolynomial<F>> {
+    /// This function evaluates polynomial in chunks.
+    pub fn eval(&self, elm: F) -> Vec<F> {
+        let mut res: Vec<F> = vec![];
+        for poly in self.polys.iter() {
+            let eval = poly.evaluate(&elm);
+            res.push(eval);
+        }
+        res
+    }
+
+    /// Multiplies the chunks of a polynomial with powers of zeta^n to make it of degree n-1.
+    /// For example, if a polynomial can be written `f = f0 + x^n f1 + x^2n f2`
+    /// (where f0, f1, f2 are of degree n-1), then this function returns the new semi-evaluated
+    /// `f'(x) = f0(x) + zeta^n f1(x) + zeta^2n f2(x)`.
+    pub fn compress_polynomial(&self, zeta_n: F) -> DensePolynomial<F> {
+        let mut scale = F::one();
+        let mut coeffs = vec![F::zero(); self.degree];
+
+        for poly in self.polys.iter() {
+            for (coeff, poly_coeff) in coeffs.iter_mut().zip(&poly.coeffs) {
+                *coeff += scale * poly_coeff;
+            }
+
+            scale *= zeta_n;
+        }
+
+        while coeffs.last().map_or(false, |c| c.is_zero()) {
+            coeffs.pop();
+        }
+
+        DensePolynomial { coeffs }
+    }
+}
+enum OptShiftedPolynomial<P> {
+    Unshifted(P),
+    Shifted(P, usize),
+}
+
+/// A formal sum of the form
+/// `s_0 * p_0 + ... s_n * p_n`
+/// where each `s_i` is a scalar and each `p_i` is an optionally shifted polynomial.
+
+///pub struct ChunkedPolynomial<F, P>(Vec<(F, OptShiftedPolynomial<P>)>);
+
+pub struct ScaledChunkedPolynomials<F, P> {
+    scale: Vec<F>,
+    chunked_polynomials: ChunkedPolynomials<OptShiftedPolynomial<P>>,
+}
+
+impl<F, P> Default for ScaledChunkedPolynomials<F, P> {
+    fn default() -> ScaledChunkedPolynomials<F, P> {
+        ScaledChunkedPolynomials {
+            scale: vec![],
+            chunked_polynomials: ChunkedPolynomials::<OptShiftedPolynomial<P>>::default(),
+        }
+    }
+}
+
+impl<F, P> ScaledChunkedPolynomials<F, P> {
+    pub fn add_unshifted(&mut self, scale: F, p: P) {
+        self.scale.push(scale);
+        self.chunked_polynomials
+            .add_chunk(OptShiftedPolynomial::Unshifted(p))
+    }
+
+    pub fn add_shifted(&mut self, scale: F, shift: usize, p: P) {
+        self.scale.push(scale);
+        self.chunked_polynomials
+            .add_chunk(OptShiftedPolynomial::Shifted(p, shift))
+    }
+}
+
+impl<'a, F: Field> ScaledChunkedPolynomials<F, &'a [F]> {
+    /// check length?
+    pub fn to_dense_polynomial(&self) -> DensePolynomial<F> {
+        let mut res = DensePolynomial::<F>::zero();
+        let zipped: Vec<_> = self
+            .scale
+            .iter()
+            .zip(&self.chunked_polynomials.polys)
+            .collect();
+        let scaled: Vec<_> = zipped
+            .par_iter()
+            .map(|(_scale, segment)| {
+                let _scale = **_scale;
+                match segment {
+                    OptShiftedPolynomial::Unshifted(segment) => {
+                        let v = segment.par_iter().map(|x| _scale * *x).collect();
+                        DensePolynomial::from_coefficients_vec(v)
+                    }
+                    OptShiftedPolynomial::Shifted(segment, shift) => {
+                        let mut v: Vec<_> = segment.par_iter().map(|x| _scale * *x).collect();
+                        let mut res = vec![F::zero(); *shift];
+                        res.append(&mut v);
+                        DensePolynomial::from_coefficients_vec(res)
+                    }
+                }
+            })
+            .collect();
+
+        for p in scaled {
+            res += &p;
+        }
+        res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ExtendedDensePolynomial;
+
+    use super::*;
+    use ark_ff::One;
+    use ark_poly::{univariate::DensePolynomial, UVPolynomial};
+    use mina_curves::pasta::fp::Fp;
+
+    #[test]
+
+    fn test_chunk_poly() {
+        let one = Fp::one();
+        let zeta = one + one;
+        let zeta_n = zeta.square();
+        let res = (one + zeta)
+            * (one + zeta_n + zeta_n * zeta.square() + zeta_n * zeta.square() * zeta.square());
+
+        // 1 + x + x^2 + x^3 + x^4 + x^5 + x^6 + x^7 = (1+x) + x^2 (1+x) + x^4 (1+x) + x^6 (1+x)
+        let coeffs = [one, one, one, one, one, one, one, one];
+        let f = DensePolynomial::from_coefficients_slice(&coeffs);
+
+        let eval = f
+            .to_chunked_polynomials(2)
+            .compress_polynomial(zeta_n)
+            .evaluate(&zeta);
+
+        assert!(eval == res);
+    }
+}

--- a/utils/src/dense_polynomial.rs
+++ b/utils/src/dense_polynomial.rs
@@ -51,15 +51,15 @@ impl<F: Field> ExtendedDensePolynomial<F> for DensePolynomial<F> {
         res
     }
 
-    fn to_chunked_polynomial(&self, size: usize) -> ChunkedPolynomial<F> {
+    fn to_chunked_polynomial(&self, chunk_size: usize) -> ChunkedPolynomial<F> {
         let mut chunk_polys: Vec<DensePolynomial<F>> = vec![];
-        for chunk in self.coeffs.chunks(size) {
+        for chunk in self.coeffs.chunks(chunk_size) {
             chunk_polys.push(DensePolynomial::from_coefficients_slice(chunk));
         }
 
         ChunkedPolynomial {
             polys: chunk_polys,
-            size: size,
+            size: chunk_size,
         }
     }
 }

--- a/utils/src/dense_polynomial.rs
+++ b/utils/src/dense_polynomial.rs
@@ -22,7 +22,7 @@ pub trait ExtendedDensePolynomial<F: Field> {
     fn eval_polynomial(coeffs: &[F], x: F) -> F;
 
     /// Convert a polynomial into chunks.
-    fn to_chunked_polynomial(&self, size: usize) -> ChunkedPolynomial<DensePolynomial<F>>;
+    fn to_chunked_polynomial(&self, size: usize) -> ChunkedPolynomial<F>;
 }
 
 impl<F: Field> ExtendedDensePolynomial<F> for DensePolynomial<F> {
@@ -51,15 +51,15 @@ impl<F: Field> ExtendedDensePolynomial<F> for DensePolynomial<F> {
         res
     }
 
-    fn to_chunked_polynomial(&self, size: usize) -> ChunkedPolynomial<DensePolynomial<F>> {
+    fn to_chunked_polynomial(&self, size: usize) -> ChunkedPolynomial<F> {
         let mut chunk_polys: Vec<DensePolynomial<F>> = vec![];
         for chunk in self.coeffs.chunks(size) {
             chunk_polys.push(DensePolynomial::from_coefficients_slice(chunk));
         }
 
-        ChunkedPolynomial::<DensePolynomial<F>> {
+        ChunkedPolynomial{
             polys: chunk_polys,
-            chunk_degree: size,
+            size: size,
         }
     }
 }

--- a/utils/src/dense_polynomial.rs
+++ b/utils/src/dense_polynomial.rs
@@ -57,7 +57,7 @@ impl<F: Field> ExtendedDensePolynomial<F> for DensePolynomial<F> {
             chunk_polys.push(DensePolynomial::from_coefficients_slice(chunk));
         }
 
-        ChunkedPolynomial{
+        ChunkedPolynomial {
             polys: chunk_polys,
             size: size,
         }

--- a/utils/src/dense_polynomial.rs
+++ b/utils/src/dense_polynomial.rs
@@ -74,7 +74,6 @@ mod tests {
     use ark_poly::{univariate::DensePolynomial, UVPolynomial};
     use mina_curves::pasta::fp::Fp;
 
-
     #[test]
     fn test_chunk() {
         let one = Fp::one();
@@ -84,7 +83,7 @@ mod tests {
         // 1 + x + x^2 + x^3 + x^4 + x^5 + x^6 + x^7
         let coeffs = [one, one, one, one, one, one, one, one];
         let f = DensePolynomial::from_coefficients_slice(&coeffs);
-        let evals = f.to_chunked_polynomials(2).eval(two);
+        let evals = f.to_chunked_polynomials(2).linearize(two);
         for i in 0..4 {
             assert!(evals[i] == three);
         }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,11 +1,12 @@
+pub mod chunked_polynomial;
 pub mod dense_polynomial;
 pub mod evaluations;
 pub mod field_helpers;
+
 pub mod hasher;
 pub mod math;
 pub mod serialization;
 pub mod types;
-pub mod chunked_polynomial;
 
 pub use dense_polynomial::ExtendedDensePolynomial;
 pub use evaluations::ExtendedEvaluations;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -5,6 +5,7 @@ pub mod hasher;
 pub mod math;
 pub mod serialization;
 pub mod types;
+pub mod chunked_polynomial;
 
 pub use dense_polynomial::ExtendedDensePolynomial;
 pub use evaluations::ExtendedEvaluations;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -2,7 +2,6 @@ pub mod chunked_polynomial;
 pub mod dense_polynomial;
 pub mod evaluations;
 pub mod field_helpers;
-
 pub mod hasher;
 pub mod math;
 pub mod serialization;


### PR DESCRIPTION
This PR (related to issue #432):
- add a new module  in `utils/chunked_polynomial.rs` with an abstract struct `ChunkedPolynomials`.
- the new `ChunkedPolynomials` struct contains two method: `linearize` and `compress_polynomial`. `linearize` evaluates all the chunked polynomials in the same point. `compress_polynomial` compresses all the chunked polynomials into one with `zeta_n`.
- refactor the original struct `ChunkedPolynomial` with `ScaledChunkedPolynomials` based on the above abstract. This struct contains `(Vec[F], Vec[P])`.
-  add a function `to_chunked_polynomials` in trait `ExtendedDensePolynomial`, which allows to transfer polynomials into multiple chunks.
- modify accordingly in the `prover.rs` file.
