### PR TITLE
[mina-hasher] Absorb domain string on update

### DIFF
--- a/hasher/Cargo.toml
+++ b/hasher/Cargo.toml
@@ -18,4 +18,5 @@ bitvec = "1.0.0"
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
+lazy_static = "1"
 serde_json = { version = "1.0" }

--- a/hasher/src/lib.rs
+++ b/hasher/src/lib.rs
@@ -80,9 +80,7 @@ pub trait Hashable: Clone {
     /// be enforced by the developer implementing the traits (see [`Hashable`] for
     ///  more details). The domain string may be parameterized by the contents of
     /// `this` and/or the generic `domain_param` argument.
-    ///
-    /// **Note:** You should always return `Some(String)`. A `None` return value
-    /// is only used for testing.
+    /// `this` is always None on `init`, and is always Some on `update`
     fn domain_string(this: Option<&Self>, domain_param: Self::D) -> Option<String>;
 }
 

--- a/hasher/src/poseidon.rs
+++ b/hasher/src/poseidon.rs
@@ -34,7 +34,7 @@ impl<SC: SpongeConstants, H: Hashable> Poseidon<SC, H> {
             sponge: ArithmeticSponge::<Fp, SC>::new(sponge_params),
             sponge_state: SpongeState::Absorbed(0),
             state: vec![],
-            domain_param: domain_param,
+            domain_param,
             phantom: PhantomData,
         };
 

--- a/hasher/tests/merkle.rs
+++ b/hasher/tests/merkle.rs
@@ -1,0 +1,51 @@
+use ark_ff::Zero;
+use mina_hasher::*;
+use std::sync::RwLock;
+
+lazy_static::lazy_static! {
+    static ref DOMAIN_STRING_CALL_COUNTER: RwLock<usize> = RwLock::new(0);
+}
+
+#[derive(Debug, Clone)]
+struct TestMerkleNode {
+    height: u32,
+    left: Fp,
+    right: Fp,
+}
+
+impl Hashable for TestMerkleNode {
+    type D = ();
+
+    fn to_roinput(&self) -> ROInput {
+        let mut roi = ROInput::new();
+        roi.append_field(self.left);
+        roi.append_field(self.right);
+        roi
+    }
+
+    fn domain_string(this: Option<&Self>, _: Self::D) -> Option<String> {
+        match this {
+            None => format!("Unused").into(),
+            Some(x) => {
+                let mut counter = DOMAIN_STRING_CALL_COUNTER.write().unwrap();
+                *counter += 1;
+                format!("TestMerkleNode{:03}", x.height).into()
+            }
+        }
+    }
+}
+
+#[test]
+fn ensure_domain_string_is_invoked() {
+    let node = TestMerkleNode {
+        height: 3,
+        left: Fp::zero(),
+        right: Fp::zero(),
+    };
+    for i in 0..10 {
+        let mut hasher = create_legacy(());
+        hasher.hash(&node);
+        let counter = DOMAIN_STRING_CALL_COUNTER.read().unwrap();
+        assert_eq!(*counter, i + 1)
+    }
+}

--- a/signer/tests/transaction.rs
+++ b/signer/tests/transaction.rs
@@ -54,14 +54,20 @@ impl Hashable for Transaction {
         roi
     }
 
-    fn domain_string(_: Option<&Self>, network_id: NetworkId) -> Option<String> {
-        // Domain strings must have length <= 20
-        match network_id {
-            NetworkId::MAINNET => "MinaSignatureMainnet",
-            NetworkId::TESTNET => "CodaSignature",
+    fn domain_string(this: Option<&Self>, network_id: NetworkId) -> Option<String> {
+        // Only for init
+        if this.is_none() {
+            // Domain strings must have length <= 20
+            match network_id {
+                NetworkId::MAINNET => "MinaSignatureMainnet",
+                NetworkId::TESTNET => "CodaSignature",
+            }
+            .to_string()
+            .into()
+        } else {
+            // No domain string for update
+            None
         }
-        .to_string()
-        .into()
     }
 }
 


### PR DESCRIPTION
This PR fixes a bug that the `domain_string` is never properly consumed in the example Merkle tree scenario described in [readme](https://github.com/o1-labs/proof-systems/tree/master/hasher)

changes:
- Changes the behavior of `update` function in Poseidon hasher, to absorb the domain string of the input when available. 
- Adds a test case for Merkle tree scenario to make sure the domain string is properly consumed.

```rust
use ark_ff::Zero;
use mina_hasher::{create_legacy, Fp, Hashable, Hasher, ROInput};

#[derive(Clone)]
struct ExampleMerkleNode {
    height: u64,
    left: Fp,
    right: Fp,
}

impl Hashable for ExampleMerkleNode {
    type D = ();

    fn to_roinput(&self) -> ROInput {
        let mut roi = ROInput::new();

        roi.append_field(self.left);
        roi.append_field(self.right);

        roi
    }

    fn domain_string(this: Option<&Self>, _: Self::D) -> Option<String> {
        match this {
            None => format!("Unused").into(),
            // This is never called.
            Some(x) => format!("ExampleMerkleNode{:03}", x.height).into(),
        }
    }
}

// Used like this
let mut hasher = create_legacy::<ExampleMerkleNode>(());
let node = ExampleMerkleNode {
    height: 3,
    left: Fp::zero(),
    right: Fp::zero(),
};
let out = hasher.hash(&node);
// Or like this..
let out = hasher.update(&node).digest();
```