### PR TITLE
[lookup] handle different table id 0

### DIFF
--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -1,10 +1,12 @@
 //! This module implements Plonk circuit constraint primitive.
 
-use crate::circuits::domain_constant_evaluation::DomainConstantEvaluations;
 use crate::circuits::{
+    domain_constant_evaluation::DomainConstantEvaluations,
     domains::EvaluationDomains,
     gate::{CircuitGate, GateType},
+    lookup::{index::LookupConstraintSystem, tables::LookupTable},
     polynomial::{WitnessEvals, WitnessOverDomains, WitnessShifts},
+    polynomials::permutation::ZK_ROWS,
     wires::*,
 };
 use ark_ff::{FftField, SquareRootField, Zero};
@@ -14,54 +16,16 @@ use ark_poly::{
 };
 use array_init::array_init;
 use blake2::{Blake2b512, Digest};
-use itertools::repeat_n;
-use o1_utils::{field_helpers::i32_to_field, ExtendedEvaluations};
+use o1_utils::ExtendedEvaluations;
 use once_cell::sync::OnceCell;
 use oracle::poseidon::ArithmeticSpongeParams;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
 use std::sync::Arc;
 
-use super::{
-    lookup::{
-        constraints::LookupConfiguration,
-        lookups::{JointLookup, LookupInfo},
-        tables::LookupTable,
-    },
-    polynomials::permutation::ZK_ROWS,
-};
-
 //
 // ConstraintSystem
 //
