### PR TITLE
Fixup ocaml-gen to emit snake-case type parameters

### DIFF
--- a/ocaml/ocaml-gen/derive/src/lib.rs
+++ b/ocaml/ocaml-gen/derive/src/lib.rs
@@ -174,10 +174,9 @@ pub fn derive_ocaml_enum(item: TokenStream) -> TokenStream {
         .params
         .iter()
         .filter_map(|g| match g {
-            GenericParam::Type(t) => Some(&t.ident),
+            GenericParam::Type(t) => Some(t.ident.to_string().to_case(Case::Snake)),
             _ => None,
         })
-        .map(|ident| ident.to_string())
         .collect();
 
     let body = {
@@ -203,7 +202,7 @@ pub fn derive_ocaml_enum(item: TokenStream) -> TokenStream {
                 Fields::Unnamed(fields) => {
                     for field in &fields.unnamed {
                         if let Some(ty) = is_generic(&generics_str, &field.ty) {
-                            types.push(format!("'{}", ty));
+                            types.push(format!("'{}", ty.to_case(Case::Snake)));
                         } else {
                             types.push("#".to_string());
                             fields_to_call.push(&field.ty);
@@ -425,10 +424,9 @@ pub fn derive_ocaml_gen(item: TokenStream) -> TokenStream {
     let generics_str: Vec<String> = generics
         .iter()
         .filter_map(|g| match g {
-            GenericParam::Type(t) => Some(&t.ident),
+            GenericParam::Type(t) => Some(t.ident.to_string().to_case(Case::Snake)),
             _ => None,
         })
-        .map(|ident| ident.to_string())
         .collect();
 
     let body = match fields {
@@ -440,7 +438,7 @@ pub fn derive_ocaml_gen(item: TokenStream) -> TokenStream {
                 let name = field.ident.as_ref().expect("a named field has an ident");
                 punctured_generics_name.push(name.to_string());
                 if let Some(ty) = is_generic(&generics_str, &field.ty) {
-                    punctured_generics_type.push(format!("'{}", ty));
+                    punctured_generics_type.push(format!("'{}", ty.to_case(Case::Snake)));
                 } else {
                     punctured_generics_type.push("#".to_string());
                     fields_to_call.push(&field.ty);
@@ -486,7 +484,7 @@ pub fn derive_ocaml_gen(item: TokenStream) -> TokenStream {
             let mut fields_to_call = vec![];
             for field in &fields.unnamed {
                 if let Some(ident) = is_generic(&generics_str, &field.ty) {
-                    punctured_generics.push(format!("'{}", ident));
+                    punctured_generics.push(format!("'{}", ident.to_case(Case::Snake)));
                 } else {
                     punctured_generics.push("#".to_string());
                     fields_to_call.push(&field.ty);


### PR DESCRIPTION
This PR tweaks ocaml-gen to use snake-case for type parameters. This makes it far easier to use OCaml derivers etc., which are currently broken by the capitalisation that we use for variables.

Example output:
```ocaml
  type nonrec 'caml_f scalar_challenge = { inner : 'caml_f } [@@boxed]
  type nonrec 'caml_f random_oracles =
    { joint_combiner : 'caml_f scalar_challenge * 'caml_f
    ; beta : 'caml_f
    ; gamma : 'caml_f
    ; alpha_chal : 'caml_f scalar_challenge
    ; alpha : 'caml_f
    ; zeta : 'caml_f
    ; v : 'caml_f
    ; u : 'caml_f
    ; zeta_chal : 'caml_f scalar_challenge
    ; v_chal : 'caml_f scalar_challenge
    ; u_chal : 'caml_f scalar_challenge
    }
```