### PR TITLE
[mina-hasher] Change append_hashable to take borrow param

### DIFF
--- a/hasher/README.md
+++ b/hasher/README.md
@@ -153,7 +153,7 @@ Here is an example showing how this is done.
 ```rust
 use mina_hasher::{Hashable, ROInput};
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct A {
     x: u32,
     y: u32,
@@ -174,7 +174,7 @@ impl Hashable for A {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct B {
     a1: A,
     a2: A,
@@ -187,7 +187,7 @@ impl Hashable for B {
     fn to_roinput(&self) -> ROInput {
         let mut roi = ROInput::new();
         // Way 1: Append Hashable input
-        roi.append_hashable(self.a1);
+        roi.append_hashable(&self.a1);
         // Way 2: Append ROInput
         roi.append_roinput(self.a2.to_roinput());
         roi.append_u32(self.z);

--- a/hasher/src/roinput.rs
+++ b/hasher/src/roinput.rs
@@ -73,7 +73,7 @@ impl ROInput {
     }
 
     /// Append a `Hashable` input
-    pub fn append_hashable(&mut self, input: impl Hashable) -> &mut Self {
+    pub fn append_hashable(&mut self, input: &impl Hashable) -> &mut Self {
         self.append_roinput(input.to_roinput());
         self
     }


### PR DESCRIPTION
This PR changes the signature of `append_hashable` in `mina_hasher::Hashable` from `fn append_hashable(&mut self, input: impl Hashable)` to `fn append_hashable(&mut self, input: &impl Hashable)`

When it takes an owned value, it forces an unnecessary `clone` or `copy` at caller, like in the original doc example, `roi.append_hashable(self.a1);` works because `struct A` derives `Copy` and an implict `copy` happens here.