### PR TITLE
[lookup] compute the joint lookup table ONCE and only once

### DIFF
--- a/kimchi/src/circuits/lookup/constraints.rs
+++ b/kimchi/src/circuits/lookup/constraints.rs
@@ -119,7 +119,7 @@ where
                 Some(count) => *count += 1,
             }
         }
-        *counts.entry(dummy_lookup_value.clone()).or_insert(0) += padding;
+        *counts.entry(dummy_lookup_value).or_insert(0) += padding;
     }
 
     let sorted = {
@@ -140,13 +140,13 @@ where
             for j in 0..t_count {
                 let idx = i + j;
                 let col = idx / lookup_rows;
-                sorted[col].push(t.clone());
+                sorted[col].push(t);
             }
             i += t_count;
         }
 
         for i in 0..max_lookups_per_row {
-            let end_val = sorted[i + 1][0].clone();
+            let end_val = sorted[i + 1][0];
             sorted[i].push(end_val);
         }
 
@@ -155,7 +155,7 @@ where
         // next column added to their end, but the final sorted column has no subsequent column to
         // pull this value from.
         let final_sorted_col = &mut sorted[max_lookups_per_row];
-        final_sorted_col.push(final_sorted_col[final_sorted_col.len() - 1].clone());
+        final_sorted_col.push(final_sorted_col[final_sorted_col.len() - 1]);
 
         // snake-ify (see top comment)
         for s in sorted.iter_mut().skip(1).step_by(2) {

--- a/kimchi/src/circuits/lookup/constraints.rs
+++ b/kimchi/src/circuits/lookup/constraints.rs
@@ -183,45 +183,6 @@ where
     Ok(sorted)
 }
 
