### PR TITLE
[specs] moving to cargo-spec 0.4.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Set up cargo-spec for specifications
         run: |
-          cargo install cargo-spec --version 0.3.0
+          cargo install cargo-spec --version 0.4.1
 
       - name: Build the kimchi specification
         run: |

--- a/book/book.toml
+++ b/book/book.toml
@@ -7,6 +7,7 @@ title = "Mina book"
 
 [output.html]
 site-url = "/proof-systems/"
+use-site-url-as-root = true
 curly-quotes = true
 git-repository-url = "https://www.github.com/o1-labs/proof-systems"
 additional-css = ["./assets/css/mdbook-admonish.css"]

--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1148,10 +1148,10 @@ To create the index, follow these steps:
 
    To do this, for each table:
 
-      - Update the corresponding entries in a table id vector (of size the domain as well)
-        with the table ID of the table.
-      - Copy the entries from the table to new rows in the corresponding columns of the concatenated table.
-      - Fill in any unused columns with 0 (to match the dummy value)
+	- Update the corresponding entries in a table id vector (of size the domain as well)
+   with the table ID of the table.
+	- Copy the entries from the table to new rows in the corresponding columns of the concatenated table.
+	- Fill in any unused columns with 0 (to match the dummy value)
 6. Pad the end of the concatened table with the dummy value.
 7. Pad the end of the table id vector with 0s.
 8. pre-compute polynomial and evaluation form for the look up tables
@@ -1485,120 +1485,123 @@ The prover then follows the following steps to create the proof:
    but instead be of the length of the (smaller) circuit.
    If we cannot add `ZK_ROWS` rows to the columns of the witness before reaching
    the size of the domain, abort.
-2. Pad the witness columns with Zero gates to make them the same length as the domain.
+1. Pad the witness columns with Zero gates to make them the same length as the domain.
    Then, randomize the last `ZK_ROWS` of each columns.
-3. Setup the Fq-Sponge.
-4. Compute the negated public input polynomial as
+1. Setup the Fq-Sponge.
+1. Compute the negated public input polynomial as
    the polynomial that evaluates to $-p_i$ for the first `public_input_size` values of the domain,
    and $0$ for the rest.
-5. Commit (non-hiding) to the negated public input polynomial.
-6. Absorb the commitment to the public polynomial with the Fq-Sponge.
+1. Commit (non-hiding) to the negated public input polynomial.
+1. Absorb the commitment to the public polynomial with the Fq-Sponge.
+
    Note: unlike the original PLONK protocol,
    the prover also provides evaluations of the public polynomial to help the verifier circuit.
    This is why we need to absorb the commitment to the public polynomial at this point.
-7. Commit to the witness columns by creating `COLUMNS` hidding commitments.
+1. Commit to the witness columns by creating `COLUMNS` hidding commitments.
+
    Note: since the witness is in evaluation form,
    we can use the `commit_evaluation` optimization.
-8. Absorb the witness commitments with the Fq-Sponge.
-9. Compute the witness polynomials by interpolating each `COLUMNS` of the witness.
+1. Absorb the witness commitments with the Fq-Sponge.
+1. Compute the witness polynomials by interpolating each `COLUMNS` of the witness.
    TODO: why not do this first, and then commit? Why commit from evaluation directly?
-10. If using lookup:
-    - If queries involve a lookup table with multiple columns
-    then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
-    otherwise set the joint combiner challenge $j'$ to $0$.
-    - Derive the scalar joint combiner $j$ from $j'$ using the endomorphism (TOOD: specify)
-    - If multiple lookup tables are involved,
-     set the `table_id_combiner` as the $j^i$ with $i$ the maximum width of any used table.
-     Essentially, this is to add a last column of table ids to the concatenated lookup tables.
-    - Compute the dummy lookup value as the combination of the last entry of the XOR table (so `(0, 0, 0)`).
-     Warning: This assumes that we always use the XOR table when using lookups.
-    - Compute the lookup table values as the combination of the lookup table entries.
-     - Compute the sorted evaluations.
-     - Randomize the last `EVALS` rows in each of the sorted polynomials
-      in order to add zero-knowledge to the protocol.
-     - Commit each of the sorted polynomials.
-     - Absorb each commitments to the sorted polynomials.
-11. Sample $\beta$ with the Fq-Sponge.
-12. Sample $\gamma$ with the Fq-Sponge.
-13. If using lookup:
-    - Compute the lookup aggregation polynomial.
-    - Commit to the aggregation polynomial.
-    - Absorb the commitment to the aggregation polynomial with the Fq-Sponge.
-14. Compute the permutation aggregation polynomial $z$.
-15. Commit (hidding) to the permutation aggregation polynomial $z$.
-16. Absorb the permutation aggregation polynomial $z$ with the Fq-Sponge.
-17. Sample $\alpha'$ with the Fq-Sponge.
-18. Derive $\alpha$ from $\alpha'$ using the endomorphism (TODO: details)
-19. TODO: instantiate alpha?
-20. Compute the quotient polynomial (the $t$ in $f = Z_H \cdot t$).
-    The quotient polynomial is computed by adding all these polynomials together:
-    - the combined constraints for all the gates
-    - the combined constraints for the permutation
-    - TODO: lookup
-    - the negated public polynomial
-    and by then dividing the resulting polynomial with the vanishing polynomial $Z_H$.
-    TODO: specify the split of the permutation polynomial into perm and bnd?
-21. commit (hiding) to the quotient polynomial $t$
-    TODO: specify the dummies
-22. Absorb the the commitment of the quotient polynomial with the Fq-Sponge.
-23. Sample $\zeta'$ with the Fq-Sponge.
-24. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify)
-25. If lookup is used, evaluate the following polynomials at $\zeta$ and $\zeta \omega$:
-    - the aggregation polynomial
-    - the sorted polynomials
-26. Chunk evaluate the following polynomials at both $\zeta$ and $\zeta \omega$:
-    * $s_i$
-    * $w_i$
-    * $z$
-    * lookup (TODO)
-    * generic selector
-    * poseidon selector
+1. If using lookup:
+	- If queries involve a lookup table with multiple columns
+	  then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
+	  otherwise set the joint combiner challenge $j'$ to $0$.
+	- Derive the scalar joint combiner $j$ from $j'$ using the endomorphism (TOOD: specify)
+	- If multiple lookup tables are involved,
+	  set the `table_id_combiner` as the $j^i$ with $i$ the maximum width of any used table.
+	  Essentially, this is to add a last column of table ids to the concatenated lookup tables.
+	- Compute the dummy lookup value as the combination of the last entry of the XOR table (so `(0, 0, 0)`).
+	  Warning: This assumes that we always use the XOR table when using lookups.
+	- Compute the lookup table values as the combination of the lookup table entries.
+	- Compute the sorted evaluations.
+	- Randomize the last `EVALS` rows in each of the sorted polynomials
+	  in order to add zero-knowledge to the protocol.
+	- Commit each of the sorted polynomials.
+	- Absorb each commitments to the sorted polynomials.
+1. Sample $\beta$ with the Fq-Sponge.
+1. Sample $\gamma$ with the Fq-Sponge.
+1. If using lookup:
+	- Compute the lookup aggregation polynomial.
+	- Commit to the aggregation polynomial.
+	- Absorb the commitment to the aggregation polynomial with the Fq-Sponge.
+1. Compute the permutation aggregation polynomial $z$.
+1. Commit (hidding) to the permutation aggregation polynomial $z$.
+1. Absorb the permutation aggregation polynomial $z$ with the Fq-Sponge.
+1. Sample $\alpha'$ with the Fq-Sponge.
+1. Derive $\alpha$ from $\alpha'$ using the endomorphism (TODO: details)
+1. TODO: instantiate alpha?
+1. Compute the quotient polynomial (the $t$ in $f = Z_H \cdot t$).
+   The quotient polynomial is computed by adding all these polynomials together:
+	- the combined constraints for all the gates
+	- the combined constraints for the permutation
+	- TODO: lookup
+	- the negated public polynomial
+   and by then dividing the resulting polynomial with the vanishing polynomial $Z_H$.
+   TODO: specify the split of the permutation polynomial into perm and bnd?
+1. commit (hiding) to the quotient polynomial $t$
+   TODO: specify the dummies
+1. Absorb the the commitment of the quotient polynomial with the Fq-Sponge.
+1. Sample $\zeta'$ with the Fq-Sponge.
+1. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify)
+1. If lookup is used, evaluate the following polynomials at $\zeta$ and $\zeta \omega$:
+	- the aggregation polynomial
+	- the sorted polynomials
+	- the table polynonial
+1. Chunk evaluate the following polynomials at both $\zeta$ and $\zeta \omega$:
+	- $s_i$
+	- $w_i$
+	- $z$
+	- lookup (TODO)
+	- generic selector
+	- poseidon selector
 
