### PR TITLE
[TOY PR] Refactoring Investigation in lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ let verifier_index = prover_index.verifier_index();
 // create a proof
 let group_map = <Affine as CommitmentCurve>::Map::setup();
 let proof =  ProverProof::create::<BaseSponge, ScalarSponge>(
-    &group_map, witness, &prover_index);
+    &group_map, witness, None, &prover_index);
 
 // verify a proof
 verify::<Affine, BaseSponge, ScalarSponge>(&group_map, verifier_index, proof).unwrap();

--- a/kimchi/src/bench.rs
+++ b/kimchi/src/bench.rs
@@ -103,6 +103,7 @@ impl BenchmarkCtx {
         ProverProof::create_recursive::<BaseSponge, ScalarSponge>(
             &self.group_map,
             witness,
+            None,
             &self.index,
             vec![prev],
         )

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -77,18 +77,20 @@ pub enum GateType {
     EndoMul = 5,
     /// Gate for computing the scalar corresponding to an endoscaling
     EndoMulScalar = 6,
-    /// ChaCha
+    // ChaCha
     ChaCha0 = 7,
     ChaCha1 = 8,
     ChaCha2 = 9,
     ChaChaFinal = 10,
     // Lookup
     Lookup = 11,
-    /// Cairo
+    // Cairo
     CairoClaim = 12,
     CairoInstruction = 13,
     CairoFlags = 14,
     CairoTransition = 15,
+    // Range
+    Range = 16,
 }
 
 #[serde_as]
@@ -156,6 +158,7 @@ impl<F: FftField> CircuitGate<F> {
             CairoClaim | CairoInstruction | CairoFlags | CairoTransition => {
                 self.verify_cairo_gate(row, witness, cs)
             }
+            Range => Ok(()),
         }
     }
 }

--- a/kimchi/src/circuits/lookup/tables/range.rs
+++ b/kimchi/src/circuits/lookup/tables/range.rs
@@ -1,0 +1,17 @@
+use crate::circuits::lookup::tables::{LookupTable, RANGE_TABLE_ID};
+use ark_ff::Field;
+
+/// The range check will be performed on values in [0, 2^12]
+const RANGE_UPPERBOUND: u32 = 1 << 2;
+
+/// A single-column table containing the numbers from 0 to 20
+pub fn range_table<F>() -> LookupTable<F>
+where
+    F: Field,
+{
+    let range = (0..RANGE_UPPERBOUND).map(|i| F::from(i)).collect();
+    LookupTable {
+        id: RANGE_TABLE_ID,
+        data: vec![range],
+    }
+}

--- a/kimchi/src/circuits/polynomials/mod.rs
+++ b/kimchi/src/circuits/polynomials/mod.rs
@@ -5,5 +5,6 @@ pub mod endosclmul;
 pub mod generic;
 pub mod permutation;
 pub mod poseidon;
+pub mod range;
 pub mod turshi;
 pub mod varbasemul;

