### PR TITLE
Add derives to compressed pub key

### DIFF
--- a/signer/src/pubkey.rs
+++ b/signer/src/pubkey.rs
@@ -171,6 +171,11 @@ impl CompressedPubKey {
     pub fn into_address(self) -> String {
         into_address(self.x, self.is_odd)
     }
+
+    /// Deserialize Mina address into compressed public key (via an uncompressed PubKey)
+    pub fn from_address(address: &str) -> Result<Self> {
+        Ok(PubKey::from_address(address)?.into_compressed())
+    }
 }
 
 #[cfg(test)]

--- a/signer/src/pubkey.rs
+++ b/signer/src/pubkey.rs
@@ -136,7 +136,7 @@ impl fmt::Display for PubKey {
 }
 
 /// Compressed public keys consist of x-coordinate and y-coordinate parity.
-#[derive(Clone, Copy)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct CompressedPubKey {
     /// X-coordinate
     pub x: BaseField,


### PR DESCRIPTION
It would be great if you could add derivations of `Debug` `PartialEq` and `Eq` to the public API for `CompressedPubKey`. This makes it consistent with `PubKey` and makes it much easier to integrate into our internal types which use the above traits for tests.

I've also included a helper for `from_address`, this is just a nice-to-have and not required.