### PR TITLE
[WIP][gates][range] add lookups

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -343,6 +343,9 @@ Kimchi currently supports a single lookup table:
 ```rs
 /// The table ID associated with the XOR lookup table.
 pub const XOR_TABLE_ID: i32 = 0;
+
+/// The range check table ID.
+pub const RANGE_CHECK_TABLE_ID: i32 = 1;
 ```
 
 

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -160,7 +160,9 @@ impl<F: FftField + SquareRootField> CircuitGate<F> {
             CairoClaim | CairoInstruction | CairoFlags | CairoTransition => {
                 self.verify_cairo_gate(row, witness, cs)
             }
-            RangeCheck0 | RangeCheck1 | RangeCheck2 => self.verify_range_check(row, witness, cs),
+            RangeCheck0 | RangeCheck1 | RangeCheck2 => self
+                .verify_range_check(row, witness, cs)
+                .map_err(|e| e.to_string()),
         }
     }
 }

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -92,7 +92,6 @@ pub enum GateType {
     // Range check (16-24)
     RangeCheck0 = 16,
     RangeCheck1 = 17,
-    RangeCheck2 = 18,
 }
 
 #[serde_as]
@@ -160,7 +159,7 @@ impl<F: FftField + SquareRootField> CircuitGate<F> {
             CairoClaim | CairoInstruction | CairoFlags | CairoTransition => {
                 self.verify_cairo_gate(row, witness, cs)
             }
-            RangeCheck0 | RangeCheck1 | RangeCheck2 => self
+            RangeCheck0 | RangeCheck1 => self
                 .verify_range_check(row, witness, cs)
                 .map_err(|e| e.to_string()),
         }

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -372,7 +372,7 @@ impl GateType {
         let range_check_where = HashSet::from([
             (RangeCheck0, Curr),
             (RangeCheck1, Curr),
-            (RangeCheck2, Curr),
+            (RangeCheck1, Next),
         ]);
 
         // List of defined lookups

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -356,18 +356,15 @@ impl GateType {
         let lookup_gate_where = HashSet::from([(Lookup, Curr)]);
 
         // Range check pattern
-
+        //   We do four range lookups:
+        //   0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
+        //   - L L L L - - - - - -  -  -  -  -
         let mut range_check_pattern = vec![];
-        for ii in 1..=4 {
-            // We do four range lookups:
-            // 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
-            // - l l l l - - - - - -  -  -  -  -
-            let index = curr_row(ii);
-
+        for column in 1..=4 {
             range_check_pattern.push(JointLookup {
                 table_id: LookupTableID::Constant(RANGE_CHECK_TABLE_ID),
                 entry: vec![SingleLookup {
-                    value: vec![(F::one(), index)],
+                    value: vec![(F::one(), curr_row(column))],
                 }],
             });
         }

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -355,7 +355,7 @@ impl GateType {
             .collect();
         let lookup_gate_where = HashSet::from([(Lookup, Curr)]);
 
-        // Range check pattern
+        // Range check gate pattern
         //   We do four range lookups:
         //   0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
         //   - L L L L - - - - - -  -  -  -  -
@@ -375,7 +375,7 @@ impl GateType {
             (RangeCheck2, Curr),
         ]);
 
-        // list lookups
+        // List of defined lookups
 
         let lookups = [
             (chacha_pattern, chacha_where, Some(GateLookupTable::Xor)),

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -355,18 +355,16 @@ impl GateType {
             .collect();
         let lookup_gate_where = HashSet::from([(Lookup, Curr)]);
 
-        // Range pattern
+        // Range check pattern
 
-        // RangeCheck0
-
-        let mut range_pattern = vec![];
+        let mut range_check_pattern = vec![];
         for ii in 1..=4 {
-            // we do four range lookups:
+            // We do four range lookups:
             // 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
             // - l l l l - - - - - -  -  -  -  -
             let index = curr_row(ii);
 
-            range_pattern.push(JointLookup {
+            range_check_pattern.push(JointLookup {
                 table_id: LookupTableID::Constant(RANGE_CHECK_TABLE_ID),
                 entry: vec![SingleLookup {
                     value: vec![(F::one(), index)],
@@ -374,10 +372,10 @@ impl GateType {
             });
         }
 
-        let range_where = HashSet::from([
+        let range_check_where = HashSet::from([
             (RangeCheck0, Curr),
             (RangeCheck1, Curr),
-            (RangeCheck1, Next),
+            (RangeCheck2, Curr),
         ]);
 
         // list lookups
@@ -391,8 +389,8 @@ impl GateType {
             ),
             (lookup_gate_pattern, lookup_gate_where, None),
             (
-                range_pattern,
-                range_where,
+                range_check_pattern,
+                range_check_where,
                 Some(GateLookupTable::RangeCheck),
             ),
         ];

--- a/kimchi/src/circuits/lookup/runtime_tables.rs
+++ b/kimchi/src/circuits/lookup/runtime_tables.rs
@@ -1,5 +1,5 @@
 //! Runtime tables are tables (or arrays) that can be produced during proof creation.
-//! The setup has to prepare for their presence using [RuntimeTableConfiguration].
+//! The setup has to prepare for their presence using [RuntimeTableCfg].
 //! At proving time, the prover can use [RuntimeTable] to specify the actual tables.
 
 use crate::circuits::{

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -5,17 +5,22 @@ use o1_utils::types::ScalarField;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
+pub mod range_check;
 pub mod xor;
 
 //~ spec:startcode
 /// The table ID associated with the XOR lookup table.
 pub const XOR_TABLE_ID: i32 = 0;
+
+/// The range check table ID.
+pub const RANGE_CHECK_TABLE_ID: i32 = 1;
 //~ spec:endcode
 
 /// Enumerates the different 'fixed' lookup tables used by individual gates
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum GateLookupTable {
     Xor,
+    RangeCheck,
 }
 
 /// Specifies the relative position of gates and the fixed lookup table (if applicable) that a
@@ -68,6 +73,7 @@ where
 pub fn get_table<F: FftField>(table_name: GateLookupTable) -> LookupTable<F> {
     match table_name {
         GateLookupTable::Xor => xor::xor_table(),
+        GateLookupTable::RangeCheck => range_check::range_table(),
     }
 }
 

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -73,7 +73,7 @@ where
 pub fn get_table<F: FftField>(table_name: GateLookupTable) -> LookupTable<F> {
     match table_name {
         GateLookupTable::Xor => xor::xor_table(),
-        GateLookupTable::RangeCheck => range_check::range_table(),
+        GateLookupTable::RangeCheck => range_check::range_check_table(),
     }
 }
 

--- a/kimchi/src/circuits/lookup/tables/range_check.rs
+++ b/kimchi/src/circuits/lookup/tables/range_check.rs
@@ -1,15 +1,17 @@
+//! Range check table
+
 use crate::circuits::lookup::tables::{LookupTable, RANGE_CHECK_TABLE_ID};
 use ark_ff::Field;
 
-/// The range check will be performed on values in `[0, 2^12]`.
-const RANGE_CHECK_UPPERBOUND: u32 = 1 << 12;
+/// The range check will be performed on12-bit values, i.e. those in `[0, 2^12]`
+pub const RANGE_CHECK_UPPERBOUND: u32 = 1 << 12;
 
-/// A single-column table containing the numbers from 0 to [RANGE_CHECK_UPPERBOUND] (included).
+/// A single-column table containing the numbers from 0 to [RANGE_CHECK_UPPERBOUND] (inclusive)
 pub fn range_check_table<F>() -> LookupTable<F>
 where
     F: Field,
 {
-    let table = vec![(0..=RANGE_CHECK_UPPERBOUND).map(|i| F::from(i)).collect()];
+    let table = vec![(0..=RANGE_CHECK_UPPERBOUND).map(F::from).collect()];
     LookupTable {
         id: RANGE_CHECK_TABLE_ID,
         data: table,

--- a/kimchi/src/circuits/lookup/tables/range_check.rs
+++ b/kimchi/src/circuits/lookup/tables/range_check.rs
@@ -3,7 +3,7 @@
 use crate::circuits::lookup::tables::{LookupTable, RANGE_CHECK_TABLE_ID};
 use ark_ff::Field;
 
-/// The range check will be performed on12-bit values, i.e. those in `[0, 2^12]`
+/// The range check will be performed on 12-bit values, i.e. those in `[0, 2^12]`
 pub const RANGE_CHECK_UPPERBOUND: u32 = 1 << 12;
 
 /// A single-column table containing the numbers from 0 to [RANGE_CHECK_UPPERBOUND] (inclusive)

--- a/kimchi/src/circuits/lookup/tables/range_check.rs
+++ b/kimchi/src/circuits/lookup/tables/range_check.rs
@@ -2,16 +2,16 @@ use crate::circuits::lookup::tables::{LookupTable, RANGE_CHECK_TABLE_ID};
 use ark_ff::Field;
 
 /// The range check will be performed on values in `[0, 2^12]`.
-const RANGE_UPPERBOUND: u32 = 1 << 12;
+const RANGE_CHECK_UPPERBOUND: u32 = 1 << 12;
 
 /// A single-column table containing the numbers from 0 to [RANGE_UPPERBOUND] (included).
-pub fn range_table<F>() -> LookupTable<F>
+pub fn range_check_table<F>() -> LookupTable<F>
 where
     F: Field,
 {
-    let range = (0..=RANGE_UPPERBOUND).map(|i| F::from(i)).collect();
+    let table = vec![(0..=RANGE_CHECK_UPPERBOUND).map(|i| F::from(i)).collect()];
     LookupTable {
         id: RANGE_CHECK_TABLE_ID,
-        data: vec![range],
+        data: table,
     }
 }

--- a/kimchi/src/circuits/lookup/tables/range_check.rs
+++ b/kimchi/src/circuits/lookup/tables/range_check.rs
@@ -4,7 +4,7 @@ use ark_ff::Field;
 /// The range check will be performed on values in `[0, 2^12]`.
 const RANGE_CHECK_UPPERBOUND: u32 = 1 << 12;
 
-/// A single-column table containing the numbers from 0 to [RANGE_UPPERBOUND] (included).
+/// A single-column table containing the numbers from 0 to [RANGE_CHECK_UPPERBOUND] (included).
 pub fn range_check_table<F>() -> LookupTable<F>
 where
     F: Field,

--- a/kimchi/src/circuits/lookup/tables/range_check.rs
+++ b/kimchi/src/circuits/lookup/tables/range_check.rs
@@ -11,7 +11,7 @@ pub fn range_check_table<F>() -> LookupTable<F>
 where
     F: Field,
 {
-    let table = vec![(0..=RANGE_CHECK_UPPERBOUND).map(F::from).collect()];
+    let table = vec![(0..RANGE_CHECK_UPPERBOUND).map(F::from).collect()];
     LookupTable {
         id: RANGE_CHECK_TABLE_ID,
         data: table,

--- a/kimchi/src/circuits/lookup/tables/range_check.rs
+++ b/kimchi/src/circuits/lookup/tables/range_check.rs
@@ -1,0 +1,17 @@
+use crate::circuits::lookup::tables::{LookupTable, RANGE_CHECK_TABLE_ID};
+use ark_ff::Field;
+
+/// The range check will be performed on values in `[0, 2^12]`.
+const RANGE_UPPERBOUND: u32 = 1 << 12;
+
+/// A single-column table containing the numbers from 0 to [RANGE_UPPERBOUND] (included).
+pub fn range_table<F>() -> LookupTable<F>
+where
+    F: Field,
+{
+    let range = (0..=RANGE_UPPERBOUND).map(|i| F::from(i)).collect();
+    LookupTable {
+        id: RANGE_CHECK_TABLE_ID,
+        data: vec![range],
+    }
+}

--- a/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
@@ -1,11 +1,10 @@
 ///```text
-/// Range check field element structure:
+/// Range check circuit gates:
 ///
-///    Each field element a should be decomposed into three 88-bit limbs a0, a1, a2 s.t. a = a0a1a2 in
-///    little-endian byte order (i.e. a = a2*2^{2b} + a1*2^b + a0).
+///    The rang check gate is comprised of three circuit gates (RangeCheck0, RangeCheck1
+///    and RangeCheck2) and can perform range checks on up to three 88-bit values: a0, a1 and a2.
 ///
-///    This gate only performs 3 88-bit range checks on a0, a1 and a2, but does not constrain that
-///    the sum of those is equal to a.
+///    The values are decomposed as follows.
 ///
 ///    L is a 12-bit lookup,
 ///    C is a 2-bit crumb.
@@ -18,33 +17,31 @@
 ///
 /// Input structure:
 ///
-///   Each of the first 3 gates checks most of a different range-check input.
-///   The final gate performs the remaining checks for all 3 inputs.
+///   The first 2 rows contain the values and decompositions of a0 and a1.
+///   The third row contains the value and part of the decomposition of a2.
+///   The final row contains the remaining parts a2's decomposition, as well
+///   as some copies of parts of a0 and a1 that need to be constrained here.
 ///
-///   Row*  Contents**
+///   Row  Contents
 ///     0   a0
 ///     1   a1
 ///     2   a2
 ///     3   a0,a1,a2
 ///
-///    (*)  Row offsets
-///    (**) Some part of the limb is contained in this row
-///
 /// Constraints:
 ///
-///   For efficiency, the field element inputs are constrained
-///   by their sublimbs according to their type.
+///   For efficiency, the values are constrained differently according to their type.
 ///    * 12-bit sublimbs are constrained with plookups
 ///    * 2-bit crumbs are constrained with degree-4 constraints
 ///
-/// Example:
+/// Layout:
 ///
-///  This example shows how input a is constrained
+///  This is how three 88-bit inputs a0, a1 and a2 are constrained
 ///
 ///   * aXpi is a 12-bit sublimb of limb aX
 ///   * aXci is a 2-bit "crumb" sublimb of aX
 ///
-/// Gate:   RangeCheck0    RangeCheck0    RangeCheck1    Zero
+/// Gate:   RangeCheck0    RangeCheck0    RangeCheck1    RangeCheck2
 ///   Rows -->
 ///         0              1              2              3
 ///  C  0 | a0           | a1           | a2           | 0
@@ -72,7 +69,7 @@
 ///
 /// Gate types:
 ///
-///   Different rows are constrained differently using different CircuitGate types
+///   Different rows are constrained using different CircuitGate types
 ///
 ///   Row   CircuitGate   Purpose
 ///     0   RangeCheck0   Partially constrain a0

--- a/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
@@ -1,64 +1,63 @@
 ///```text
 /// Range check circuit gates:
 ///
-///    The rang check gate is comprised of three circuit gates (RangeCheck0, RangeCheck1
-///    and RangeCheck2) and can perform range checks on up to three 88-bit values: a0, a1 and a2.
+///    The range check gate is comprised of three circuit gates (RangeCheck0, RangeCheck1
+///    and RangeCheck2) and can perform range checks on up to three 88-bit values: v0, v1 and v2.
 ///
-///    The values are decomposed as follows.
+///    The values are decomposed into limbs follows.
 ///
-///    L is a 12-bit lookup,
-///    C is a 2-bit crumb.
+///    L is a 12-bit lookup limb,
+///    C is a 2-bit "crumb" limb.
 ///
 ///         <----6----> <------8------>
-///    a0 = L L L L L L C C C C C C C C
-///    a1 = L L L L L L C C C C C C C C
+///    v0 = L L L L L L C C C C C C C C
+///    v1 = L L L L L L C C C C C C C C
 ///         <--4--> <------------------20----------------->
-///    a2 = L L L L C C C C C C C C C C C C C C C C C C C C
+///    v2 = L L L L C C C C C C C C C C C C C C C C C C C C
 ///
-/// Input structure:
-///
-///   The first 2 rows contain the values and decompositions of a0 and a1.
-///   The third row contains the value and part of the decomposition of a2.
-///   The final row contains the remaining parts a2's decomposition, as well
-///   as some copies of parts of a0 and a1 that need to be constrained here.
+/// Witness structure:
 ///
 ///   Row  Contents
-///     0   a0
-///     1   a1
-///     2   a2
-///     3   a0,a1,a2
+///     0   v0
+///     1   v1
+///     2   v2
+///     3   v0,v1,v2
+///
+///   * The first 2 rows contain v0 and v1 and their respective decompositions into 12-bit and 2-bit limbs
+///   * The 3rd row contains v2 and part of its decomposition: four 12-bit limbs and the 1st 10 crumbs
+///   * The final row contains v0's and v1's 5th and 6th 12-bit limbs as well as the remaining 10 crumbs of v2
 ///
 /// Constraints:
 ///
 ///   For efficiency, the values are constrained differently according to their type.
-///    * 12-bit sublimbs are constrained with plookups
+///    * 12-bit limbs are constrained with plookups
 ///    * 2-bit crumbs are constrained with degree-4 constraints
 ///
 /// Layout:
 ///
-///  This is how three 88-bit inputs a0, a1 and a2 are constrained
+///  This is how three 88-bit inputs v0, v1 and v2 are layed out and constrained.
 ///
-///   * aXpi is a 12-bit sublimb of limb aX
-///   * aXci is a 2-bit "crumb" sublimb of aX
+///   * vipj is the jth 12-bit limb of vi
+///   * vicj is the jth 2-bit crumb limb of vi
 ///
 /// Gate:   RangeCheck0    RangeCheck0    RangeCheck1    RangeCheck2
 ///   Rows -->
 ///         0              1              2              3
-///  C  0 | a0           | a1           | a2           | 0
-///  o  1 | plookup a0p0 | plookup a1p0 | plookup a2p0 | plookup a0p4
-///  l  2 | plookup a0p1 | plookup a1p1 | plookup a2p1 | plookup a0p5
-///  s  3 | plookup a0p2 | plookup a1p2 | plookup a2p2 | plookup a1p4
-///  |  4 | plookup a0p3 | plookup a1p3 | plookup a2p3 | plookup a1p5
-/// \ / 5 | copy a0p4    | copy a1p4    | crumb a2c0   | crumb a2c10
-///  '  6 | copy a0p5    | copy a1p5    | crumb a2c1   | crumb a2c11
-///     7 | crumb a0c0   | crumb a1c0   | crumb a2c2   | crumb a2c12
-///     8 | crumb a0c1   | crumb a1c1   | crumb a2c3   | crumb a2c13
-///     9 | crumb a0c2   | crumb a1c2   | crumb a2c4   | crumb a2c14
-///    10 | crumb a0c3   | crumb a1c3   | crumb a2c5   | crumb a2c15
-///    11 | crumb a0c4   | crumb a1c4   | crumb a2c6   | crumb a2c16
-///    12 | crumb a0c5   | crumb a1c5   | crumb a2c7   | crumb a2c17
-///    13 | crumb a0c6   | crumb a1c6   | crumb a2c8   | crumb a2c18
-///    14 | crumb a0c7   | crumb a1c7   | crumb a2c9   | crumb a2c19
+///  C  0 | v0           | v1           | v2           | 0
+///  o  1 | plookup v0p0 | plookup v1p0 | plookup v2p0 | plookup v0p4
+///  l  2 | plookup v0p1 | plookup v1p1 | plookup v2p1 | plookup v0p5
+///  s  3 | plookup v0p2 | plookup v1p2 | plookup v2p2 | plookup v1p4
+///  |  4 | plookup v0p3 | plookup v1p3 | plookup v2p3 | plookup v1p5
+/// \ / 5 | copy v0p4    | copy v1p4    | crumb v2c0   | crumb v2c10
+///  '  6 | copy v0p5    | copy v1p5    | crumb v2c1   | crumb v2c11
+///     7 | crumb v0c0   | crumb v1c0   | crumb v2c2   | crumb v2c12
+///     8 | crumb v0c1   | crumb v1c1   | crumb v2c3   | crumb v2c13
+///     9 | crumb v0c2   | crumb v1c2   | crumb v2c4   | crumb v2c14
+///    10 | crumb v0c3   | crumb v1c3   | crumb v2c5   | crumb v2c15
+///    11 | crumb v0c4   | crumb v1c4   | crumb v2c6   | crumb v2c16
+///    12 | crumb v0c5   | crumb v1c5   | crumb v2c7   | crumb v2c17
+///    13 | crumb v0c6   | crumb v1c6   | crumb v2c8   | crumb v2c18
+///    14 | crumb v0c7   | crumb v1c7   | crumb v2c9   | crumb v2c19
 ///
 ///   The 12-bit chunks are constrained with plookups and the 2-bit crumbs constrained with
 ///   degree-4 constraints of the form x*(x - 1)*(x - 2)*(x - 3).
@@ -72,10 +71,10 @@
 ///   Different rows are constrained using different CircuitGate types
 ///
 ///   Row   CircuitGate   Purpose
-///     0   RangeCheck0   Partially constrain a0
-///     1   RangeCheck0   Partially constrain a1
-///     2   RangeCheck1   Fully constrain a2
-///     3   RangeCheck2   Complete the constraining of a0 and a1
+///     0   RangeCheck0   Partially constrain v0
+///     1   RangeCheck0   Partially constrain v1
+///     2   RangeCheck1   Fully constrain v2
+///     3   RangeCheck2   Complete the constraining of v0 and v1
 ///
 ///  Nb. each CircuitGate type corresponds to a unique polynomial and thus
 ///       is assigned its own unique powers of alpha
@@ -92,35 +91,35 @@ use ark_ff::{FftField, One, Zero};
 
 /// RangeCheck0 - Range check constraints
 ///
-///    Field element F is comprised of three 88-bit limbs L0L1L2
-///
-///    * This circuit gate is used to partially constrain L0 and L1
-///    * The rest of L0 and L1 are constrained by a single RangeCheck2
-///    * This gate operates on the Curr row
+///   * This circuit gate is used to partially constrain values v0 and v1
+///   * The rest of v0 and v1 are constrained by a single RangeCheck2
+///   * This gate operates on the Curr row
 ///
 /// It uses three different types of constraints
 ///   * plookup - plookup (12-bits)
 ///   * copy    - copy to another cell (12-bits)
 ///   * crumb   - degree-4 constraint (2-bits)
 ///
-/// For limb L the layout looks like this
+/// Given value v the layout looks like this
 ///
 /// Column | Curr
-///      0 | L
-///      1 | plookup Lp0
-///      2 | plookup Lp1
-///      3 | plookup Lp2
-///      4 | plookup Lp3
-///      5 | copy Lp4
-///      6 | copy Lp5
-///      7 | crumb Lc0
-///      8 | crumb Lc1
-///      9 | crumb Lc2
-///     10 | crumb Lc3
-///     11 | crumb Lc4
-///     12 | crumb Lc5
-///     13 | crumb Lc6
-///     14 | crumb Lc7
+///      0 | v
+///      1 | plookup vp0
+///      2 | plookup vp1
+///      3 | plookup vp2
+///      4 | plookup vp3
+///      5 | copy vp4
+///      6 | copy vp5
+///      7 | crumb vc0
+///      8 | crumb vc1
+///      9 | crumb vc2
+///     10 | crumb vc3
+///     11 | crumb vc4
+///     12 | crumb vc5
+///     13 | crumb vc6
+///     14 | crumb vc7
+///
+/// where the notation vpi and vci defined in the "Layout" section above.
 
 #[derive(Default)]
 pub struct RangeCheck0<F>(PhantomData<F>);
@@ -134,45 +133,45 @@ where
 
     // Constraints for RangeCheck0
     //   * Operates on Curr row
-    //   * Range constrain all sublimbs except p4 and p5 (barring plookup constraints, which are done elsewhere)
-    //   * Constrain that combining all sublimbs equals the limb stored in column 0
+    //   * Range constrain all limbs except vp4 and vp5 (barring plookup constraints, which are done elsewhere)
+    //   * Constrain that combining all limbs equals the limb stored in column 0
     fn constraints() -> Vec<E<F>> {
-        // 1) Apply range constraints on sublimbs
+        // 1) Apply range constraints on limbs
         // Columns 1-4 are 12-bit plookup range constraints (these are specified elsewhere)
         // Create 8 2-bit chunk range constraints
         let mut constraints = (7..COLUMNS)
             .map(|i| crumb(&witness_curr(i)))
             .collect::<Vec<E<F>>>();
 
-        // 2) Constrain that the combined sublimbs equals the limb stored in w(0) where
-        //    limb = lp0 lp1 lp2 lp3 lp4 lp5 lc0 lc1 lc2 lc3 lc4 lc5 lc6 lc7
+        // 2) Constrain that the combined limbs equals the limb stored in w(0) where
+        //    v = vp0 vp1 vp2 vp3 vp4 vp5 vc0 vc1 vc2 vc3 vc4 vc5 vc6 vc7
         //    in big-endian byte order.
         //
         //          Columns
         //          0      1    2    3    4    5    6    7    8    9    10   11   12   13   14
-        //    Curr  limb   lp0  lp1  lp2  lp3  lp4  lp5  lc0  lc1  lc2  lc3  lc4  lc5  lc6  lc7  <- LSB
+        //    Curr  v      vp0  vp1  vp2  vp3  vp4  vp5  vc0  vc1  vc2  vc3  vc4  vc5  vc6  vc7  <- LSB
         //
-        // Check limb =  lp0*2^0 + lp1*2^{12}  + ... + p5*2^{60}   + lc0*2^{72}  + lc1*2^{74}  + ... + lc7*2^{86}
+        // Check v    =  vp0*2^0 + vp1*2^{12}  + ... + p5*2^{60}   + vc0*2^{72}  + vc1*2^{74}  + ... + vc7*2^{86}
         //       w(0) = w(1)*2^0 + w(2)*2^{12} + ... + w(6)*2^{60} + w(7)*2^{72} + w(8)*2^{74} + ... + w(14)*2^{86}
         //            = \sum i \in [1,7] 2^{12*(i - 1)}*w(i) + \sum i \in [8,14] 2^{2*(i - 7) + 6*12}*w(i)
 
         let mut power_of_2 = E::one();
-        let mut sum_of_sublimbs = E::zero();
+        let mut sum_of_limbs = E::zero();
 
-        // Sum 12-bit sublimbs
+        // Sum 12-bit limbs
         for i in 1..7 {
-            sum_of_sublimbs += power_of_2.clone() * witness_curr(i);
+            sum_of_limbs += power_of_2.clone() * witness_curr(i);
             power_of_2 *= 4096u64.into(); // 12 bits
         }
 
-        // Sum 2-bit sublimbs
+        // Sum 2-bit limbs
         for i in 7..COLUMNS {
-            sum_of_sublimbs += power_of_2.clone() * witness_curr(i);
+            sum_of_limbs += power_of_2.clone() * witness_curr(i);
             power_of_2 *= 4u64.into(); // 2 bits
         }
 
-        // Check limb against the sum of sublimbs
-        constraints.push(sum_of_sublimbs - witness_curr(0));
+        // Check value v against the sum of limbs
+        constraints.push(sum_of_limbs - witness_curr(0));
 
         constraints
     }
@@ -180,31 +179,33 @@ where
 
 /// RangeCheck1 - Range check constraints
 ///
-///    Field element F is comprised of three 88-bit limbs L0L1L2
-///
-///    * This circuit gate is used to fully constrain L2
-///    * It operates on the Curr and Next rows
+///   * This circuit gate is used to fully constrain v2
+///   * It operates on the Curr and Next rows
 ///
 /// It uses two different types of constraints
 ///   * plookup - plookup (12-bits)
 ///   * crumb   - degree-4 constraint (2-bits)
 ///
+/// Given value v2 the layout looks like this
+///
 /// Column | Curr         | Next
-///      0 | L2           | (ignored)
-///      1 | plookup L2p0 | (ignored)
-///      2 | plookup L2p1 | (ignored)
-///      3 | plookup L2p2 | (ignored)
-///      4 | plookup L2p3 | (ignored)
-///      5 | crumb L2c0   | crumb L2c10
-///      6 | crumb L2c1   | crumb L2c11
-///      7 | crumb L2c2   | crumb L2c12
-///      8 | crumb L2c3   | crumb L2c13
-///      9 | crumb L2c4   | crumb L2c14
-///     10 | crumb L2c5   | crumb L2c15
-///     11 | crumb L2c6   | crumb L2c16
-///     12 | crumb L2c7   | crumb L2c17
-///     13 | crumb L2c8   | crumb L2c18
-///     14 | crumb L2c9   | crumb L2c19
+///      0 | v2           | (ignored)
+///      1 | plookup v2p0 | (ignored)
+///      2 | plookup v2p1 | (ignored)
+///      3 | plookup v2p2 | (ignored)
+///      4 | plookup v2p3 | (ignored)
+///      5 | crumb v2c0   | crumb v2c10
+///      6 | crumb v2c1   | crumb v2c11
+///      7 | crumb v2c2   | crumb v2c12
+///      8 | crumb v2c3   | crumb v2c13
+///      9 | crumb v2c4   | crumb v2c14
+///     10 | crumb v2c5   | crumb v2c15
+///     11 | crumb v2c6   | crumb v2c16
+///     12 | crumb v2c7   | crumb v2c17
+///     13 | crumb v2c8   | crumb v2c18
+///     14 | crumb v2c9   | crumb v2c19
+///
+/// where the notation v2i and v2i defined in the "Layout" section above.
 
 #[derive(Default)]
 pub struct RangeCheck1<F>(PhantomData<F>);
@@ -218,10 +219,10 @@ where
 
     // Constraints for RangeCheck1
     //   * Operates on Curr and Next row
-    //   * Range constrain all sublimbs (barring plookup constraints, which are done elsewhere)
-    //   * Constrain that combining all sublimbs equals the limb stored in row Curr, column 0
+    //   * Range constrain all limbs (barring plookup constraints, which are done elsewhere)
+    //   * Constrain that combining all limbs equals the value v2 stored in row Curr, column 0
     fn constraints() -> Vec<E<F>> {
-        // 1) Apply range constraints on sublimbs
+        // 1) Apply range constraints on limbs
         // Columns 1-4 are 12-bit plookup range constraints (these are specified elsewhere)
 
         // Create 10 2-bit chunk range constraints using Curr row
@@ -236,44 +237,44 @@ where
                 .collect::<Vec<E<F>>>(),
         );
 
-        // 2) Constrain that the combined sublimbs equals the limb l2 stored in w(0) where
-        //    l2 = lp0 lp1 lp2 lp3 lc0 lc1 lc2 lc3 lc4 lc5 lc6 lc7 lc8 lc9 lc10 lc11 lc12 lc13 lc14 lc15 lc16 lc17 lc18 lc19
+        // 2) Constrain that the combined limbs equals the value v2 stored in w(0) where
+        //    v2 = vp0 vp1 vp2 vp3 vc0 vc1 vc2 vc3 vc4 vc5 vc6 vc7 vc8 vc9 vc10 vc11 vc12 vc13 vc14 vc15 vc16 vc17 vc18 vc19
         //    in little-endian byte order.
         //
         //          Columns
         //          0    1   2   3   4   5    6    7    8    9    10   11   12   13   14
-        //    Curr  l2   lp0 lp1 lp2 lp3 lc0  lc1  lc2  lc3  lc4  lc5  lc6  lc7  lc8  lc9
-        //    Next                       lc10 lc11 lc12 lc13 lc14 lc15 lc16 lc17 lc18 lc19
+        //    Curr  v2   vp0 vp1 vp2 vp3 vc0  vc1  vc2  vc3  vc4  vc5  vc6  vc7  vc8  vc9
+        //    Next                       vc10 vc11 vc12 vc13 vc14 vc15 vc16 vc17 vc18 vc19
         //
-        // Check   l2 = lp0*2^0          + lp1*2^{12}       + ... + lp3*2^{36}       + lc0*2^{48}     + lc1*2^{50}     + ... + lc19*2^{66}
+        // Check   v2 = vp0*2^0          + vp1*2^{12}       + ... + vp3*2^{36}       + vc0*2^{48}     + vc1*2^{50}     + ... + vc19*2^{66}
         //       w(0) = w_curr(1)*2^0    + w_curr(2)*2^{12} + ... + w_curr(4)*2^{36} + w_curr(5)*2^48 + w_curr(6)*2^50 + ... + w_curr(14)*2^66
         //            + w_next(5)*2^{68} + w_next(6)*2^{70} + ... + w_next(14)*2^{86}
         // (1st part) = \sum i \in [1,5] 2^{12*(i - 1)}*w_curr(i) + \sum i \in [6,14] 2^{2*(i - 5) + 4*12}*w_curr(i)
         // (2nd part) + \sum i \in [5,14] 2^{2*(i - 5} + 68)*w_next(i)
 
         let mut power_of_2 = E::one();
-        let mut sum_of_sublimbs = E::zero();
+        let mut sum_of_limbs = E::zero();
 
-        // 1st part: Sum 12-bit sublimbs (row Curr)
+        // 1st part: Sum 12-bit limbs (row Curr)
         for i in 1..5 {
-            sum_of_sublimbs += power_of_2.clone() * witness_curr(i);
+            sum_of_limbs += power_of_2.clone() * witness_curr(i);
             power_of_2 *= 4096u64.into(); // 12 bits
         }
 
-        // 1st part:  Sum 2-bit sublimbs (row Curr)
+        // 1st part:  Sum 2-bit limbs (row Curr)
         for i in 5..COLUMNS {
-            sum_of_sublimbs += power_of_2.clone() * witness_curr(i);
+            sum_of_limbs += power_of_2.clone() * witness_curr(i);
             power_of_2 *= 4u64.into(); // 2 bits
         }
 
-        // 2nd part: Sum 2-bit sublimbs
+        // 2nd part: Sum 2-bit limbs (row Next)
         for i in 5..COLUMNS {
-            sum_of_sublimbs += power_of_2.clone() * witness_next(i);
+            sum_of_limbs += power_of_2.clone() * witness_next(i);
             power_of_2 *= 4u64.into(); // 2 bits
         }
 
-        // Check limb against the sum of sublimbs
-        constraints.push(sum_of_sublimbs - witness_curr(0));
+        // Check value v2 against the sum of limbs
+        constraints.push(sum_of_limbs - witness_curr(0));
 
         constraints
     }

--- a/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
@@ -3,8 +3,9 @@
 ///
 ///    The range check gate is comprised of three circuit gates (RangeCheck0, RangeCheck1
 ///    and Zero) and can perform range checks on up to three 88-bit values: v0, v1 and v2.
+///    Each value is in little-endian byte order.
 ///
-///    The values are decomposed into limbs follows.
+///    The values are decomposed into limbs as follows.
 ///
 ///    L is a 12-bit lookup limb,
 ///    C is a 2-bit "crumb" limb.

--- a/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
@@ -2,7 +2,7 @@
 /// Range check circuit gates:
 ///
 ///    The range check gate is comprised of three circuit gates (RangeCheck0, RangeCheck1
-///    and RangeCheck2) and can perform range checks on up to three 88-bit values: v0, v1 and v2.
+///    and Zero) and can perform range checks on up to three 88-bit values: v0, v1 and v2.
 ///
 ///    The values are decomposed into limbs follows.
 ///
@@ -40,7 +40,7 @@
 ///   * vipj is the jth 12-bit limb of vi
 ///   * vicj is the jth 2-bit crumb limb of vi
 ///
-/// Gate:   RangeCheck0    RangeCheck0    RangeCheck1    RangeCheck2
+/// Gate:   RangeCheck0    RangeCheck0    RangeCheck1    Zero
 ///   Rows -->
 ///         0              1              2              3
 ///  C  0 | v0           | v1           | v2           | 0
@@ -62,7 +62,7 @@
 ///   The 12-bit chunks are constrained with plookups and the 2-bit crumbs constrained with
 ///   degree-4 constraints of the form x*(x - 1)*(x - 2)*(x - 3).
 ///
-///   Note that copy denotes a plookup that is deferred to the RangeCheck2 gate.
+///   Note that copy denotes a plookup that is deferred to the 4th gate (i.e. Zero).
 ///   This is because of the limitation that we have at most 4 lookups per row.
 ///   The copies are constrained using the permutation argument.
 ///
@@ -73,8 +73,8 @@
 ///   Row   CircuitGate   Purpose
 ///     0   RangeCheck0   Partially constrain v0
 ///     1   RangeCheck0   Partially constrain v1
-///     2   RangeCheck1   Fully constrain v2
-///     3   RangeCheck2   Complete the constraining of v0 and v1
+///     2   RangeCheck1   Fully constrain v2 (and trigger plookups constraints on row 3)
+///     3   Zero          Complete the constraining of v0 and v1
 ///
 ///  Nb. each CircuitGate type corresponds to a unique polynomial and thus
 ///       is assigned its own unique powers of alpha
@@ -92,7 +92,7 @@ use ark_ff::{FftField, One, Zero};
 /// RangeCheck0 - Range check constraints
 ///
 ///   * This circuit gate is used to partially constrain values v0 and v1
-///   * The rest of v0 and v1 are constrained by a single RangeCheck2
+///   * The rest of v0 and v1 are constrained by the lookups in the Zero gate row
 ///   * This gate operates on the Curr row
 ///
 /// It uses three different types of constraints

--- a/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
@@ -44,7 +44,7 @@
 ///   * aXpi is a 12-bit sublimb of limb aX
 ///   * aXci is a 2-bit "crumb" sublimb of aX
 ///
-/// Gate:   RangeCheck0    RangeCheck0    RangeCheck1    RangeCheck2
+/// Gate:   RangeCheck0    RangeCheck0    RangeCheck1    Zero
 ///   Rows -->
 ///         0              1              2              3
 ///  C  0 | a0           | a1           | a2           | 0

--- a/kimchi/src/circuits/polynomials/range_check/gate.rs
+++ b/kimchi/src/circuits/polynomials/range_check/gate.rs
@@ -285,7 +285,7 @@ mod tests {
     use ark_ec::AffineCurve;
     use ark_ff::One;
     use mina_curves::pasta::pallas;
-    use num_bigint::BigUint;
+    use o1_utils::FieldHelpers;
 
     use array_init::array_init;
 
@@ -324,12 +324,6 @@ mod tests {
         new_index_for_test_with_lookups(gates, public_size, vec![range_check::lookup_table()], None)
     }
 
-    fn biguint_from_hex_le(hex: &str) -> BigUint {
-        let mut bytes = hex::decode(hex).expect("invalid hex");
-        bytes.reverse();
-        BigUint::from_bytes_le(&bytes)
-    }
-
     #[test]
     fn verify_range_check0_zero_valid_witness() {
         let cs = create_test_constraint_system();
@@ -355,9 +349,20 @@ mod tests {
     fn verify_range_check0_valid_witness() {
         let cs = create_test_constraint_system();
 
-        let witness: [Vec<PallasField>; 15] = range_check::create_witness(biguint_from_hex_le(
-            "1112223334445556667777888999aaabbbcccdddeeefff111222333444555611",
-        ));
+        let witness = range_check::create_witness::<PallasField>(
+            PallasField::from_hex(
+                "115655443433221211ffef000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "eeddcdccbbabaa99898877000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "7766565544343322121100000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
 
         // gates[0] is RangeCheck0
         assert_eq!(cs.gates[0].verify_range_check(0, &witness, &cs), Ok(()));
@@ -365,9 +370,20 @@ mod tests {
         // gates[1] is RangeCheck0
         assert_eq!(cs.gates[1].verify_range_check(1, &witness, &cs), Ok(()));
 
-        let witness: [Vec<PallasField>; 15] = range_check::create_witness(biguint_from_hex_le(
-            "f59abe33f5d808f8df3e63984621b01e375585fea8dd4030f71a0d80ac06d423",
-        ));
+        let witness = range_check::create_witness::<PallasField>(
+            PallasField::from_hex(
+                "23d406ac800d1af73040dd000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "a8fe8555371eb021469863000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "3edff808d8f533be9af500000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
 
         // gates[0] is RangeCheck0
         assert_eq!(cs.gates[0].verify_range_check(0, &witness, &cs), Ok(()));
@@ -380,8 +396,19 @@ mod tests {
     fn verify_range_check0_invalid_witness() {
         let cs = create_test_constraint_system();
 
-        let mut witness: [Vec<PallasField>; COLUMNS] = range_check::create_witness(
-            biguint_from_hex_le("bca91cf9df6cfd8bd225fd3f46ba2f3f33809d0ee2e7ad338448b4ece7b4f622"),
+        let mut witness = range_check::create_witness::<PallasField>(
+            PallasField::from_hex(
+                "22f6b4e7ecb4488433ade7000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "e20e9d80333f2fba463ffd000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "25d28bfd6cdff91ca9bc00000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
         );
 
         // Invalidate witness
@@ -395,9 +422,20 @@ mod tests {
             ))
         );
 
-        let mut witness: [Vec<PallasField>; 15] = range_check::create_witness(biguint_from_hex_le(
-            "301a091e9f74cd459a448c311ae47fe2f4311db61ae1cbd2afee0171e2b5ca22",
-        ));
+        let mut witness = range_check::create_witness::<PallasField>(
+            PallasField::from_hex(
+                "22cab5e27101eeafd2cbe1000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "1ab61d31f4e27fe41a318c000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "449a45cd749f1e091a3000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
 
         // Invalidate witness
         witness[8][0] = witness[0][0] + PallasField::one();
@@ -413,16 +451,38 @@ mod tests {
     fn verify_range_check1_valid_witness() {
         let cs = create_test_constraint_system();
 
-        let witness: [Vec<PallasField>; 15] = range_check::create_witness(biguint_from_hex_le(
-            "72de0b593fbd97e172ddfb1d7c1f7488948c622a7ff6bffa0279e35a7c148733",
-        ));
+        let witness = range_check::create_witness::<PallasField>(
+            PallasField::from_hex(
+                "22cab5e27101eeafd2cbe1000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "1ab61d31f4e27fe41a318c000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "449a45cd749f1e091a3000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
 
         // gates[2] is RangeCheck1
         assert_eq!(cs.gates[2].verify_range_check(2, &witness, &cs), Ok(()));
 
-        let witness: [Vec<PallasField>; 15] = range_check::create_witness(biguint_from_hex_le(
-            "58372fb93039e7106c68488dceb6cab3ffb0e7c8594dcc3bc7160321fcf6960d",
-        ));
+        let witness = range_check::create_witness::<PallasField>(
+            PallasField::from_hex(
+                "0d96f6fc210316c73bcc4d000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "59c8e7b0ffb3cab6ce8d48000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "686c10e73930b92f375800000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
 
         // gates[2] is RangeCheck1
         assert_eq!(cs.gates[2].verify_range_check(2, &witness, &cs), Ok(()));
@@ -432,9 +492,20 @@ mod tests {
     fn verify_range_check1_invalid_witness() {
         let cs = create_test_constraint_system();
 
-        let mut witness: [Vec<PallasField>; 15] = range_check::create_witness(biguint_from_hex_le(
-            "260efa1879427b08ca608d455d9f39954b5243dd52117e9ed5982f94acd3e22c",
-        ));
+        let mut witness = range_check::create_witness::<PallasField>(
+            PallasField::from_hex(
+                "2ce2d3ac942f98d59e7e11000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "52dd43524b95399f5d458d000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "60ca087b427918fa0e2600000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
 
         // Corrupt witness
         witness[0][2] = witness[7][2];
@@ -445,9 +516,20 @@ mod tests {
             Err(String::from("Invalid RangeCheck1 constraint"))
         );
 
-        let mut witness: [Vec<PallasField>; 15] = range_check::create_witness(biguint_from_hex_le(
-            "afd209d02c77546022ea860f9340e4289ecdd783e9c0012fd383dcd2940cd51b",
-        ));
+        let mut witness = range_check::create_witness::<PallasField>(
+            PallasField::from_hex(
+                "1bd50c94d2dc83d32f01c0000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "e983d7cd9e28e440930f86000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "ea226054772cd009d2af00000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
 
         // Corrupt witness
         witness[13][2] = witness[1][2];
@@ -478,9 +560,20 @@ mod tests {
         let prover_index = create_test_prover_index(0);
 
         // Create witness
-        let witness: [Vec<PallasField>; 15] = range_check::create_witness(biguint_from_hex_le(
-            "56acede83576c45ec8c11a85ac97e2393a9f88308b4b42d1b1506f2faaafc02b",
-        ));
+        let witness = range_check::create_witness::<PallasField>(
+            PallasField::from_hex(
+                "2bc0afaa2f6f50b1d1424b000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "8b30889f3a39e297ac851a000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            PallasField::from_hex(
+                "c1c85ec47635e8edac5600000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
 
         // Verify computed witness satisfies the circuit
         prover_index.cs.verify(&witness, &[]).unwrap();

--- a/kimchi/src/circuits/polynomials/range_check/gate.rs
+++ b/kimchi/src/circuits/polynomials/range_check/gate.rs
@@ -300,6 +300,7 @@ mod tests {
             vec![lookup::tables::get_table::<PallasField>(
                 GateLookupTable::RangeCheck,
             )],
+            None,
             oracle::pasta::fp_kimchi::params(),
             0,
         )
@@ -317,7 +318,7 @@ mod tests {
             next_row += 1;
         }
 
-        new_index_for_test_with_lookups(gates, public_size, vec![])
+        new_index_for_test_with_lookups(gates, public_size, vec![], None)
     }
 
     fn biguint_from_hex_le(hex: &str) -> BigUint {

--- a/kimchi/src/circuits/polynomials/range_check/gate.rs
+++ b/kimchi/src/circuits/polynomials/range_check/gate.rs
@@ -17,6 +17,10 @@ use crate::{
         domains::EvaluationDomains,
         expr::{self, l0_1, Environment, E},
         gate::{CircuitGate, GateType},
+        lookup::{
+            self,
+            tables::{GateLookupTable, LookupTable},
+        },
         polynomial::COLUMNS,
         wires::{GateWires, Wire},
     },
@@ -262,16 +266,17 @@ pub fn selector_polynomials<F: FftField>(
     }))
 }
 
+/// Get the range check lookup table
+pub fn lookup_table<F: FftField>() -> LookupTable<F> {
+    lookup::tables::get_table::<F>(GateLookupTable::RangeCheck)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
         circuits::{
-            constraints::ConstraintSystem,
-            gate::CircuitGate,
-            lookup::{self, tables::GateLookupTable},
-            polynomial::COLUMNS,
-            polynomials::range_check,
-            wires::Wire,
+            constraints::ConstraintSystem, gate::CircuitGate, polynomial::COLUMNS,
+            polynomials::range_check, wires::Wire,
         },
         proof::ProverProof,
         prover_index::testing::new_index_for_test_with_lookups,
@@ -297,9 +302,7 @@ mod tests {
 
         ConstraintSystem::create(
             gates,
-            vec![lookup::tables::get_table::<PallasField>(
-                GateLookupTable::RangeCheck,
-            )],
+            vec![range_check::lookup_table()],
             None,
             oracle::pasta::fp_kimchi::params(),
             0,
@@ -318,7 +321,7 @@ mod tests {
             next_row += 1;
         }
 
-        new_index_for_test_with_lookups(gates, public_size, vec![], None)
+        new_index_for_test_with_lookups(gates, public_size, vec![range_check::lookup_table()], None)
     }
 
     fn biguint_from_hex_le(hex: &str) -> BigUint {

--- a/kimchi/src/circuits/polynomials/range_check/witness.rs
+++ b/kimchi/src/circuits/polynomials/range_check/witness.rs
@@ -71,8 +71,9 @@ const WITNESS_SHAPE: [[WitnessCell; COLUMNS]; 4] = [
         LimbWitnessCell::create(0, 0, 36, 48),
         /* 12-bit copies */
         // Copy cells are required because we have a limit
-        // of 4 lookups per row.  These two lookups are deferred
-        // until the RangeCheck2 gate, which handles them.
+        // of 4 lookups per row.  These two lookups are moved to
+        // the 4th row (i.e. Zero circuit gate) and the RangeCheck1
+        // circuit gate triggers the lookup constraints.
         LimbWitnessCell::create(0, 0, 48, 60),
         LimbWitnessCell::create(0, 0, 60, 72),
         /* 2-bit crumbs */
@@ -126,7 +127,7 @@ const WITNESS_SHAPE: [[WitnessCell; COLUMNS]; 4] = [
         LimbWitnessCell::create(2, 0, 64, 66),
         LimbWitnessCell::create(2, 0, 66, 68),
     ],
-    /* row 4, RangeCheck2 row */
+    /* row 4, Zero row */
     [
         ZeroWitnessCell::create(),
         /* 12-bit plookups (see note about copies above) */

--- a/kimchi/src/circuits/polynomials/range_check/witness.rs
+++ b/kimchi/src/circuits/polynomials/range_check/witness.rs
@@ -1,21 +1,15 @@
-//! Witness computation
+//! Range check witness computation
 
-/// TODO: make dynamic
 use ark_ff::PrimeField;
 use array_init::array_init;
-use num_bigint::BigUint;
 use o1_utils::FieldHelpers;
 
 use crate::circuits::polynomial::COLUMNS;
 
-// The maximum supported range check element size is 264-bits
-const MAX_LIMBS: usize = 3;
-const LIMB_SIZE: usize = 88;
-
 enum WitnessCell {
     Copy(CopyWitnessCell),
-    Limb,
-    Sublimb(SublimbWitnessCell),
+    Value,
+    Limb(LimbWitnessCell),
     Zero,
 }
 
@@ -31,24 +25,24 @@ impl CopyWitnessCell {
 }
 
 // Witness cell for a range check field element limb
-struct LimbWitnessCell;
-impl LimbWitnessCell {
+struct ValueWitnessCell;
+impl ValueWitnessCell {
     const fn create() -> WitnessCell {
-        WitnessCell::Limb
+        WitnessCell::Value
     }
 }
 
 // Witness cell for a range check field element sub-limb
-struct SublimbWitnessCell {
+struct LimbWitnessCell {
     row: usize,   // Cell row
     col: usize,   // Cell col
     start: usize, // Starting bit offset
     end: usize,   // Ending bit offset (exclusive)
 }
-impl SublimbWitnessCell {
+impl LimbWitnessCell {
     // Params: source (row, col), starting bit offset and ending bit offset (exclusive)
     const fn create(row: usize, col: usize, start: usize, end: usize) -> WitnessCell {
-        WitnessCell::Sublimb(SublimbWitnessCell {
+        WitnessCell::Limb(LimbWitnessCell {
             row,
             col,
             start,
@@ -69,68 +63,68 @@ impl ZeroWitnessCell {
 const WITNESS_SHAPE: [[WitnessCell; COLUMNS]; 4] = [
     /* row 1, RangeCheck0 row */
     [
-        LimbWitnessCell::create(),
+        ValueWitnessCell::create(),
         /* 12-bit plookups */
-        SublimbWitnessCell::create(0, 0, 0, 12),
-        SublimbWitnessCell::create(0, 0, 12, 24),
-        SublimbWitnessCell::create(0, 0, 24, 36),
-        SublimbWitnessCell::create(0, 0, 36, 48),
+        LimbWitnessCell::create(0, 0, 0, 12),
+        LimbWitnessCell::create(0, 0, 12, 24),
+        LimbWitnessCell::create(0, 0, 24, 36),
+        LimbWitnessCell::create(0, 0, 36, 48),
         /* 12-bit copies */
         // Copy cells are required because we have a limit
         // of 4 lookups per row.  These two lookups are deferred
         // until the RangeCheck2 gate, which handles them.
-        SublimbWitnessCell::create(0, 0, 48, 60),
-        SublimbWitnessCell::create(0, 0, 60, 72),
+        LimbWitnessCell::create(0, 0, 48, 60),
+        LimbWitnessCell::create(0, 0, 60, 72),
         /* 2-bit crumbs */
-        SublimbWitnessCell::create(0, 0, 72, 74),
-        SublimbWitnessCell::create(0, 0, 74, 76),
-        SublimbWitnessCell::create(0, 0, 76, 78),
-        SublimbWitnessCell::create(0, 0, 78, 80),
-        SublimbWitnessCell::create(0, 0, 80, 82),
-        SublimbWitnessCell::create(0, 0, 82, 84),
-        SublimbWitnessCell::create(0, 0, 84, 86),
-        SublimbWitnessCell::create(0, 0, 86, 88),
+        LimbWitnessCell::create(0, 0, 72, 74),
+        LimbWitnessCell::create(0, 0, 74, 76),
+        LimbWitnessCell::create(0, 0, 76, 78),
+        LimbWitnessCell::create(0, 0, 78, 80),
+        LimbWitnessCell::create(0, 0, 80, 82),
+        LimbWitnessCell::create(0, 0, 82, 84),
+        LimbWitnessCell::create(0, 0, 84, 86),
+        LimbWitnessCell::create(0, 0, 86, 88),
     ],
     /* row 2, RangeCheck0 row */
     [
-        LimbWitnessCell::create(),
+        ValueWitnessCell::create(),
         /* 12-bit plookups */
-        SublimbWitnessCell::create(1, 0, 0, 12),
-        SublimbWitnessCell::create(1, 0, 12, 24),
-        SublimbWitnessCell::create(1, 0, 24, 36),
-        SublimbWitnessCell::create(1, 0, 36, 48),
+        LimbWitnessCell::create(1, 0, 0, 12),
+        LimbWitnessCell::create(1, 0, 12, 24),
+        LimbWitnessCell::create(1, 0, 24, 36),
+        LimbWitnessCell::create(1, 0, 36, 48),
         /* 12-bit copies (see note about copies above) */
-        SublimbWitnessCell::create(1, 0, 48, 60),
-        SublimbWitnessCell::create(1, 0, 60, 72),
+        LimbWitnessCell::create(1, 0, 48, 60),
+        LimbWitnessCell::create(1, 0, 60, 72),
         /* 2-bit crumbs */
-        SublimbWitnessCell::create(1, 0, 72, 74),
-        SublimbWitnessCell::create(1, 0, 74, 76),
-        SublimbWitnessCell::create(1, 0, 76, 78),
-        SublimbWitnessCell::create(1, 0, 78, 80),
-        SublimbWitnessCell::create(1, 0, 80, 82),
-        SublimbWitnessCell::create(1, 0, 82, 84),
-        SublimbWitnessCell::create(1, 0, 84, 86),
-        SublimbWitnessCell::create(1, 0, 86, 88),
+        LimbWitnessCell::create(1, 0, 72, 74),
+        LimbWitnessCell::create(1, 0, 74, 76),
+        LimbWitnessCell::create(1, 0, 76, 78),
+        LimbWitnessCell::create(1, 0, 78, 80),
+        LimbWitnessCell::create(1, 0, 80, 82),
+        LimbWitnessCell::create(1, 0, 82, 84),
+        LimbWitnessCell::create(1, 0, 84, 86),
+        LimbWitnessCell::create(1, 0, 86, 88),
     ],
     /* row 3, RangeCheck1 row */
     [
-        LimbWitnessCell::create(),
+        ValueWitnessCell::create(),
         /* 12-bit plookups */
-        SublimbWitnessCell::create(2, 0, 0, 12),
-        SublimbWitnessCell::create(2, 0, 12, 24),
-        SublimbWitnessCell::create(2, 0, 24, 36),
-        SublimbWitnessCell::create(2, 0, 36, 48),
+        LimbWitnessCell::create(2, 0, 0, 12),
+        LimbWitnessCell::create(2, 0, 12, 24),
+        LimbWitnessCell::create(2, 0, 24, 36),
+        LimbWitnessCell::create(2, 0, 36, 48),
         /* 2-bit crumbs */
-        SublimbWitnessCell::create(2, 0, 48, 50),
-        SublimbWitnessCell::create(2, 0, 50, 52),
-        SublimbWitnessCell::create(2, 0, 52, 54),
-        SublimbWitnessCell::create(2, 0, 54, 56),
-        SublimbWitnessCell::create(2, 0, 56, 58),
-        SublimbWitnessCell::create(2, 0, 58, 60),
-        SublimbWitnessCell::create(2, 0, 60, 62),
-        SublimbWitnessCell::create(2, 0, 62, 64),
-        SublimbWitnessCell::create(2, 0, 64, 66),
-        SublimbWitnessCell::create(2, 0, 66, 68),
+        LimbWitnessCell::create(2, 0, 48, 50),
+        LimbWitnessCell::create(2, 0, 50, 52),
+        LimbWitnessCell::create(2, 0, 52, 54),
+        LimbWitnessCell::create(2, 0, 54, 56),
+        LimbWitnessCell::create(2, 0, 56, 58),
+        LimbWitnessCell::create(2, 0, 58, 60),
+        LimbWitnessCell::create(2, 0, 60, 62),
+        LimbWitnessCell::create(2, 0, 62, 64),
+        LimbWitnessCell::create(2, 0, 64, 66),
+        LimbWitnessCell::create(2, 0, 66, 68),
     ],
     /* row 4, RangeCheck2 row */
     [
@@ -141,37 +135,37 @@ const WITNESS_SHAPE: [[WitnessCell; COLUMNS]; 4] = [
         CopyWitnessCell::create(1, 5),
         CopyWitnessCell::create(1, 6),
         /* 2-bit crumbs */
-        SublimbWitnessCell::create(2, 0, 68, 70),
-        SublimbWitnessCell::create(2, 0, 70, 72),
-        SublimbWitnessCell::create(2, 0, 72, 74),
-        SublimbWitnessCell::create(2, 0, 74, 76),
-        SublimbWitnessCell::create(2, 0, 76, 78),
-        SublimbWitnessCell::create(2, 0, 78, 80),
-        SublimbWitnessCell::create(2, 0, 80, 82),
-        SublimbWitnessCell::create(2, 0, 82, 84),
-        SublimbWitnessCell::create(2, 0, 84, 86),
-        SublimbWitnessCell::create(2, 0, 86, 88),
+        LimbWitnessCell::create(2, 0, 68, 70),
+        LimbWitnessCell::create(2, 0, 70, 72),
+        LimbWitnessCell::create(2, 0, 72, 74),
+        LimbWitnessCell::create(2, 0, 74, 76),
+        LimbWitnessCell::create(2, 0, 76, 78),
+        LimbWitnessCell::create(2, 0, 78, 80),
+        LimbWitnessCell::create(2, 0, 80, 82),
+        LimbWitnessCell::create(2, 0, 82, 84),
+        LimbWitnessCell::create(2, 0, 84, 86),
+        LimbWitnessCell::create(2, 0, 86, 88),
     ],
 ];
 
-fn limb_to_sublimb<F: PrimeField>(fe: F, start: usize, end: usize) -> F {
+fn value_to_limb<F: PrimeField>(fe: F, start: usize, end: usize) -> F {
     F::from_bits(&fe.to_bits()[start..end]).expect("failed to deserialize field bits")
 }
 
-fn init_range_check_row<F: PrimeField>(witness: &mut [Vec<F>; COLUMNS], row: usize, limb: F) {
+fn init_range_check_row<F: PrimeField>(witness: &mut [Vec<F>; COLUMNS], row: usize, value: F) {
     for col in 0..COLUMNS {
         match &WITNESS_SHAPE[row][col] {
             WitnessCell::Copy(copy_cell) => {
                 witness[col][row] = witness[copy_cell.col][copy_cell.row];
             }
-            WitnessCell::Limb => {
-                witness[col][row] = limb;
+            WitnessCell::Value => {
+                witness[col][row] = value;
             }
-            WitnessCell::Sublimb(sublimb_cell) => {
-                witness[col][row] = limb_to_sublimb(
-                    witness[sublimb_cell.col][sublimb_cell.row], // limb cell (row, col)
-                    sublimb_cell.start,                          // starting bit
-                    sublimb_cell.end,                            // ending bit (exclusive)
+            WitnessCell::Limb(limb_cell) => {
+                witness[col][row] = value_to_limb(
+                    witness[limb_cell.col][limb_cell.row], // limb cell (row, col)
+                    limb_cell.start,                       // starting bit
+                    limb_cell.end,                         // ending bit (exclusive)
                 );
             }
             WitnessCell::Zero => {
@@ -181,36 +175,14 @@ fn init_range_check_row<F: PrimeField>(witness: &mut [Vec<F>; COLUMNS], row: usi
     }
 }
 
-fn append_range_check_field_element_rows<F: PrimeField>(
-    witness: &mut [Vec<F>; COLUMNS],
-    fe: BigUint,
-) {
-    assert!(fe.bits() <= (MAX_LIMBS * LIMB_SIZE) as u64);
-    let mut last_row_number = 0;
-
-    for (row, chunk) in fe
-        .to_bytes_le() // F::from_bytes() below is little-endian
-        .chunks(LIMB_SIZE / 8 + (LIMB_SIZE % 8 != 0) as usize)
-        .enumerate()
-    {
-        // Convert chunk to field element and store in column 0
-        let mut limb_bytes = chunk.to_vec();
-        limb_bytes.resize(32 /* F::size_in_bytes() */, 0);
-        let limb_fe = F::from_bytes(&limb_bytes).expect("failed to deserialize limb field bytes");
-
-        // Initialize the row based on the limb and public input shape
-        init_range_check_row(witness, row, limb_fe);
-        last_row_number += 1;
-    }
-
-    // Initialize last row
-    init_range_check_row(witness, last_row_number, F::zero());
-}
-
 /// Create a range check witness
-pub fn create_witness<F: PrimeField>(fe: BigUint) -> [Vec<F>; COLUMNS] {
-    assert!(fe.bits() <= (MAX_LIMBS * LIMB_SIZE) as u64);
+pub fn create_witness<F: PrimeField>(val1: F, val2: F, val3: F) -> [Vec<F>; COLUMNS] {
     let mut witness: [Vec<F>; COLUMNS] = array_init(|_| vec![F::zero(); 4]);
-    append_range_check_field_element_rows(&mut witness, fe);
+
+    init_range_check_row(&mut witness, 0, val1);
+    init_range_check_row(&mut witness, 1, val2);
+    init_range_check_row(&mut witness, 2, val3);
+    init_range_check_row(&mut witness, 3, F::zero());
+
     witness
 }

--- a/kimchi/src/circuits/polynomials/range_check/witness.rs
+++ b/kimchi/src/circuits/polynomials/range_check/witness.rs
@@ -176,12 +176,13 @@ fn init_range_check_row<F: PrimeField>(witness: &mut [Vec<F>; COLUMNS], row: usi
 }
 
 /// Create a range check witness
-pub fn create_witness<F: PrimeField>(val1: F, val2: F, val3: F) -> [Vec<F>; COLUMNS] {
+/// Input: three values: v0, v1 and v2
+pub fn create_witness<F: PrimeField>(v0: F, v1: F, v2: F) -> [Vec<F>; COLUMNS] {
     let mut witness: [Vec<F>; COLUMNS] = array_init(|_| vec![F::zero(); 4]);
 
-    init_range_check_row(&mut witness, 0, val1);
-    init_range_check_row(&mut witness, 1, val2);
-    init_range_check_row(&mut witness, 2, val3);
+    init_range_check_row(&mut witness, 0, v0);
+    init_range_check_row(&mut witness, 1, v1);
+    init_range_check_row(&mut witness, 2, v2);
     init_range_check_row(&mut witness, 3, F::zero());
 
     witness

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -658,7 +658,6 @@ where
                             }
                             RangeCheck0 => &index.range_check_comm[0],
                             RangeCheck1 => &index.range_check_comm[1],
-                            RangeCheck2 => &index.range_check_comm[2],
                         };
                         scalars.push(scalar);
                         commitments.push(c);

--- a/utils/src/field_helpers.rs
+++ b/utils/src/field_helpers.rs
@@ -14,11 +14,12 @@ pub enum FieldHelpersError {
 pub type Result<T> = std::result::Result<T, FieldHelpersError>;
 
 /// Field element helpers
+///   Unless otherwise stated everything is in little-endian byte order.
 pub trait FieldHelpers<F> {
     /// Deserialize from bytes
     fn from_bytes(bytes: &[u8]) -> Result<F>;
 
-    /// Deserialize from hex
+    /// Deserialize from little-endian hex
     fn from_hex(hex: &str) -> Result<F>;
 
     /// Deserialize from bits


### PR DESCRIPTION
This adds the lookups needed in the range check gate. 

TODO:

- [x] add lookups
- [x] remove fmul-isms and make documentation more consistent
- [x] update witness generation code (remove fmul related concepts)
- [x] enable plookups in verify_range_check 
- [x] add range check specific tests
- [x] add plookup specific tests
- [x] remove the `RangeCheck2` gate

Closes #559