### PR TITLE
Use explicitly-labelled lookup selectors

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1207,7 +1207,7 @@ pub struct LookupVerifierIndex<G: CommitmentCurve> {
     #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
     pub lookup_table: Vec<PolyComm<G>>,
     #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
-    pub lookup_selectors: Vec<PolyComm<G>>,
+    pub lookup_selectors: LookupSelectors<PolyComm<G>>,
 
     /// Table IDs for the lookup values.
     /// This may be `None` if all lookups originate from table 0.

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -114,7 +114,7 @@ impl<'a, F: FftField> Environment<'a, F> {
             Witness(i) => Some(&self.witness[*i]),
             Coefficient(i) => Some(&self.coefficient[*i]),
             Z => Some(self.z),
-            LookupKindIndex(i) => lookup.map(|l| &l.selectors[*i]),
+            LookupKindIndex(i) => lookup.and_then(|l| l.selectors[*i].as_ref()),
             LookupSorted(i) => lookup.map(|l| &l.sorted[*i]),
             LookupAggreg => lookup.map(|l| l.aggreg),
             LookupTable => lookup.map(|l| l.table),

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -2,6 +2,7 @@ use crate::{
     circuits::{
         domains::EvaluationDomains,
         gate::{CurrOrNext, GateType},
+        lookup::index::LookupSelectors,
         polynomials::permutation::eval_vanishes_on_last_4_rows,
         wires::COLUMNS,
     },
@@ -70,7 +71,7 @@ pub struct LookupEnvironment<'a, F: FftField> {
     /// The lookup aggregation polynomials.
     pub aggreg: &'a Evaluations<F, D<F>>,
     /// The lookup-type selector polynomials.
-    pub selectors: &'a Vec<Evaluations<F, D<F>>>,
+    pub selectors: &'a LookupSelectors<Evaluations<F, D<F>>>,
     /// The evaluations of the combined lookup table polynomial.
     pub table: &'a Evaluations<F, D<F>>,
     /// The evaluations of the optional runtime selector polynomial.

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -2,7 +2,7 @@ use crate::{
     circuits::{
         domains::EvaluationDomains,
         gate::{CurrOrNext, GateType},
-        lookup::index::LookupSelectors,
+        lookup::{index::LookupSelectors, lookups::LookupPattern},
         polynomials::permutation::eval_vanishes_on_last_4_rows,
         wires::COLUMNS,
     },
@@ -154,7 +154,7 @@ pub enum Column {
     LookupSorted(usize),
     LookupAggreg,
     LookupTable,
-    LookupKindIndex(usize),
+    LookupKindIndex(LookupPattern),
     LookupRuntimeSelector,
     LookupRuntimeTable,
     Index(GateType),
@@ -176,7 +176,7 @@ impl Column {
             Column::LookupSorted(i) => format!("s_{{{}}}", i),
             Column::LookupAggreg => "a".to_string(),
             Column::LookupTable => "t".to_string(),
-            Column::LookupKindIndex(i) => format!("k_{{{}}}", i),
+            Column::LookupKindIndex(i) => format!("k_{{{:?}}}", i),
             Column::LookupRuntimeSelector => "rts".to_string(),
             Column::LookupRuntimeTable => "rt".to_string(),
             Column::Index(gate) => {

--- a/kimchi/src/circuits/lookup/constraints.rs
+++ b/kimchi/src/circuits/lookup/constraints.rs
@@ -374,8 +374,7 @@ pub fn constraints<F: FftField>(configuration: &LookupConfiguration<F>) -> Vec<E
             let lookup_indicator = lookup_info
                 .kinds
                 .iter()
-                .enumerate()
-                .map(|(i, _)| column(Column::LookupKindIndex(i)))
+                .map(|spec| column(Column::LookupKindIndex(*spec)))
                 .fold(E::zero(), |acc: E<F>, x| acc + x);
 
             E::one() - lookup_indicator
@@ -455,8 +454,7 @@ pub fn constraints<F: FftField>(configuration: &LookupConfiguration<F>) -> Vec<E
             lookup_info
                 .kinds
                 .iter()
-                .enumerate()
-                .map(|(i, spec)| column(Column::LookupKindIndex(i)) * f_term(&spec.lookups::<F>()))
+                .map(|spec| column(Column::LookupKindIndex(*spec)) * f_term(&spec.lookups::<F>()))
                 .fold(dummy_rows, |acc, x| acc + x)
         };
 

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -119,6 +119,9 @@ impl<T> LookupSelectors<T> {
             chacha_final,
             lookup_gate,
         } = self;
+        // This closure isn't really redundant -- it shields the parameter from a copy -- but
+        // clippy isn't smart enough to figure that out..
+        #[allow(clippy::redundant_closure)]
         let f = |x| f(x);
         LookupSelectors {
             chacha: chacha.map(f),

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -91,13 +91,13 @@ impl<'de, F: FftField> serde_with::DeserializeAs<'de, LookupSelectors<E<F, D<F>>
 }
 
 impl<T> std::ops::Index<LookupPattern> for LookupSelectors<T> {
-    type Output = T;
+    type Output = Option<T>;
 
     fn index(&self, index: LookupPattern) -> &Self::Output {
         match index {
-            LookupPattern::ChaCha => self.chacha.as_ref().expect("has chacha"),
-            LookupPattern::ChaChaFinal => self.chacha_final.as_ref().expect("has chacha_final"),
-            LookupPattern::LookupGate => self.lookup_gate.as_ref().expect("has lookup_gate"),
+            LookupPattern::ChaCha => &self.chacha,
+            LookupPattern::ChaChaFinal => &self.chacha_final,
+            LookupPattern::LookupGate => &self.lookup_gate,
         }
     }
 }
@@ -105,9 +105,9 @@ impl<T> std::ops::Index<LookupPattern> for LookupSelectors<T> {
 impl<T> std::ops::IndexMut<LookupPattern> for LookupSelectors<T> {
     fn index_mut(&mut self, index: LookupPattern) -> &mut Self::Output {
         match index {
-            LookupPattern::ChaCha => self.chacha.as_mut().expect("has chacha"),
-            LookupPattern::ChaChaFinal => self.chacha_final.as_mut().expect("has chacha_final"),
-            LookupPattern::LookupGate => self.lookup_gate.as_mut().expect("has lookup_gate"),
+            LookupPattern::ChaCha => &mut self.chacha,
+            LookupPattern::ChaChaFinal => &mut self.chacha_final,
+            LookupPattern::LookupGate => &mut self.lookup_gate,
         }
     }
 }

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -4,7 +4,7 @@ use crate::circuits::{domains::EvaluationDomains, gate::CircuitGate};
 use crate::circuits::{
     lookup::{
         constraints::LookupConfiguration,
-        lookups::{JointLookup, LookupInfo},
+        lookups::{JointLookup, LookupInfo, LookupPattern},
         tables::LookupTable,
     },
     polynomials::permutation::ZK_ROWS,
@@ -90,26 +90,24 @@ impl<'de, F: FftField> serde_with::DeserializeAs<'de, LookupSelectors<E<F, D<F>>
     }
 }
 
-impl<T> std::ops::Index<usize> for LookupSelectors<T> {
+impl<T> std::ops::Index<LookupPattern> for LookupSelectors<T> {
     type Output = T;
 
-    fn index(&self, index: usize) -> &Self::Output {
+    fn index(&self, index: LookupPattern) -> &Self::Output {
         match index {
-            0 => self.chacha.as_ref().expect("has chacha"),
-            1 => self.chacha_final.as_ref().expect("has chacha_final"),
-            2 => self.lookup_gate.as_ref().expect("has lookup_gate"),
-            _ => panic!("Lookup selector index out of bounds"),
+            LookupPattern::ChaCha => self.chacha.as_ref().expect("has chacha"),
+            LookupPattern::ChaChaFinal => self.chacha_final.as_ref().expect("has chacha_final"),
+            LookupPattern::LookupGate => self.lookup_gate.as_ref().expect("has lookup_gate"),
         }
     }
 }
 
-impl<T> std::ops::IndexMut<usize> for LookupSelectors<T> {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+impl<T> std::ops::IndexMut<LookupPattern> for LookupSelectors<T> {
+    fn index_mut(&mut self, index: LookupPattern) -> &mut Self::Output {
         match index {
-            0 => self.chacha.as_mut().expect("has chacha"),
-            1 => self.chacha_final.as_mut().expect("has chacha_final"),
-            2 => self.lookup_gate.as_mut().expect("has lookup_gate"),
-            _ => panic!("Lookup selector index out of bounds"),
+            LookupPattern::ChaCha => self.chacha.as_mut().expect("has chacha"),
+            LookupPattern::ChaChaFinal => self.chacha_final.as_mut().expect("has chacha_final"),
+            LookupPattern::LookupGate => self.lookup_gate.as_mut().expect("has lookup_gate"),
         }
     }
 }

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -36,11 +36,16 @@ pub enum LookupError {
     TableIDZeroMustHaveZeroEntry,
 }
 
+/// Lookup selectors
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct LookupSelectors<T> {
+    /// Chacha pattern lookup selector
     pub chacha: Option<T>,
+    /// ChachaFinal pattern lookup selector
     pub chacha_final: Option<T>,
+    /// LookupGate pattern lookup selector
     pub lookup_gate: Option<T>,
+    /// RangeCheckGate pattern lookup selector
     pub range_check_gate: Option<T>,
 }
 

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -89,7 +89,7 @@ impl LookupInfo {
 
         let mut selector_values: LookupSelectors<_> = Default::default();
         for kind in self.kinds.iter() {
-            selector_values[kind.to_index()] = vec![F::zero(); n];
+            selector_values[*kind] = vec![F::zero(); n];
         }
 
         let mut gate_tables = HashSet::new();
@@ -99,13 +99,13 @@ impl LookupInfo {
             let typ = gate.typ;
 
             if let Some(lookup_pattern) = LookupPattern::from_gate(typ, CurrOrNext::Curr) {
-                selector_values[lookup_pattern.to_index()][i] = F::one();
+                selector_values[lookup_pattern][i] = F::one();
                 if let Some(table_kind) = lookup_pattern.table() {
                     gate_tables.insert(table_kind);
                 }
             }
             if let Some(lookup_pattern) = LookupPattern::from_gate(typ, CurrOrNext::Next) {
-                selector_values[lookup_pattern.to_index()][i + 1] = F::one();
+                selector_values[lookup_pattern][i + 1] = F::one();
                 if let Some(table_kind) = lookup_pattern.table() {
                     gate_tables.insert(table_kind);
                 }
@@ -250,7 +250,7 @@ impl<F: Copy> JointLookup<SingleLookup<F>, LookupTableID> {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum LookupPattern {
     ChaCha,
     ChaChaFinal,
@@ -349,14 +349,6 @@ impl LookupPattern {
         match self {
             LookupPattern::ChaCha | LookupPattern::ChaChaFinal => Some(GateLookupTable::Xor),
             LookupPattern::LookupGate => None,
-        }
-    }
-
-    fn to_index(&self) -> usize {
-        match self {
-            LookupPattern::ChaCha => 0,
-            LookupPattern::ChaChaFinal => 1,
-            LookupPattern::LookupGate => 2,
         }
     }
 

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -91,7 +91,7 @@ impl LookupInfo {
     ) -> (LookupSelectors<Evaluations<F>>, Vec<LookupTable<F>>) {
         let n = domain.d1.size();
 
-        let mut selector_values: LookupSelectors<_> = Default::default();
+        let mut selector_values = LookupSelectors::default();
         for kind in self.kinds.iter() {
             selector_values[*kind] = Some(vec![F::zero(); n]);
         }

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -92,7 +92,7 @@ impl LookupInfo {
         let n = domain.d1.size();
 
         let mut selector_values = LookupSelectors::default();
-        for kind in self.kinds.iter() {
+        for kind in &self.kinds {
             selector_values[*kind] = Some(vec![F::zero(); n]);
         }
 

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -620,7 +620,12 @@ where
                         }
                         Some(lindex) => {
                             scalars.push(scalar);
-                            commitments.push(&lindex.lookup_selectors[*i]);
+                            commitments.push(lindex.lookup_selectors[*i].as_ref().expect(
+                                &*format!(
+                                "Attempted to use {:?}, but it was not found in the verifier index",
+                                col
+                            ),
+                            ));
                         }
                     },
                     LookupTable => panic!("Lookup table is unused in the linearization"),

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -2,7 +2,7 @@
 //! You can derive this struct from the [ProverIndex] struct.
 
 use crate::alphas::Alphas;
-use crate::circuits::lookup::lookups::LookupsUsed;
+use crate::circuits::lookup::{index::LookupSelectors, lookups::LookupsUsed};
 use crate::circuits::polynomials::permutation::zk_polynomial;
 use crate::circuits::polynomials::permutation::zk_w3;
 use crate::circuits::{
@@ -37,7 +37,7 @@ pub struct LookupVerifierIndex<G: CommitmentCurve> {
     #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
     pub lookup_table: Vec<PolyComm<G>>,
     #[serde(bound = "PolyComm<G>: Serialize + DeserializeOwned")]
-    pub lookup_selectors: Vec<PolyComm<G>>,
+    pub lookup_selectors: LookupSelectors<PolyComm<G>>,
 
     /// Table IDs for the lookup values.
     /// This may be `None` if all lookups originate from table 0.
@@ -151,9 +151,8 @@ where
                     lookup_used: cs.configuration.lookup_used,
                     lookup_selectors: cs
                         .lookup_selectors
-                        .iter()
-                        .map(|e| self.srs.commit_evaluations_non_hiding(domain, e, None))
-                        .collect(),
+                        .as_ref()
+                        .map(|e| self.srs.commit_evaluations_non_hiding(domain, e, None)),
                     lookup_table: cs
                         .lookup_table8
                         .iter()


### PR DESCRIPTION
This PR builds on top of #583.

This refactors the `lookup_selectors` store to use a structured `LookupSelectors` record. This allows us finer-grained control over which selectors are used or unused, which we couldn't previously have with the vector-position system.