### PR TITLE
[lookup] simplify code

### DIFF
--- a/kimchi/src/circuits/lookup/constraints.rs
+++ b/kimchi/src/circuits/lookup/constraints.rs
@@ -119,7 +119,7 @@ where
                 Some(count) => *count += 1,
             }
         }
-        *counts.entry(dummy_lookup_value.clone()).or_insert(0) += padding;
+        *counts.entry(dummy_lookup_value).or_insert(0) += padding;
     }
 
     let sorted = {
@@ -140,13 +140,13 @@ where
             for j in 0..t_count {
                 let idx = i + j;
                 let col = idx / lookup_rows;
-                sorted[col].push(t.clone());
+                sorted[col].push(t);
             }
             i += t_count;
         }
 
         for i in 0..max_lookups_per_row {
-            let end_val = sorted[i + 1][0].clone();
+            let end_val = sorted[i + 1][0];
             sorted[i].push(end_val);
         }
 
@@ -155,7 +155,7 @@ where
         // next column added to their end, but the final sorted column has no subsequent column to
         // pull this value from.
         let final_sorted_col = &mut sorted[max_lookups_per_row];
-        final_sorted_col.push(final_sorted_col[final_sorted_col.len() - 1].clone());
+        final_sorted_col.push(final_sorted_col[final_sorted_col.len() - 1]);
 
         // snake-ify (see top comment)
         for s in sorted.iter_mut().skip(1).step_by(2) {

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -76,31 +76,6 @@ impl<F: Field> Entry for CombinedEntry<F> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct UncombinedEntry<F>(pub Vec<F>);
-
-impl<F: Field> Entry for UncombinedEntry<F> {
-    type Field = F;
-    type Params = ();
-
-    fn evaluate(
-        _: &(),
-        j: &JointLookupSpec<F>,
-        witness: &[Vec<F>; COLUMNS],
-        row: usize,
-    ) -> UncombinedEntry<F> {
-        let eval = |pos: LocalPosition| -> F {
-            let row = match pos.row {
-                Curr => row,
-                Next => row + 1,
-            };
-            witness[pos.column][row]
-        };
-
-        UncombinedEntry(j.entry.iter().map(|s| s.evaluate(&eval)).collect())
-    }
-}
-
 /// A table of values that can be used for a lookup, along with the ID for the table.
 #[derive(Debug)]
 pub struct LookupTable<F> {

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -3,7 +3,7 @@ use crate::circuits::{
     lookup::lookups::{JointLookupSpec, LocalPosition},
     wires::COLUMNS,
 };
-use ark_ff::{FftField, Field, One, Zero};
+use ark_ff::{FftField, One, Zero};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use CurrOrNext::{Curr, Next};

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -235,21 +235,19 @@ where
             lookup_context.dummy_lookup_value = Some(dummy_lookup_value);
 
             //~      - Compute the sorted evaluations.
-            let iter_lookup_table = || {
-                (0..d1_size).map(|i| {
-                    let row = lcs.lookup_table8.iter().map(|e| &e.evals[8 * i]);
-                    let table_id = match lcs.table_ids8.as_ref() {
-                        Some(table_ids8) => table_ids8.evals[8 * i],
-                        None =>
-                        // If there is no `table_ids8` in the constraint system,
-                        // every table ID is identically 0.
-                        {
-                            ScalarField::<G>::zero()
-                        }
-                    };
-                    combine_table_entry(&joint_combiner, &table_id_combiner, row, &table_id)
-                })
-            };
+            let iter_lookup_table = (0..d1_size).map(|i| {
+                let row = lcs.lookup_table8.iter().map(|e| &e.evals[8 * i]);
+                let table_id = match lcs.table_ids8.as_ref() {
+                    Some(table_ids8) => table_ids8.evals[8 * i],
+                    None =>
+                    // If there is no `table_ids8` in the constraint system,
+                    // every table ID is identically 0.
+                    {
+                        ScalarField::<G>::zero()
+                    }
+                };
+                combine_table_entry(&joint_combiner, &table_id_combiner, row, &table_id)
+            });
 
             // TODO: Once we switch to committing using lagrange commitments,
             // `witness` will be consumed when we interpolate, so interpolation will


### PR DESCRIPTION
check the commits, they:

1. remove the type `UncombinedEntry` as it was deadcode
2. remove the type `CombinedEntry` (which allows us to remove the trait `Entry`) as it doesn't seem to serve much purpose
3. simplify `sorted` to take an iterator instead of a closure, this simplifies the signature and the code
