### PR TITLE
Compute linearization expression independently of domain size

### DIFF
--- a/kimchi/src/alphas.rs
+++ b/kimchi/src/alphas.rs
@@ -324,7 +324,6 @@ mod tests {
         let gates = vec![CircuitGate::<Fp>::zero(Wire::new(0)); 2];
         let index = new_index_for_test(gates, 0);
         let (_linearization, powers_of_alpha) = expr_linearization(
-            index.cs.domain.d1,
             index.cs.chacha8.is_some(),
             index
                 .cs

--- a/kimchi/src/circuits/lookup/constraints.rs
+++ b/kimchi/src/circuits/lookup/constraints.rs
@@ -9,7 +9,7 @@ use crate::{
     error::ProofError,
 };
 use ark_ff::{FftField, One, Zero};
-use ark_poly::{EvaluationDomain, Evaluations, Radix2EvaluationDomain as D};
+use ark_poly::{Evaluations, Radix2EvaluationDomain as D};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -432,7 +432,7 @@ pub struct LookupConfiguration<F: FftField> {
 }
 
 /// Specifies the lookup constraints as expressions.
-pub fn constraints<F: FftField>(configuration: &LookupConfiguration<F>, d1: D<F>) -> Vec<E<F>> {
+pub fn constraints<F: FftField>(configuration: &LookupConfiguration<F>) -> Vec<E<F>> {
     // Something important to keep in mind is that the last 2 rows of
     // all columns will have random values in them to maintain zero-knowledge.
     //
@@ -606,8 +606,7 @@ pub fn constraints<F: FftField>(configuration: &LookupConfiguration<F>, d1: D<F>
     let aggreg_equation = E::cell(Column::LookupAggreg, Next) * denominator
         - E::cell(Column::LookupAggreg, Curr) * numerator;
 
-    let num_rows = d1.size();
-    let num_lookup_rows = num_rows - ZK_ROWS - 1;
+    let num_lookup_rows = -(ZK_ROWS as i32) - 1;
 
     let mut res = vec![
         // the accumulator except for the last 4 rows

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -17,10 +17,8 @@ use crate::circuits::{
     wires::*,
 };
 use ark_ff::{FftField, SquareRootField};
-use ark_poly::Radix2EvaluationDomain as D;
 
 pub fn constraints_expr<F: FftField + SquareRootField>(
-    domain: D<F>,
     chacha: bool,
     lookup_constraint_system: Option<&LookupConfiguration<F>>,
 ) -> (Expr<ConstantExpr<F>>, Alphas<F>) {
@@ -56,7 +54,7 @@ pub fn constraints_expr<F: FftField + SquareRootField>(
         let alphas =
             powers_of_alpha.get_exponents(ArgumentType::Lookup, lookup::constraints::CONSTRAINTS);
 
-        let constraints = lookup::constraints::constraints(lcs, domain);
+        let constraints = lookup::constraints::constraints(lcs);
         let combined = Expr::combine_constraints(alphas, constraints);
         expr += combined;
     }
@@ -90,13 +88,12 @@ pub fn linearization_columns<F: FftField + SquareRootField>(
 }
 
 pub fn expr_linearization<F: FftField + SquareRootField>(
-    domain: D<F>,
     chacha: bool,
     lookup_constraint_system: Option<&LookupConfiguration<F>>,
 ) -> (Linearization<Vec<PolishToken<F>>>, Alphas<F>) {
     let evaluated_cols = linearization_columns::<F>(lookup_constraint_system);
 
-    let (expr, powers_of_alpha) = constraints_expr(domain, chacha, lookup_constraint_system);
+    let (expr, powers_of_alpha) = constraints_expr(chacha, lookup_constraint_system);
 
     let linearization = expr
         .linearize(evaluated_cols)

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -640,8 +640,7 @@ where
             if let Some(lcs) = index.cs.lookup_constraint_system.as_ref() {
                 let lookup_alphas =
                     all_alphas.get_alphas(ArgumentType::Lookup, lookup::constraints::CONSTRAINTS);
-                let constraints =
-                    lookup::constraints::constraints(&lcs.configuration, index.cs.domain.d1);
+                let constraints = lookup::constraints::constraints(&lcs.configuration);
 
                 for (constraint, alpha_pow) in constraints.into_iter().zip_eq(lookup_alphas) {
                     let mut eval = constraint.evaluations(&env);

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -70,7 +70,6 @@ where
 
         // pre-compute the linearization
         let (linearization, powers_of_alpha) = expr_linearization(
-            cs.domain.d1,
             cs.chacha8.is_some(),
             cs.lookup_constraint_system
                 .as_ref()


### PR DESCRIPTION
This PR tweaks the representation of the normalized lagrange basis to be independent of the domain size.

This allows us to use the expression from OCaml without locking-in a particular choice of domain.