### PR TITLE
fix rust-analyzer complaint about `rand` function

### DIFF
--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -112,7 +112,7 @@ where
 
             // zk-rows
             for row in w.iter_mut().rev().take(ZK_ROWS as usize) {
-                *row = ScalarField::<G>::rand(rng);
+                *row = <ScalarField<G> as UniformRand>::rand(rng);
             }
         }
 
@@ -691,7 +691,7 @@ where
             // the higher degree coefficients of `t` are 0.
             for _ in 0..dummies {
                 use ark_ec::ProjectiveCurve;
-                let w = ScalarField::<G>::rand(rng);
+                let w = <ScalarField<G> as UniformRand>::rand(rng);
                 t_comm.unshifted.push(index.srs.h.mul(w).into_affine());
                 omega_t.unshifted.push(w);
             }

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -213,8 +213,8 @@ impl<G: CommitmentCurve> SRS<G> {
             let (a_lo, a_hi) = (&a[0..n], &a[n..]);
             let (b_lo, b_hi) = (&b[0..n], &b[n..]);
 
-            let rand_l = ScalarField::<G>::rand(rng);
-            let rand_r = ScalarField::<G>::rand(rng);
+            let rand_l = <ScalarField<G> as UniformRand>::rand(rng);
+            let rand_r = <ScalarField<G> as UniformRand>::rand(rng);
 
             let l = VariableBaseMSM::multi_scalar_mul(
                 &[&g[0..n], &[self.h, u]].concat(),
@@ -287,8 +287,8 @@ impl<G: CommitmentCurve> SRS<G> {
             .map(|((l, r), (u, u_inv))| ((*l) * u_inv) + (*r * u))
             .fold(blinding_factor, |acc, x| acc + x);
 
-        let d = ScalarField::<G>::rand(rng);
-        let r_delta = ScalarField::<G>::rand(rng);
+        let d = <ScalarField<G> as UniformRand>::rand(rng);
+        let r_delta = <ScalarField<G> as UniformRand>::rand(rng);
 
         let delta = ((g0.into_projective() + (u.mul(b0))).into_affine().mul(d)
             + self.h.mul(r_delta))


### PR DESCRIPTION
Whenever both `UniformRand` and `UVPolynomial` traits are used, the rust-analyzer complains when accessing the `rand` function inside `UniformRand` (using only 1 argument), and expects the 2 arguments of the `rand` in `UVPolynomial`. Nonetheless, the execution correctly chooses the correct function. I will create an issue (here https://github.com/rust-lang/rust-analyzer/issues/12119) for the rust-analyzer team to fix this conflict. In the meantime, @mimoo suggested to cast `ScalarField<G>` as `UniformRand`, so that the `rand` function is interpreted correctly even at the rust-analyzer level.