### PR TITLE
Only add lookup selectors for used gates

### DIFF
--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -182,12 +182,14 @@ impl<F: FftField + SquareRootField> LookupConstraintSystem<F> {
         runtime_tables: Option<Vec<RuntimeTableCfg<F>>>,
         domain: &EvaluationDomains<F>,
     ) -> Result<Option<Self>, LookupError> {
-        let lookup_info = LookupInfo::create(runtime_tables.is_some());
-
         //~ 1. If no lookup is used in the circuit, do not create a lookup index
-        match lookup_info.lookup_used(gates) {
+        match LookupInfo::create_from_gates(gates, runtime_tables.is_some()) {
             None => Ok(None),
-            Some(lookup_used) => {
+            Some(lookup_info) => {
+                let lookup_used = match lookup_info.lookup_used() {
+                    Some(lookup_used) => lookup_used,
+                    None => return Ok(None),
+                };
                 let d1_size = domain.d1.size();
 
                 // The maximum number of entries that can be provided across all tables.

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -86,7 +86,7 @@ impl LookupInfo {
     /// Check what kind of lookups, if any, are used by this circuit.
     pub fn lookup_used(&self) -> Option<LookupsUsed> {
         let mut lookups_used = None;
-        for lookup_pattern in self.kinds.iter() {
+        for lookup_pattern in &self.kinds {
             if lookup_pattern.max_joint_size() > 1 {
                 return Some(LookupsUsed::Joint);
             } else {

--- a/kimchi/src/circuits/polynomials/chacha.rs
+++ b/kimchi/src/circuits/polynomials/chacha.rs
@@ -471,7 +471,7 @@ mod tests {
         alphas::Alphas,
         circuits::{
             expr::{Column, Constants, PolishToken},
-            lookup::lookups::LookupInfo,
+            lookup::lookups::{LookupInfo, LookupPattern},
             wires::*,
         },
         proof::{LookupEvaluations, ProofEvaluations},
@@ -503,7 +503,12 @@ mod tests {
 
     #[test]
     fn chacha_linearization() {
-        let lookup_info = LookupInfo::create(false);
+        let lookup_info = LookupInfo::create(
+            [LookupPattern::ChaCha, LookupPattern::ChaChaFinal]
+                .into_iter()
+                .collect(),
+            false,
+        );
 
         let evaluated_cols = {
             let mut h = std::collections::HashSet::new();


### PR DESCRIPTION
This PR builds upon #584.

This tweaks the logic in `ConstraintSystem::create` so that it only uses the lookups for gates that are present in the circuit. In particular, this allows us to migrate the pickles recursion layer to using these lookups without needing to support the `LookupPattern`s for all possible gates.