-    By "chunk evaluate" we mean that the evaluation of each polynomial can potentially be a vector of values.
-    This is because the index's `max_poly_size` parameter dictates the maximum size of a polynomial in the protocol.
-    If a polynomial $f$ exceeds this size, it must be split into several polynomials like so:
-    $$f(x) = f_0(x) + x^n f_1(x) + x^{2n} f_2(x) + \cdots$$
+   By "chunk evaluate" we mean that the evaluation of each polynomial can potentially be a vector of values.
+   This is because the index's `max_poly_size` parameter dictates the maximum size of a polynomial in the protocol.
+   If a polynomial $f$ exceeds this size, it must be split into several polynomials like so:
+   $$f(x) = f_0(x) + x^n f_1(x) + x^{2n} f_2(x) + \cdots$$
 
-    And the evaluation of such a polynomial is the following list for $x \in {\zeta, \zeta\omega}$:
+   And the evaluation of such a polynomial is the following list for $x \in {\zeta, \zeta\omega}$:
 
-    $$(f_0(x), f_1(x), f_2(x), \ldots)$$
+   $$(f_0(x), f_1(x), f_2(x), \ldots)$$
 
-     TODO: do we want to specify more on that? It seems unecessary except for the t polynomial (or if for some reason someone sets that to a low value)
-27. Evaluate the same polynomials without chunking them
-    (so that each polynomial should correspond to a single value this time).
-28. Compute the ft polynomial.
-    This is to implement [Maller's optimization](https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html).
-29. construct the blinding part of the ft polynomial commitment
-    see https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html#evaluation-proof-and-blinding-factors
-30. Evaluate the ft polynomial at $\zeta\omega$ only.
-31. Setup the Fr-Sponge
-32. Squeeze the Fq-sponge and absorb the result with the Fr-Sponge.
-33. Evaluate the negated public polynomial (if present) at $\zeta$ and $\zeta\omega$.
-34. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
-    - the public polynomial
-    - z
-    - generic selector
-    - poseidon selector
-    - the 15 register/witness
-    - 6 sigmas evaluations (the last one is not evaluated)
-35. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
-36. Sample $v'$ with the Fr-Sponge
-37. Derive $v$ from $v'$ using the endomorphism (TODO: specify)
-38. Sample $u'$ with the Fr-Sponge
-39. Derive $u$ from $u'$ using the endomorphism (TODO: specify)
-40. Create a list of all polynomials that will require evaluations
-    (and evaluation proofs) in the protocol.
-    First, include the previous challenges, in case we are in a recursive prover.
-41. Then, include:
-    - the negated public polynomial
-    - the ft polynomial
-    - the permutation aggregation polynomial z polynomial
-    - the generic selector
-    - the poseidon selector
-    - the 15 registers/witness columns
-    - the 6 sigmas
-    - optionally, the runtime table
-42. Create an aggregated evaluation proof for all of these polynomials at $\zeta$ and $\zeta\omega$ using $u$ and $v$.
+   TODO: do we want to specify more on that? It seems unecessary except for the t polynomial (or if for some reason someone sets that to a low value)
+1. Evaluate the same polynomials without chunking them
+   (so that each polynomial should correspond to a single value this time).
+1. Compute the ft polynomial.
+   This is to implement [Maller's optimization](https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html).
+1. construct the blinding part of the ft polynomial commitment
+   see https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html#evaluation-proof-and-blinding-factors
+1. Evaluate the ft polynomial at $\zeta\omega$ only.
+1. Setup the Fr-Sponge
+1. Squeeze the Fq-sponge and absorb the result with the Fr-Sponge.
+1. Evaluate the negated public polynomial (if present) at $\zeta$ and $\zeta\omega$.
+1. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
+	- the public polynomial
+	- z
+	- generic selector
+	- poseidon selector
+	- the 15 register/witness
+	- 6 sigmas evaluations (the last one is not evaluated)
+1. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
+1. Sample $v'$ with the Fr-Sponge
+1. Derive $v$ from $v'$ using the endomorphism (TODO: specify)
+1. Sample $u'$ with the Fr-Sponge
+1. Derive $u$ from $u'$ using the endomorphism (TODO: specify)
+1. Create a list of all polynomials that will require evaluations
+   (and evaluation proofs) in the protocol.
+   First, include the previous challenges, in case we are in a recursive prover.
+1. Then, include:
+	- the negated public polynomial
+	- the ft polynomial
+	- the permutation aggregation polynomial z polynomial
+	- the generic selector
+	- the poseidon selector
+	- the 15 registers/witness columns
+	- the 6 sigmas
+	- optionally, the runtime table
+1. Create an aggregated evaluation proof for all of these polynomials at $\zeta$ and $\zeta\omega$ using $u$ and $v$.
 
 
 ### Proof Verification
@@ -1613,43 +1616,44 @@ We define two helper algorithms below, used in the batch verification of proofs.
 We run the following algorithm:
 
 1. Setup the Fq-Sponge.
-2. Absorb the commitment of the public input polynomial with the Fq-Sponge.
-3. Absorb the commitments to the registers / witness columns with the Fq-Sponge.
-4. If lookup is used:
-   - If it involves queries to a multiple-column lookup table,
-     then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
-     otherwise set the joint combiner challenge $j'$ to $0$.
-   - Derive the scalar joint combiner challenge $j$ from $j'$ using the endomorphism.
-   (TODO: specify endomorphism)
-   - absorb the commitments to the sorted polynomials.
-5. Sample $\beta$ with the Fq-Sponge.
-6. Sample $\gamma$ with the Fq-Sponge.
-7. If using lookup, absorb the commitment to the aggregation lookup polynomial.
-8. Absorb the commitment to the permutation trace with the Fq-Sponge.
-9. Sample $\alpha'$ with the Fq-Sponge.
-10. Derive $\alpha$ from $\alpha'$ using the endomorphism (TODO: details).
-11. Enforce that the length of the $t$ commitment is of size `PERMUTS`.
-12. Absorb the commitment to the quotient polynomial $t$ into the argument.
-13. Sample $\zeta'$ with the Fq-Sponge.
-14. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify).
-15. Setup the Fr-Sponge.
-16. Squeeze the Fq-sponge and absorb the result with the Fr-Sponge.
-17. Evaluate the negated public polynomial (if present) at $\zeta$ and $\zeta\omega$.
-    NOTE: this works only in the case when the poly segment size is not smaller than that of the domain.
-18. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
-    - the public polynomial
-    - z
-    - generic selector
-    - poseidon selector
-    - the 15 register/witness
-    - 6 sigmas evaluations (the last one is not evaluated)
-19. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
-20. Sample $v'$ with the Fr-Sponge.
-21. Derive $v$ from $v'$ using the endomorphism (TODO: specify).
-22. Sample $u'$ with the Fr-Sponge.
-23. Derive $u$ from $u'$ using the endomorphism (TODO: specify).
-24. Create a list of all polynomials that have an evaluation proof.
-25. Compute the evaluation of $ft(\zeta)$.
+1. Absorb the commitment of the public input polynomial with the Fq-Sponge.
+1. Absorb the commitments to the registers / witness columns with the Fq-Sponge.
+1. If lookup is used:
+	- If it involves queries to a multiple-column lookup table,
+	  then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
+	  otherwise set the joint combiner challenge $j'$ to $0$.
+	- Derive the scalar joint combiner challenge $j$ from $j'$ using the endomorphism.
+	  (TODO: specify endomorphism)
+	- absorb the commitments to the sorted polynomials.
+1. Sample $\beta$ with the Fq-Sponge.
+1. Sample $\gamma$ with the Fq-Sponge.
+1. If using lookup, absorb the commitment to the aggregation lookup polynomial.
+1. Absorb the commitment to the permutation trace with the Fq-Sponge.
+1. Sample $\alpha'$ with the Fq-Sponge.
+1. Derive $\alpha$ from $\alpha'$ using the endomorphism (TODO: details).
+1. Enforce that the length of the $t$ commitment is of size `PERMUTS`.
+1. Absorb the commitment to the quotient polynomial $t$ into the argument.
+1. Sample $\zeta'$ with the Fq-Sponge.
+1. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify).
+1. Setup the Fr-Sponge.
+1. Squeeze the Fq-sponge and absorb the result with the Fr-Sponge.
+1. Evaluate the negated public polynomial (if present) at $\zeta$ and $\zeta\omega$.
+
+   NOTE: this works only in the case when the poly segment size is not smaller than that of the domain.
+1. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
+	- the public polynomial
+	- z
+	- generic selector
+	- poseidon selector
+	- the 15 register/witness
+	- 6 sigmas evaluations (the last one is not evaluated)
+1. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
+1. Sample $v'$ with the Fr-Sponge.
+1. Derive $v$ from $v'$ using the endomorphism (TODO: specify).
+1. Sample $u'$ with the Fr-Sponge.
+1. Derive $u$ from $u'$ using the endomorphism (TODO: specify).
+1. Create a list of all polynomials that have an evaluation proof.
+1. Compute the evaluation of $ft(\zeta)$.
 
 #### Partial verification
 