-struct AdjacentPairs<A, I: Iterator<Item = A>> {
-    prev_second_component: Option<A>,
-    i: I,
-}
-
-impl<A: Copy, I: Iterator<Item = A>> Iterator for AdjacentPairs<A, I> {
-    type Item = (A, A);
-
-    fn next(&mut self) -> Option<(A, A)> {
-        match self.prev_second_component {
-            Some(x) => match self.i.next() {
-                None => None,
-                Some(y) => {
-                    self.prev_second_component = Some(y);
-                    Some((x, y))
-                }
-            },
-            None => {
-                let x = self.i.next();
-                let y = self.i.next();
-                match (x, y) {
-                    (None, _) | (_, None) => None,
-                    (Some(x), Some(y)) => {
-                        self.prev_second_component = Some(y);
-                        Some((x, y))
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn adjacent_pairs<A: Copy, I: Iterator<Item = A>>(i: I) -> AdjacentPairs<A, I> {
-    AdjacentPairs {
-        i,
-        prev_second_component: None,
-    }
-}
-
 /// Computes the aggregation polynomial for maximum n lookups per row, whose kth entry is the product of terms
 ///
 ///  (gamma(1 + beta) + t_i + beta t_{i+1}) \prod_{0 <= j < n} ( (1 + beta) (gamma + f_{i,j}) )

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -109,6 +109,7 @@ pub fn combine_table_entry<'a, F, I>(
     joint_combiner: &F,
     table_id_combiner: &F,
     v: I,
+    // TODO: this should be an option?
     table_id: &F,
 ) -> F
 where

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -76,31 +76,6 @@ impl<F: Field> Entry for CombinedEntry<F> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct UncombinedEntry<F>(pub Vec<F>);
-
-impl<F: Field> Entry for UncombinedEntry<F> {
-    type Field = F;
-    type Params = ();
-
-    fn evaluate(
-        _: &(),
-        j: &JointLookupSpec<F>,
-        witness: &[Vec<F>; COLUMNS],
-        row: usize,
-    ) -> UncombinedEntry<F> {
-        let eval = |pos: LocalPosition| -> F {
-            let row = match pos.row {
-                Curr => row,
-                Next => row + 1,
-            };
-            witness[pos.column][row]
-        };
-
-        UncombinedEntry(j.entry.iter().map(|s| s.evaluate(&eval)).collect())
-    }
-}
-
 /// A table of values that can be used for a lookup, along with the ID for the table.
 #[derive(Debug)]
 pub struct LookupTable<F> {

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -3,7 +3,7 @@ use crate::circuits::{
     lookup::lookups::{JointLookupSpec, LocalPosition},
     wires::COLUMNS,
 };
-use ark_ff::{FftField, Field, One, Zero};
+use ark_ff::{FftField, One, Zero};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use CurrOrNext::{Curr, Next};

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -235,21 +235,19 @@ where
             lookup_context.dummy_lookup_value = Some(dummy_lookup_value);
 
             //~      - Compute the sorted evaluations.
-            let iter_lookup_table = || {
-                (0..d1_size).map(|i| {
-                    let row = lcs.lookup_table8.iter().map(|e| &e.evals[8 * i]);
-                    let table_id = match lcs.table_ids8.as_ref() {
-                        Some(table_ids8) => table_ids8.evals[8 * i],
-                        None =>
-                        // If there is no `table_ids8` in the constraint system,
-                        // every table ID is identically 0.
-                        {
-                            ScalarField::<G>::zero()
-                        }
-                    };
-                    combine_table_entry(&joint_combiner, &table_id_combiner, row, &table_id)
-                })
-            };
+            let iter_lookup_table = (0..d1_size).map(|i| {
+                let row = lcs.lookup_table8.iter().map(|e| &e.evals[8 * i]);
+                let table_id = match lcs.table_ids8.as_ref() {
+                    Some(table_ids8) => table_ids8.evals[8 * i],
+                    None =>
+                    // If there is no `table_ids8` in the constraint system,
+                    // every table ID is identically 0.
+                    {
+                        ScalarField::<G>::zero()
+                    }
+                };
+                combine_table_entry(&joint_combiner, &table_id_combiner, row, &table_id)
+            });
 
             // TODO: Once we switch to committing using lagrange commitments,
             // `witness` will be consumed when we interpolate, so interpolation will

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -34,10 +34,7 @@ use commitment_dlog::commitment::{b_poly_coefficients, CommitmentCurve, PolyComm
 use itertools::Itertools;
 use o1_utils::{types::fields::*, ExtendedDensePolynomial as _};
 use oracle::{sponge::ScalarChallenge, FqSponge};
-use rayon::iter::{
-    IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
-};
-use std::{collections::HashMap, iter};
+use std::collections::HashMap;
 
 /// The result of a proof creation or verification.
 type Result<T> = std::result::Result<T, ProverError>;

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -321,18 +321,9 @@ where
             //~     - Compute the lookup aggregation polynomial.
             let joint_lookup_table_d8 = lookup_context.joint_lookup_table_d8.as_ref().unwrap();
 
-            let joint_lookup_table = {
-                let mut evals = vec![];
-
-                for e in joint_lookup_table_d8.evals.iter().step_by(8) {
-                    evals.push(*e);
-                }
-                Evaluations::from_vec_and_domain(evals, index.cs.domain.d1)
-            };
-
-            let aggreg = lookup::constraints::aggregation::<_, ScalarField<G>, _>(
+            let aggreg = lookup::constraints::aggregation::<_, ScalarField<G>>(
                 lookup_context.dummy_lookup_value.unwrap(),
-                joint_lookup_table.evals.into_iter(),
+                joint_lookup_table_d8,
                 index.cs.domain.d1,
                 &index.cs.gates,
                 &witness,

--- a/utils/src/adjacent_pairs.rs
+++ b/utils/src/adjacent_pairs.rs
@@ -1,4 +1,24 @@
-struct AdjacentPairs<A, I: Iterator<Item = A>> {
+//! This module hosts the [AdjancentPairs] type,
+//! which can be used to list all the adjacent pairs of a list.
+//! For example, if you have a list of integers `[1, 2, 3]`,
+//! you can use it to obtain the list of tuples `[(1, 2), (2, 3)]`.
+
+/// You can create a new [AdjacentPairs] from an iterator using:
+///
+/// ```
+/// use o1_utils::adjacent_pairs::AdjacentPairs;
+///
+/// let a = vec![1, 2, 3];
+/// let mut pairs = AdjacentPairs::from(a);
+///
+/// assert_eq!(pairs.next(), Some((1, 2)));
+/// assert_eq!(pairs.next(), Some((2, 3)));
+/// assert_eq!(pairs.next(), None);
+/// ```
+pub struct AdjacentPairs<A, I>
+where
+    I: Iterator<Item = A>,
+{
     prev_second_component: Option<A>,
     i: I,
 }
@@ -30,9 +50,15 @@ impl<A: Copy, I: Iterator<Item = A>> Iterator for AdjacentPairs<A, I> {
     }
 }
 
-fn adjacent_pairs<A: Copy, I: Iterator<Item = A>>(i: I) -> AdjacentPairs<A, I> {
-    AdjacentPairs {
-        i,
-        prev_second_component: None,
+impl<A, I, T> From<T> for AdjacentPairs<A, I>
+where
+    T: IntoIterator<Item = A, IntoIter = I>,
+    I: Iterator<Item = A>,
+{
+    fn from(i: T) -> Self {
+        Self {
+            i: i.into_iter(),
+            prev_second_component: None,
+        }
     }
 }

--- a/utils/src/adjacent_pairs.rs
+++ b/utils/src/adjacent_pairs.rs
@@ -1,0 +1,38 @@
+struct AdjacentPairs<A, I: Iterator<Item = A>> {
+    prev_second_component: Option<A>,
+    i: I,
+}
+
+impl<A: Copy, I: Iterator<Item = A>> Iterator for AdjacentPairs<A, I> {
+    type Item = (A, A);
+
+    fn next(&mut self) -> Option<(A, A)> {
+        match self.prev_second_component {
+            Some(x) => match self.i.next() {
+                None => None,
+                Some(y) => {
+                    self.prev_second_component = Some(y);
+                    Some((x, y))
+                }
+            },
+            None => {
+                let x = self.i.next();
+                let y = self.i.next();
+                match (x, y) {
+                    (None, _) | (_, None) => None,
+                    (Some(x), Some(y)) => {
+                        self.prev_second_component = Some(y);
+                        Some((x, y))
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn adjacent_pairs<A: Copy, I: Iterator<Item = A>>(i: I) -> AdjacentPairs<A, I> {
+    AdjacentPairs {
+        i,
+        prev_second_component: None,
+    }
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod adjacent_pairs;
 pub mod chunked_polynomial;
 pub mod dense_polynomial;
 pub mod evaluations;


### PR DESCRIPTION
The prover computes the lookup argument by computing:

1. the joint table
2. the numerator part of the argument (using an `f_part` and `t_part`)
3. the denominator part of the argument (called `sorted`)

Both the numerator and the denominator make use of the joint table. Looking at the spec, we compute them in this order: 3 - 1 - 2. 

But why not do 1 - 3 - 2 and use the computed joint table in the computation of the denominator as well?

This PR fixes this.
