### PR TITLE
[easy][lookup] light cleanup

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1385,7 +1385,9 @@ The prover then follows the following steps to create the proof:
 8. Absorb the witness commitments with the Fq-Sponge.
 9. Compute the witness polynomials by interpolating each `COLUMNS` of the witness.
    TODO: why not do this first, and then commit? Why commit from evaluation directly?
-10. TODO: lookup
+10. If there's a joint lookup being used in the circuit (TODO: define joint lookup vs single lookup):
+    - Sample the joint combinator (lookup challenge) $j$ with the Fq-Sponge.
+    - derive the scalar joint combinator $j$ from $j'$ using the endomorphism (TODO: details, explicitly say that we change the field).
 11. Sample $\beta$ with the Fq-Sponge.
 12. Sample $\gamma$ with the Fq-Sponge.
 13. TODO: lookup

--- a/kimchi/src/circuits/lookup/constraints.rs
+++ b/kimchi/src/circuits/lookup/constraints.rs
@@ -4,6 +4,10 @@ use crate::{
     circuits::{
         expr::{prologue::*, Column, ConstantExpr},
         gate::{CircuitGate, CurrOrNext},
+        lookup::{
+            lookups::{JointLookup, JointLookupSpec, LocalPosition, LookupInfo, LookupsUsed},
+            tables::Entry,
+        },
         wires::COLUMNS,
     },
     error::ProofError,
@@ -14,11 +18,6 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use CurrOrNext::{Curr, Next};
-
-use super::{
-    lookups::{JointLookup, JointLookupSpec, LocalPosition, LookupInfo, LookupsUsed},
-    tables::Entry,
-};
 
 /// Number of constraints produced by the argument.
 pub const CONSTRAINTS: u32 = 7;
@@ -195,6 +194,7 @@ pub fn sorted<
         counts.entry(t).or_insert(1);
     }
 
+    // TODO: shouldn't we make sure that lookup rows is the same as the number of active gates in the circuit as well? danger: What if we have gates that use lookup but are not counted here?
     for (i, row) in by_row.iter().enumerate().take(lookup_rows) {
         let spec = row;
         let padding = max_lookups_per_row - spec.len();

--- a/kimchi/src/circuits/lookup/tables.rs
+++ b/kimchi/src/circuits/lookup/tables.rs
@@ -47,6 +47,7 @@ pub trait Entry {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct CombinedEntry<F>(pub F);
+
 impl<F: Field> Entry for CombinedEntry<F> {
     type Field = F;
     type Params = (F, F);

--- a/kimchi/src/error.rs
+++ b/kimchi/src/error.rs
@@ -30,4 +30,7 @@ pub enum VerifyError {
 
     #[error("the opening proof failed to verify")]
     OpenProof,
+
+    #[error("lookup used in circuit, but proof is missing lookup commitments")]
+    LookupCommitmentMissing,
 }

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -164,9 +164,9 @@ where
             )
             .interpolate()
         });
-
-        //~ 10. TODO: lookup
-        let joint_combiner_ = {
+        //~ 10. If there's a joint lookup being used in the circuit (TODO: define joint lookup vs single lookup):
+        let joint_combiner: ScalarField<G> = {
+            //~     - Sample the joint combinator (lookup challenge) $j$ with the Fq-Sponge.
             // TODO: how will the verifier circuit handle these kind of things? same with powers of alpha...
             let s = match index.cs.lookup_constraint_system.as_ref() {
                 None
@@ -187,11 +187,10 @@ where
                     ..
                 }) => ScalarChallenge(fq_sponge.challenge()),
             };
-            (s, s.to_field(&index.srs.endo_r))
-        };
 
-        // TODO: that seems like an unecessary line
-        let joint_combiner: ScalarField<G> = joint_combiner_.1;
+            //~     - derive the scalar joint combinator $j$ from $j'$ using the endomorphism (TODO: details, explicitly say that we change the field).
+            s.to_field(&index.srs.endo_r)
+        };
 
         let table_id_combiner: ScalarField<G> =
             if let Some(lcs) = index.cs.lookup_constraint_system.as_ref() {

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -48,7 +48,7 @@ where
     pub p_eval: Vec<Vec<ScalarField<G>>>,
     /// zeta^n and (zeta * omega)^n
     pub powers_of_eval_points_for_chunks: [ScalarField<G>; 2],
-    /// ?
+    /// recursion data
     #[allow(clippy::type_complexity)]
     pub polys: Vec<(PolyComm<G>, Vec<Vec<ScalarField<G>>>)>,
     /// pre-computed zeta^n
@@ -553,7 +553,7 @@ where
                 let scalar =
                     PolishToken::evaluate(tokens, index.domain, oracles.zeta, &evals, &constants)
                         .expect("should evaluate");
-                let l = proof.commitments.lookup.as_ref();
+
                 use Column::*;
                 match col {
                     Witness(i) => {
@@ -569,12 +569,22 @@ where
                         commitments.push(&proof.commitments.z_comm);
                     }
                     LookupSorted(i) => {
+                        let lookup_coms = proof
+                            .commitments
+                            .lookup
+                            .as_ref()
+                            .ok_or(VerifyError::LookupCommitmentMissing)?;
                         scalars.push(scalar);
-                        commitments.push(&l.unwrap().sorted[*i])
+                        commitments.push(&lookup_coms.sorted[*i])
                     }
                     LookupAggreg => {
+                        let lookup_coms = proof
+                            .commitments
+                            .lookup
+                            .as_ref()
+                            .ok_or(VerifyError::LookupCommitmentMissing)?;
                         scalars.push(scalar);
-                        commitments.push(&l.unwrap().aggreg)
+                        commitments.push(&lookup_coms.aggreg)
                     }
                     LookupKindIndex(i) => match index.lookup_index.as_ref() {
                         None => {


### PR DESCRIPTION
- added an `LookupCommitmentMissing` error instead of crashing if a commitment is missing in the proof
- added some spec comment