--- a/kimchi/src/circuits/polynomials/range.rs
+++ b/kimchi/src/circuits/polynomials/range.rs
@@ -1,0 +1,17 @@
+use crate::circuits::{
+    argument::{Argument, ArgumentType},
+    expr::{prologue::*, Cache},
+    gate::{CircuitGate, GateType},
+    wires::{GateWires, COLUMNS},
+};
+use ark_ff::{FftField, Field, One};
+
+impl<F: FftField> CircuitGate<F> {
+    pub fn create_range(wires: GateWires) -> Self {
+        CircuitGate {
+            typ: GateType::Range,
+            wires,
+            coeffs: vec![],
+        }
+    }
+}

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -22,7 +22,7 @@ use ark_poly::Radix2EvaluationDomain as D;
 pub fn constraints_expr<F: FftField + SquareRootField>(
     domain: D<F>,
     chacha: bool,
-    lookup_constraint_system: Option<&LookupConfiguration<F>>,
+    lookup_constraint_system: Option<&LookupConfiguration>,
 ) -> (Expr<ConstantExpr<F>>, Alphas<F>) {
     // register powers of alpha so that we don't reuse them across mutually inclusive constraints
     let mut powers_of_alpha = Alphas::<F>::default();
@@ -66,7 +66,7 @@ pub fn constraints_expr<F: FftField + SquareRootField>(
 }
 
 pub fn linearization_columns<F: FftField + SquareRootField>(
-    lookup_constraint_system: Option<&LookupConfiguration<F>>,
+    lookup_constraint_system: Option<&LookupConfiguration>,
 ) -> std::collections::HashSet<Column> {
     let mut h = std::collections::HashSet::new();
     use Column::*;
@@ -92,7 +92,7 @@ pub fn linearization_columns<F: FftField + SquareRootField>(
 pub fn expr_linearization<F: FftField + SquareRootField>(
     domain: D<F>,
     chacha: bool,
-    lookup_constraint_system: Option<&LookupConfiguration<F>>,
+    lookup_constraint_system: Option<&LookupConfiguration>,
 ) -> (Linearization<Vec<PolishToken<F>>>, Alphas<F>) {
     let evaluated_cols = linearization_columns::<F>(lookup_constraint_system);
 

--- a/kimchi/src/tests/chacha.rs
+++ b/kimchi/src/tests/chacha.rs
@@ -87,7 +87,7 @@ fn chacha_prover() {
 
     let start = Instant::now();
     let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index).unwrap();
+        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, None, &index).unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
     let start = Instant::now();
@@ -227,7 +227,7 @@ fn chacha_setup_bad_lookup(table_id: i32) {
 
     let start = Instant::now();
     let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index).unwrap();
+        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, None, &index).unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
     let start = Instant::now();

--- a/kimchi/src/tests/ec.rs
+++ b/kimchi/src/tests/ec.rs
@@ -170,7 +170,7 @@ fn ec_test() {
 
     let start = Instant::now();
     let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index).unwrap();
+        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, None, &index).unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
     let start = Instant::now();

--- a/kimchi/src/tests/endomul.rs
+++ b/kimchi/src/tests/endomul.rs
@@ -133,7 +133,7 @@ fn endomul_test() {
 
     let start = Instant::now();
     let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index).unwrap();
+        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, None, &index).unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
     let start = Instant::now();

--- a/kimchi/src/tests/endomul_scalar.rs
+++ b/kimchi/src/tests/endomul_scalar.rs
@@ -80,7 +80,7 @@ fn endomul_scalar_test() {
 
     let start = Instant::now();
     let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index).unwrap();
+        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, None, &index).unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
     let start = Instant::now();

--- a/kimchi/src/tests/generic.rs
+++ b/kimchi/src/tests/generic.rs
@@ -78,6 +78,7 @@ fn verify_proof(gates: Vec<CircuitGate<Fp>>, witness: [Vec<Fp>; COLUMNS], public
     let proof = ProverProof::create_recursive::<BaseSponge, ScalarSponge>(
         &group_map,
         witness,
+        None,
         &index,
         vec![prev],
     )

--- a/kimchi/src/tests/lookup.rs
+++ b/kimchi/src/tests/lookup.rs
@@ -116,7 +116,7 @@ fn setup_lookup_proof(use_values_from_table: bool, num_lookups: usize, table_siz
 
     let start = Instant::now();
     let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index).unwrap();
+        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, None, &index).unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
     let start = Instant::now();

--- a/kimchi/src/tests/mod.rs
+++ b/kimchi/src/tests/mod.rs
@@ -5,5 +5,6 @@ mod endomul_scalar;
 mod generic;
 mod lookup;
 mod poseidon;
+mod range;
 mod turshi;
 mod varbasemul;

