### PR TITLE
implementation of runtime tables

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1216,6 +1216,10 @@ pub struct LookupVerifierIndex<G: CommitmentCurve> {
 
     /// The maximum joint size of any joint lookup in a constraint in `kinds`. This can be computed from `kinds`.
     pub max_joint_size: u32,
+
+    /// An optional selector polynomial for runtime tables
+    #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
+    pub runtime_tables_selector: Option<PolyComm<G>>,
 }
 
 #[serde_as]
@@ -1377,6 +1381,9 @@ pub struct LookupEvaluations<Field> {
     // TODO: May be possible to optimize this away?
     /// lookup table polynomial
     pub table: Field,
+
+    /// Optionally, a runtime table polynomial.
+    pub runtime: Option<Field>,
 }
 
 // TODO: this should really be vectors here, perhaps create another type for chunked evaluations?
@@ -1402,6 +1409,9 @@ pub struct ProofEvaluations<Field> {
 pub struct LookupCommitments<G: AffineCurve> {
     pub sorted: Vec<PolyComm<G>>,
     pub aggreg: PolyComm<G>,
+
+    /// Optional commitment to concatenated runtime tables
+    pub runtime: Option<PolyComm<G>>,
 }
 
 /// All the commitments that the prover creates as part of the proof.
@@ -1530,6 +1540,8 @@ The prover then follows the following steps to create the proof:
 23. Sample $\zeta'$ with the Fq-Sponge.
 24. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify)
 25. If lookup is used, evaluate the following polynomials at $\zeta$ and $\zeta \omega$:
+    - the aggregation polynomial
+    - the sorted polynomials
 26. Chunk evaluate the following polynomials at both $\zeta$ and $\zeta \omega$:
     * $s_i$
     * $w_i$
@@ -1581,6 +1593,7 @@ The prover then follows the following steps to create the proof:
     - the poseidon selector
     - the 15 registers/witness columns
     - the 6 sigmas
+    - optionally, the runtime table
 42. Create an aggregated evaluation proof for all of these polynomials at $\zeta$ and $\zeta\omega$ using $u$ and $v$.
 
 

--- a/kimchi/Cargo.toml
+++ b/kimchi/Cargo.toml
@@ -44,6 +44,7 @@ wasm-bindgen = { version = "0.2", optional = true }
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
 colored = "2.0.0"
+num-bigint = "0.4.3"
 
 # benchmarks
 criterion = "0.3"

--- a/kimchi/src/bench.rs
+++ b/kimchi/src/bench.rs
@@ -103,6 +103,7 @@ impl BenchmarkCtx {
         ProverProof::create_recursive::<BaseSponge, ScalarSponge>(
             &self.group_map,
             witness,
+            &[],
             &self.index,
             vec![prev],
         )

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -51,6 +51,10 @@ pub struct LookupEnvironment<'a, F: FftField> {
     pub selectors: &'a Vec<Evaluations<F, D<F>>>,
     /// The evaluations of the combined lookup table polynomial.
     pub table: &'a Evaluations<F, D<F>>,
+    /// The evaluations of the optional runtime selector polynomial.
+    pub runtime_selector: Option<&'a Evaluations<F, D<F>>>,
+    /// The evaluations of the optional runtime table.
+    pub runtime_table: Option<&'a Evaluations<F, D<F>>>,
 }
 
 /// The collection of polynomials (all in evaluation form) and constants
