### PR TITLE
[lookup] refactor prover + spec

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1411,27 +1411,44 @@ The prover then follows the following steps to create the proof:
 8. Absorb the witness commitments with the Fq-Sponge.
 9. Compute the witness polynomials by interpolating each `COLUMNS` of the witness.
    TODO: why not do this first, and then commit? Why commit from evaluation directly?
-10. If there's a joint lookup being used in the circuit (TODO: define joint lookup vs single lookup):
-    - Sample the joint combinator (lookup challenge) $j$ with the Fq-Sponge.
-    - derive the scalar joint combinator $j$ from $j'$ using the endomorphism (TODO: details, explicitly say that we change the field).
-12. If using lookup:
-    - Compute the sorted table.
-    - Compute the sorted coefficients.
-    - Commit to each of the sorted table columns.
-      (See section on lookup to see how to compute it.)
+10. If using lookup:
+    - If queries involve a lookup table with multiple columns
+    then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
+    otherwise set the joint combiner challenge $j'$ to $0$.
+    - Derive the scalar joint combiner $j$ from $j'$ using the endomorphism (TOOD: specify)
+    - If multiple lookup tables are involved,
+     set the `table_id_combiner` as the $j^i$ with $i$ the maximum width of any used table.
+     Essentially, this is to add a last column of table ids to the concatenated lookup tables.
+    - Compute the dummy lookup value as the combination of the last entry of the XOR table (so `(0, 0, 0)`).
+     Warning: This assumes that we always use the XOR table when using lookups.
+     - Compute the sorted evaluations.
+     - Randomize the last `EVALS` rows in each of the sorted polynomials
+      in order to add zero-knowledge to the protocol.
+     - Commit each of the sorted polynomials.
+     - Absorb each commitments to the sorted polynomials.
 11. Sample $\beta$ with the Fq-Sponge.
 12. Sample $\gamma$ with the Fq-Sponge.
-13. TODO: lookup
+13. If using lookup:
+    - Compute the lookup aggregation polynomial.
+    - Commit to the aggregation polynomial.
+    - Absorb the commitment to the aggregation polynomial with the Fq-Sponge.
 14. Compute the permutation aggregation polynomial $z$.
 15. Commit (hidding) to the permutation aggregation polynomial $z$.
 16. Absorb the permutation aggregation polynomial $z$ with the Fq-Sponge.
 17. Sample $\alpha'$ with the Fq-Sponge.
 18. Derive $\alpha$ from $\alpha'$ using the endomorphism (TODO: details)
 19. TODO: instantiate alpha?
-20. TODO: this is just an optimization, ignore?
-21. TODO: lookup
-22. TODO: setup the env
-23. Compute the quotient polynomial (the $t$ in $f = Z_H \cdot t$).
+20. If using lookup:
+    - computing the combined lookup table by combining the
+      columns of the lookup table with the joint combiner $j$:
+      $$
+      t[0] + j \cdot t[1] + j^2 \cdot t[2] + \cdots
+      $$
+      where $t$ is the lookup table.
+    - if we are using several lookup tables, add the table id vector
+      as the last column of the concatenated lookup tables
+      (including padding via the `table_id_combiner`).
+21. Compute the quotient polynomial (the $t$ in $f = Z_H \cdot t$).
     The quotient polynomial is computed by adding all these polynomials together:
     - the combined constraints for all the gates
     - the combined constraints for the permutation
@@ -1439,13 +1456,13 @@ The prover then follows the following steps to create the proof:
     - the negated public polynomial
     and by then dividing the resulting polynomial with the vanishing polynomial $Z_H$.
     TODO: specify the split of the permutation polynomial into perm and bnd?
-24. commit (hiding) to the quotient polynomial $t$
+22. commit (hiding) to the quotient polynomial $t$
     TODO: specify the dummies
-25. Absorb the the commitment of the quotient polynomial with the Fq-Sponge.
-26. Sample $\zeta'$ with the Fq-Sponge.
-27. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify)
-28. TODO: lookup
-29. Chunk evaluate the following polynomials at both $\zeta$ and $\zeta \omega$:
+23. Absorb the the commitment of the quotient polynomial with the Fq-Sponge.
+24. Sample $\zeta'$ with the Fq-Sponge.
+25. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify)
+26. If lookup is used, evaluate the following polynomials at $\zeta$ and $\zeta \omega$:
+27. Chunk evaluate the following polynomials at both $\zeta$ and $\zeta \omega$:
     * $s_i$
     * $w_i$
     * $z$
@@ -1463,32 +1480,32 @@ The prover then follows the following steps to create the proof:
     $$(f_0(x), f_1(x), f_2(x), \ldots)$$
 
      TODO: do we want to specify more on that? It seems unecessary except for the t polynomial (or if for some reason someone sets that to a low value)