--- a/kimchi/src/tests/poseidon.rs
+++ b/kimchi/src/tests/poseidon.rs
@@ -66,14 +66,7 @@ fn test_poseidon() {
     // custom constraints for Poseidon hash function permutation
     // ROUNDS_FULL full rounds constraint gates
     for _ in 0..NUM_POS {
-        let first_wire = Wire::new(abs_row);
-        let last_row = abs_row + POS_ROWS_PER_HASH;
-        let last_wire = Wire::new(last_row);
-        let (poseidon, row) = CircuitGate::<Fp>::create_poseidon_gadget(
-            abs_row,
-            [first_wire, last_wire],
-            &round_constants,
-        );
+        let (poseidon, row) = CircuitGate::<Fp>::create_poseidon_gadget(abs_row, &round_constants);
         gates.extend(poseidon);
         abs_row = row;
     }
@@ -157,6 +150,7 @@ fn positive(index: &ProverIndex<Affine>) {
             ProverProof::create_recursive::<BaseSponge, ScalarSponge>(
                 &group_map,
                 witness_cols,
+                None,
                 index,
                 vec![prev],
             )

--- a/kimchi/src/tests/range.rs
+++ b/kimchi/src/tests/range.rs
@@ -1,0 +1,59 @@
+use crate::circuits::polynomials::generic::testing::{create_circuit, fill_in_witness};
+use crate::circuits::wires::Wire;
+use crate::circuits::{gate::CircuitGate, wires::COLUMNS};
+use crate::proof::ProverProof;
+use crate::prover_index::testing::new_index_for_test;
+use crate::verifier::verify;
+use ark_ff::{UniformRand, Zero};
+use ark_poly::{univariate::DensePolynomial, UVPolynomial};
+use array_init::array_init;
+use commitment_dlog::commitment::{b_poly_coefficients, CommitmentCurve};
+use groupmap::GroupMap;
+use itertools::iterate;
+use mina_curves::pasta::{
+    fp::Fp,
+    vesta::{Affine, VestaParameters},
+};
+use oracle::{
+    constants::PlonkSpongeConstantsKimchi,
+    sponge::{DefaultFqSponge, DefaultFrSponge},
+};
+use rand::{rngs::StdRng, SeedableRng};
+
+use o1_utils::math;
+
+// aliases
+
+type SpongeParams = PlonkSpongeConstantsKimchi;
+type BaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;
+type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
+
+#[test]
+fn test_range_gate() {
+    let mut gates = vec![];
+    let mut gates_row = iterate(0, |&i| i + 1);
+    let mut row = || gates_row.next().unwrap();
+
+    // public input
+    for _ in 0..5 {
+        gates.push(CircuitGate::create_range(Wire::new(row())));
+    }
+
+    // create BAD witness
+    let mut witness: [Vec<Fp>; COLUMNS] = array_init(|_| vec![Fp::zero(); gates.len()]);
+    witness[0][0] = Fp::from((1 << 13) as u32);
+
+    // create and verify proof based on the witness
+    // create the index
+    let index = new_index_for_test(gates, 0);
+
+    // add the proof to the batch
+    let group_map = <Affine as CommitmentCurve>::Map::setup();
+    let proof =
+        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, None, &index).unwrap();
+
+    // verify the proof
+    let verifier_index = index.verifier_index();
+
+    verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &verifier_index, &proof).unwrap();
+}

--- a/kimchi/src/tests/varbasemul.rs
+++ b/kimchi/src/tests/varbasemul.rs
@@ -108,7 +108,7 @@ fn varbase_mul_test() {
 
     let start = Instant::now();
     let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index).unwrap();
+        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, None, &index).unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
     let start = Instant::now();

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -647,6 +647,7 @@ where
                             CairoClaim | CairoInstruction | CairoFlags | CairoTransition => {
                                 unimplemented!()
                             }
+                            Range => unimplemented!(),
                         };
                         scalars.push(scalar);
                         commitments.push(c);

--- a/tools/kimchi-visu/src/lib.rs
+++ b/tools/kimchi-visu/src/lib.rs
@@ -56,7 +56,7 @@ where
 {
 }
 
-///
+/// Produces the constraints in LaTeX format
 pub fn latex_constraints<G>() -> HashMap<&'static str, Vec<Vec<String>>>
 where
     G: CommitmentCurve,