-
-#[serde_as]
-#[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct LookupConstraintSystem<F: FftField> {
-    /// Lookup tables
-    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
-    pub lookup_table: Vec<DP<F>>,
-    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
-    pub lookup_table8: Vec<E<F, D<F>>>,
-
-    /// Table IDs for the lookup values.
-    /// This may be `None` if all lookups originate from table 0.
-    #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]
-    pub table_ids: Option<DP<F>>,
-    #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]
-    pub table_ids8: Option<E<F, D<F>>>,
-
-    /// Lookup selectors:
-    /// For each kind of lookup-pattern, we have a selector that's
-    /// 1 at the rows where that pattern should be enforced, and 0 at
-    /// all other rows.
-    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
-    pub lookup_selectors: Vec<E<F, D<F>>>,
-
-    /// Configuration for the lookup constraint.
-    #[serde(bound = "LookupConfiguration<F>: Serialize + DeserializeOwned")]
-    pub configuration: LookupConfiguration<F>,
-}
 
 #[serde_as]
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -245,138 +209,6 @@ pub enum GateError {
     IncorrectPublic(usize),
     /// A specific gate did not verify correctly
     Custom { row: usize, err: String },
-}
-
-/// Represents an error found when computing the lookup constraint system
-#[derive(Debug)]
-pub enum LookupError {
-    /// One of the lookup tables has columns of different lengths
-    InconsistentTableLength,
-    /// The combined lookup table is larger than allowed by the domain size
-    LookupTableTooLong {
-        length: usize,
-        maximum_allowed: usize,
-    },
-}
-
-impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
-    pub fn create(
-        gates: &[CircuitGate<F>],
-        lookup_tables: Vec<LookupTable<F>>,
-        domain: &EvaluationDomains<F>,
-    ) -> Result<Option<Self>, LookupError> {
-        let lookup_info = LookupInfo::<F>::create();
-        match lookup_info.lookup_used(gates) {
-            None => Ok(None),
-            Some(lookup_used) => {
-                let d1_size = domain.d1.size();
-
-                let (lookup_selectors, gate_lookup_tables) =
-                    lookup_info.selector_polynomials_and_tables(domain, gates);
-
-                let lookup_tables: Vec<_> = gate_lookup_tables
-                    .into_iter()
-                    .chain(lookup_tables.into_iter())
-                    .collect();
-
-                // Get the max width of all lookup tables
-                let max_table_width = lookup_tables
-                    .iter()
-                    .map(|table| table.data.len())
-                    .max()
-                    .unwrap_or(0);
-
-                // The maximum number of entries that can be provided across all tables.
-                // Since we do not assert the lookup constraint on the final `ZK_ROWS` rows, and
-                // because the row before is used to assert that the lookup argument's final
-                // product is 1, we cannot use those rows to store any values.
-                let max_num_entries = d1_size - (ZK_ROWS as usize) - 1;
-
-                let mut lookup_table = vec![Vec::with_capacity(d1_size); max_table_width];
-                let mut table_ids: Vec<F> = Vec::with_capacity(d1_size);
-                let mut non_zero_table_id = false;
-                for table in lookup_tables.iter() {
-                    let table_len = table.data[0].len();
-
-                    // Update table IDs
-                    if table.id != 0 {
-                        non_zero_table_id = true;
-                    }
-                    let table_id: F = i32_to_field(table.id);
-                    table_ids.extend(repeat_n(table_id, table_len));
-
-                    // Update lookup_table values
-                    for (i, col) in table.data.iter().enumerate() {
-                        if col.len() != table_len {
-                            return Err(LookupError::InconsistentTableLength);
-                        }
-                        lookup_table[i].extend(col);
-                    }
-
-                    // Fill in any unused columns with 0 to match the dummy value
-                    for lookup_table in lookup_table.iter_mut().skip(table.data.len()) {
-                        lookup_table.extend(repeat_n(F::zero(), table_len))
-                    }
-                }
-
-                // Note: we use `>=` here to leave space for the dummy value.
-                if lookup_table[0].len() >= max_num_entries {
-                    return Err(LookupError::LookupTableTooLong {
-                        length: lookup_table[0].len(),
-                        maximum_allowed: max_num_entries - 1,
-                    });
-                }
-
-                // For computational efficiency, we choose the dummy lookup value to be all 0s in
-                // table 0.
-                let dummy_lookup = JointLookup {
-                    entry: vec![],
-                    table_id: F::zero(),
-                };
-
-                // Pad up to the end of the table with the dummy value.
-                lookup_table
-                    .iter_mut()
-                    .for_each(|col| col.extend(repeat_n(F::zero(), max_num_entries - col.len())));
-                table_ids.extend(repeat_n(F::zero(), max_num_entries - table_ids.len()));
-
-                // pre-compute polynomial and evaluation form for the look up tables
-                let mut lookup_table_polys: Vec<DP<F>> = vec![];
-                let mut lookup_table8: Vec<E<F, D<F>>> = vec![];
-                for col in lookup_table.into_iter() {
-                    let poly = E::<F, D<F>>::from_vec_and_domain(col, domain.d1).interpolate();
-                    let eval = poly.evaluate_over_domain_by_ref(domain.d8);
-                    lookup_table_polys.push(poly);
-                    lookup_table8.push(eval);
-                }
-
-                // pre-compute polynomial and evaluation form for the table IDs, if needed
-                let (table_ids, table_ids8) = if non_zero_table_id {
-                    let table_ids: DP<F> =
-                        E::<F, D<F>>::from_vec_and_domain(table_ids, domain.d1).interpolate();
-                    let table_ids8: E<F, D<F>> = table_ids.evaluate_over_domain_by_ref(domain.d8);
-                    (Some(table_ids), Some(table_ids8))
-                } else {
-                    (None, None)
-                };
-
-                // generate the look up selector polynomials
-                Ok(Some(Self {
-                    lookup_selectors,
-                    lookup_table8,
-                    lookup_table: lookup_table_polys,
-                    table_ids,
-                    table_ids8,
-                    configuration: LookupConfiguration {
-                        lookup_used,
-                        max_lookups_per_row: lookup_info.max_per_row as usize,
-                        max_joint_size: lookup_info.max_joint_size,
-                        dummy_lookup,
-                    },
-                }))
-            }
-        }
-    }
 }
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -417,7 +417,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
         // ------
 
         let lookup_constraint_system =
-            LookupConstraintSystem::create(&gates, lookup_tables, &domain).ok()?;
+            LookupConstraintSystem::create(&gates, lookup_tables, &domain).unwrap();
 
         let sid = shifts.map[0].clone();
 

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -119,10 +119,8 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
                     //~ b. Make sure that if table with id 0 is used, then it's the XOR table.
                     //~    We do this because we use a table with id 0 and
                     //~