@@ -91,6 +95,8 @@ impl<'a, F: FftField> Environment<'a, F> {
             LookupSorted(i) => lookup.map(|l| &l.sorted[*i]),
             LookupAggreg => lookup.map(|l| l.aggreg),
             LookupTable => lookup.map(|l| l.table),
+            LookupRuntimeSelector => lookup.and_then(|l| l.runtime_selector),
+            LookupRuntimeTable => lookup.and_then(|l| l.runtime_table),
             Index(t) => match self.index.get(t) {
                 None => None,
                 Some(e) => Some(e),
@@ -126,6 +132,8 @@ pub enum Column {
     LookupAggreg,
     LookupTable,
     LookupKindIndex(usize),
+    LookupRuntimeSelector,
+    LookupRuntimeTable,
     Index(GateType),
     Coefficient(usize),
 }
@@ -146,6 +154,8 @@ impl Column {
             Column::LookupAggreg => "a".to_string(),
             Column::LookupTable => "t".to_string(),
             Column::LookupKindIndex(i) => format!("k_{{{}}}", i),
+            Column::LookupRuntimeSelector => "rts".to_string(),
+            Column::LookupRuntimeTable => "rt".to_string(),
             Column::Index(gate) => {
                 format!("{:?}", gate)
             }
@@ -409,13 +419,14 @@ impl Variable {
             LookupSorted(i) => l.map(|l| l.sorted[i]),
             LookupAggreg => l.map(|l| l.aggreg),
             LookupTable => l.map(|l| l.table),
+            LookupRuntimeTable => l.and_then(|l| l.runtime.ok_or("runtime table not available")),
             Index(GateType::Poseidon) => Ok(evals.poseidon_selector),
             Index(GateType::Generic) => Ok(evals.generic_selector),
             Index(GateType::CairoClaim)
             | Index(GateType::CairoInstruction)
             | Index(GateType::CairoFlags)
             | Index(GateType::CairoTransition) => todo!(),
-            Coefficient(_) | LookupKindIndex(_) | Index(_) => {
+            Coefficient(_) | LookupKindIndex(_) | Index(_) | LookupRuntimeSelector => {
                 Err("Cannot get index evaluation (should have been linearized away)")
             }
         }

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -39,6 +39,9 @@ pub enum ExprError {
 
     #[error("Linearization failed")]
     FailedLinearization,
+
+    #[error("runtime table not available")]
+    MissingRuntime,
 }
 
 /// The collection of constants required to evaluate an `Expr`.
@@ -438,7 +441,7 @@ impl Variable {
             LookupSorted(i) => l.map(|l| l.sorted[i]),
             LookupAggreg => l.map(|l| l.aggreg),
             LookupTable => l.map(|l| l.table),
-            LookupRuntimeTable => l.and_then(|l| l.runtime.ok_or("runtime table not available")),
+            LookupRuntimeTable => l.and_then(|l| l.runtime.ok_or(ExprError::MissingRuntime)),
             Index(GateType::Poseidon) => Ok(evals.poseidon_selector),
             Index(GateType::Generic) => Ok(evals.generic_selector),
             Coefficient(_) | LookupKindIndex(_) | LookupRuntimeSelector | Index(_) => {

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -307,7 +307,7 @@ mod tests {
         #[test]
         fn test_gate_serialization(cg in arb_circuit_gate()) {
             let encoded = rmp_serde::to_vec(&cg).unwrap();
-            let decoded: CircuitGate<Fp> = rmp_serde::from_read_ref(&encoded).unwrap();
+            let decoded: CircuitGate<Fp> = rmp_serde::from_slice(&encoded).unwrap();
             prop_assert_eq!(cg.typ, decoded.typ);
             for i in 0..PERMUTS {
                 prop_assert_eq!(cg.wires[i], decoded.wires[i]);

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -119,7 +119,7 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
                         let runtime_selector = {
                             let mut evals = Vec::with_capacity(d1_size);
 
-                            // it's 0 everywhere, except at the entries where
+                            // it's 1 everywhere, except at the entries where
                             // the runtime table applies
                             evals.extend(iter::repeat(F::one()).take(runtime_table_offset));
                             evals.extend(iter::repeat(F::zero()).take(runtime_len));

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use crate::circuits::{domains::EvaluationDomains, gate::CircuitGate};
 use crate::circuits::{
     lookup::{
@@ -17,6 +19,8 @@ use o1_utils::field_helpers::i32_to_field;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
 use thiserror::Error;
+
+use super::runtime_tables::RuntimeTableConfiguration;
 
 /// Represents an error found when computing the lookup constraint system
 #[derive(Debug, Error)]
@@ -55,6 +59,11 @@ pub struct LookupConstraintSystem<F: FftField> {
     #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
     pub lookup_selectors: Vec<E<F, D<F>>>,
 
+    /// An optional runtime table selector. It is 0 everywhere,
+    /// except at the rows where the runtime tables apply.
+    #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]
+    pub runtime_selector: Option<E<F, D<F>>>,
+
     /// Configuration for the lookup constraint.
     #[serde(bound = "LookupConfiguration<F>: Serialize + DeserializeOwned")]
     pub configuration: LookupConfiguration<F>,
@@ -64,6 +73,7 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
     pub fn create(
         gates: &[CircuitGate<F>],
         lookup_tables: Vec<LookupTable<F>>,
+        runtime_tables: Option<Vec<RuntimeTableConfiguration>>,
         domain: &EvaluationDomains<F>,
     ) -> Result<Option<Self>, LookupError> {
         let lookup_info = LookupInfo::<F>::create();
@@ -85,10 +95,62 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
                     lookup_info.selector_polynomials_and_tables(domain, gates);
 
                 //~ 3. Concatenate runtime lookup tables with the ones used by gates
-                let lookup_tables: Vec<_> = gate_lookup_tables
+                let mut lookup_tables: Vec<_> = gate_lookup_tables
                     .into_iter()
                     .chain(lookup_tables.into_iter())
                     .collect();
+
+                // if we are using runtime tables
+                let (runtime_table_offset, runtime_selector) =
+                    if let Some(runtime_tables) = &runtime_tables {
+                        // save the offset of the end of the table
+                        let mut runtime_table_offset = 0;
+                        for table in &lookup_tables {
+                            runtime_table_offset += table.len();
+                        }
+
+                        // compute the length of the runtime table
+                        let mut runtime_len = 0;
+                        for t in runtime_tables {
+                            runtime_len += t.len;
+                        }
+
+                        // compute the runtime selector
+                        let runtime_selector = {
+                            let mut evals = Vec::with_capacity(d1_size);
+
+                            // it's 0 everywhere, except at the entries where
+                            // the runtime table applies
+                            evals.extend(iter::repeat(F::one()).take(runtime_table_offset));
+                            evals.extend(iter::repeat(F::zero()).take(runtime_len));
+                            evals.extend(
+                                iter::repeat(F::one())
+                                    .take(d1_size - runtime_table_offset - runtime_len),
+                            );
+
+                            // although the last ZK_ROWS are fine
+                            for e in evals.iter_mut().rev().take(ZK_ROWS as usize) {
+                                *e = F::zero();
+                            }
+
+                            E::<F, D<F>>::from_vec_and_domain(evals, domain.d1)
+                                .interpolate()
+                                .evaluate_over_domain(domain.d8)
+                        };
+
+                        // create fixed tables for indexing the runtime tables
+                        for &RuntimeTableConfiguration { id, len } in runtime_tables {
+                            let indexes = (0..(len as u32)).map(F::from).collect();
+                            let placeholders = vec![F::zero(); len];
+                            let data = vec![indexes, placeholders];
+                            let table = LookupTable { id, data };
+                            lookup_tables.push(table);
+                        }
+
+                        (Some(runtime_table_offset), Some(runtime_selector))
+                    } else {
+                        (None, None)
+                    };
 
                 //~ 4. Get the highest number of columns `max_table_width`
                 //~    that a lookup table can have.
@@ -220,10 +282,13 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
                     lookup_table: lookup_table_polys,
                     table_ids,
                     table_ids8,
+                    runtime_selector,
                     configuration: LookupConfiguration {
                         lookup_used,
                         max_lookups_per_row: lookup_info.max_per_row as usize,
                         max_joint_size: lookup_info.max_joint_size,
+                        runtime_tables,
+                        runtime_table_offset,
                         dummy_lookup,
                     },
                 }))

--- a/kimchi/src/circuits/lookup/mod.rs
+++ b/kimchi/src/circuits/lookup/mod.rs
@@ -4,4 +4,5 @@
 pub mod constraints;
 pub mod index;
 pub mod lookups;
+pub mod runtime_tables;
 pub mod tables;

--- a/kimchi/src/circuits/lookup/runtime_tables.rs
+++ b/kimchi/src/circuits/lookup/runtime_tables.rs
@@ -1,0 +1,43 @@
+//! What are runtime tables?
+
+use crate::circuits::{
+    expr::{prologue::*, Column},
+    gate::CurrOrNext,
+};
+use ark_ff::Field;
+use serde::{Deserialize, Serialize};
+
+/// The configuration of a runtime table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeTableConfiguration {
+    /// The table id (must be negative).
+    pub id: i32,
+    /// The length of the runtime table.
+    pub len: usize,
+}
+
+/// A runtime table.
+#[derive(Debug, Clone)]
+pub struct RuntimeTable<F> {
+    /// The table id (must be negative).
+    pub id: i32,
+    /// A single column.
+    pub data: Vec<F>,
+}
+
+/// Returns the constraints related to the runtime table.
+pub fn constraints<F>() -> Vec<E<F>>
+where
+    F: Field,
+{
+    // This constrains that runtime_table takes values
+    // when selector_RT is 1, and doesn't when selector_RT is 0.
+    //
+    // runtime_table (1 - selector_RT) = 0
+    //
+    let var = |x| E::cell(x, CurrOrNext::Curr);
+
+    let rt_check = var(Column::LookupRuntimeTable) * var(Column::LookupRuntimeSelector);
+
+    vec![rt_check]
+}

--- a/kimchi/src/circuits/lookup/runtime_tables.rs
+++ b/kimchi/src/circuits/lookup/runtime_tables.rs
@@ -1,4 +1,6 @@
-//! What are runtime tables?
+//! Runtime tables are tables (or arrays) that can be produced during proof creation.
+//! The setup has to prepare for their presence using [RuntimeTableConfiguration].
+//! At proving time, the prover can use [RuntimeTable] to specify the actual tables.
 
 use crate::circuits::{
     expr::{prologue::*, Column},
@@ -10,30 +12,33 @@ use serde::{Deserialize, Serialize};
 /// The configuration of a runtime table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuntimeTableConfiguration {
-    /// The table id (must be negative).
+    /// The table id.
+    /// Note that these should be chosen not to collide with other runtime tables' IDs,
+    /// as well as other types of lookup tables and their IDs.
     pub id: i32,
     /// The length of the runtime table.
     pub len: usize,
 }
 
-/// A runtime table.
+/// A runtime table. Runtime tables must match the configuration
+/// that was specified via [RuntimeTableConfiguration].
 #[derive(Debug, Clone)]
 pub struct RuntimeTable<F> {
-    /// The table id (must be negative).
+    /// The table id.
     pub id: i32,
     /// A single column.
     pub data: Vec<F>,
 }
 
-/// Returns the constraints related to the runtime table.
+/// Returns the constraints related to the runtime tables.
 pub fn constraints<F>() -> Vec<E<F>>
 where
     F: Field,
 {
     // This constrains that runtime_table takes values
-    // when selector_RT is 1, and doesn't when selector_RT is 0.
+    // when selector_RT is 0, and doesn't when selector_RT is 1:
     //
-    // runtime_table (1 - selector_RT) = 0
+    // runtime_table * selector_RT = 0
     //
     let var = |x| E::cell(x, CurrOrNext::Curr);
 

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -62,6 +62,16 @@ where
 
         false
     }
+
+    /// Returns the length of the table.
+    pub fn len(&self) -> usize {
+        self.data[0].len()
+    }
+
+    /// Returns `true` if the lookup table is empty, `false` otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
 }
 
 /// Returns the lookup table associated to a [GateLookupTable].
@@ -108,6 +118,7 @@ pub fn combine_table<G>(
     column_combiner: ScalarField<G>,
     table_id_combiner: ScalarField<G>,
     table_id_vector: Option<&PolyComm<G>>,
+    runtime_vector: Option<&PolyComm<G>>,
 ) -> PolyComm<G>
 where
     G: commitment_dlog::commitment::CommitmentCurve,
@@ -128,6 +139,12 @@ where
     if let Some(table_id) = table_id_vector {
         scalars.push(table_id_combiner);
         commitments.push(table_id);
+    }
+
+    // combine the runtime vector
+    if let Some(runtime) = runtime_vector {
+        scalars.push(column_combiner); // 2nd column idx is j^1
+        commitments.push(runtime);
     }
 
     PolyComm::multi_scalar_mul(&commitments, &scalars)

--- a/kimchi/src/circuits/polynomials/chacha.rs
+++ b/kimchi/src/circuits/polynomials/chacha.rs
@@ -551,6 +551,7 @@ mod tests {
                     .collect(),
                 aggreg: F::rand(rng),
                 table: F::rand(rng),
+                runtime: None,
             }),
         };
         let evals = vec![eval(), eval()];

--- a/kimchi/src/circuits/polynomials/range_check/gate.rs
+++ b/kimchi/src/circuits/polynomials/range_check/gate.rs
@@ -285,14 +285,15 @@ mod tests {
     fn create_test_constraint_system() -> ConstraintSystem<PallasField> {
         let (_, gates) = CircuitGate::<PallasField>::create_range_check(0);
 
-        ConstraintSystem::create(gates, vec![], oracle::pasta::fp_kimchi::params(), 0).unwrap()
+        ConstraintSystem::create(gates, vec![], None, oracle::pasta::fp_kimchi::params(), 0)
+            .unwrap()
     }
 
     fn create_test_prover_index(
         public_size: usize,
     ) -> ProverIndex<mina_curves::pasta::vesta::Affine> {
         let (_, gates) = CircuitGate::<PallasField>::create_range_check(0);
-        new_index_for_test_with_lookups(gates, public_size, vec![])
+        new_index_for_test_with_lookups(gates, public_size, vec![], None)
     }
 
     fn biguint_from_hex_le(hex: &str) -> BigUint {
@@ -458,9 +459,13 @@ mod tests {
 
         // Generate proof
         let group_map = <pasta_curves::vesta::Affine as CommitmentCurve>::Map::setup();
-        let proof =
-            ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &prover_index)
-                .expect("failed to generate proof");
+        let proof = ProverProof::create::<BaseSponge, ScalarSponge>(
+            &group_map,
+            witness,
+            &[],
+            &prover_index,
+        )
+        .expect("failed to generate proof");
 
         // Get the verifier index
         let verifier_index = prover_index.verifier_index();

--- a/kimchi/src/error.rs
+++ b/kimchi/src/error.rs
@@ -20,6 +20,9 @@ pub enum ProverError {
 
     #[error("the lookup failed to find a match in the table")]
     ValueNotInTable,
+
+    #[error("the runtime tables provided did not match the index's configuration")]
+    RuntimeTablesInconsistent,
 }
 
 /// Errors that can arise when verifying a proof
@@ -39,6 +42,9 @@ pub enum VerifyError {
 
     #[error("lookup used in circuit, but proof has inconsistent number of lookup evaluations and commitments")]
     ProofInconsistentLookup,
+
+    #[error("runtime tables are used, but missing from the proof")]
+    IncorrectRuntimeProof,
 }
 
 /// Errors that can arise when preparing the setup

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -52,12 +52,18 @@ pub fn constraints_expr<F: FftField + SquareRootField>(
 
     // lookup
     if let Some(lcs) = lookup_constraint_system.as_ref() {
-        powers_of_alpha.register(ArgumentType::Lookup, lookup::constraints::CONSTRAINTS);
-        let alphas =
-            powers_of_alpha.get_exponents(ArgumentType::Lookup, lookup::constraints::CONSTRAINTS);
-
         let constraints = lookup::constraints::constraints(lcs, domain);
+
+        // note: the number of constraints depends on the lookup configuration,
+        // specifically the presence of runtime tables.
+        let constraints_len = u32::try_from(constraints.len())
+            .expect("we always expect a relatively low amount of constraints");
+
+        powers_of_alpha.register(ArgumentType::Lookup, constraints_len);
+
+        let alphas = powers_of_alpha.get_exponents(ArgumentType::Lookup, constraints_len);
         let combined = Expr::combine_constraints(alphas, constraints);
+
         expr += combined;
     }
 
@@ -65,27 +71,42 @@ pub fn constraints_expr<F: FftField + SquareRootField>(
     (expr, powers_of_alpha)
 }
 
+/// Adds the polynomials that are evaluated as part of the proof
+/// for the linearization to work.
 pub fn linearization_columns<F: FftField + SquareRootField>(
     lookup_constraint_system: Option<&LookupConfiguration<F>>,
 ) -> std::collections::HashSet<Column> {
     let mut h = std::collections::HashSet::new();
     use Column::*;
+
+    // the witness polynomials
     for i in 0..COLUMNS {
         h.insert(Witness(i));
     }
-    match lookup_constraint_system.as_ref() {
-        None => (),
-        Some(lcs) => {
-            for i in 0..(lcs.max_lookups_per_row + 1) {
-                h.insert(LookupSorted(i));
-            }
+
+    // the lookup polynomials
+    if let Some(lcs) = &lookup_constraint_system {
+        for i in 0..(lcs.max_lookups_per_row + 1) {
+            h.insert(LookupSorted(i));
+        }
+        h.insert(LookupAggreg);
+        h.insert(LookupTable);
+
+        // the runtime lookup polynomials
+        if lcs.runtime_tables.is_some() {
+            h.insert(LookupRuntimeTable);
         }
     }
+
+    // the permutation polynomial
     h.insert(Z);
-    h.insert(LookupAggreg);
-    h.insert(LookupTable);
+
+    // the poseidon selector polynomial
     h.insert(Index(GateType::Poseidon));
+
+    // the generic selector polynomial
     h.insert(Index(GateType::Generic));
+
     h
 }
 

--- a/kimchi/src/plonk_sponge.rs
+++ b/kimchi/src/plonk_sponge.rs
@@ -74,5 +74,17 @@ impl<Fr: PrimeField> FrSponge<Fr> for DefaultFrSponge<Fr, SC> {
         for p in &points {
             self.sponge.absorb(p);
         }
+
+        if let Some(lookup) = &e.lookup {
+            for s in &lookup.sorted {
+                self.sponge.absorb(s);
+            }
+            self.sponge.absorb(&lookup.aggreg);
+            self.sponge.absorb(&lookup.table);
+
+            if let Some(runtime_table) = &lookup.runtime {
+                self.sponge.absorb(runtime_table);
+            }
+        }
     }
 }

--- a/kimchi/src/proof.rs
+++ b/kimchi/src/proof.rs
@@ -18,6 +18,9 @@ pub struct LookupEvaluations<Field> {
     // TODO: May be possible to optimize this away?
     /// lookup table polynomial
     pub table: Field,
+
+    /// Optionally, a runtime table polynomial.
+    pub runtime: Option<Field>,
 }
 
 // TODO: this should really be vectors here, perhaps create another type for chunked evaluations?
@@ -43,6 +46,9 @@ pub struct ProofEvaluations<Field> {
 pub struct LookupCommitments<G: AffineCurve> {
     pub sorted: Vec<PolyComm<G>>,
     pub aggreg: PolyComm<G>,
+
+    /// Optional commitment to concatenated runtime tables
+    pub runtime: Option<PolyComm<G>>,
 }
 
 /// All the commitments that the prover creates as part of the proof.
@@ -109,6 +115,10 @@ impl<F: FftField> ProofEvaluations<Vec<F>> {
                     .iter()
                     .map(|x| DensePolynomial::eval_polynomial(x, pt))
                     .collect(),
+                runtime: l
+                    .runtime
+                    .as_ref()
+                    .map(|rt| DensePolynomial::eval_polynomial(rt, pt)),
             }),
             generic_selector: DensePolynomial::eval_polynomial(&self.generic_selector, pt),
             poseidon_selector: DensePolynomial::eval_polynomial(&self.poseidon_selector, pt),
@@ -133,6 +143,7 @@ pub mod caml {
         pub sorted: Vec<Vec<CamlF>>,
         pub aggreg: Vec<CamlF>,
         pub table: Vec<CamlF>,
+        pub runtime: Option<Vec<CamlF>>,
     }
 
     impl<F, CamlF> From<LookupEvaluations<Vec<F>>> for CamlLookupEvaluations<CamlF>
@@ -149,6 +160,7 @@ pub mod caml {
                     .collect(),
                 aggreg: le.aggreg.into_iter().map(Into::into).collect(),
                 table: le.table.into_iter().map(Into::into).collect(),
+                runtime: le.runtime.map(|r| r.into_iter().map(Into::into).collect()),
             }
         }
     }
@@ -166,6 +178,7 @@ pub mod caml {
                     .collect(),
                 aggreg: pe.aggreg.into_iter().map(Into::into).collect(),
                 table: pe.table.into_iter().map(Into::into).collect(),
+                runtime: pe.runtime.map(|r| r.into_iter().map(Into::into).collect()),
             }
         }
     }

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -5,7 +5,9 @@ use crate::{
         argument::{Argument, ArgumentType},
         expr::{l0_1, Constants, Environment, LookupEnvironment},
         gate::GateType,
-        lookup::{self, lookups::LookupsUsed, tables::combine_table_entry},
+        lookup::{
+            self, lookups::LookupsUsed, runtime_tables::RuntimeTable, tables::combine_table_entry,
+        },
         polynomials::{
             chacha::{ChaCha0, ChaCha1, ChaCha2, ChaChaFinal},
             complete_add::CompleteAdd,
@@ -42,16 +44,16 @@ type Result<T> = std::result::Result<T, ProverError>;
 /// Helper to quickly test if a witness satisfies a constraint
 macro_rules! check_constraint {
     ($index:expr, $evaluation:expr) => {{
+        check_constraint!($index, stringify!($evaluation), $evaluation);
+    }};
+    ($index:expr, $label:expr, $evaluation:expr) => {{
         if cfg!(debug_assertions) {
             let (_, res) = $evaluation
                 .interpolate_by_ref()
                 .divide_by_vanishing_poly($index.cs.domain.d1)
                 .unwrap();
             if !res.is_zero() {
-                panic!(
-                    "couldn't divide by vanishing polynomial: {}",
-                    stringify!($evaluation)
-                );
+                panic!("couldn't divide by vanishing polynomial: {}", $label);
             }
         }
     }};
@@ -92,6 +94,12 @@ where
     /// The evaluations of the aggregation polynomial for the proof
     eval_zeta: Option<LookupEvaluations<Vec<F>>>,
     eval_zeta_omega: Option<LookupEvaluations<Vec<F>>>,
+
+    /// Runtime table
+    runtime_table: Option<DensePolynomial<F>>,
+    runtime_table_d8: Option<Evaluations<F, D<F>>>,
+    runtime_table_comm: Option<(PolyComm<G>, PolyComm<ScalarField<G>>)>,
+    runtime_second_col_d8: Option<Evaluations<F, D<F>>>,
 }
 
 impl<G: CommitmentCurve> ProverProof<G>
@@ -105,9 +113,16 @@ where
     >(
         groupmap: &G::Map,
         witness: [Vec<ScalarField<G>>; COLUMNS],
+        runtime_tables: &[RuntimeTable<ScalarField<G>>],
         index: &ProverIndex<G>,
     ) -> Result<Self> {
-        Self::create_recursive::<EFqSponge, EFrSponge>(groupmap, witness, index, Vec::new())
+        Self::create_recursive::<EFqSponge, EFrSponge>(
+            groupmap,
+            witness,
+            runtime_tables,
+            index,
+            Vec::new(),
+        )
     }
 
     /// This function constructs prover's recursive zk-proof from the witness & the ProverIndex against SRS instance
@@ -117,6 +132,7 @@ where
     >(
         group_map: &G::Map,
         mut witness: [Vec<ScalarField<G>>; COLUMNS],
+        runtime_tables: &[RuntimeTable<ScalarField<G>>],
         index: &ProverIndex<G>,
         prev_challenges: Vec<(Vec<ScalarField<G>>, PolyComm<G>)>,
     ) -> Result<Self> {
@@ -216,6 +232,71 @@ where
 
         //~ 10. If using lookup:
         if let Some(lcs) = &index.cs.lookup_constraint_system {
+            // if using runtime table
+            if let Some(cfg_runtime_tables) = &lcs.configuration.runtime_tables {
+                // check that all the provided runtime tables have length and IDs that match the runtime table configuration of the index
+                // we expect the given runtime tables to be sorted as configured, this makes it easier afterwards
+                let expected_runtime: Vec<_> = cfg_runtime_tables
+                    .iter()
+                    .map(|rt| (rt.id, rt.len))
+                    .collect();
+                let runtime: Vec<_> = runtime_tables
+                    .iter()
+                    .map(|rt| (rt.id, rt.data.len()))
+                    .collect();
+                if expected_runtime != runtime {
+                    return Err(ProverError::RuntimeTablesInconsistent);
+                }
+
+                // calculate the contribution to the second column of the lookup table
+                // (the runtime vector)
+                let (runtime_table_contribution, runtime_table_contribution_d8) = {
+                    let mut offset = lcs
+                        .configuration
+                        .runtime_table_offset
+                        .expect("runtime configuration missing offset");
+
+                    let mut evals = vec![ScalarField::<G>::zero(); d1_size];
+                    for rt in runtime_tables {
+                        let range = offset..(offset + rt.data.len());
+                        evals[range].copy_from_slice(&rt.data);
+                        offset += rt.data.len();
+                    }
+
+                    // zero-knowledge
+                    for e in evals.iter_mut().rev().take(ZK_ROWS as usize) {
+                        *e = <ScalarField<G> as UniformRand>::rand(rng);
+                    }
+
+                    // get coeff and evaluation form
+                    let runtime_table_contribution =
+                        Evaluations::from_vec_and_domain(evals, index.cs.domain.d1).interpolate();
+
+                    let runtime_table_contribution_d8 =
+                        runtime_table_contribution.evaluate_over_domain_by_ref(index.cs.domain.d8);
+
+                    (runtime_table_contribution, runtime_table_contribution_d8)
+                };
+
+                // commit the runtime polynomial
+                // (and save it to the proof)
+                let runtime_table_comm = index.srs.commit(&runtime_table_contribution, None, rng);
+
+                // absorb the commitment
+                fq_sponge.absorb_g(&runtime_table_comm.0.unshifted);
+
+                // pre-compute the updated second column of the lookup table
+                let mut second_column_d8 = runtime_table_contribution_d8.clone();
+                for (row, e) in second_column_d8.evals.iter_mut().enumerate() {
+                    *e += lcs.lookup_table8[1][row];
+                }
+
+                lookup_context.runtime_table = Some(runtime_table_contribution);
+                lookup_context.runtime_table_d8 = Some(runtime_table_contribution_d8);
+                lookup_context.runtime_table_comm = Some(runtime_table_comm);
+                lookup_context.runtime_second_col_d8 = Some(second_column_d8);
+            }
+
             //~     - If queries involve a lookup table with multiple columns
             //~     then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
             //~     otherwise set the joint combiner challenge $j'$ to $0$.
@@ -255,7 +336,6 @@ where
                 let mut evals = Vec::with_capacity(d1_size);
 
                 for idx in 0..(d1_size * 8) {
-                    let table_row = lcs.lookup_table8.iter().map(|e| &e.evals[idx]);
                     let table_id = match lcs.table_ids8.as_ref() {
                         Some(table_ids8) => table_ids8.evals[idx],
                         None =>
@@ -266,12 +346,34 @@ where
                         }
                     };
 
-                    let combined_entry = combine_table_entry(
-                        &joint_combiner,
-                        &table_id_combiner,
-                        table_row,
-                        &table_id,
-                    );
+                    let combined_entry = if lcs.configuration.runtime_tables.is_none() {
+                        let table_row = lcs.lookup_table8.iter().map(|e| &e.evals[idx]);
+
+                        combine_table_entry(
+                            &joint_combiner,
+                            &table_id_combiner,
+                            table_row,
+                            &table_id,
+                        )
+                    } else {
+                        // if runtime table are used, the second row is modified
+                        let second_col = lookup_context.runtime_second_col_d8.as_ref().unwrap();
+
+                        let table_row = lcs.lookup_table8.iter().enumerate().map(|(col, e)| {
+                            if col == 1 {
+                                &second_col.evals[idx]
+                            } else {
+                                &e.evals[idx]
+                            }
+                        });
+
+                        combine_table_entry(
+                            &joint_combiner,
+                            &table_id_combiner,
+                            table_row,
+                            &table_id,
+                        )
+                    };
                     evals.push(combined_entry);
                 }
 
@@ -412,6 +514,8 @@ where
                 sorted: lookup_context.sorted8.as_ref().unwrap(),
                 selectors: &lcs.lookup_selectors,
                 table: joint_lookup_table_d8,
+                runtime_selector: lcs.runtime_selector.as_ref(),
+                runtime_table: lookup_context.runtime_table_d8.as_ref(),
             })
         } else {
             None
@@ -546,22 +650,32 @@ where
             }
 
             // lookup
-            if let Some(lcs) = index.cs.lookup_constraint_system.as_ref() {
-                let lookup_alphas =
-                    all_alphas.get_alphas(ArgumentType::Lookup, lookup::constraints::CONSTRAINTS);
-                let constraints =
-                    lookup::constraints::constraints(&lcs.configuration, index.cs.domain.d1);
+            {
+                if let Some(lcs) = index.cs.lookup_constraint_system.as_ref() {
+                    let constraints =
+                        lookup::constraints::constraints(&lcs.configuration, index.cs.domain.d1);
+                    let constraints_len = u32::try_from(constraints.len())
+                        .expect("not expecting a large amount of constraints");
+                    let lookup_alphas =
+                        all_alphas.get_alphas(ArgumentType::Lookup, constraints_len);
 
-                for (constraint, alpha_pow) in constraints.into_iter().zip_eq(lookup_alphas) {
-                    let mut eval = constraint.evaluations(&env);
-                    eval.evals.iter_mut().for_each(|x| *x *= alpha_pow);
+                    // as lookup constraints are computed with the expression framework,
+                    // each of them can result in Evaluations of different domains
+                    for (ii, (constraint, alpha_pow)) in
+                        constraints.into_iter().zip_eq(lookup_alphas).enumerate()
+                    {
+                        let mut eval = constraint.evaluations(&env);
+                        eval.evals.iter_mut().for_each(|x| *x *= alpha_pow);
 
-                    if eval.domain().size == t4.domain().size {
-                        t4 += &eval;
-                    } else if eval.domain().size == t8.domain().size {
-                        t8 += &eval;
-                    } else {
-                        panic!("Bad evaluation")
+                        if eval.domain().size == t4.domain().size {
+                            t4 += &eval;
+                        } else if eval.domain().size == t8.domain().size {
+                            t8 += &eval;
+                        } else {
+                            panic!("Bad evaluation")
+                        }
+
+                        check_constraint!(index, format!("lookup constraint #{ii}"), eval);
                     }
                 }
             }
@@ -616,15 +730,15 @@ where
         let zeta_omega = zeta * omega;
 
         //~ 25. If lookup is used, evaluate the following polynomials at $\zeta$ and $\zeta \omega$:
-        if let Some(lcs) = &index.cs.lookup_constraint_system {
-            //     - the aggregation polynomial
+        if index.cs.lookup_constraint_system.is_some() {
+            //~     - the aggregation polynomial
             let aggreg = lookup_context
                 .aggreg_coeffs
                 .as_ref()
                 .unwrap()
                 .to_chunked_polynomial(index.max_poly_size);
 
-            //      - the sorted polynomials
+            //~     - the sorted polynomials
             let sorted = lookup_context
                 .sorted_coeffs
                 .as_ref()
@@ -632,43 +746,27 @@ where
                 .iter()
                 .map(|c| c.to_chunked_polynomial(index.max_poly_size));
 
-            //      - the table polynonials
-            let base_table = lcs
-                .lookup_table
-                .iter()
-                .map(|p| p.to_chunked_polynomial(index.max_poly_size));
+            // ~     - the table polynonial
+            let joint_table = lookup_context.joint_lookup_table.as_ref().unwrap();
+            let joint_table = joint_table.to_chunked_polynomial(index.max_poly_size);
 
-            let table_ids = lcs
-                .table_ids
-                .as_ref()
-                .map(|tids| tids.to_chunked_polynomial(index.max_poly_size));
+            let lookup_evals = |eval_point: ScalarField<G>| {
+                let table = joint_table.evaluate_chunks(eval_point);
 
-            let lookup_evals = |e: ScalarField<G>| {
-                let table = base_table.clone().map(|p| p.evaluate_chunks(e)).rev().fold(
-                    vec![ScalarField::<G>::zero()],
-                    |acc, x| {
-                        acc.into_iter()
-                            .zip(x.iter())
-                            .map(|(acc, x)| acc * lookup_context.joint_combiner.unwrap() + x)
-                            .collect()
-                    },
-                );
-
-                let table = match &table_ids {
-                    None => table,
-                    Some(table_ids) => table
-                        .into_iter()
-                        .zip(table_ids.evaluate_chunks(e))
-                        .map(|(x, table_id)| {
-                            x + (lookup_context.table_id_combiner.unwrap() * table_id)
-                        })
-                        .collect(),
-                };
+                // the runtime table polynomial
+                let runtime_table = lookup_context.runtime_table.as_ref().map(|rt| {
+                    rt.to_chunked_polynomial(index.max_poly_size)
+                        .evaluate_chunks(eval_point)
+                });
 
                 LookupEvaluations {
-                    aggreg: aggreg.evaluate_chunks(e),
-                    sorted: sorted.clone().map(|s| s.evaluate_chunks(e)).collect(),
+                    aggreg: aggreg.evaluate_chunks(eval_point),
+                    sorted: sorted
+                        .clone()
+                        .map(|s| s.evaluate_chunks(eval_point))
+                        .collect(),
                     table,
+                    runtime: runtime_table,
                 }
             };
 
@@ -783,6 +881,10 @@ where
                             .iter()
                             .map(|p| DensePolynomial::eval_polynomial(p, e1))
                             .collect(),
+                        runtime: l
+                            .runtime
+                            .as_ref()
+                            .map(|p| DensePolynomial::eval_polynomial(p, e1)),
                     }),
                     generic_selector: DensePolynomial::eval_polynomial(&es.generic_selector, e1),
                     poseidon_selector: DensePolynomial::eval_polynomial(&es.poseidon_selector, e1),
@@ -923,6 +1025,7 @@ where
         //~     - the poseidon selector
         //~     - the 15 registers/witness columns
         //~     - the 6 sigmas
+        //~     - optionally, the runtime table
         polynomials.extend(vec![(&public_poly, None, non_hiding(1))]);
         polynomials.extend(vec![(&ft, None, blinding_ft)]);
         polynomials.extend(vec![(&z_poly, None, z_comm.1)]);
@@ -943,10 +1046,12 @@ where
         );
 
         // if using lookup
-        if index.cs.lookup_constraint_system.is_some() {
+
+        if let Some(lcs) = &index.cs.lookup_constraint_system {
             // add the sorted polynomials
             let sorted_poly = lookup_context.sorted_coeffs.as_ref().unwrap();
             let sorted_comms = lookup_context.sorted_comms.as_ref().unwrap();
+
             for (poly, comm) in sorted_poly.iter().zip(sorted_comms) {
                 polynomials.push((poly, None, comm.1.clone()));
             }
@@ -957,8 +1062,31 @@ where
             polynomials.push((aggreg_poly, None, aggreg_comm.1.clone()));
 
             // add the combined table polynomial
+            let table_blinding = if lcs.runtime_selector.is_some() {
+                let runtime_comm = lookup_context.runtime_table_comm.as_ref().unwrap();
+                let joint_combiner = lookup_context.joint_combiner.as_ref().unwrap();
+
+                let blinding = runtime_comm.1.unshifted[0];
+
+                PolyComm {
+                    unshifted: vec![*joint_combiner * blinding],
+                    shifted: None,
+                }
+            } else {
+                non_hiding(1)
+            };
+
             let joint_lookup_table = lookup_context.joint_lookup_table.as_ref().unwrap();
-            polynomials.push((joint_lookup_table, None, non_hiding(1)));
+
+            polynomials.push((joint_lookup_table, None, table_blinding));
+
+            // add the runtime table polynomial
+            if lcs.runtime_selector.is_some() {
+                let runtime_table_comm = lookup_context.runtime_table_comm.as_ref().unwrap();
+                let runtime_table = lookup_context.runtime_table.as_ref().unwrap();
+
+                polynomials.push((runtime_table, None, runtime_table_comm.1.clone()));
+            }
         }
 
         //~ 42. Create an aggregated evaluation proof for all of these polynomials at $\zeta$ and $\zeta\omega$ using $u$ and $v$.
@@ -978,6 +1106,7 @@ where
             .map(|(a, s)| LookupCommitments {
                 aggreg: a.0,
                 sorted: s.iter().map(|(x, _)| x.clone()).collect(),
+                runtime: lookup_context.runtime_table_comm.map(|x| x.0),
             });
 
         Ok(Self {

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -97,7 +97,10 @@ where
 
 pub mod testing {
     use super::*;
-    use crate::circuits::{gate::CircuitGate, lookup::tables::LookupTable};
+    use crate::circuits::{
+        gate::CircuitGate,
+        lookup::{runtime_tables::RuntimeTableConfiguration, tables::LookupTable},
+    };
     use commitment_dlog::srs::endos;
     use mina_curves::pasta::{pallas::Affine as Other, vesta::Affine, Fp};
 
@@ -105,12 +108,19 @@ pub mod testing {
         gates: Vec<CircuitGate<Fp>>,
         public: usize,
         lookup_tables: Vec<LookupTable<Fp>>,
+        runtime_tables: Option<Vec<RuntimeTableConfiguration>>,
     ) -> ProverIndex<Affine> {
         let fp_sponge_params = oracle::pasta::fp_kimchi::params();
 
         // not sure if theres a smarter way instead of the double unwrap, but should be fine in the test
-        let cs =
-            ConstraintSystem::<Fp>::create(gates, lookup_tables, fp_sponge_params, public).unwrap();
+        let cs = ConstraintSystem::<Fp>::create(
+            gates,
+            lookup_tables,
+            runtime_tables,
+            fp_sponge_params,
+            public,
+        )
+        .unwrap();
         let mut srs = SRS::<Affine>::create(cs.domain.d1.size as usize);
         srs.add_lagrange_basis(cs.domain.d1);
         let srs = Arc::new(srs);
@@ -120,6 +130,6 @@ pub mod testing {
         ProverIndex::<Affine>::create(cs, fq_sponge_params, endo_q, srs)
     }
     pub fn new_index_for_test(gates: Vec<CircuitGate<Fp>>, public: usize) -> ProverIndex<Affine> {
-        new_index_for_test_with_lookups(gates, public, vec![])
+        new_index_for_test_with_lookups(gates, public, vec![], None)
     }
 }

--- a/kimchi/src/tests/chacha.rs
+++ b/kimchi/src/tests/chacha.rs
@@ -89,7 +89,7 @@ fn chacha_prover() {
 
     let start = Instant::now();
     let proof =
-        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index).unwrap();
+        ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &[], &index).unwrap();
     println!("{}{:?}", "Prover time: ".yellow(), start.elapsed());
 
     let start = Instant::now();
@@ -222,7 +222,7 @@ fn chacha_setup_bad_lookup(table_id: i32) {
         }
     }
 
-    TestFramework::run_test_lookups(gates, witness, &[], lookup_tables);
+    TestFramework::run_test_lookups(gates, witness, &[], lookup_tables, None);
 }
 
 // Test lookup domain separation: if a different table ID is used, we shouldn't be able to use a

--- a/kimchi/src/tests/framework.rs
+++ b/kimchi/src/tests/framework.rs
@@ -1,11 +1,12 @@
 //! Test Framework
 
+use crate::circuits::lookup::runtime_tables::{RuntimeTable, RuntimeTableConfiguration};
 use crate::circuits::lookup::tables::LookupTable;
 use crate::circuits::{gate::CircuitGate, wires::COLUMNS};
 use crate::proof::ProverProof;
 use crate::prover_index::testing::{new_index_for_test, new_index_for_test_with_lookups};
 use crate::verifier::verify;
-use ark_ff::UniformRand;
+use ark_ff::{PrimeField, UniformRand};
 use ark_poly::univariate::DensePolynomial;
 use ark_poly::UVPolynomial;
 use commitment_dlog::commitment::{b_poly_coefficients, CommitmentCurve};
@@ -14,6 +15,7 @@ use mina_curves::pasta::{
     fp::Fp,
     vesta::{Affine, VestaParameters},
 };
+use num_bigint::BigUint;
 use o1_utils::math;
 use oracle::{
     constants::PlonkSpongeConstantsKimchi,
@@ -51,7 +53,8 @@ impl TestFramework {
         let start = Instant::now();
         let group_map = <Affine as CommitmentCurve>::Map::setup();
         let proof =
-            ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index).unwrap();
+            ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &[], &index)
+                .unwrap();
         println!("- time to create proof: {:?}s", start.elapsed().as_secs());
 
         // verify the proof
@@ -94,6 +97,7 @@ impl TestFramework {
         let proof = ProverProof::create_recursive::<BaseSponge, ScalarSponge>(
             &group_map,
             witness,
+            &[],
             &index,
             vec![prev_challenges],
         )
@@ -112,10 +116,21 @@ impl TestFramework {
         witness: [Vec<Fp>; COLUMNS],
         public: &[Fp],
         lookup_tables: Vec<LookupTable<Fp>>,
+        runtime_tables: Option<Vec<RuntimeTable<Fp>>>,
     ) {
         // create the index
         let start = Instant::now();
-        let index = new_index_for_test_with_lookups(gates, public.len(), lookup_tables);
+        let runtime_tables_cfg = runtime_tables.as_ref().map(|tables| {
+            tables
+                .iter()
+                .map(|table| RuntimeTableConfiguration {
+                    id: table.id,
+                    len: table.data.len(),
+                })
+                .collect()
+        });
+        let index =
+            new_index_for_test_with_lookups(gates, public.len(), lookup_tables, runtime_tables_cfg);
         let verifier_index = index.verifier_index();
         println!("- time to create index: {:?}s", start.elapsed().as_secs());
 
@@ -125,13 +140,38 @@ impl TestFramework {
         // add the proof to the batch
         let start = Instant::now();
         let group_map = <Affine as CommitmentCurve>::Map::setup();
-        let proof =
-            ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &index).unwrap();
+        let runtime_tables = runtime_tables.unwrap_or(vec![]);
+        let proof = ProverProof::create::<BaseSponge, ScalarSponge>(
+            &group_map,
+            witness,
+            &runtime_tables,
+            &index,
+        )
+        .unwrap();
         println!("- time to create proof: {:?}s", start.elapsed().as_secs());
 
         // verify the proof
         let start = Instant::now();
         verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &verifier_index, &proof).unwrap();
         println!("- time to verify: {}ms", start.elapsed().as_millis());
+    }
+}
+
+pub fn print_witness<F>(cols: &[Vec<F>; COLUMNS], start_row: usize, end_row: usize)
+where
+    F: PrimeField,
+{
+    let rows = cols[0].len();
+    if start_row > rows || end_row > rows {
+        panic!("start_row and end_row are supposed to be in [0, {rows}]");
+    }
+
+    for row in start_row..end_row {
+        let mut line = "| ".to_string();
+        for col in cols {
+            let bigint: BigUint = col[row].into();
+            line.push_str(&format!("{} | ", bigint));
+        }
+        println!("{line}");
     }
 }

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -139,6 +139,21 @@ where
 
         //~ 4. If lookup is used:
         let joint_combiner = if let Some(l) = &index.lookup_index {
+            let lookup_commits = self
+                .commitments
+                .lookup
+                .as_ref()
+                .ok_or(VerifyError::LookupCommitmentMissing)?;
+
+            // if runtime is used, absorb the commitment
+            if l.runtime_tables_selector.is_some() {
+                let runtime_commit = lookup_commits
+                    .runtime
+                    .as_ref()
+                    .ok_or(VerifyError::IncorrectRuntimeProof)?;
+                fq_sponge.absorb_g(&runtime_commit.unshifted);
+            }
+
             //~    - If it involves queries to a multiple-column lookup table,
             //~      then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
             //~      otherwise set the joint combiner challenge $j'$ to $0$.
@@ -155,11 +170,9 @@ where
             let joint_combiner = (joint_combiner, joint_combiner.to_field(&index.srs.endo_r));
 
             //~    - absorb the commitments to the sorted polynomials.
-            self.commitments.lookup.iter().for_each(|l| {
-                l.sorted
-                    .iter()
-                    .for_each(|c| fq_sponge.absorb_g(&c.unshifted));
-            });
+            for com in &lookup_commits.sorted {
+                fq_sponge.absorb_g(&com.unshifted);
+            }
 
             Some(joint_combiner)
         } else {
@@ -610,6 +623,21 @@ where
                         }
                     },
                     LookupTable => panic!("Lookup table is unused in the linearization"),
+                    LookupRuntimeSelector => match index.lookup_index.as_ref() {
+                        None => {
+                            panic!("Attempted to use {:?}, but no lookup index was given", col)
+                        }
+                        Some(lindex) => match &lindex.runtime_tables_selector {
+                            None => panic!("No runtime selector was given"),
+                            Some(comm) => {
+                                scalars.push(scalar);
+                                commitments.push(comm);
+                            }
+                        },
+                    },
+                    LookupRuntimeTable => {
+                        panic!("runtime lookup table is unused in the linearization")
+                    }
                     Index(t) => {
                         use GateType::*;
                         let c = match t {
@@ -792,15 +820,19 @@ where
 
         // compute table commitment
         let table_comm = {
-            // TODO: should we return an error instead?
-            let joint_combiner = oracles.joint_combiner.expect("????");
+            let joint_combiner = oracles
+                .joint_combiner
+                .expect("joint_combiner should be present if lookups are used");
             let table_id_combiner = joint_combiner.1.pow([li.max_joint_size as u64]);
             let lookup_table: Vec<_> = li.lookup_table.iter().collect();
+            let runtime = lookup_comms.runtime.as_ref();
+
             combine_table(
                 &lookup_table,
                 joint_combiner.1,
                 table_id_combiner,
                 li.table_ids.as_ref(),
+                runtime,
             )
         };
 
@@ -810,6 +842,30 @@ where
             evaluations: vec![lookup_eval0.table.clone(), lookup_eval1.table.clone()],
             degree_bound: None,
         });
+
+        // add evaluation of the runtime table polynomial
+        if li.runtime_tables_selector.is_some() {
+            let runtime = lookup_comms
+                .runtime
+                .as_ref()
+                .ok_or(VerifyError::IncorrectRuntimeProof)?;
+            let runtime_eval0 = lookup_eval0
+                .runtime
+                .as_ref()
+                .cloned()
+                .ok_or(VerifyError::IncorrectRuntimeProof)?;
+            let runtime_eval1 = lookup_eval1
+                .runtime
+                .as_ref()
+                .cloned()
+                .ok_or(VerifyError::IncorrectRuntimeProof)?;
+
+            evaluations.push(Evaluation {
+                commitment: runtime.clone(),
+                evaluations: vec![runtime_eval0, runtime_eval1],
+                degree_bound: None,
+            });
+        }
     }
 
     // prepare for the opening proof verification

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -46,6 +46,10 @@ pub struct LookupVerifierIndex<G: CommitmentCurve> {
 
     /// The maximum joint size of any joint lookup in a constraint in `kinds`. This can be computed from `kinds`.
     pub max_joint_size: u32,
+
+    /// An optional selector polynomial for runtime tables
+    #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
+    pub runtime_tables_selector: Option<PolyComm<G>>,
 }
 
 #[serde_as]
@@ -134,6 +138,7 @@ where
     /// Produces the [VerifierIndex] from the prover's [ProverIndex].
     pub fn verifier_index(&self) -> VerifierIndex<G> {
         let domain = self.cs.domain.d1;
+
         let lookup_index = {
             self.cs
                 .lookup_constraint_system
@@ -155,6 +160,10 @@ where
                             .commit_evaluations_non_hiding(domain, table_ids8, None)
                     }),
                     max_joint_size: cs.configuration.max_joint_size,
+                    runtime_tables_selector: cs
+                        .runtime_selector
+                        .as_ref()
+                        .map(|e| self.srs.commit_evaluations_non_hiding(domain, e, None)),
                 })
         };
 


### PR DESCRIPTION
This PR implements runtime tables, following [RFC: Extended lookup tables](https://github.com/o1-labs/proof-systems/pull/250). 

## Overview

![IMG_B6603DA52925-1](https://user-images.githubusercontent.com/1316043/166825620-e94ef16d-4459-4dc9-a689-aaa15d6c2031.jpeg)

## Implementation details

**setup**:
- [x] we obtain the runtime table configuration from the caller, which consists of table IDs (~must be negative~) and length
- [x] we integrate that in both the big concatenated table (an indexing on the first column that restarts from 0 for each table) and the table id vector (now contains the IDs of the runtime tables)
- [x] we also want to keep track of where the runtime table applies (we pre-compute a runtime selector, that will live in both the prover and verifier index) as well as what the offset row of the runtime tables in the big concatenated table is (will be useful later)
- [x] the linearization must add a new constraint if runtime tables are used: `RT(x) (1 - selector_RT(x)) = 0` to enforce that the runtime table `RT` in the proof only has values where it is allowed to have them (enforced by `selector_RT`)
- [x] - powers of alphas must either handle this branch, or add one more constraint always
- [x] the linearization must also modify the lookup constraint if runtime tables are used, to replace the `t` term of the nominator with `t + runtime_stuff` where `runtime_stuff = j * RT(x) + \beta * j * RT(x \omega)`
- [x] add the relevant commitments to the linearization columns (in `linearization_columns`)

**prover side**: 
- [x] we obtain the actual runtime tables from the caller (as a list of ~negative~ table IDs, and values that must match the configuration)
- [x] from these runtime tables, we can create the runtime polynomial that evaluates to all these values (or 0 when not applied) and save a commitment to it in the proof
- [x] we must add zero-knowledge to this runtime table, we can take advantage of the last `ZK_ROWS` of the domain that are already made for that
- [x] we later evaluate this runtime table at the two challenge points and save them in the proof (as well as absorb them)
- [x] we also produce an evaluation proof for these two evaluations
- [x] since `f` is built using the linearization, we don't have to do anything but pass what the environment needs
- [x] since `aggreg` and `sorted` are computed manually, we modify their behavior so that when runtime tables are used the big concatenated table used also contains the contribution/mask from the runtime table
- [x] since the quotient poly `t` is computed via the linearization, we don't have to do anything either

**verifier side**:
- [x] we use the constraints (linearization) all the time, so this will combine the runtime table with the table for us
- [x] we add the evaluation of the runtime table vector to the aggregated proof
- [x] we also need to absorb the runtime commitment (and evaluations) at the correct places

**ocaml**:
- [x] update associated `Caml` types with new fields

**tests**:
- [x] write a simple test to see if we can handle multiple runtime tables

## Data structure changes

proof:

```diff
pub struct LookupCommitments<G: AffineCurve> {
     // ...
+    /// Optional Commitment to concatenated runtime tables
+    pub runtime: Option<PolyComm<G>>,
}

pub struct LookupEvaluations<Field> {
    // ...
+    /// Optionally, a runtime table polynomial
+    pub runtime: Option<Field>,
}
```

prover index:

```diff
pub struct LookupConstraintSystem<F: FftField> {
    // ...
+    /// An optional runtime table selector. It is 0 everywhere,
+    /// except at the rows where the runtime tables apply.
+    pub runtime_selector: Option<E<F, D<F>>>,
    // ...
}

pub struct LookupConfiguration<F: FftField> {
    // ...
+    /// The runtime tables used,
+    /// seen as tuples of `(length, id)`.
+    pub runtime_tables: Option<Vec<RuntimeTableConfiguration>>,
+
+    /// The offset of the runtime table within the concatenated table
+    pub runtime_table_offset: Option<usize>,
    // ...
}
```

verifier index:

```diff
pub struct LookupVerifierIndex<G: CommitmentCurve> {
    // ...
+    /// An optional selector polynomial for runtime tables
+    pub runtime_tables_selector: Option<PolyComm<G>>,
}
```

## Notes 

From discussion with matthew on things we want to do next:

- [ ] make it work with arbitrary-length runtime tables
- [ ] we should have a mode where indexing of these tables can be provided by the caller/front-end as well (not just a counter starting from 0)
- [ ] optimization: in the constraint`(rt_selector - 1) * rt_table` we can precompute `one_min_rt_selector` as `rt_selector -1` and use that in the index
- [x] let's not enforce negative IDs (I'm not totally a fan of this, but let's add a comment for now warning the caller)