--- a/tools/kimchi-visu/src/main.rs
+++ b/tools/kimchi-visu/src/main.rs
@@ -1,7 +1,7 @@
 use kimchi::{
     circuits::{
         gate::CircuitGate,
-        polynomials::{generic::GenericGateSpec, poseidon::generate_witness},
+        polynomials::{generic::GenericGateSpec, poseidon},
         wires::Wire,
     },
     prover_index::testing::new_index_for_test,
@@ -33,26 +33,29 @@ fn main() {
         // poseidon
         let row = {
             let round_constants = &poseidon_params.round_constants;
-            let (g, row) = CircuitGate::<Fp>::create_poseidon_gadget(
-                row,
-                [Wire::new(row), Wire::new(row + 11)],
-                round_constants,
-            );
+            let (g, row) = CircuitGate::<Fp>::create_poseidon_gadget(row, round_constants);
             gates.extend(g);
             row
         };
 
         // public input is output of poseidon
-        {
-            gates[0].wires[0] = Wire { row, col: 0 };
-            gates[1].wires[0] = Wire { row, col: 1 };
-            gates[2].wires[0] = Wire { row, col: 2 };
+        let output_row = row - 1;
+        gates[0].wires[0] = Wire { row, col: 0 };
+        gates[1].wires[0] = Wire { row, col: 1 };
+        gates[2].wires[0] = Wire { row, col: 2 };
 
-            let poseidon_output = &mut gates[row].wires;
-            poseidon_output[0] = Wire { row: 0, col: 0 };
-            poseidon_output[1] = Wire { row: 0, col: 1 };
-            poseidon_output[2] = Wire { row: 0, col: 2 };
-        }
+        let poseidon_output = &mut gates[output_row].wires;
+        poseidon_output[0] = Wire { row: 0, col: 0 };
+        poseidon_output[1] = Wire { row: 0, col: 1 };
+        poseidon_output[2] = Wire { row: 0, col: 2 };
+
+        // range checks (using lookup)
+        let row = {
+            let wires = Wire::new(row);
+            let g = CircuitGate::<Fp>::create_range(wires);
+            gates.push(g);
+            row + 1
+        };
 
         (gates, row)
     };
@@ -61,9 +64,22 @@ fn main() {
     let index = new_index_for_test(gates, public);
 
     // create the witness
-    let mut witness = Witness::new(row + 1).inner();
-    let input = [1u32.into(), 2u32.into(), 3u32.into()];
-    generate_witness(3, poseidon_params, &mut witness, input);
+    let witness = {
+        let mut witness = Witness::new(row + 1).inner();
+        let input = [1u32.into(), 2u32.into(), 3u32.into()];
+        poseidon::generate_witness(3, poseidon_params, &mut witness, input);
+
+        // lookup
+        witness[0][row] = 1u32.into();
+        witness[1][row] = 1u32.into();
+        witness[2][row] = 1u32.into();
+        witness[3][row] = 1u32.into();
+        witness[4][row] = 1u32.into();
+        witness[5][row] = 1u32.into();
+        witness[6][row] = 1u32.into();
+
+        witness
+    };
 
     // create the HTML
     visu(&index, Some(witness.into()));


### PR DESCRIPTION
this PR will be closed, but for now it seeks to investigate several refactoring opportunities:

- [x] add a range lookup (for values in `[0, 2^12]`), this will be needed for the foreign mul gate
- [x] add a range gate (just for testing, not sure we will actually need it since we have the lookup gate)
- [ ] add runtime table support
- [ ] refactor lookup to make it work
  - [x] LookupConfiguration that's based only on tables used by the circuit
  - [ ] LookupConfiguration that has selectors that's based on what's used in the circuit
  - [x] dynamic IDs based on the tables used in the circuit
  - [ ] use these dynamic IDs in the constraints (JointLookup)
  - [x] enforce that user-provided fixed tables, and runtime tables have negative IDs
  - [x] add a dummy table when needed (the only case where it's not needed is when only a single built-in fixed table is used and it has an entry of all zeros) 

the goal is to play around to make these things work. We can then discuss if this is the proper way forward, and if we want to split this up in more PRs

PS: I'm making the distinction between two types of fixed tables: built-in (like the XOR table) and user-provided (the one passed at setup time)