### PR TITLE
[lookup][runtime] making first column of runtime tables customizable

### DIFF
--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -27,7 +27,7 @@ use serde_with::serde_as;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use super::lookup::runtime_tables::RuntimeTableConfiguration;
+use super::lookup::runtime_tables::RuntimeTableCfg;
 
 //
 // ConstraintSystem
@@ -231,7 +231,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
     pub fn create(
         gates: Vec<CircuitGate<F>>,
         lookup_tables: Vec<LookupTable<F>>,
-        runtime_tables: Option<Vec<RuntimeTableConfiguration>>,
+        runtime_tables: Option<Vec<RuntimeTableCfg<F>>>,
         fr_sponge_params: ArithmeticSpongeParams<F>,
         public: usize,
     ) -> Result<Self, SetupError> {
@@ -254,7 +254,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
     pub fn create_with_shared_precomputations(
         mut gates: Vec<CircuitGate<F>>,
         lookup_tables: Vec<LookupTable<F>>,
-        runtime_tables: Option<Vec<RuntimeTableConfiguration>>,
+        runtime_tables: Option<Vec<RuntimeTableCfg<F>>>,
         fr_sponge_params: ArithmeticSpongeParams<F>,
         public: usize,
         precomputations: Option<Arc<DomainConstantEvaluations<F>>>,

--- a/kimchi/src/circuits/lookup/constraints.rs
+++ b/kimchi/src/circuits/lookup/constraints.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use CurrOrNext::{Curr, Next};
 
-use super::runtime_tables::{self, RuntimeTableConfiguration};
+use super::runtime_tables::{self, RuntimeTableSpec};
 
 /// Number of constraints produced by the argument.
 pub const CONSTRAINTS: u32 = 7;
@@ -338,7 +338,7 @@ pub struct LookupConfiguration<F: FftField> {
     pub max_joint_size: u32,
 
     /// Optional runtime tables, listed as tuples `(length, id)`.
-    pub runtime_tables: Option<Vec<RuntimeTableConfiguration>>,
+    pub runtime_tables: Option<Vec<RuntimeTableSpec>>,
 
     /// The offset of the runtime table within the concatenated table
     pub runtime_table_offset: Option<usize>,

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -20,7 +20,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
 use thiserror::Error;
 
-use super::runtime_tables::RuntimeTableConfiguration;
+use super::runtime_tables::{RuntimeTableCfg, RuntimeTableSpec};
 
 /// Represents an error found when computing the lookup constraint system
 #[derive(Debug, Error)]
@@ -73,7 +73,7 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
     pub fn create(
         gates: &[CircuitGate<F>],
         lookup_tables: Vec<LookupTable<F>>,
-        runtime_tables: Option<Vec<RuntimeTableConfiguration>>,
+        runtime_tables: Option<Vec<RuntimeTableCfg<F>>>,
         domain: &EvaluationDomains<F>,
     ) -> Result<Option<Self>, LookupError> {
         let lookup_info = LookupInfo::<F>::create();
@@ -112,7 +112,7 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
                         // compute the length of the runtime table
                         let mut runtime_len = 0;
                         for t in runtime_tables {
-                            runtime_len += t.len;
+                            runtime_len += t.len();
                         }
 
                         // compute the runtime selector
@@ -139,10 +139,21 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
                         };
 
                         // create fixed tables for indexing the runtime tables
-                        for &RuntimeTableConfiguration { id, len } in runtime_tables {
-                            let indexes = (0..(len as u32)).map(F::from).collect();
-                            let placeholders = vec![F::zero(); len];
-                            let data = vec![indexes, placeholders];
+                        for runtime_table in runtime_tables {
+                            use RuntimeTableCfg::*;
+                            let (id, first_column) = match runtime_table {
+                                &Indexed(RuntimeTableSpec { id, len }) => {
+                                    let indexes = (0..(len as u32)).map(F::from).collect();
+                                    (id, indexes)
+                                }
+                                Custom { id, first_column } => (*id, first_column.clone()),
+                            };
+
+                            // important: we still need a placeholder column to make sure that
+                            // if all other tables have a single column
+                            // we don't use the second table as table ID column.
+                            let placeholders = vec![F::zero(); first_column.len()];
+                            let data = vec![first_column, placeholders];
                             let table = LookupTable { id, data };
                             lookup_tables.push(table);
                         }
@@ -275,6 +286,10 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
                 } else {
                     (None, None)
                 };
+
+                // store only the length of custom runtime tables in the index
+                let runtime_tables =
+                    runtime_tables.map(|rt| rt.into_iter().map(Into::into).collect());
 
                 Ok(Some(Self {
                     lookup_selectors,

--- a/kimchi/src/circuits/lookup/runtime_tables.rs
+++ b/kimchi/src/circuits/lookup/runtime_tables.rs
@@ -9,19 +9,65 @@ use crate::circuits::{
 use ark_ff::Field;
 use serde::{Deserialize, Serialize};
 
-/// The configuration of a runtime table.
+/// The specification of a runtime table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RuntimeTableConfiguration {
-    /// The table id.
-    /// Note that these should be chosen not to collide with other runtime tables' IDs,
-    /// as well as other types of lookup tables and their IDs.
+pub struct RuntimeTableSpec {
+    /// The table ID.
     pub id: i32,
-    /// The length of the runtime table.
+    /// The number of entries contained in the runtime table.
     pub len: usize,
 }
 
+/// Use this type at setup time, to list all the runtime tables.
+///
+/// Note: care must be taken as table IDs can collide with IDs of other types of lookup tables.
+pub enum RuntimeTableCfg<F> {
+    /// An indexed runtime table has a counter (starting at zero) in its first column.
+    Indexed(RuntimeTableSpec),
+    /// A custom runtime table has its first column fixed at setup time.
+    Custom {
+        /// The table ID.
+        id: i32,
+        /// The content of the first column of the runtime table.
+        first_column: Vec<F>,
+    },
+}
+
+impl<F> RuntimeTableCfg<F> {
+    /// Returns the ID of the runtime table.
+    pub fn id(&self) -> i32 {
+        use RuntimeTableCfg::*;
+        match self {
+            Indexed(cfg) => cfg.id,
+            &Custom { id, .. } => id,
+        }
+    }
+
+    /// Returns the length of the runtime table.
+    pub fn len(&self) -> usize {
+        use RuntimeTableCfg::*;
+        match self {
+            Indexed(cfg) => cfg.len,
+            Custom { first_column, .. } => first_column.len(),
+        }
+    }
+}
+
+impl<F> From<RuntimeTableCfg<F>> for RuntimeTableSpec {
+    fn from(from: RuntimeTableCfg<F>) -> Self {
+        use RuntimeTableCfg::*;
+        match from {
+            Indexed(cfg) => cfg,
+            Custom { id, first_column } => RuntimeTableSpec {
+                id: id,
+                len: first_column.len(),
+            },
+        }
+    }
+}
+
 /// A runtime table. Runtime tables must match the configuration
-/// that was specified via [RuntimeTableConfiguration].
+/// that was specified in [RuntimeTableCfg].
 #[derive(Debug, Clone)]
 pub struct RuntimeTable<F> {
     /// The table id.

--- a/kimchi/src/circuits/lookup/runtime_tables.rs
+++ b/kimchi/src/circuits/lookup/runtime_tables.rs
@@ -51,6 +51,15 @@ impl<F> RuntimeTableCfg<F> {
             Custom { first_column, .. } => first_column.len(),
         }
     }
+
+    /// Returns `true` if the runtime table is empty.
+    pub fn is_empty(&self) -> bool {
+        use RuntimeTableCfg::*;
+        match self {
+            Indexed(cfg) => cfg.len == 0,
+            Custom { first_column, .. } => first_column.is_empty(),
+        }
+    }
 }
 
 impl<F> From<RuntimeTableCfg<F>> for RuntimeTableSpec {
@@ -59,7 +68,7 @@ impl<F> From<RuntimeTableCfg<F>> for RuntimeTableSpec {
         match from {
             Indexed(cfg) => cfg,
             Custom { id, first_column } => RuntimeTableSpec {
-                id: id,
+                id,
                 len: first_column.len(),
             },
         }

--- a/kimchi/src/circuits/lookup/runtime_tables.rs
+++ b/kimchi/src/circuits/lookup/runtime_tables.rs
@@ -24,7 +24,7 @@ pub struct RuntimeTableSpec {
 pub enum RuntimeTableCfg<F> {
     /// An indexed runtime table has a counter (starting at zero) in its first column.
     Indexed(RuntimeTableSpec),
-    /// A custom runtime table has its first column fixed at setup time.
+    /// A custom runtime table can contain arbitrary values in its first column.
     Custom {
         /// The table ID.
         id: i32,

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -101,7 +101,7 @@ pub mod testing {
     use super::*;
     use crate::circuits::{
         gate::CircuitGate,
-        lookup::{runtime_tables::RuntimeTableConfiguration, tables::LookupTable},
+        lookup::{runtime_tables::RuntimeTableCfg, tables::LookupTable},
     };
     use ark_poly::EvaluationDomain;
     use commitment_dlog::srs::endos;
@@ -111,7 +111,7 @@ pub mod testing {
         gates: Vec<CircuitGate<Fp>>,
         public: usize,
         lookup_tables: Vec<LookupTable<Fp>>,
-        runtime_tables: Option<Vec<RuntimeTableConfiguration>>,
+        runtime_tables: Option<Vec<RuntimeTableCfg<Fp>>>,
     ) -> ProverIndex<Affine> {
         let fp_sponge_params = oracle::pasta::fp_kimchi::params();
 

--- a/kimchi/src/tests/framework.rs
+++ b/kimchi/src/tests/framework.rs
@@ -1,6 +1,6 @@
 //! Test Framework
 
-use crate::circuits::lookup::runtime_tables::{RuntimeTable, RuntimeTableConfiguration};
+use crate::circuits::lookup::runtime_tables::{RuntimeTable, RuntimeTableCfg};
 use crate::circuits::lookup::tables::LookupTable;
 use crate::circuits::{gate::CircuitGate, wires::COLUMNS};
 use crate::proof::ProverProof;
@@ -37,7 +37,7 @@ pub(crate) struct TestFramework {
     witness: Option<[Vec<Fp>; COLUMNS]>,
     public_inputs: Vec<Fp>,
     lookup_tables: Vec<LookupTable<Fp>>,
-    runtime_tables_cfg: Option<Vec<RuntimeTableConfiguration>>,
+    runtime_tables_setup: Option<Vec<RuntimeTableCfg<Fp>>>,
     runtime_tables: Vec<RuntimeTable<Fp>>,
     recursion: Vec<(Vec<Fp>, PolyComm<Affine>)>,
 
@@ -71,11 +71,11 @@ impl TestFramework {
     }
 
     #[must_use]
-    pub(crate) fn runtime_tables_cfg(
+    pub(crate) fn runtime_tables_setup(
         mut self,
-        runtime_tables_cfg: Vec<RuntimeTableConfiguration>,
+        runtime_tables_setup: Vec<RuntimeTableCfg<Fp>>,
     ) -> Self {
-        self.runtime_tables_cfg = Some(runtime_tables_cfg);
+        self.runtime_tables_setup = Some(runtime_tables_setup);
         self
     }
 
@@ -97,13 +97,13 @@ impl TestFramework {
         let start = Instant::now();
 
         let lookup_tables = mem::replace(&mut self.lookup_tables, vec![]);
-        let runtime_tables_cfg = mem::replace(&mut self.runtime_tables_cfg, None);
+        let runtime_tables_setup = mem::replace(&mut self.runtime_tables_setup, None);
 
         let index = new_index_for_test_with_lookups(
             self.gates.take().unwrap(),
             self.public_inputs.len(),
             lookup_tables,
-            runtime_tables_cfg,
+            runtime_tables_setup,
         );
         println!(
             "- time to create prover index: {:?}s",

--- a/kimchi/src/tests/lookup.rs
+++ b/kimchi/src/tests/lookup.rs
@@ -171,7 +171,7 @@ fn runtime_table(num: usize, indexed: bool) {
             // create queries into our runtime lookup table
             let lookup_cols = &mut lookup_cols[1..];
             for chunk in lookup_cols.chunks_mut(2) {
-                chunk[0][row] = 1u32.into(); // index
+                chunk[0][row] = if indexed { 1u32.into() } else { 9u32.into() }; // index
                 chunk[1][row] = 2u32.into(); // value
             }
         }

--- a/kimchi/src/tests/lookup.rs
+++ b/kimchi/src/tests/lookup.rs
@@ -2,7 +2,7 @@ use super::framework::{print_witness, TestFramework};
 use crate::circuits::{
     gate::{CircuitGate, GateType},
     lookup::{
-        runtime_tables::{RuntimeTable, RuntimeTableConfiguration},
+        runtime_tables::{RuntimeTable, RuntimeTableCfg, RuntimeTableSpec},
         tables::LookupTable,
     },
     polynomial::COLUMNS,
@@ -120,21 +120,29 @@ fn lookup_gate_rejects_bad_lookups_multiple_tables() {
     setup_lookup_proof(false, 500, vec![100, 50, 50, 2, 2])
 }
 
-fn runtime(num: usize) {
+fn runtime_table(num: usize, indexed: bool) {
     // runtime
-    let mut runtime_tables_cfg = vec![];
+    let mut runtime_tables_setup = vec![];
     for table_id in 0..num {
-        runtime_tables_cfg.push(RuntimeTableConfiguration {
-            id: table_id as i32,
-            len: 5,
-        });
+        let cfg = if indexed {
+            RuntimeTableCfg::Indexed(RuntimeTableSpec {
+                id: table_id as i32,
+                len: 5,
+            })
+        } else {
+            RuntimeTableCfg::Custom {
+                id: table_id as i32,
+                first_column: [8u32, 9, 8, 7, 1].into_iter().map(Into::into).collect(),
+            }
+        };
+        runtime_tables_setup.push(cfg);
     }
 
     let data: Vec<Fp> = [0u32, 2, 3, 4, 5].into_iter().map(Into::into).collect();
-    let runtime_tables: Vec<RuntimeTable<Fp>> = runtime_tables_cfg
+    let runtime_tables: Vec<RuntimeTable<Fp>> = runtime_tables_setup
         .iter()
         .map(|cfg| RuntimeTable {
-            id: cfg.id,
+            id: cfg.id(),
             data: data.clone(),
         })
         .collect();
@@ -176,7 +184,7 @@ fn runtime(num: usize) {
     TestFramework::default()
         .gates(gates)
         .witness(witness)
-        .runtime_tables_cfg(runtime_tables_cfg)
+        .runtime_tables_setup(runtime_tables_setup)
         .runtime_tables(runtime_tables)
         .setup()
         .prove_and_verify();
@@ -184,5 +192,12 @@ fn runtime(num: usize) {
 
 #[test]
 fn test_indexed_runtime_table() {
-    runtime(5);
+    runtime_table(5, true);
 }
+
+#[test]
+fn test_custom_runtime_table() {
+    runtime_table(5, false);
+}
+
+// TODO: add a test with a runtime table with ID 0 (it should panic)


### PR DESCRIPTION
currently the first column of all runtime tables is an indexed column (0, 1, 2, ...)
this PR allows the first column to be determined arbitrarily at setup