@@ -1658,8 +1662,8 @@ This allows us to potentially batch verify a number of partially verified proofs
 Essentially, this steps verifies that $f(\zeta) = t(\zeta) * Z_H(\zeta)$.
 
 1. Commit to the negated public input polynomial.
-2. Run the [Fiat-Shamir argument](#fiat-shamir-argument).
-3. Combine the chunked polynomials' evaluations
+1. Run the [Fiat-Shamir argument](#fiat-shamir-argument).
+1. Combine the chunked polynomials' evaluations
    (TODO: most likely only the quotient polynomial is chunked)
    with the right powers of $\zeta^n$ and $(\zeta * \omega)^n$.
 4. Compute the commitment to the linearized polynomial $f$.
@@ -1670,18 +1674,18 @@ Essentially, this steps verifies that $f(\zeta) = t(\zeta) * Z_H(\zeta)$.
    contained in the verifier index or in the proof,
    unless a polynomial has its evaluation provided by the proof
    in which case the evaluation should be used in place of the commitment.
-5. Compute the (chuncked) commitment of $ft$
+1. Compute the (chuncked) commitment of $ft$
    (see [Maller's optimization](../crypto/plonk/maller_15.html)).
-6. List the polynomial commitments, and their associated evaluations,
+1. List the polynomial commitments, and their associated evaluations,
    that are associated to the aggregated evaluation proof in the proof:
-    - recursion
-    - public input commitment
-    - ft commitment (chunks of it)
-    - permutation commitment
-    - index commitments that use the coefficients
-    - witness commitments
-    - sigma commitments
-    - lookup commitments
+	- recursion
+	- public input commitment
+	- ft commitment (chunks of it)
+	- permutation commitment
+	- index commitments that use the coefficients
+	- witness commitments
+	- sigma commitments
+	- lookup commitments
 #### Batch verification of proofs
 
 Below, we define the steps to verify a number of proofs
@@ -1689,9 +1693,9 @@ Below, we define the steps to verify a number of proofs
 You can, of course, use it to verify a single proof.
 
 1. If there's no proof to verify, the proof validates trivially.
-2. Ensure that all the proof's verifier index have a URS of the same length. (TODO: do they have to be the same URS though? should we check for that?)
-3. Validate each proof separately following the [partial verification](#partial-verification) steps.
-4. Use the [`PolyCom.verify`](#polynomial-commitments) to verify the partially evaluated proofs.
+1. Ensure that all the proof's verifier index have a URS of the same length. (TODO: do they have to be the same URS though? should we check for that?)
+1. Validate each proof separately following the [partial verification](#partial-verification) steps.
+1. Use the [`PolyCom.verify`](#polynomial-commitments) to verify the partially evaluated proofs.
 
 
 ## Optimizations

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -238,12 +238,12 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
                         }
                     }
 
-                    //~       - Update the corresponding entries in a table id vector (of size the domain as well)
-                    //~         with the table ID of the table.
+                    //~~ - Update the corresponding entries in a table id vector (of size the domain as well)
+                    //~    with the table ID of the table.
                     let table_id: F = i32_to_field(table.id);
                     table_ids.extend(repeat_n(table_id, table_len));
 
-                    //~       - Copy the entries from the table to new rows in the corresponding columns of the concatenated table.
+                    //~~ - Copy the entries from the table to new rows in the corresponding columns of the concatenated table.
                     for (i, col) in table.data.iter().enumerate() {
                         if col.len() != table_len {
                             return Err(LookupError::InconsistentTableLength);
@@ -251,7 +251,7 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
                         lookup_table[i].extend(col);
                     }
 
-                    //~       - Fill in any unused columns with 0 (to match the dummy value)
+                    //~~ - Fill in any unused columns with 0 (to match the dummy value)
                     for lookup_table in lookup_table.iter_mut().skip(table.data.len()) {
                         lookup_table.extend(repeat_n(F::zero(), table_len))
                     }

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -169,7 +169,7 @@ where
             return Err(ProverError::NoRoomForZkInWitness);
         }
 
-        //~ 2. Pad the witness columns with Zero gates to make them the same length as the domain.
+        //~ 1. Pad the witness columns with Zero gates to make them the same length as the domain.
         //~    Then, randomize the last `ZK_ROWS` of each columns.
         for w in &mut witness {
             if w.len() != length_witness {
@@ -185,10 +185,10 @@ where
             }
         }
 
-        //~ 3. Setup the Fq-Sponge.
+        //~ 1. Setup the Fq-Sponge.
         let mut fq_sponge = EFqSponge::new(index.fq_sponge_params.clone());
 
-        //~ 4. Compute the negated public input polynomial as
+        //~ 1. Compute the negated public input polynomial as
         //~    the polynomial that evaluates to $-p_i$ for the first `public_input_size` values of the domain,
         //~    and $0$ for the rest.
         let public = witness[0][0..index.cs.public].to_vec();
@@ -198,16 +198,18 @@ where
         )
         .interpolate();
 
-        //~ 5. Commit (non-hiding) to the negated public input polynomial.
+        //~ 1. Commit (non-hiding) to the negated public input polynomial.
         let public_comm = index.srs.commit_non_hiding(&public_poly, None);
 
-        //~ 6. Absorb the commitment to the public polynomial with the Fq-Sponge.
+        //~ 1. Absorb the commitment to the public polynomial with the Fq-Sponge.
+        //~
         //~    Note: unlike the original PLONK protocol,
         //~    the prover also provides evaluations of the public polynomial to help the verifier circuit.
         //~    This is why we need to absorb the commitment to the public polynomial at this point.
         fq_sponge.absorb_g(&public_comm.unshifted);
 
-        //~ 7. Commit to the witness columns by creating `COLUMNS` hidding commitments.
+        //~ 1. Commit to the witness columns by creating `COLUMNS` hidding commitments.
+        //~
         //~    Note: since the witness is in evaluation form,
         //~    we can use the `commit_evaluation` optimization.
         let w_comm: [(PolyComm<G>, PolyComm<ScalarField<G>>); COLUMNS] = array_init(|i| {
@@ -220,12 +222,12 @@ where
                 .commit_evaluations(index.cs.domain.d1, &e, None, rng)
         });
 
-        //~ 8. Absorb the witness commitments with the Fq-Sponge.
+        //~ 1. Absorb the witness commitments with the Fq-Sponge.
         w_comm
             .iter()
             .for_each(|c| fq_sponge.absorb_g(&c.0.unshifted));
 
-        //~ 9. Compute the witness polynomials by interpolating each `COLUMNS` of the witness.
+        //~ 1. Compute the witness polynomials by interpolating each `COLUMNS` of the witness.
         //~    TODO: why not do this first, and then commit? Why commit from evaluation directly?
         let witness_poly: [DensePolynomial<ScalarField<G>>; COLUMNS] = array_init(|i| {
             Evaluations::<ScalarField<G>, D<ScalarField<G>>>::from_vec_and_domain(
@@ -237,7 +239,7 @@ where
 
         let mut lookup_context = LookupContext::default();
 
-        //~ 10. If using lookup:
+        //~ 1. If using lookup:
         if let Some(lcs) = &index.cs.lookup_constraint_system {
             // if using runtime table
             if let Some(cfg_runtime_tables) = &lcs.configuration.runtime_tables {
@@ -304,9 +306,9 @@ where
                 lookup_context.runtime_second_col_d8 = Some(second_column_d8);
             }
 
-            //~     - If queries involve a lookup table with multiple columns
-            //~     then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
-            //~     otherwise set the joint combiner challenge $j'$ to $0$.
+            //~~ - If queries involve a lookup table with multiple columns
+            //~~   then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
+            //~~   otherwise set the joint combiner challenge $j'$ to $0$.
             let joint_lookup_used = matches!(lcs.configuration.lookup_used, LookupsUsed::Joint);
 
             let joint_combiner = if joint_lookup_used {
@@ -315,13 +317,13 @@ where
                 ScalarField::<G>::zero()
             };
 
-            //~     - Derive the scalar joint combiner $j$ from $j'$ using the endomorphism (TOOD: specify)
+            //~~ - Derive the scalar joint combiner $j$ from $j'$ using the endomorphism (TOOD: specify)
             let joint_combiner: ScalarField<G> =
                 ScalarChallenge(joint_combiner).to_field(&index.srs.endo_r);
 
-            //~     - If multiple lookup tables are involved,
-            //~      set the `table_id_combiner` as the $j^i$ with $i$ the maximum width of any used table.
-            //~      Essentially, this is to add a last column of table ids to the concatenated lookup tables.
+            //~~ - If multiple lookup tables are involved,
+            //~~   set the `table_id_combiner` as the $j^i$ with $i$ the maximum width of any used table.
+            //~~   Essentially, this is to add a last column of table ids to the concatenated lookup tables.
             let table_id_combiner: ScalarField<G> = if lcs.table_ids8.as_ref().is_some() {
                 joint_combiner.pow([lcs.configuration.max_joint_size as u64])
             } else {
@@ -330,15 +332,15 @@ where
             };
             lookup_context.table_id_combiner = Some(table_id_combiner);
 
-            //~     - Compute the dummy lookup value as the combination of the last entry of the XOR table (so `(0, 0, 0)`).
-            //~      Warning: This assumes that we always use the XOR table when using lookups.
+            //~~ - Compute the dummy lookup value as the combination of the last entry of the XOR table (so `(0, 0, 0)`).
+            //~~   Warning: This assumes that we always use the XOR table when using lookups.
             let dummy_lookup_value = lcs
                 .configuration
                 .dummy_lookup
                 .evaluate(&joint_combiner, &table_id_combiner);
             lookup_context.dummy_lookup_value = Some(dummy_lookup_value);
 
-            //~     - Compute the lookup table values as the combination of the lookup table entries.
+            //~~ - Compute the lookup table values as the combination of the lookup table entries.
             let joint_lookup_table_d8 = {
                 let mut evals = Vec::with_capacity(d1_size);
 
@@ -389,7 +391,7 @@ where
 
             let joint_lookup_table = joint_lookup_table_d8.interpolate_by_ref();
 
-            //~      - Compute the sorted evaluations.
+            //~~ - Compute the sorted evaluations.
             // TODO: Once we switch to committing using lagrange commitments,
             // `witness` will be consumed when we interpolate, so interpolation will
             // have to moved below this.
@@ -403,14 +405,14 @@ where
                 table_id_combiner,
             )?;
 
-            //~      - Randomize the last `EVALS` rows in each of the sorted polynomials
-            //~       in order to add zero-knowledge to the protocol.
+            //~~ - Randomize the last `EVALS` rows in each of the sorted polynomials
+            //~~   in order to add zero-knowledge to the protocol.
             let sorted: Vec<_> = sorted
                 .into_iter()
                 .map(|chunk| lookup::constraints::zk_patch(chunk, index.cs.domain.d1, rng))
                 .collect();
 
-            //~      - Commit each of the sorted polynomials.
+            //~~ - Commit each of the sorted polynomials.
             let sorted_comms: Vec<_> = sorted
                 .iter()
                 .map(|v| {
@@ -420,7 +422,7 @@ where
                 })
                 .collect();
 
-            //~      - Absorb each commitments to the sorted polynomials.
+            //~~ - Absorb each commitments to the sorted polynomials.
             sorted_comms
                 .iter()
                 .for_each(|c| fq_sponge.absorb_g(&c.0.unshifted));
@@ -442,15 +444,15 @@ where
             lookup_context.joint_lookup_table = Some(joint_lookup_table);
         }
 
-        //~ 11. Sample $\beta$ with the Fq-Sponge.
+        //~ 1. Sample $\beta$ with the Fq-Sponge.
         let beta = fq_sponge.challenge();
 
-        //~ 12. Sample $\gamma$ with the Fq-Sponge.
+        //~ 1. Sample $\gamma$ with the Fq-Sponge.
         let gamma = fq_sponge.challenge();
 
-        //~ 13. If using lookup:
+        //~ 1. If using lookup:
         if index.cs.lookup_constraint_system.is_some() {
-            //~     - Compute the lookup aggregation polynomial.
+            //~~ - Compute the lookup aggregation polynomial.
             let joint_lookup_table_d8 = lookup_context.joint_lookup_table_d8.as_ref().unwrap();
 
             let aggreg = lookup::constraints::aggregation::<_, ScalarField<G>>(
@@ -467,12 +469,12 @@ where
                 rng,
             )?;
 
-            //~     - Commit to the aggregation polynomial.
+            //~~ - Commit to the aggregation polynomial.
             let aggreg_comm = index
                 .srs
                 .commit_evaluations(index.cs.domain.d1, &aggreg, None, rng);
 
-            //~     - Absorb the commitment to the aggregation polynomial with the Fq-Sponge.
+            //~~ - Absorb the commitment to the aggregation polynomial with the Fq-Sponge.
             fq_sponge.absorb_g(&aggreg_comm.0.unshifted);
 
             // precompute different forms of the aggregation polynomial for later
@@ -486,33 +488,33 @@ where
             lookup_context.aggreg8 = Some(aggreg8);
         }
 
-        //~ 14. Compute the permutation aggregation polynomial $z$.
+        //~ 1. Compute the permutation aggregation polynomial $z$.
         let z_poly = index.cs.perm_aggreg(&witness, &beta, &gamma, rng)?;
 
-        //~ 15. Commit (hidding) to the permutation aggregation polynomial $z$.
+        //~ 1. Commit (hidding) to the permutation aggregation polynomial $z$.
         let z_comm = index.srs.commit(&z_poly, None, rng);
 
-        //~ 16. Absorb the permutation aggregation polynomial $z$ with the Fq-Sponge.
+        //~ 1. Absorb the permutation aggregation polynomial $z$ with the Fq-Sponge.
         fq_sponge.absorb_g(&z_comm.0.unshifted);
 
-        //~ 17. Sample $\alpha'$ with the Fq-Sponge.
+        //~ 1. Sample $\alpha'$ with the Fq-Sponge.
         let alpha_chal = ScalarChallenge(fq_sponge.challenge());
 
-        //~ 18. Derive $\alpha$ from $\alpha'$ using the endomorphism (TODO: details)
+        //~ 1. Derive $\alpha$ from $\alpha'$ using the endomorphism (TODO: details)
         let alpha: ScalarField<G> = alpha_chal.to_field(&index.srs.endo_r);
 
-        //~ 19. TODO: instantiate alpha?
+        //~ 1. TODO: instantiate alpha?
         let mut all_alphas = index.powers_of_alpha.clone();
         all_alphas.instantiate(alpha);
 
-        //~ 20. Compute the quotient polynomial (the $t$ in $f = Z_H \cdot t$).
-        //~     The quotient polynomial is computed by adding all these polynomials together:
-        //~     - the combined constraints for all the gates
-        //~     - the combined constraints for the permutation
-        //~     - TODO: lookup
-        //~     - the negated public polynomial
-        //~     and by then dividing the resulting polynomial with the vanishing polynomial $Z_H$.
-        //~     TODO: specify the split of the permutation polynomial into perm and bnd?
+        //~ 1. Compute the quotient polynomial (the $t$ in $f = Z_H \cdot t$).
+        //~    The quotient polynomial is computed by adding all these polynomials together:
+        //~~ - the combined constraints for all the gates
+        //~~ - the combined constraints for the permutation
+        //~~ - TODO: lookup
+        //~~ - the negated public polynomial
+        //~    and by then dividing the resulting polynomial with the vanishing polynomial $Z_H$.
+        //~    TODO: specify the split of the permutation polynomial into perm and bnd?
         let lookup_env = if let Some(lcs) = &index.cs.lookup_constraint_system {
             let joint_lookup_table_d8 = lookup_context.joint_lookup_table_d8.as_ref().unwrap();
 
@@ -742,8 +744,8 @@ where
             quotient
         };
 
-        //~ 21. commit (hiding) to the quotient polynomial $t$
-        //~     TODO: specify the dummies
+        //~ 1. commit (hiding) to the quotient polynomial $t$
+        //~    TODO: specify the dummies
         let t_comm = {
             let (mut t_comm, mut omega_t) = index.srs.commit(&quotient_poly, None, rng);
 
@@ -761,28 +763,28 @@ where
             (t_comm, omega_t)
         };
 
-        //~ 22. Absorb the the commitment of the quotient polynomial with the Fq-Sponge.
+        //~ 1. Absorb the the commitment of the quotient polynomial with the Fq-Sponge.
         fq_sponge.absorb_g(&t_comm.0.unshifted);
 
-        //~ 23. Sample $\zeta'$ with the Fq-Sponge.
+        //~ 1. Sample $\zeta'$ with the Fq-Sponge.
         let zeta_chal = ScalarChallenge(fq_sponge.challenge());
 
-        //~ 24. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify)
+        //~ 1. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify)
         let zeta = zeta_chal.to_field(&index.srs.endo_r);
 
         let omega = index.cs.domain.d1.group_gen;
         let zeta_omega = zeta * omega;
 
-        //~ 25. If lookup is used, evaluate the following polynomials at $\zeta$ and $\zeta \omega$:
+        //~ 1. If lookup is used, evaluate the following polynomials at $\zeta$ and $\zeta \omega$:
         if index.cs.lookup_constraint_system.is_some() {
-            //~     - the aggregation polynomial
+            //~~ - the aggregation polynomial
             let aggreg = lookup_context
                 .aggreg_coeffs
                 .as_ref()
                 .unwrap()
                 .to_chunked_polynomial(index.max_poly_size);
 
-            //~     - the sorted polynomials
+            //~~ - the sorted polynomials
             let sorted = lookup_context
                 .sorted_coeffs
                 .as_ref()
@@ -790,7 +792,7 @@ where
                 .iter()
                 .map(|c| c.to_chunked_polynomial(index.max_poly_size));
 
-            // ~     - the table polynonial
+            //~~ - the table polynonial
             let joint_table = lookup_context.joint_lookup_table.as_ref().unwrap();
             let joint_table = joint_table.to_chunked_polynomial(index.max_poly_size);
 
@@ -818,24 +820,24 @@ where
             lookup_context.eval_zeta_omega = Some(lookup_evals(zeta_omega));
         }
 
-        //~ 26. Chunk evaluate the following polynomials at both $\zeta$ and $\zeta \omega$:
-        //~     * $s_i$
-        //~     * $w_i$
-        //~     * $z$
-        //~     * lookup (TODO)
-        //~     * generic selector
-        //~     * poseidon selector
+        //~ 1. Chunk evaluate the following polynomials at both $\zeta$ and $\zeta \omega$:
+        //~~ - $s_i$
+        //~~ - $w_i$
+        //~~ - $z$
+        //~~ - lookup (TODO)
+        //~~ - generic selector
+        //~~ - poseidon selector
         //~
-        //~     By "chunk evaluate" we mean that the evaluation of each polynomial can potentially be a vector of values.
-        //~     This is because the index's `max_poly_size` parameter dictates the maximum size of a polynomial in the protocol.
-        //~     If a polynomial $f$ exceeds this size, it must be split into several polynomials like so:
-        //~     $$f(x) = f_0(x) + x^n f_1(x) + x^{2n} f_2(x) + \cdots$$
+        //~    By "chunk evaluate" we mean that the evaluation of each polynomial can potentially be a vector of values.
+        //~    This is because the index's `max_poly_size` parameter dictates the maximum size of a polynomial in the protocol.
+        //~    If a polynomial $f$ exceeds this size, it must be split into several polynomials like so:
+        //~    $$f(x) = f_0(x) + x^n f_1(x) + x^{2n} f_2(x) + \cdots$$
         //~
-        //~     And the evaluation of such a polynomial is the following list for $x \in {\zeta, \zeta\omega}$:
+        //~    And the evaluation of such a polynomial is the following list for $x \in {\zeta, \zeta\omega}$:
         //~
-        //~     $$(f_0(x), f_1(x), f_2(x), \ldots)$$
+        //~    $$(f_0(x), f_1(x), f_2(x), \ldots)$$
         //~
-        //~      TODO: do we want to specify more on that? It seems unecessary except for the t polynomial (or if for some reason someone sets that to a low value)
+        //~    TODO: do we want to specify more on that? It seems unecessary except for the t polynomial (or if for some reason someone sets that to a low value)
         let chunked_evals = {
             let chunked_evals_zeta = ProofEvaluations::<Vec<ScalarField<G>>> {
                 s: array_init(|i| {
@@ -906,8 +908,8 @@ where
         let zeta_omega_to_srs_len = zeta.pow(&[index.max_poly_size as u64]);
         let zeta_to_domain_size = zeta.pow(&[d1_size as u64]);
 
-        //~ 27. Evaluate the same polynomials without chunking them
-        //~     (so that each polynomial should correspond to a single value this time).
+        //~ 1. Evaluate the same polynomials without chunking them
+        //~    (so that each polynomial should correspond to a single value this time).
         let evals = {
             let power_of_eval_points_for_chunks = [zeta_to_srs_len, zeta_omega_to_srs_len];
             &chunked_evals
@@ -936,8 +938,8 @@ where
                 .collect::<Vec<_>>()
         };
 
-        //~ 28. Compute the ft polynomial.
-        //~     This is to implement [Maller's optimization](https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html).
+        //~ 1. Compute the ft polynomial.
+        //~    This is to implement [Maller's optimization](https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html).
         let ft: DensePolynomial<ScalarField<G>> = {
             let f_chunked = {
                 // TODO: compute the linearization polynomial in evaluation form so
@@ -977,8 +979,8 @@ where
             &f_chunked - &t_chunked.scale(zeta_to_domain_size - ScalarField::<G>::one())
         };
 
-        //~ 29. construct the blinding part of the ft polynomial commitment
-        //~     see https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html#evaluation-proof-and-blinding-factors
+        //~ 1. construct the blinding part of the ft polynomial commitment
+        //~    see https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html#evaluation-proof-and-blinding-factors
         let blinding_ft = {
             let blinding_t = t_comm.1.chunk_blinding(zeta_to_srs_len);
             let blinding_f = ScalarField::<G>::zero();
@@ -992,17 +994,17 @@ where
             }
         };
 
-        //~ 30. Evaluate the ft polynomial at $\zeta\omega$ only.
+        //~ 1. Evaluate the ft polynomial at $\zeta\omega$ only.
         let ft_eval1 = ft.evaluate(&zeta_omega);
 
-        //~ 31. Setup the Fr-Sponge
+        //~ 1. Setup the Fr-Sponge
         let fq_sponge_before_evaluations = fq_sponge.clone();
         let mut fr_sponge = EFrSponge::new(index.cs.fr_sponge_params.clone());
 
-        //~ 32. Squeeze the Fq-sponge and absorb the result with the Fr-Sponge.
+        //~ 1. Squeeze the Fq-sponge and absorb the result with the Fr-Sponge.
         fr_sponge.absorb(&fq_sponge.digest());
 
-        //~ 33. Evaluate the negated public polynomial (if present) at $\zeta$ and $\zeta\omega$.
+        //~ 1. Evaluate the negated public polynomial (if present) at $\zeta$ and $\zeta\omega$.
         let public_evals = if public_poly.is_zero() {
             [Vec::new(), Vec::new()]
         } else {
@@ -1012,35 +1014,35 @@ where
             ]
         };
 
-        //~ 34. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
-        //~     - the public polynomial
-        //~     - z
-        //~     - generic selector
-        //~     - poseidon selector
-        //~     - the 15 register/witness
-        //~     - 6 sigmas evaluations (the last one is not evaluated)
+        //~ 1. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
+        //~~ - the public polynomial
+        //~~ - z
+        //~~ - generic selector
+        //~~ - poseidon selector
+        //~~ - the 15 register/witness
+        //~~ - 6 sigmas evaluations (the last one is not evaluated)
         for i in 0..2 {
             fr_sponge.absorb_evaluations(&public_evals[i], &chunked_evals[i])
         }
 
-        //~ 35. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
+        //~ 1. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
         fr_sponge.absorb(&ft_eval1);
 
-        //~ 36. Sample $v'$ with the Fr-Sponge
+        //~ 1. Sample $v'$ with the Fr-Sponge
         let v_chal = fr_sponge.challenge();
 
-        //~ 37. Derive $v$ from $v'$ using the endomorphism (TODO: specify)
+        //~ 1. Derive $v$ from $v'$ using the endomorphism (TODO: specify)
         let v = v_chal.to_field(&index.srs.endo_r);
 
-        //~ 38. Sample $u'$ with the Fr-Sponge
+        //~ 1. Sample $u'$ with the Fr-Sponge
         let u_chal = fr_sponge.challenge();
 
-        //~ 39. Derive $u$ from $u'$ using the endomorphism (TODO: specify)
+        //~ 1. Derive $u$ from $u'$ using the endomorphism (TODO: specify)
         let u = u_chal.to_field(&index.srs.endo_r);
 
-        //~ 40. Create a list of all polynomials that will require evaluations
-        //~     (and evaluation proofs) in the protocol.
-        //~     First, include the previous challenges, in case we are in a recursive prover.
+        //~ 1. Create a list of all polynomials that will require evaluations
+        //~    (and evaluation proofs) in the protocol.
+        //~    First, include the previous challenges, in case we are in a recursive prover.
         let non_hiding = |d1_size: usize| PolyComm {
             unshifted: vec![ScalarField::<G>::zero(); d1_size],
             shifted: None,
@@ -1061,15 +1063,15 @@ where
             .map(|(p, d1_size)| (p, None, non_hiding(*d1_size)))
             .collect::<Vec<_>>();
 
-        //~ 41. Then, include:
-        //~     - the negated public polynomial
-        //~     - the ft polynomial
-        //~     - the permutation aggregation polynomial z polynomial
-        //~     - the generic selector
-        //~     - the poseidon selector
-        //~     - the 15 registers/witness columns
-        //~     - the 6 sigmas
-        //~     - optionally, the runtime table
+        //~ 1. Then, include:
+        //~~ - the negated public polynomial
+        //~~ - the ft polynomial
+        //~~ - the permutation aggregation polynomial z polynomial
+        //~~ - the generic selector
+        //~~ - the poseidon selector
+        //~~ - the 15 registers/witness columns
+        //~~ - the 6 sigmas
+        //~~ - optionally, the runtime table
         polynomials.extend(vec![(&public_poly, None, non_hiding(1))]);
         polynomials.extend(vec![(&ft, None, blinding_ft)]);
         polynomials.extend(vec![(&z_poly, None, z_comm.1)]);
@@ -1133,7 +1135,7 @@ where
             }
         }
 
-        //~ 42. Create an aggregated evaluation proof for all of these polynomials at $\zeta$ and $\zeta\omega$ using $u$ and $v$.
+        //~ 1. Create an aggregated evaluation proof for all of these polynomials at $\zeta$ and $\zeta\omega$ using $u$ and $v$.
         let proof = index.srs.open(
             group_map,
             &polynomials,

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -128,16 +128,16 @@ where
         //~ 1. Setup the Fq-Sponge.
         let mut fq_sponge = EFqSponge::new(index.fq_sponge_params.clone());
 
-        //~ 2. Absorb the commitment of the public input polynomial with the Fq-Sponge.
+        //~ 1. Absorb the commitment of the public input polynomial with the Fq-Sponge.
         fq_sponge.absorb_g(&p_comm.unshifted);
 
-        //~ 3. Absorb the commitments to the registers / witness columns with the Fq-Sponge.
+        //~ 1. Absorb the commitments to the registers / witness columns with the Fq-Sponge.
         self.commitments
             .w_comm
             .iter()
             .for_each(|c| fq_sponge.absorb_g(&c.unshifted));
 
-        //~ 4. If lookup is used:
+        //~ 1. If lookup is used:
         let joint_combiner = if let Some(l) = &index.lookup_index {
             let lookup_commits = self
                 .commitments
@@ -154,9 +154,9 @@ where
                 fq_sponge.absorb_g(&runtime_commit.unshifted);
             }
 
-            //~    - If it involves queries to a multiple-column lookup table,
-            //~      then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
-            //~      otherwise set the joint combiner challenge $j'$ to $0$.
+            //~~ - If it involves queries to a multiple-column lookup table,
+            //~~   then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
+            //~~   otherwise set the joint combiner challenge $j'$ to $0$.
             let joint_lookup_used = matches!(l.lookup_used, LookupsUsed::Joint);
             let joint_combiner = if joint_lookup_used {
                 fq_sponge.challenge()
@@ -164,12 +164,12 @@ where
                 ScalarField::<G>::zero()
             };
 
-            //~    - Derive the scalar joint combiner challenge $j$ from $j'$ using the endomorphism.
-            //~    (TODO: specify endomorphism)
+            //~~ - Derive the scalar joint combiner challenge $j$ from $j'$ using the endomorphism.
+            //~~   (TODO: specify endomorphism)
             let joint_combiner = ScalarChallenge(joint_combiner);
             let joint_combiner = (joint_combiner, joint_combiner.to_field(&index.srs.endo_r));
 
-            //~    - absorb the commitments to the sorted polynomials.
+            //~~ - absorb the commitments to the sorted polynomials.
             for com in &lookup_commits.sorted {
                 fq_sponge.absorb_g(&com.unshifted);
             }
@@ -179,45 +179,45 @@ where
             None
         };
 
-        //~ 5. Sample $\beta$ with the Fq-Sponge.
+        //~ 1. Sample $\beta$ with the Fq-Sponge.
         let beta = fq_sponge.challenge();
 
-        //~ 6. Sample $\gamma$ with the Fq-Sponge.
+        //~ 1. Sample $\gamma$ with the Fq-Sponge.
         let gamma = fq_sponge.challenge();
 
-        //~ 7. If using lookup, absorb the commitment to the aggregation lookup polynomial.
+        //~ 1. If using lookup, absorb the commitment to the aggregation lookup polynomial.
         self.commitments.lookup.iter().for_each(|l| {
             fq_sponge.absorb_g(&l.aggreg.unshifted);
         });
 
-        //~ 8. Absorb the commitment to the permutation trace with the Fq-Sponge.
+        //~ 1. Absorb the commitment to the permutation trace with the Fq-Sponge.
         fq_sponge.absorb_g(&self.commitments.z_comm.unshifted);
 
-        //~ 9. Sample $\alpha'$ with the Fq-Sponge.
+        //~ 1. Sample $\alpha'$ with the Fq-Sponge.
         let alpha_chal = ScalarChallenge(fq_sponge.challenge());
 
-        //~ 10. Derive $\alpha$ from $\alpha'$ using the endomorphism (TODO: details).
+        //~ 1. Derive $\alpha$ from $\alpha'$ using the endomorphism (TODO: details).
         let alpha = alpha_chal.to_field(&index.srs.endo_r);
 
-        //~ 11. Enforce that the length of the $t$ commitment is of size `PERMUTS`.
+        //~ 1. Enforce that the length of the $t$ commitment is of size `PERMUTS`.
         if self.commitments.t_comm.unshifted.len() != PERMUTS {
             return Err(VerifyError::IncorrectCommitmentLength("t"));
         }
 
-        //~ 12. Absorb the commitment to the quotient polynomial $t$ into the argument.
+        //~ 1. Absorb the commitment to the quotient polynomial $t$ into the argument.
         fq_sponge.absorb_g(&self.commitments.t_comm.unshifted);
 
-        //~ 13. Sample $\zeta'$ with the Fq-Sponge.
+        //~ 1. Sample $\zeta'$ with the Fq-Sponge.
         let zeta_chal = ScalarChallenge(fq_sponge.challenge());
 
-        //~ 14. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify).
+        //~ 1. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify).
         let zeta = zeta_chal.to_field(&index.srs.endo_r);
 
-        //~ 15. Setup the Fr-Sponge.
+        //~ 1. Setup the Fr-Sponge.
         let digest = fq_sponge.clone().digest();
         let mut fr_sponge = EFrSponge::new(index.fr_sponge_params.clone());
 
-        //~ 16. Squeeze the Fq-sponge and absorb the result with the Fr-Sponge.
+        //~ 1. Squeeze the Fq-sponge and absorb the result with the Fr-Sponge.
         fr_sponge.absorb(&digest);
 
         // prepare some often used values
@@ -239,8 +239,9 @@ where
 
         ark_ff::fields::batch_inversion::<ScalarField<G>>(&mut zeta_minus_x);
 
-        //~ 17. Evaluate the negated public polynomial (if present) at $\zeta$ and $\zeta\omega$.
-        //~     NOTE: this works only in the case when the poly segment size is not smaller than that of the domain.
+        //~ 1. Evaluate the negated public polynomial (if present) at $\zeta$ and $\zeta\omega$.
+        //~
+        //~    NOTE: this works only in the case when the poly segment size is not smaller than that of the domain.
         let p_eval = if !self.public.is_empty() {
             vec![
                 vec![
@@ -270,33 +271,33 @@ where
             vec![Vec::<ScalarField<G>>::new(), Vec::<ScalarField<G>>::new()]
         };
 
-        //~ 18. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
-        //~     - the public polynomial
-        //~     - z
-        //~     - generic selector
-        //~     - poseidon selector
-        //~     - the 15 register/witness
-        //~     - 6 sigmas evaluations (the last one is not evaluated)
+        //~ 1. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
+        //~~ - the public polynomial
+        //~~ - z
+        //~~ - generic selector
+        //~~ - poseidon selector
+        //~~ - the 15 register/witness
+        //~~ - 6 sigmas evaluations (the last one is not evaluated)
         for (p, e) in p_eval.iter().zip(&self.evals) {
             fr_sponge.absorb_evaluations(p, e);
         }
 
-        //~ 19. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
+        //~ 1. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
         fr_sponge.absorb(&self.ft_eval1);
 
-        //~ 20. Sample $v'$ with the Fr-Sponge.
+        //~ 1. Sample $v'$ with the Fr-Sponge.
         let v_chal = fr_sponge.challenge();
 
-        //~ 21. Derive $v$ from $v'$ using the endomorphism (TODO: specify).
+        //~ 1. Derive $v$ from $v'$ using the endomorphism (TODO: specify).
         let v = v_chal.to_field(&index.srs.endo_r);
 
-        //~ 22. Sample $u'$ with the Fr-Sponge.
+        //~ 1. Sample $u'$ with the Fr-Sponge.
         let u_chal = fr_sponge.challenge();
 
-        //~ 23. Derive $u$ from $u'$ using the endomorphism (TODO: specify).
+        //~ 1. Derive $u$ from $u'$ using the endomorphism (TODO: specify).
         let u = u_chal.to_field(&index.srs.endo_r);
 
-        //~ 24. Create a list of all polynomials that have an evaluation proof.
+        //~ 1. Create a list of all polynomials that have an evaluation proof.
         let evaluation_points = [zeta, zetaw];
         let powers_of_eval_points_for_chunks = [
             zeta.pow(&[index.max_poly_size as u64]),
@@ -315,7 +316,7 @@ where
             self.evals[1].combine(powers_of_eval_points_for_chunks[1]),
         ];
 
-        //~ 25. Compute the evaluation of $ft(\zeta)$.
+        //~ 1. Compute the evaluation of $ft(\zeta)$.
         let ft_eval0 = {
             let zkp = index.zkpm.evaluate(&zeta);
             let zeta1m1 = zeta1 - ScalarField::<G>::one();
@@ -504,7 +505,7 @@ where
     let elm: Vec<_> = proof.public.iter().map(|s| -*s).collect();
     let p_comm = PolyComm::<G>::multi_scalar_mul(&com_ref, &elm);
 
-    //~ 2. Run the [Fiat-Shamir argument](#fiat-shamir-argument).
+    //~ 1. Run the [Fiat-Shamir argument](#fiat-shamir-argument).
     let OraclesResult {
         fq_sponge,
         oracles,
@@ -517,7 +518,7 @@ where
         ..
     } = proof.oracles::<EFqSponge, EFrSponge>(index, &p_comm)?;
 
-    //~ 3. Combine the chunked polynomials' evaluations
+    //~ 1. Combine the chunked polynomials' evaluations
     //~    (TODO: most likely only the quotient polynomial is chunked)
     //~    with the right powers of $\zeta^n$ and $(\zeta * \omega)^n$.
     let evals = vec![
@@ -671,7 +672,7 @@ where
         PolyComm::multi_scalar_mul(&commitments, &scalars)
     };
 
-    //~ 5. Compute the (chuncked) commitment of $ft$
+    //~ 1. Compute the (chuncked) commitment of $ft$
     //~    (see [Maller's optimization](../crypto/plonk/maller_15.html)).
     let ft_comm = {
         let zeta_to_srs_len = oracles.zeta.pow(&[index.max_poly_size as u64]);
@@ -680,39 +681,39 @@ where
         &chunked_f_comm - &chunked_t_comm.scale(zeta_to_domain_size - ScalarField::<G>::one())
     };
 
-    //~ 6. List the polynomial commitments, and their associated evaluations,
+    //~ 1. List the polynomial commitments, and their associated evaluations,
     //~    that are associated to the aggregated evaluation proof in the proof:
     let mut evaluations = vec![];
 
-    //~     - recursion
+    //~~ - recursion
     evaluations.extend(polys.into_iter().map(|(c, e)| Evaluation {
         commitment: c,
         evaluations: e,
         degree_bound: None,
     }));
 
-    //~     - public input commitment
+    //~~ - public input commitment
     evaluations.push(Evaluation {
         commitment: p_comm,
         evaluations: p_eval,
         degree_bound: None,
     });
 
-    //~     - ft commitment (chunks of it)
+    //~~ - ft commitment (chunks of it)
     evaluations.push(Evaluation {
         commitment: ft_comm,
         evaluations: vec![vec![ft_eval0], vec![proof.ft_eval1]],
         degree_bound: None,
     });
 
-    //~     - permutation commitment
+    //~~ - permutation commitment
     evaluations.push(Evaluation {
         commitment: proof.commitments.z_comm.clone(),
         evaluations: proof.evals.iter().map(|e| e.z.clone()).collect(),
         degree_bound: None,
     });
 
-    //~     - index commitments that use the coefficients
+    //~~ - index commitments that use the coefficients
     evaluations.push(Evaluation {
         commitment: index.generic_comm.clone(),
         evaluations: proof
@@ -732,7 +733,7 @@ where
         degree_bound: None,
     });
 
-    //~     - witness commitments
+    //~~ - witness commitments
     evaluations.extend(
         proof
             .commitments
@@ -756,7 +757,7 @@ where
             }),
     );
 
-    //~     - sigma commitments
+    //~~ - sigma commitments
     evaluations.extend(
         index
             .sigma_comm
@@ -779,7 +780,7 @@ where
             }),
     );
 
-    //~     - lookup commitments
+    //~~ - lookup commitments
     if let Some(li) = &index.lookup_index {
         let lookup_comms = proof
             .commitments
@@ -925,7 +926,7 @@ where
         return Ok(());
     }
 
-    //~ 2. Ensure that all the proof's verifier index have a URS of the same length. (TODO: do they have to be the same URS though? should we check for that?)
+    //~ 1. Ensure that all the proof's verifier index have a URS of the same length. (TODO: do they have to be the same URS though? should we check for that?)
     // TODO: Account for the different SRS lengths
     let srs = &proofs[0].0.srs;
     for (index, _) in proofs.iter() {
@@ -939,13 +940,13 @@ where
         }
     }
 
-    //~ 3. Validate each proof separately following the [partial verification](#partial-verification) steps.
+    //~ 1. Validate each proof separately following the [partial verification](#partial-verification) steps.
     let mut batch = vec![];
     for (index, proof) in proofs {
         batch.push(to_batch::<G, EFqSponge, EFrSponge>(index, proof)?);
     }
 
-    //~ 4. Use the [`PolyCom.verify`](#polynomial-commitments) to verify the partially evaluated proofs.
+    //~ 1. Use the [`PolyCom.verify`](#polynomial-commitments) to verify the partially evaluated proofs.
     match srs.verify::<EFqSponge, _>(group_map, &mut batch, &mut thread_rng()) {
         false => Err(VerifyError::OpenProof),
         true => Ok(()),


### PR DESCRIPTION
New version of cargo spec allows us to use `//~~` for nested lists, which will make it nicer to write specs.
Also, I just use `1.` everywhere for lists, which is easier to maintain as we move things around or add/remove steps.