-30. Evaluate the same polynomials without chunking them
+28. Evaluate the same polynomials without chunking them
     (so that each polynomial should correspond to a single value this time).
-31. Compute the ft polynomial.
+29. Compute the ft polynomial.
     This is to implement [Maller's optimization](https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html).
-32. construct the blinding part of the ft polynomial commitment
+30. construct the blinding part of the ft polynomial commitment
     see https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html#evaluation-proof-and-blinding-factors
-33. Evaluate the ft polynomial at $\zeta\omega$ only.
-34. Setup the Fr-Sponge
-35. Squeeze the Fq-sponge and absorb the result with the Fr-Sponge.
-36. Evaluate the negated public polynomial (if present) at $\zeta$ and $\zeta\omega$.
-37. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
+31. Evaluate the ft polynomial at $\zeta\omega$ only.
+32. Setup the Fr-Sponge
+33. Squeeze the Fq-sponge and absorb the result with the Fr-Sponge.
+34. Evaluate the negated public polynomial (if present) at $\zeta$ and $\zeta\omega$.
+35. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
     - the public polynomial
     - z
     - generic selector
     - poseidon selector
     - the 15 register/witness
     - 6 sigmas evaluations (the last one is not evaluated)
-38. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
-39. Sample $v'$ with the Fr-Sponge
-40. Derive $v$ from $v'$ using the endomorphism (TODO: specify)
-41. Sample $u'$ with the Fr-Sponge
-42. Derive $u$ from $u'$ using the endomorphism (TODO: specify)
-43. Create a list of all polynomials that will require evaluations
+36. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
+37. Sample $v'$ with the Fr-Sponge
+38. Derive $v$ from $v'$ using the endomorphism (TODO: specify)
+39. Sample $u'$ with the Fr-Sponge
+40. Derive $u$ from $u'$ using the endomorphism (TODO: specify)
+41. Create a list of all polynomials that will require evaluations
     (and evaluation proofs) in the protocol.
     First, include the previous challenges, in case we are in a recursive prover.
-44. Then, include:
+42. Then, include:
     - the negated public polynomial
     - the ft polynomial
     - the permutation aggregation polynomial z polynomial
@@ -1496,7 +1513,7 @@ The prover then follows the following steps to create the proof:
     - the poseidon selector
     - the 15 registers/witness columns
     - the 6 sigmas
-44. Create an aggregated evaluation proof for all of these polynomials at $\zeta$ and $\zeta\omega$ using $u$ and $v$.
+43. Create an aggregated evaluation proof for all of these polynomials at $\zeta$ and $\zeta\omega$ using $u$ and $v$.
 
 
 ### Proof Verification
@@ -1511,39 +1528,41 @@ We run the following algorithm:
 1. Setup the Fq-Sponge.
 2. Absorb the commitment of the public input polynomial with the Fq-Sponge.
 3. Absorb the commitments to the registers / witness columns with the Fq-Sponge.
-4. If lookup is not used,
-   or is used with queries to single-column lookup tables only,
-   then set the joint combiner challenge $j$ to $0$.
-   Otherwise, squeeze the Fq-Sponge to obtain the joint combiner challenge $j$.
-5. If using lookup, absorb the commitments to the sorted polynomials.
-6. Sample $\beta$ with the Fq-Sponge.
-7. Sample $\gamma$ with the Fq-Sponge.
-8. If using lookup, absorb the commitment to the aggregation lookup polynomial.
-9. Absorb the commitment to the permutation trace with the Fq-Sponge.
-10. Sample $\alpha'$ with the Fq-Sponge.
-11. Derive $\alpha$ from $\alpha'$ using the endomorphism (TODO: details).
-12. Enforce that the length of the $t$ commitment is of size `PERMUTS`.
-13. Absorb the commitment to the quotient polynomial $t$ into the argument.
-14. Sample $\zeta'$ with the Fq-Sponge.
-15. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify).
-16. Setup the Fr-Sponge.
-17. Squeeze the Fq-sponge and absorb the result with the Fr-Sponge.
-18. Evaluate the negated public polynomial (if present) at $\zeta$ and $\zeta\omega$.
+4. If lookup is used:
+   - If it involves queries to a multiple-column lookup table,
+     then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
+     otherwise set the joint combiner challenge $j'$ to $0$.
+   - Derive the scalar joint combiner challenge $j$ from $j'$ using the endomorphism.
+   (TODO: specify endomorphism)
+   - absorb the commitments to the sorted polynomials.
+5. Sample $\beta$ with the Fq-Sponge.
+6. Sample $\gamma$ with the Fq-Sponge.
+7. If using lookup, absorb the commitment to the aggregation lookup polynomial.
+8. Absorb the commitment to the permutation trace with the Fq-Sponge.
+9. Sample $\alpha'$ with the Fq-Sponge.
+10. Derive $\alpha$ from $\alpha'$ using the endomorphism (TODO: details).
+11. Enforce that the length of the $t$ commitment is of size `PERMUTS`.
+12. Absorb the commitment to the quotient polynomial $t$ into the argument.
+13. Sample $\zeta'$ with the Fq-Sponge.
+14. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify).
+15. Setup the Fr-Sponge.
+16. Squeeze the Fq-sponge and absorb the result with the Fr-Sponge.
+17. Evaluate the negated public polynomial (if present) at $\zeta$ and $\zeta\omega$.
     NOTE: this works only in the case when the poly segment size is not smaller than that of the domain.