-                    if table.id == 0 {
-                        if !table.has_zero_entry() {
-                            return Err(LookupError::TableIDZeroMustHaveZeroEntry);
-                        }
+                    if table.id == 0 && !table.has_zero_entry() {
+                        return Err(LookupError::TableIDZeroMustHaveZeroEntry);
                     }
 
                     //~ c. Update table IDs

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -1,0 +1,178 @@
+use crate::circuits::{domains::EvaluationDomains, gate::CircuitGate};
+use crate::circuits::{
+    lookup::{
+        constraints::LookupConfiguration,
+        lookups::{JointLookup, LookupInfo},
+        tables::LookupTable,
+    },
+    polynomials::permutation::ZK_ROWS,
+};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{
+    univariate::DensePolynomial as DP, EvaluationDomain, Evaluations as E,
+    Radix2EvaluationDomain as D,
+};
+use itertools::repeat_n;
+use o1_utils::field_helpers::i32_to_field;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_with::serde_as;
+
+/// Represents an error found when computing the lookup constraint system
+#[derive(Debug)]
+pub enum LookupError {
+    /// One of the lookup tables has columns of different lengths
+    InconsistentTableLength,
+    /// The combined lookup table is larger than allowed by the domain size
+    LookupTableTooLong {
+        length: usize,
+        maximum_allowed: usize,
+    },
+}
+
+#[serde_as]
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct LookupConstraintSystem<F: FftField> {
+    /// Lookup tables
+    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
+    pub lookup_table: Vec<DP<F>>,
+    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
+    pub lookup_table8: Vec<E<F, D<F>>>,
+
+    /// Table IDs for the lookup values.
+    /// This may be `None` if all lookups originate from table 0.
+    #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]
+    pub table_ids: Option<DP<F>>,
+    #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]
+    pub table_ids8: Option<E<F, D<F>>>,
+
+    /// Lookup selectors:
+    /// For each kind of lookup-pattern, we have a selector that's
+    /// 1 at the rows where that pattern should be enforced, and 0 at
+    /// all other rows.
+    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
+    pub lookup_selectors: Vec<E<F, D<F>>>,
+
+    /// Configuration for the lookup constraint.
+    #[serde(bound = "LookupConfiguration<F>: Serialize + DeserializeOwned")]
+    pub configuration: LookupConfiguration<F>,
+}
+
+impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
+    pub fn create(
+        gates: &[CircuitGate<F>],
+        lookup_tables: Vec<LookupTable<F>>,
+        domain: &EvaluationDomains<F>,
+    ) -> Result<Option<Self>, LookupError> {
+        let lookup_info = LookupInfo::<F>::create();
+        match lookup_info.lookup_used(gates) {
+            None => Ok(None),
+            Some(lookup_used) => {
+                let d1_size = domain.d1.size();
+
+                let (lookup_selectors, gate_lookup_tables) =
+                    lookup_info.selector_polynomials_and_tables(domain, gates);
+
+                let lookup_tables: Vec<_> = gate_lookup_tables
+                    .into_iter()
+                    .chain(lookup_tables.into_iter())
+                    .collect();
+
+                // Get the max width of all lookup tables
+                let max_table_width = lookup_tables
+                    .iter()
+                    .map(|table| table.data.len())
+                    .max()
+                    .unwrap_or(0);
+
+                // The maximum number of entries that can be provided across all tables.
+                // Since we do not assert the lookup constraint on the final `ZK_ROWS` rows, and
+                // because the row before is used to assert that the lookup argument's final
+                // product is 1, we cannot use those rows to store any values.
+                let max_num_entries = d1_size - (ZK_ROWS as usize) - 1;
+
+                let mut lookup_table = vec![Vec::with_capacity(d1_size); max_table_width];
+                let mut table_ids: Vec<F> = Vec::with_capacity(d1_size);
+                let mut non_zero_table_id = false;
+                for table in lookup_tables.iter() {
+                    let table_len = table.data[0].len();
+
+                    // Update table IDs
+                    if table.id != 0 {
+                        non_zero_table_id = true;
+                    }
+                    let table_id: F = i32_to_field(table.id);
+                    table_ids.extend(repeat_n(table_id, table_len));
+
+                    // Update lookup_table values
+                    for (i, col) in table.data.iter().enumerate() {
+                        if col.len() != table_len {
+                            return Err(LookupError::InconsistentTableLength);
+                        }
+                        lookup_table[i].extend(col);
+                    }
+
+                    // Fill in any unused columns with 0 to match the dummy value
+                    for lookup_table in lookup_table.iter_mut().skip(table.data.len()) {
+                        lookup_table.extend(repeat_n(F::zero(), table_len))
+                    }
+                }
+
+                // Note: we use `>=` here to leave space for the dummy value.
+                if lookup_table[0].len() >= max_num_entries {
+                    return Err(LookupError::LookupTableTooLong {
+                        length: lookup_table[0].len(),
+                        maximum_allowed: max_num_entries - 1,
+                    });
+                }
+
+                // For computational efficiency, we choose the dummy lookup value to be all 0s in
+                // table 0.
+                let dummy_lookup = JointLookup {
+                    entry: vec![],
+                    table_id: F::zero(),
+                };
+
+                // Pad up to the end of the table with the dummy value.
+                lookup_table
+                    .iter_mut()
+                    .for_each(|col| col.extend(repeat_n(F::zero(), max_num_entries - col.len())));
+                table_ids.extend(repeat_n(F::zero(), max_num_entries - table_ids.len()));
+
+                // pre-compute polynomial and evaluation form for the look up tables
+                let mut lookup_table_polys: Vec<DP<F>> = vec![];
+                let mut lookup_table8: Vec<E<F, D<F>>> = vec![];
+                for col in lookup_table.into_iter() {
+                    let poly = E::<F, D<F>>::from_vec_and_domain(col, domain.d1).interpolate();
+                    let eval = poly.evaluate_over_domain_by_ref(domain.d8);
+                    lookup_table_polys.push(poly);
+                    lookup_table8.push(eval);
+                }
+
+                // pre-compute polynomial and evaluation form for the table IDs, if needed
+                let (table_ids, table_ids8) = if non_zero_table_id {
+                    let table_ids: DP<F> =
+                        E::<F, D<F>>::from_vec_and_domain(table_ids, domain.d1).interpolate();
+                    let table_ids8: E<F, D<F>> = table_ids.evaluate_over_domain_by_ref(domain.d8);
+                    (Some(table_ids), Some(table_ids8))
+                } else {
+                    (None, None)
+                };
+
+                // generate the look up selector polynomials
+                Ok(Some(Self {
+                    lookup_selectors,
+                    lookup_table8,
+                    lookup_table: lookup_table_polys,
+                    table_ids,
+                    table_ids8,
+                    configuration: LookupConfiguration {
+                        lookup_used,
+                        max_lookups_per_row: lookup_info.max_per_row as usize,
+                        max_joint_size: lookup_info.max_joint_size,
+                        dummy_lookup,
+                    },
+                }))
+            }
+        }
+    }
+}

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::circuits::{domains::EvaluationDomains, gate::CircuitGate};
 use crate::circuits::{
     lookup::{
@@ -103,9 +105,16 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
                 //~ 5. Add the table ID stuff
                 let mut lookup_table = vec![Vec::with_capacity(d1_size); max_table_width];
                 let mut table_ids: Vec<F> = Vec::with_capacity(d1_size);
+                let mut table_ids_so_far = HashSet::new();
+
                 //~ 6. For each table:
                 for table in lookup_tables.iter() {
                     let table_len = table.data[0].len();
+
+                    //~ a. Make sure tables don't share the same id.
+                    if !table_ids_so_far.insert(table.id) {
+                        return Err(LookupError::DuplicateTableID);
+                    }
 
                     //~ b. Make sure that if table with id 0 is used, then it's the XOR table.
                     //~    We do this because we use a table with id 0 and

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -18,15 +18,19 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
 
 /// Represents an error found when computing the lookup constraint system
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum LookupError {
-    /// One of the lookup tables has columns of different lengths
+    #[error("One of the lookup tables has columns of different lengths")]
     InconsistentTableLength,
-    /// The combined lookup table is larger than allowed by the domain size
+    #[error("The combined lookup table is larger than allowed by the domain size. Obsered: {length}, expected: {maximum_allowed}")]
     LookupTableTooLong {
         length: usize,
         maximum_allowed: usize,
     },
+    #[error("Multiple tables shared the same table IDs")]
+    DuplicateTableID,
+    #[error("The table with id 0 must have an entry of all zeros")]
+    TableIDZeroMustHaveZeroEntry,
 }
 
 #[serde_as]

--- a/kimchi/src/circuits/lookup/mod.rs
+++ b/kimchi/src/circuits/lookup/mod.rs
@@ -2,5 +2,6 @@
 //! See <https://eprint.iacr.org/2020/315.pdf>
 
 pub mod constraints;
+pub mod index;
 pub mod lookups;
 pub mod tables;

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -102,9 +102,25 @@ impl<F: Field> Entry for UncombinedEntry<F> {
 }
 
 /// A table of values that can be used for a lookup, along with the ID for the table.
+#[derive(Debug)]
 pub struct LookupTable<F> {
     pub id: i32,
     pub data: Vec<Vec<F>>,
+}
+
+impl<F> LookupTable<F>
+where
+    F: FftField,
+{
+    /// Return true if the table has an entry containing all zeros.
+    pub fn has_zero_entry(&self) -> bool {
+        for entry in &self.data {
+            if entry.iter().all(|e| e.is_zero()) {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 /// Returns the lookup table associated to a [GateLookupTable].

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -114,11 +114,17 @@ where
 {
     /// Return true if the table has an entry containing all zeros.
     pub fn has_zero_entry(&self) -> bool {
-        for entry in &self.data {
-            if entry.iter().all(|e| e.is_zero()) {
+        // reminder: a table is written as a list of columns,
+        // not as a list of row entries.
+        for row in 0..self.data[0].len() {
+            for col in &self.data {
+                if !col[row].is_zero() {
+                    continue;
+                }
                 return true;
             }
         }
+
         false
     }
 }

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -4,12 +4,12 @@ use crate::prover::permutation::ZK_ROWS;
 use crate::{
     circuits::{
         argument::{Argument, ArgumentType},
-        constraints::LookupConstraintSystem,
         expr::{l0_1, Constants, Environment, LookupEnvironment},
         gate::GateType,
         lookup::{
             self,
             constraints::LookupConfiguration,
+            index::LookupConstraintSystem,
             lookups::LookupsUsed,
             tables::{combine_table_entry, CombinedEntry},
         },

--- a/kimchi/src/tests/chacha.rs
+++ b/kimchi/src/tests/chacha.rs
@@ -202,16 +202,10 @@ fn chacha_setup_bad_lookup(table_id: i32) {
     // .. and one fake witness.
     push_rows(true);
 
-    let lookup_tables = vec![
-        LookupTable {
-            id: 0,
-            data: vec![vec![Fp::from(0); 10]],
-        },
-        LookupTable {
-            id: table_id,
-            data: fakes,
-        },
-    ];
+    let lookup_tables = vec![LookupTable {
+        id: table_id,
+        data: fakes,
+    }];
 
     // create the index
     let index = new_index_for_test_with_lookups(gates, PUBLIC, lookup_tables);
@@ -251,9 +245,9 @@ fn chacha_prover_fake_lookup_in_different_table_fails() {
     chacha_setup_bad_lookup(XOR_TABLE_ID + 1)
 }
 
-// Test lookup domain collisions: if the same table ID is used, we should be able to inject and use
-// a value when it wasn't previously in the table.
+// Test lookup domain collisions: if the same table ID is used, we should panic.
 #[test]
+#[should_panic]
 fn chacha_prover_fake_lookup_in_same_table() {
     chacha_setup_bad_lookup(XOR_TABLE_ID)
 }


### PR DESCRIPTION
This PR moves the lookup constraint system to its own module so that we can specify it. It also refactors it as explained below.

We currently use an XOR table with id = 0 and the last dummy entry `(0, 0, 0)`. We then generalize based on these assumptions:

* we will always use the XOR table when doing lookups
* the XOR table will always be the only table with id = 0

This is in part so that we can use the dummy entry. 

This PR tries to improve the situation to avoid users shooting themselves in the foot:

* it enforces that we cannot use different lookup tables with the same ID
* it enforces that whatever is the table with ID = 0 then it has a dummy entry that is all zeros

This should allow us to do lookups without having to use the XOR table, as long as the first table has an entry with all-zeroes (BTW do we need this entry to be the last one? This is what we check in the XOR table but I don't see how it's important anymore)
If the tables you want to use don't have a single entry of all zeros, then create a DummyTable with ID=0 that has a single entry of all zeros.
