### PR TITLE
enforce length of SRS to be at least the domain size

### DIFF
--- a/kimchi/src/error.rs
+++ b/kimchi/src/error.rs
@@ -21,7 +21,7 @@ pub enum ProverError {
     #[error("the lookup failed to find a match in the table")]
     ValueNotInTable,
 
-    #[error("kimchi does not support SRS of size smaller than the domain")]
+    #[error("SRS size is smaller than the domain size required by the circuit")]
     SRSTooSmall,
 }
 
@@ -43,10 +43,10 @@ pub enum VerifyError {
     #[error("lookup used in circuit, but proof has inconsistent number of lookup evaluations and commitments")]
     ProofInconsistentLookup,
 
-    #[error("kimchi does not support batching verification of proofs of different SRS")]
+    #[error("cannot batch proofs using different SRSes")]
     DifferentSRS,
 
-    #[error("kimchi does not support SRS of size smaller than the domain")]
+    #[error("SRS size is smaller than the domain size required by the circuit")]
     SRSTooSmall,
 }
 

--- a/kimchi/src/error.rs
+++ b/kimchi/src/error.rs
@@ -43,6 +43,9 @@ pub enum VerifyError {
     #[error("lookup used in circuit, but proof has inconsistent number of lookup evaluations and commitments")]
     ProofInconsistentLookup,
 
+    #[error("kimchi does not support batching verification of proofs of different SRS")]
+    DifferentSRS,
+
     #[error("kimchi does not support SRS of size smaller than the domain")]
     SRSTooSmall,
 }

--- a/kimchi/src/error.rs
+++ b/kimchi/src/error.rs
@@ -20,6 +20,9 @@ pub enum ProverError {
 
     #[error("the lookup failed to find a match in the table")]
     ValueNotInTable,
+
+    #[error("kimchi does not support SRS of size smaller than the domain")]
+    SRSTooSmall,
 }
 
 /// Errors that can arise when verifying a proof
@@ -39,6 +42,9 @@ pub enum VerifyError {
 
     #[error("lookup used in circuit, but proof has inconsistent number of lookup evaluations and commitments")]
     ProofInconsistentLookup,
+
+    #[error("kimchi does not support SRS of size smaller than the domain")]
+    SRSTooSmall,
 }
 
 /// Errors that can arise when preparing the setup

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -28,7 +28,8 @@ use crate::{
 };
 use ark_ff::{FftField, Field, One, PrimeField, UniformRand, Zero};
 use ark_poly::{
-    univariate::DensePolynomial, Evaluations, Polynomial, Radix2EvaluationDomain as D, UVPolynomial,
+    univariate::DensePolynomial, EvaluationDomain, Evaluations, Polynomial,
+    Radix2EvaluationDomain as D, UVPolynomial,
 };
 use array_init::array_init;
 use commitment_dlog::commitment::{b_poly_coefficients, CommitmentCurve, PolyComm};
@@ -121,7 +122,12 @@ where
         index: &ProverIndex<G>,
         prev_challenges: Vec<(Vec<ScalarField<G>>, PolyComm<G>)>,
     ) -> Result<Self> {
-        let d1_size = index.cs.domain.d1.size as usize;
+        // make sure that the SRS is not smaller than the domain size
+        let d1_size = index.cs.domain.d1.size();
+        if index.srs.max_degree() < d1_size {
+            return Err(ProverError::SRSTooSmall);
+        }
+
         // TODO: rng should be passed as arg
         let rng = &mut rand::rngs::OsRng;
 

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -873,7 +873,10 @@ where
     // TODO: Account for the different SRS lengths
     let srs = &proofs[0].0.srs;
     for (index, _) in proofs.iter() {
-        assert_eq!(index.srs.g.len(), srs.g.len());
+        if index.srs.g.len() != srs.g.len() {
+            return Err(VerifyError::DifferentSRS);
+        }
+
         // also make sure that the SRS is not smaller than the domain size
         if index.srs.max_degree() < index.domain.size() {
             return Err(VerifyError::SRSTooSmall);

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -874,6 +874,10 @@ where
     let srs = &proofs[0].0.srs;
     for (index, _) in proofs.iter() {
         assert_eq!(index.srs.g.len(), srs.g.len());
+        // also make sure that the SRS is not smaller than the domain size
+        if index.srs.max_degree() < index.domain.size() {
+            return Err(VerifyError::SRSTooSmall);
+        }
     }
 
     //~ 3. Validate each proof separately following the [partial verification](#partial-verification) steps.


### PR DESCRIPTION
in practice it is possible that using SRS that have a smaller size than the domain could work, as we support splitting every polynomials we use, but I'm not sure we did think of every corner cases. It's probably safer to just not allow this edge-case.