-19. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
+18. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
     - the public polynomial
     - z
     - generic selector
     - poseidon selector
     - the 15 register/witness
     - 6 sigmas evaluations (the last one is not evaluated)
-20. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
-21. Sample $v'$ with the Fr-Sponge.
-22. Derive $v$ from $v'$ using the endomorphism (TODO: specify).
-23. Sample $u'$ with the Fr-Sponge.
-24. Derive $u$ from $u'$ using the endomorphism (TODO: specify).
-25. Create a list of all polynomials that have an evaluation proof.
-26. Compute the evaluation of $ft(\zeta)$.
+19. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
+20. Sample $v'$ with the Fr-Sponge.
+21. Derive $v$ from $v'$ using the endomorphism (TODO: specify).
+22. Sample $u'$ with the Fr-Sponge.
+23. Derive $u$ from $u'$ using the endomorphism (TODO: specify).
+24. Create a list of all polynomials that have an evaluation proof.
+25. Compute the evaluation of $ft(\zeta)$.
 
 #### Partial verification
 

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -32,7 +32,7 @@ pub struct Constants<F> {
     pub gamma: F,
     /// The challenge joint_combiner which is used to combine
     /// joint lookup tables.
-    pub joint_combiner: F,
+    pub joint_combiner: Option<F>,
     /// The endomorphism coefficient
     pub endo_coefficient: F,
     /// The MDS matrix
@@ -261,7 +261,7 @@ impl<F: Field> ConstantExpr<F> {
             Alpha => c.alpha,
             Beta => c.beta,
             Gamma => c.gamma,
-            JointCombiner => c.joint_combiner,
+            JointCombiner => c.joint_combiner.expect("lookup was not expected"),
             EndoCoefficient => c.endo_coefficient,
             Mds { row, col } => c.mds[*row][*col],
             Literal(x) => *x,
@@ -438,7 +438,7 @@ impl<F: FftField> PolishToken<F> {
                 Alpha => stack.push(c.alpha),
                 Beta => stack.push(c.beta),
                 Gamma => stack.push(c.gamma),
-                JointCombiner => stack.push(c.joint_combiner),
+                JointCombiner => stack.push(c.joint_combiner.expect("no lookup was expected")),
                 EndoCoefficient => stack.push(c.endo_coefficient),
                 Mds { row, col } => stack.push(c.mds[*row][*col]),
                 VanishesOnLast4Rows => stack.push(eval_vanishes_on_last_4_rows(d, pt)),
@@ -2204,7 +2204,7 @@ pub mod test {
                 alpha: one,
                 beta: one,
                 gamma: one,
-                joint_combiner: one,
+                joint_combiner: None,
                 endo_coefficient: one,
                 mds: vec![vec![]],
             },

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -259,7 +259,7 @@ impl<F: Field> ConstantExpr<F> {
             Alpha => c.alpha,
             Beta => c.beta,
             Gamma => c.gamma,
-            JointCombiner => c.joint_combiner.expect("lookup was not expected"),
+            JointCombiner => c.joint_combiner.expect("joint lookup was not expected"),
             EndoCoefficient => c.endo_coefficient,
             Mds { row, col } => c.mds[*row][*col],
             Literal(x) => *x,
@@ -440,7 +440,9 @@ impl<F: FftField> PolishToken<F> {
                 Alpha => stack.push(c.alpha),
                 Beta => stack.push(c.beta),
                 Gamma => stack.push(c.gamma),
-                JointCombiner => stack.push(c.joint_combiner.expect("no lookup was expected")),
+                JointCombiner => {
+                    stack.push(c.joint_combiner.expect("no joint lookup was expected"))
+                }
                 EndoCoefficient => stack.push(c.endo_coefficient),
                 Mds { row, col } => stack.push(c.mds[*row][*col]),
                 VanishesOnLast4Rows => stack.push(eval_vanishes_on_last_4_rows(d, pt)),

--- a/kimchi/src/circuits/lookup/constraints.rs
+++ b/kimchi/src/circuits/lookup/constraints.rs
@@ -319,7 +319,15 @@ pub fn aggregation<R: Rng + ?Sized, F: FftField, I: Iterator<Item = F>>(
             lookup_aggreg[i + 1] *= prev;
         });
 
-    Ok(zk_patch(lookup_aggreg, d1, rng))
+    let res = zk_patch(lookup_aggreg, d1, rng);
+
+    // check that the final evaluation is equal to 1
+    let final_val = res.evals[d1.size() - (ZK_ROWS + 1)];
+    if cfg!(debug_assertions) && final_val != F::one() {
+        panic!("aggregation incorrect: {}", final_val);
+    }
+
+    Ok(res)
 }
 
 /// Configuration for the lookup constraint.

--- a/kimchi/src/circuits/lookup/constraints.rs
+++ b/kimchi/src/circuits/lookup/constraints.rs
@@ -325,9 +325,11 @@ pub fn aggregation<R: Rng + ?Sized, F: FftField, I: Iterator<Item = F>>(
     let res = zk_patch(lookup_aggreg, d1, rng);
 
     // check that the final evaluation is equal to 1
-    let final_val = res.evals[d1.size() - (ZK_ROWS + 1)];
-    if cfg!(debug_assertions) && final_val != F::one() {
-        panic!("aggregation incorrect: {}", final_val);
+    if cfg!(debug_assertions) {
+        let final_val = res.evals[d1.size() - (ZK_ROWS + 1)];
+        if final_val != F::one() {
+            panic!("aggregation incorrect: {}", final_val);
+        }
     }
 
     Ok(res)

--- a/kimchi/src/circuits/polynomials/chacha.rs
+++ b/kimchi/src/circuits/polynomials/chacha.rs
@@ -559,7 +559,7 @@ mod tests {
             alpha: F::rand(rng),
             beta: F::rand(rng),
             gamma: F::rand(rng),
-            joint_combiner: F::rand(rng),
+            joint_combiner: None,
             endo_coefficient: F::zero(),
             mds: vec![],
         };

--- a/kimchi/src/circuits/polynomials/endosclmul.rs
+++ b/kimchi/src/circuits/polynomials/endosclmul.rs
@@ -136,7 +136,7 @@ impl<F: FftField> CircuitGate<F> {
             alpha: F::zero(),
             beta: F::zero(),
             gamma: F::zero(),
-            joint_combiner: F::zero(),
+            joint_combiner: None,
             mds: vec![],
             endo_coefficient: cs.endo,
         };

--- a/kimchi/src/circuits/polynomials/turshi.rs
+++ b/kimchi/src/circuits/polynomials/turshi.rs
@@ -235,7 +235,7 @@ impl<F: FftField> CircuitGate<F> {
             alpha: F::rand(rng),
             beta: F::rand(rng),
             gamma: F::rand(rng),
-            joint_combiner: F::rand(rng),
+            joint_combiner: None,
             endo_coefficient: cs.endo,
             mds: vec![],
         };

--- a/kimchi/src/circuits/scalars.rs
+++ b/kimchi/src/circuits/scalars.rs
@@ -5,7 +5,7 @@ use oracle::sponge::ScalarChallenge;
 
 #[derive(Clone, Debug)]
 pub struct RandomOracles<F: Field> {
-    pub joint_combiner: (ScalarChallenge<F>, F),
+    pub joint_combiner: Option<(ScalarChallenge<F>, F)>,
     pub beta: F,
     pub gamma: F,
     pub alpha_chal: ScalarChallenge<F>,
@@ -32,7 +32,7 @@ impl<F: Field> Default for RandomOracles<F> {
             zeta_chal: c,
             v_chal: c,
             u_chal: c,
-            joint_combiner: (c, F::zero()),
+            joint_combiner: None,
         }
     }
 }

--- a/kimchi/src/circuits/scalars.rs
+++ b/kimchi/src/circuits/scalars.rs
@@ -52,7 +52,7 @@ pub mod caml {
 
     #[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
     pub struct CamlRandomOracles<CamlF> {
-        pub joint_combiner: (CamlScalarChallenge<CamlF>, CamlF),
+        pub joint_combiner: Option<(CamlScalarChallenge<CamlF>, CamlF)>,
         pub beta: CamlF,
         pub gamma: CamlF,
         pub alpha_chal: CamlScalarChallenge<CamlF>,
@@ -72,7 +72,7 @@ pub mod caml {
     {
         fn from(ro: RandomOracles<F>) -> Self {
             Self {
-                joint_combiner: (ro.joint_combiner.0.into(), ro.joint_combiner.1.into()),
+                joint_combiner: ro.joint_combiner.map(|(l, r)| (l.into(), r.into())),
                 beta: ro.beta.into(),
                 gamma: ro.gamma.into(),
                 alpha_chal: ro.alpha_chal.into(),
@@ -94,7 +94,7 @@ pub mod caml {
     {
         fn into(self) -> RandomOracles<F> {
             RandomOracles {
-                joint_combiner: (self.joint_combiner.0.into(), self.joint_combiner.1.into()),
+                joint_combiner: self.joint_combiner.map(|(l, r)| (l.into(), r.into())),
                 beta: self.beta.into(),
                 gamma: self.gamma.into(),
                 alpha_chal: self.alpha_chal.into(),

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -3,12 +3,11 @@
 use crate::{
     circuits::{
         argument::{Argument, ArgumentType},
-        constraints::{LookupConstraintSystem, ZK_ROWS},
+        constraints::ZK_ROWS,
         expr::{l0_1, Constants, Environment, LookupEnvironment},
         gate::GateType,
         lookup::{
             self,
-            constraints::LookupConfiguration,
             lookups::LookupsUsed,
             tables::{combine_table_entry, CombinedEntry},
         },
@@ -30,7 +29,7 @@ use crate::{
     },
     prover_index::ProverIndex,
 };
-use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
+use ark_ff::{FftField, Field, One, PrimeField, UniformRand, Zero};
 use ark_poly::{
     univariate::DensePolynomial, Evaluations, Polynomial, Radix2EvaluationDomain as D, UVPolynomial,
 };
@@ -444,7 +443,16 @@ where
             None
         };
 
-        //~ 22. TODO: setup the env
+        //~ 21. Compute the quotient polynomial (the $t$ in $f = Z_H \cdot t$).
+        //~     The quotient polynomial is computed by adding all these polynomials together:
+        //~     - the combined constraints for all the gates
+        //~     - the combined constraints for the permutation
+        //~     - TODO: lookup
+        //~     - the negated public polynomial
+        //~     and by then dividing the resulting polynomial with the vanishing polynomial $Z_H$.
+        //~     TODO: specify the split of the permutation polynomial into perm and bnd?
+
+        let lagrange = index.cs.evaluate(&witness_poly, &z_poly);
         let env = {
             let mut index_evals = HashMap::new();
             use GateType::*;
@@ -467,7 +475,7 @@ where
                     alpha,
                     beta,
                     gamma,
-                    joint_combiner,
+                    joint_combiner: lookup_context.joint_combiner,
                     endo_coefficient: index.cs.endo,
                     mds: index.cs.fr_sponge_params.mds.clone(),
                 },
@@ -482,14 +490,6 @@ where
             }
         };
 
-        //~ 23. Compute the quotient polynomial (the $t$ in $f = Z_H \cdot t$).
-        //~     The quotient polynomial is computed by adding all these polynomials together:
-        //~     - the combined constraints for all the gates
-        //~     - the combined constraints for the permutation
-        //~     - TODO: lookup
-        //~     - the negated public polynomial
-        //~     and by then dividing the resulting polynomial with the vanishing polynomial $Z_H$.
-        //~     TODO: specify the split of the permutation polynomial into perm and bnd?
         let quotient_poly = {
             // generic
             let alphas =
@@ -683,7 +683,7 @@ where
             quotient
         };
 
-        //~ 24. commit (hiding) to the quotient polynomial $t$
+        //~ 22. commit (hiding) to the quotient polynomial $t$
         //~     TODO: specify the dummies
         let t_comm = {
             let (mut t_comm, mut omega_t) = index.srs.commit(&quotient_poly, None, rng);
@@ -702,67 +702,79 @@ where
             (t_comm, omega_t)
         };
 
-        //~ 25. Absorb the the commitment of the quotient polynomial with the Fq-Sponge.
+        //~ 23. Absorb the the commitment of the quotient polynomial with the Fq-Sponge.
         fq_sponge.absorb_g(&t_comm.0.unshifted);
 
-        //~ 26. Sample $\zeta'$ with the Fq-Sponge.
+        //~ 24. Sample $\zeta'$ with the Fq-Sponge.
         let zeta_chal = ScalarChallenge(fq_sponge.challenge());
 
-        //~ 27. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify)
+        //~ 25. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify)
         let zeta = zeta_chal.to_field(&index.srs.endo_r);
 
         let omega = index.cs.domain.d1.group_gen;
         let zeta_omega = zeta * omega;
 
-        //~ 28. TODO: lookup
-        let lookup_evals = |e: ScalarField<G>| {
-            lookup_aggreg_coeffs
+        //~ 26. If lookup is used, evaluate the following polynomials at $\zeta$ and $\zeta \omega$:
+        if let Some(lcs) = &index.cs.lookup_constraint_system {
+            //     - the aggregation polynomial
+            let aggreg = lookup_context
+                .aggreg_coeffs
+                .unwrap()
+                .to_chunked_polynomial(index.max_poly_size);
+
+            //      - the sorted polynomials
+            let sorted = lookup_context
+                .sorted_coeffs
                 .as_ref()
-                .zip(lookup_sorted_coeffs.as_ref())
-                .zip(index.cs.lookup_constraint_system.as_ref())
-                .map(|((aggreg, sorted), lcs)| LookupEvaluations {
-                    aggreg: aggreg
-                        .to_chunked_polynomial(index.max_poly_size)
-                        .evaluate_chunks(e),
-                    sorted: sorted
-                        .iter()
-                        .map(|c| {
-                            c.to_chunked_polynomial(index.max_poly_size)
-                                .evaluate_chunks(e)
+                .unwrap()
+                .iter()
+                .map(|c| c.to_chunked_polynomial(index.max_poly_size));
+
+            //      - the table polynonials
+            let base_table = lcs
+                .lookup_table
+                .iter()
+                .map(|p| p.to_chunked_polynomial(index.max_poly_size));
+
+            let table_ids = lcs
+                .table_ids
+                .as_ref()
+                .map(|tids| tids.to_chunked_polynomial(index.max_poly_size));
+
+            let lookup_evals = |e: ScalarField<G>| {
+                let table = base_table.clone().map(|p| p.evaluate_chunks(e)).rev().fold(
+                    vec![ScalarField::<G>::zero()],
+                    |acc, x| {
+                        acc.into_iter()
+                            .zip(x.iter())
+                            .map(|(acc, x)| acc * lookup_context.joint_combiner.unwrap() + x)
+                            .collect()
+                    },
+                );
+
+                let table = match &table_ids {
+                    None => table,
+                    Some(table_ids) => table
+                        .into_iter()
+                        .zip(table_ids.evaluate_chunks(e))
+                        .map(|(x, table_id)| {
+                            x + (lookup_context.table_id_combiner.unwrap() * table_id)
                         })
                         .collect(),
-                    table: {
-                        let base_table = lcs
-                            .lookup_table
-                            .iter()
-                            .map(|p| {
-                                p.to_chunked_polynomial(index.max_poly_size)
-                                    .evaluate_chunks(e)
-                            })
-                            .rev()
-                            .fold(vec![ScalarField::<G>::zero()], |acc, x| {
-                                acc.into_iter()
-                                    .zip(x.iter())
-                                    .map(|(acc, x)| acc * joint_combiner + x)
-                                    .collect()
-                            });
-                        match lcs.table_ids.as_ref() {
-                            None => base_table,
-                            Some(table_ids) => base_table
-                                .into_iter()
-                                .zip(
-                                    table_ids
-                                        .to_chunked_polynomial(index.max_poly_size)
-                                        .evaluate_chunks(e),
-                                )
-                                .map(|(x, table_id)| x + (table_id_combiner * table_id))
-                                .collect(),
-                        }
-                    },
-                })
-        };
+                };
 
-        //~ 29. Chunk evaluate the following polynomials at both $\zeta$ and $\zeta \omega$:
+                LookupEvaluations {
+                    aggreg: aggreg.evaluate_chunks(e),
+                    sorted: sorted.clone().map(|s| s.evaluate_chunks(e)).collect(),
+                    table,
+                }
+            };
+
+            lookup_context.eval_zeta = Some(lookup_evals(zeta));
+            lookup_context.eval_zeta_omega = Some(lookup_evals(zeta_omega));
+        }
+
+        //~ 27. Chunk evaluate the following polynomials at both $\zeta$ and $\zeta \omega$:
         //~     * $s_i$
         //~     * $w_i$
         //~     * $z$
@@ -797,7 +809,7 @@ where
                     .to_chunked_polynomial(index.max_poly_size)
                     .evaluate_chunks(zeta),
 
-                lookup: lookup_evals(zeta),
+                lookup: lookup_context.eval_zeta,
 
                 generic_selector: index
                     .cs
@@ -828,7 +840,7 @@ where
                     .to_chunked_polynomial(index.max_poly_size)
                     .evaluate_chunks(zeta_omega),
 
-                lookup: lookup_evals(zeta_omega),
+                lookup: lookup_context.eval_zeta_omega,
 
                 generic_selector: index
                     .cs
@@ -846,14 +858,11 @@ where
             [chunked_evals_zeta, chunked_evals_zeta_omega]
         };
 
-        drop(lookup_aggreg_coeffs);
-        drop(lookup_sorted_coeffs);
-
         let zeta_to_srs_len = zeta.pow(&[index.max_poly_size as u64]);
         let zeta_omega_to_srs_len = zeta.pow(&[index.max_poly_size as u64]);
         let zeta_to_domain_size = zeta.pow(&[d1_size as u64]);
 
-        //~ 30. Evaluate the same polynomials without chunking them
+        //~ 28. Evaluate the same polynomials without chunking them
         //~     (so that each polynomial should correspond to a single value this time).
         let evals = {
             let power_of_eval_points_for_chunks = [zeta_to_srs_len, zeta_omega_to_srs_len];
@@ -879,7 +888,7 @@ where
                 .collect::<Vec<_>>()
         };
 
-        //~ 31. Compute the ft polynomial.
+        //~ 29. Compute the ft polynomial.
         //~     This is to implement [Maller's optimization](https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html).
         let ft: DensePolynomial<ScalarField<G>> = {
             let f_chunked = {
@@ -907,9 +916,6 @@ where
                 };
 
                 drop(env);
-                drop(lookup_sorted8);
-                drop(lookup_aggreg8);
-                drop(lookup_table_combined);
 
                 // see https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html#the-prover-side
                 f.to_chunked_polynomial(index.max_poly_size)
@@ -923,7 +929,7 @@ where
             &f_chunked - &t_chunked.scale(zeta_to_domain_size - ScalarField::<G>::one())
         };
 
-        //~ 32. construct the blinding part of the ft polynomial commitment
+        //~ 30. construct the blinding part of the ft polynomial commitment
         //~     see https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html#evaluation-proof-and-blinding-factors
         let blinding_ft = {
             let blinding_t = t_comm.1.chunk_blinding(zeta_to_srs_len);
@@ -938,17 +944,17 @@ where
             }
         };
 
-        //~ 33. Evaluate the ft polynomial at $\zeta\omega$ only.
+        //~ 31. Evaluate the ft polynomial at $\zeta\omega$ only.
         let ft_eval1 = ft.evaluate(&zeta_omega);
 
-        //~ 34. Setup the Fr-Sponge
+        //~ 32. Setup the Fr-Sponge
         let fq_sponge_before_evaluations = fq_sponge.clone();
         let mut fr_sponge = EFrSponge::new(index.cs.fr_sponge_params.clone());
 
-        //~ 35. Squeeze the Fq-sponge and absorb the result with the Fr-Sponge.
+        //~ 33. Squeeze the Fq-sponge and absorb the result with the Fr-Sponge.
         fr_sponge.absorb(&fq_sponge.digest());
 
-        //~ 36. Evaluate the negated public polynomial (if present) at $\zeta$ and $\zeta\omega$.
+        //~ 34. Evaluate the negated public polynomial (if present) at $\zeta$ and $\zeta\omega$.
         let public_evals = if public_poly.is_zero() {
             [Vec::new(), Vec::new()]
         } else {
@@ -958,7 +964,7 @@ where
             ]
         };
 
-        //~ 37. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
+        //~ 35. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
         //~     - the public polynomial
         //~     - z
         //~     - generic selector
@@ -969,22 +975,22 @@ where
             fr_sponge.absorb_evaluations(&public_evals[i], &chunked_evals[i])
         }
 
-        //~ 38. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
+        //~ 36. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
         fr_sponge.absorb(&ft_eval1);
 
-        //~ 39. Sample $v'$ with the Fr-Sponge
+        //~ 37. Sample $v'$ with the Fr-Sponge
         let v_chal = fr_sponge.challenge();
 
-        //~ 40. Derive $v$ from $v'$ using the endomorphism (TODO: specify)
+        //~ 38. Derive $v$ from $v'$ using the endomorphism (TODO: specify)
         let v = v_chal.to_field(&index.srs.endo_r);
 
-        //~ 41. Sample $u'$ with the Fr-Sponge
+        //~ 39. Sample $u'$ with the Fr-Sponge
         let u_chal = fr_sponge.challenge();
 
-        //~ 42. Derive $u$ from $u'$ using the endomorphism (TODO: specify)
+        //~ 40. Derive $u$ from $u'$ using the endomorphism (TODO: specify)
         let u = u_chal.to_field(&index.srs.endo_r);
 
-        //~ 43. Create a list of all polynomials that will require evaluations
+        //~ 41. Create a list of all polynomials that will require evaluations
         //~     (and evaluation proofs) in the protocol.
         //~     First, include the previous challenges, in case we are in a recursive prover.
         let non_hiding = |d1_size: usize| PolyComm {
@@ -1007,7 +1013,7 @@ where
             .map(|(p, d1_size)| (p, None, non_hiding(*d1_size)))
             .collect::<Vec<_>>();
 
-        //~ 44. Then, include:
+        //~ 42. Then, include:
         //~     - the negated public polynomial
         //~     - the ft polynomial
         //~     - the permutation aggregation polynomial z polynomial
@@ -1034,7 +1040,7 @@ where
                 .collect::<Vec<_>>(),
         );
 
-        //~ 44. Create an aggregated evaluation proof for all of these polynomials at $\zeta$ and $\zeta\omega$ using $u$ and $v$.
+        //~ 43. Create an aggregated evaluation proof for all of these polynomials at $\zeta$ and $\zeta\omega$ using $u$ and $v$.
         let proof = index.srs.open(
             group_map,
             &polynomials,
@@ -1045,17 +1051,20 @@ where
             rng,
         );
 
+        let lookup = lookup_context
+            .aggreg_comm
+            .zip(lookup_context.sorted_comm)
+            .map(|(a, s)| LookupCommitments {
+                aggreg: a.0,
+                sorted: s.iter().map(|(x, _)| x.clone()).collect(),
+            });
+
         Ok(Self {
             commitments: ProverCommitments {
                 w_comm: array_init(|i| w_comm[i].0.clone()),
                 z_comm: z_comm.0,
                 t_comm: t_comm.0,
-                lookup: lookup_aggreg_comm.zip(lookup_sorted_comm).map(|(a, s)| {
-                    LookupCommitments {
-                        aggreg: a.0,
-                        sorted: s.iter().map(|(x, _)| x.clone()).collect(),
-                    }
-                }),
+                lookup,
             },
             proof,
             evals: chunked_evals,

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -403,10 +403,6 @@ where
                             &lookup_sorted,
                             rng)?;
 
-                    if aggreg.evals[d1_size - (ZK_ROWS as usize + 1)] != ScalarField::<G>::one() {
-                        panic!("aggregation incorrect: {}", aggreg.evals[d1_size-(ZK_ROWS as usize + 1)]);
-                    }
-
                     let comm = index.srs.commit_evaluations(index.cs.domain.d1, &aggreg, None, rng);
                     fq_sponge.absorb_g(&comm.0.unshifted);
 

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -47,6 +47,42 @@ use std::collections::HashMap;
 /// The result of a proof creation or verification.
 type Result<T> = std::result::Result<T, ProofError>;
 
+/// Contains variables needed for lookup in the prover algorithm.
+#[derive(Default)]
+struct LookupContext<G, F>
+where
+    G: CommitmentCurve,
+    F: FftField,
+{
+    /// The joint combiner used to join the columns of lookup tables
+    joint_combiner: Option<F>,
+
+    /// The power of the joint_combiner that can be used to add a table_id column
+    /// to the concatenated lookup tables.
+    table_id_combiner: Option<F>,
+
+    /// The combined lookup entry that can be used as dummy value
+    dummy_lookup_value: Option<CombinedEntry<F>>,
+
+    /// The combined lookup table
+    combined_table: Option<Evaluations<F, D<F>>>,
+
+    /// The sorted polynomials `s` in different forms
+    sorted: Option<Vec<Evaluations<F, D<F>>>>,
+    sorted_coeffs: Option<Vec<DensePolynomial<F>>>,
+    sorted_comm: Option<Vec<(PolyComm<G>, PolyComm<F>)>>,
+    sorted8: Option<Vec<Evaluations<F, D<F>>>>,
+
+    /// The aggregation polynomial in different forms
+    aggreg_coeffs: Option<DensePolynomial<F>>,
+    aggreg_comm: Option<(PolyComm<G>, PolyComm<F>)>,
+    aggreg8: Option<Evaluations<F, D<F>>>,
+
+    /// The evaluations of the aggregation polynomial for the proof
+    eval_zeta: Option<LookupEvaluations<Vec<F>>>,
+    eval_zeta_omega: Option<LookupEvaluations<Vec<F>>>,
+}
+
 impl<G: CommitmentCurve> ProverProof<G>
 where
     G::BaseField: PrimeField,

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -45,7 +45,7 @@ use rayon::iter::{
 use std::collections::HashMap;
 
 /// The result of a proof creation or verification.
-pub type Result<T> = std::result::Result<T, ProofError>;
+type Result<T> = std::result::Result<T, ProofError>;
 
 impl<G: CommitmentCurve> ProverProof<G>
 where


### PR DESCRIPTION
In this PR I do three things:

* I create a `LookupContext` struct in `prover.rs` to keep track of variables that are related to the lookup flow. This is so that we can track them across optional blocks (as lookup is an optional feature) instead of tracking a bunch of variables that pollute the scope
* I enclose each steps related to the lookup feature within a `if let Some(lcs) = &index.cs.lookup_constraint_system {`
* I add specification comments where relevant

(I tried to split the changes incrementally in commits)