### PR TITLE
specify endomul_scalar gate

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -731,6 +731,102 @@ constraint 7:
 
 #### Endo Scalar
 
+We give constraints for the endomul scalar computation.
+
+Each row corresponds to 8 iterations of the inner loop in "Algorithm 2" on page 29 of
+[the Halo paper](https://eprint.iacr.org/2019/1021.pdf).
+
+The state of the algorithm that's updated across iterations of the loop is `(a, b)`.
+It's clear from that description of the algorithm that an iteration of the loop can
+be written as
+
+```ignore
+(a, b, i) ->
+  ( 2 * a + c_func(r_{2 * i}, r_{2 * i + 1}),
+    2 * b + d_func(r_{2 * i}, r_{2 * i + 1}) )
+```
+
+for some functions `c_func` and `d_func`. If one works out what these functions are on
+every input (thinking of a two-bit input as a number in $\{0, 1, 2, 3\}$), one finds they
+are given by
+
+`c_func(x)`, defined by
+- `c_func(0) = 0`
+- `c_func(1) = 0`
+- `c_func(2) = -1`
+- `c_func(3) = 1`
+
+`d_func(x)`, defined by
+- `d_func(0) = -1`
+- `d_func(1) = 1`
+- `d_func(2) = 0`
+- `d_func(3) = 0`
+
+One can then interpolate to find polynomials that implement these functions on $\{0, 1, 2, 3\}$.
+
+You can use [`sage`](https://www.sagemath.org/), as
+```ignore
+R = PolynomialRing(QQ, 'x')
+c_func = R.lagrange_polynomial([(0, 0), (1, 0), (2, -1), (3, 1)])
+d_func = R.lagrange_polynomial([(0, -1), (1, 1), (2, 0), (3, 0)])
+```
+
+Then, `c_func` is given by
+
+```ignore
+2/3 * x^3 - 5/2 * x^2 + 11/6 * x
+```
+
+and `d_func` is given by
+```ignore
+2/3 * x^3 - 7/2 * x^2 + 29/6 * x - 1 <=> c_func + (-x^2 + 3x - 1)
+```
+
+We lay it out the witness as
+
+|  0 |  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14 | Type |
+|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|------|
+| n0 | n8 | a0 | b0 | a8 | b8 | x0 | x1 | x2 | x3 | x4 | x5 | x6 | x7 |    | ENDO |
+
+where each `xi` is a two-bit "crumb".
+
+We also use a polynomial to check that each `xi` is indeed in $\{0, 1, 2, 3\}$,
+which can be done by checking that each $x_i$ is a root of the polyunomial below:
+
+```ignore
+crumb(x)
+= x (x - 1) (x - 2) (x - 3)
+= x^4 - 6*x^3 + 11*x^2 - 6*x
+= x *(x^3 - 6*x^2 + 11*x - 6)
+```
+Each iteration performs the following computations
+
+* Update $n$: $\quad n_{i+1} = 2 \cdot n_{i} + x_i$
+* Update $a$: $\quad a_{i+1} = 2 \cdot a_{i} + c_i$
+* Update $b$: $\quad b_{i+1} = 2 \cdot b_{i} + d_i$
+
+Then, after the 8 iterations, we compute expected values of the above operations as:
+
+* `expected_n8 := 2 * ( 2 * ( 2 * ( 2 * ( 2 * ( 2 * ( 2 * (2 * n0 + x0) + x1 ) + x2 ) + x3 ) + x4 ) + x5 ) + x6 ) + x7`
+* `expected_a8 := 2 * ( 2 * ( 2 * ( 2 * ( 2 * ( 2 * ( 2 * (2 * a0 + c0) + c1 ) + c2 ) + c3 ) + c4 ) + c5 ) + c6 ) + c7`
+* `expected_b8 := 2 * ( 2 * ( 2 * ( 2 * ( 2 * ( 2 * ( 2 * (2 * b0 + d0) + d1 ) + d2 ) + d3 ) + d4 ) + d5 ) + d6 ) + d7`
+
+Putting together all of the above, these are the 11 constraints for this gate
+
+* Checking values after the 8 iterations:
+  * Constrain $n$: ` 0 = expected_n8 - n8`
+  * Constrain $a$: ` 0 = expected_a8 - a8`
+  * Constrain $b$: ` 0 = expected_b8 - b8`
+* Checking the crumbs, meaning each $x$ is indeed in the range $\{0, 1, 2, 3\}$:
+  * Constrain $x_0$: `0 = x0 * ( x0^3 - 6 * x0^2 + 11 * x0 - 6 )`
+  * Constrain $x_1$: `0 = x1 * ( x1^3 - 6 * x1^2 + 11 * x1 - 6 )`
+  * Constrain $x_2$: `0 = x2 * ( x2^3 - 6 * x2^2 + 11 * x2 - 6 )`
+  * Constrain $x_3$: `0 = x3 * ( x3^3 - 6 * x3^2 + 11 * x3 - 6 )`
+  * Constrain $x_4$: `0 = x4 * ( x4^3 - 6 * x4^2 + 11 * x4 - 6 )`
+  * Constrain $x_5$: `0 = x5 * ( x5^3 - 6 * x5^2 + 11 * x5 - 6 )`
+  * Constrain $x_6$: `0 = x6 * ( x6^3 - 6 * x6^2 + 11 * x6 - 6 )`
+  * Constrain $x_7$: `0 = x7 * ( x7^3 - 6 * x7^2 + 11 * x7 - 6 )`
+
 
 
 #### Endo Scalar Multiplication

--- a/kimchi/src/circuits/polynomials/endomul_scalar.rs
+++ b/kimchi/src/circuits/polynomials/endomul_scalar.rs
@@ -1,3 +1,6 @@
+//! Implementation of the EndomulScalar gate for the endomul scalar multiplication.
+//! This gate checks 8 rounds of the Algorithm 2 in the [Halo paper](https://eprint.iacr.org/2019/1021.pdf) per row.
+
 use std::marker::PhantomData;
 
 use crate::circuits::{
@@ -47,75 +50,103 @@ fn polynomial<F: Field>(coeffs: &[F], x: &E<F>) -> E<F> {
         .fold(E::zero(), |acc, c| acc * x.clone() + E::literal(*c))
 }
 
-/// Implementation of the EndomulScalar gate.
-/// The constraint for the endomul scalar computation
-///
-/// Each row corresponds to 8 iterations of the inner loop in "algorithm 2" on page 29 of
-/// [this paper](https://eprint.iacr.org/2019/1021.pdf).
-///
-/// The state of the algorithm that's updated across iterations of the loop is (a, b).
-/// It's clear from that description of the algorithm that an iteration of the loop can
-/// be written as
-///
-/// ```ignore
-/// (a, b, i) ->
-///   ( 2 * a + c_func(r_{2 * i}, r_{2 * i + 1}),
-///     2 * b + d_func(r_{2 * i}, r_{2 * i + 1}) )
-/// ```
-///
-/// for some functions c_func and d_func. If one works out what these functions are on
-/// every input (thinking of a two bit input as a number in {0, 1, 2, 3}), one finds they
-/// are given by
-///
-/// c_func(x), defined by
-/// - c_func(0) = 0
-/// - c_func(1) = 0
-/// - c_func(2) = -1
-/// - c_func(3) = 1
-///
-/// d_func(x), defined by
-/// - d_func(0) = -1
-/// - d_func(1) = 1
-/// - d_func(2) = 0
-/// - d_func(3) = 0
-///
-/// One can then interpolate to find polynomials that implement these functions on {0, 1, 2, 3}.
-///
-/// You can use sage, as
-/// ```ignore
-/// R = PolynomialRing(QQ, 'x')
-/// c_func = R.lagrange_polynomial([(0, 0), (1, 0), (2, -1), (3, 1)])
-/// d_func = R.lagrange_polynomial([(0, -1), (1, 1), (2, 0), (3, 0)])
-/// ```
-///
-/// Then, c_func is given by
-///
-/// ```ignore
-/// 2/3*x^3 - 5/2*x^2 + 11/6*x
-/// ```
-///
-/// and d_func is given by
-/// ```ignore
-/// 2/3*x^3 - 7/2*x^2 + 29/6*x - 1 = c_func + (-x^2 + 3x - 1)
-/// ```
-///
-/// We lay it out as
-///
-/// <pre>
-/// 0    1    2    3    4    5    6    7    8    9    10   11   12   13   14
-/// n0   n8   a0   b0   a8   b8   x0   x1   x2   x3   x4   x5   x6   x7
-/// </pre>
-///
-/// where each `xi` is a two bit "crumb".
-///
-/// We also use a polynomial to check that each `xi` is indeed in {0, 1, 2, 3},
-///
-/// ```ignore
-/// crumb(x)
-/// = x (x - 1) (x - 2) (x - 3)
-/// = x^4 - 6*x^3 + 11*x^2 - 6*x
-/// = x *(x^3 - 6*x^2 + 11*x - 6)
-/// ```
+//~ We give constraints for the endomul scalar computation.
+//~
+//~ Each row corresponds to 8 iterations of the inner loop in "Algorithm 2" on page 29 of
+//~ [the Halo paper](https://eprint.iacr.org/2019/1021.pdf).
+//~
+//~ The state of the algorithm that's updated across iterations of the loop is `(a, b)`.
+//~ It's clear from that description of the algorithm that an iteration of the loop can
+//~ be written as
+//~
+//~ ```ignore
+//~ (a, b, i) ->
+//~   ( 2 * a + c_func(r_{2 * i}, r_{2 * i + 1}),
+//~     2 * b + d_func(r_{2 * i}, r_{2 * i + 1}) )
+//~ ```
+//~
+//~ for some functions `c_func` and `d_func`. If one works out what these functions are on
+//~ every input (thinking of a two-bit input as a number in $\{0, 1, 2, 3\}$), one finds they
+//~ are given by
+//~
+//~ `c_func(x)`, defined by
+//~ - `c_func(0) = 0`
+//~ - `c_func(1) = 0`
+//~ - `c_func(2) = -1`
+//~ - `c_func(3) = 1`
+//~
+//~ `d_func(x)`, defined by
+//~ - `d_func(0) = -1`
+//~ - `d_func(1) = 1`
+//~ - `d_func(2) = 0`
+//~ - `d_func(3) = 0`
+//~
+//~ One can then interpolate to find polynomials that implement these functions on $\{0, 1, 2, 3\}$.
+//~
+//~ You can use [`sage`](https://www.sagemath.org/), as
+//~ ```ignore
+//~ R = PolynomialRing(QQ, 'x')
+//~ c_func = R.lagrange_polynomial([(0, 0), (1, 0), (2, -1), (3, 1)])
+//~ d_func = R.lagrange_polynomial([(0, -1), (1, 1), (2, 0), (3, 0)])
+//~ ```
+//~
+//~ Then, `c_func` is given by
+//~
+//~ ```ignore
+//~ 2/3 * x^3 - 5/2 * x^2 + 11/6 * x
+//~ ```
+//~
+//~ and `d_func` is given by
+//~ ```ignore
+//~ 2/3 * x^3 - 7/2 * x^2 + 29/6 * x - 1 <=> c_func + (-x^2 + 3x - 1)
+//~ ```
+//~
+//~ We lay it out the witness as
+//~
+//~ |  0 |  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14 | Type |
+//~ |----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|------|
+//~ | n0 | n8 | a0 | b0 | a8 | b8 | x0 | x1 | x2 | x3 | x4 | x5 | x6 | x7 |    | ENDO |
+//~
+//~ where each `xi` is a two-bit "crumb".
+//~
+//~ We also use a polynomial to check that each `xi` is indeed in $\{0, 1, 2, 3\}$,
+//~ which can be done by checking that each $x_i$ is a root of the polyunomial below:
+//~
+//~ ```ignore
+//~ crumb(x)
+//~ = x (x - 1) (x - 2) (x - 3)
+//~ = x^4 - 6*x^3 + 11*x^2 - 6*x
+//~ = x *(x^3 - 6*x^2 + 11*x - 6)
+//~ ```
+//~ Each iteration performs the following computations
+//~
+//~ * Update $n$: $\quad n_{i+1} = 2 \cdot n_{i} + x_i$
+//~ * Update $a$: $\quad a_{i+1} = 2 \cdot a_{i} + c_i$
+//~ * Update $b$: $\quad b_{i+1} = 2 \cdot b_{i} + d_i$
+//~
+//~ Then, after the 8 iterations, we compute expected values of the above operations as:
+//~
+//~ * `expected_n8 := 2 * ( 2 * ( 2 * ( 2 * ( 2 * ( 2 * ( 2 * (2 * n0 + x0) + x1 ) + x2 ) + x3 ) + x4 ) + x5 ) + x6 ) + x7`
+//~ * `expected_a8 := 2 * ( 2 * ( 2 * ( 2 * ( 2 * ( 2 * ( 2 * (2 * a0 + c0) + c1 ) + c2 ) + c3 ) + c4 ) + c5 ) + c6 ) + c7`
+//~ * `expected_b8 := 2 * ( 2 * ( 2 * ( 2 * ( 2 * ( 2 * ( 2 * (2 * b0 + d0) + d1 ) + d2 ) + d3 ) + d4 ) + d5 ) + d6 ) + d7`
+//~
+//~ Putting together all of the above, these are the 11 constraints for this gate
+//~
+//~ * Checking values after the 8 iterations:
+//~   * Constrain $n$: ` 0 = expected_n8 - n8`
+//~   * Constrain $a$: ` 0 = expected_a8 - a8`
+//~   * Constrain $b$: ` 0 = expected_b8 - b8`
+//~ * Checking the crumbs, meaning each $x$ is indeed in the range $\{0, 1, 2, 3\}$:
+//~   * Constrain $x_0$: `0 = x0 * ( x0^3 - 6 * x0^2 + 11 * x0 - 6 )`
+//~   * Constrain $x_1$: `0 = x1 * ( x1^3 - 6 * x1^2 + 11 * x1 - 6 )`
+//~   * Constrain $x_2$: `0 = x2 * ( x2^3 - 6 * x2^2 + 11 * x2 - 6 )`
+//~   * Constrain $x_3$: `0 = x3 * ( x3^3 - 6 * x3^2 + 11 * x3 - 6 )`
+//~   * Constrain $x_4$: `0 = x4 * ( x4^3 - 6 * x4^2 + 11 * x4 - 6 )`
+//~   * Constrain $x_5$: `0 = x5 * ( x5^3 - 6 * x5^2 + 11 * x5 - 6 )`
+//~   * Constrain $x_6$: `0 = x6 * ( x6^3 - 6 * x6^2 + 11 * x6 - 6 )`
+//~   * Constrain $x_7$: `0 = x7 * ( x7^3 - 6 * x7^2 + 11 * x7 - 6 )`
+//~
+
 pub struct EndomulScalar<F>(PhantomData<F>);
 
 impl<F> Argument<F> for EndomulScalar<F>
@@ -133,6 +164,7 @@ where
         let a8 = witness_curr(4);
         let b8 = witness_curr(5);
 
+        // x0..x7
         let xs: [_; 8] = array_init(|i| witness_curr(6 + i));
 
         let mut cache = Cache::default();


### PR DESCRIPTION
This is a specification of the `endomul_scalar` gate. 

It includes the previous documentation comments as part of the spec now, together with a bunch of new content to explain more verbosely the resulting constraints. 