### PR TITLE
[snarky-rs] add Sys to Var

### DIFF
--- a/circuit-construction/src/lib.rs
+++ b/circuit-construction/src/lib.rs
@@ -15,6 +15,9 @@ use mina_curves::pasta::{fp::Fp, fq::Fq, pallas::Affine as Other, vesta::Affine}
 use oracle::{constants::*, permutation::full_round, poseidon::ArithmeticSpongeParams, FqSponge};
 use std::{cell::RefCell, collections::HashMap, ops::Add, rc::Rc};
 
+#[cfg(test)]
+mod tests;
+
 pub const GENERICS: usize = 3;
 pub const ZK_ROWS: usize = kimchi::circuits::polynomials::permutation::ZK_ROWS as usize;
 

--- a/circuit-construction/src/lib.rs
+++ b/circuit-construction/src/lib.rs
@@ -186,7 +186,7 @@ pub trait Cs<F: PrimeField>: Sized + Clone {
     /// and can be anything that the prover wants.
     /// For example, division can be implemented as:
     ///
-    /// ```
+    /// ```ignore
     /// let a = sys.constant(5u32.into());
     /// let b = sys.constant(10u32.into());
     /// let c = sys.var(|| {
@@ -892,7 +892,7 @@ pub trait Cs<F: PrimeField>: Sized + Clone {
     }
 }
 
-impl<F: FftField + PrimeField> Cs<F> for Ref<WitnessGenerator<F>> {
+impl<F: PrimeField> Cs<F> for Ref<WitnessGenerator<F>> {
     fn var<G>(&self, g: G) -> Var<Self, F>
     where
         G: FnOnce() -> F,

--- a/circuit-construction/src/tests/mod.rs
+++ b/circuit-construction/src/tests/mod.rs
@@ -1,0 +1,1 @@
+mod poseidon;

--- a/circuit-construction/src/tests/poseidon.rs
+++ b/circuit-construction/src/tests/poseidon.rs
@@ -1,0 +1,125 @@
+use ark_ec::{AffineCurve, ProjectiveCurve};
+use ark_ff::{FftField, PrimeField, UniformRand};
+use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as D};
+use commitment_dlog::{commitment::CommitmentCurve, srs::SRS};
+use groupmap::GroupMap;
+use kimchi::verifier::verify;
+use mina_curves::pasta::{
+    fp::Fp,
+    pallas::Affine as Other,
+    vesta::{Affine, VestaParameters},
+};
+use o1_utils::types::fields::*;
+use oracle::{
+    constants::*,
+    poseidon::{ArithmeticSponge, Sponge},
+    sponge::{DefaultFqSponge, DefaultFrSponge},
+};
+use std::sync::Arc;
+
+use crate::{
+    fp_constants, generate_prover_index, prove, Constants, CoordinateCurve, Cs, FpInner, Var,
+};
+
+type SpongeQ = DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>;
+type SpongeR = DefaultFrSponge<Fp, PlonkSpongeConstantsKimchi>;
+
+pub struct Witness<G: AffineCurve> {
+    pub s: ScalarField<G>,
+    pub preimage: G::BaseField,
+}
+
+// Prove knowledge of discrete log and poseidon preimage of a hash
+pub fn circuit<
+    F: PrimeField + FftField,
+    G: AffineCurve<BaseField = F> + CoordinateCurve,
+    Sys: Cs<F>,
+>(
+    constants: &Constants<F>,
+    // The witness
+    witness: Option<&Witness<G>>,
+    sys: Sys,
+    public_input: Vec<Var<Sys, F>>,
+) {
+    let zero = sys.constant(F::zero());
+
+    let constant_curve_pt = |sys: &Sys, (x, y)| {
+        let x = sys.constant(x);
+        let y = sys.constant(y);
+        (x, y)
+    };
+
+    let base = constant_curve_pt(&sys, G::prime_subgroup_generator().to_coords().unwrap());
+    let scalar = sys.scalar(G::ScalarField::size_in_bits(), || {
+        witness.as_ref().unwrap().s
+    });
+    let actual = sys.scalar_mul(zero.clone(), base, scalar);
+
+    let preimage = sys.var(|| witness.as_ref().unwrap().preimage);
+    let actual_hash = sys.poseidon(constants, vec![preimage, zero.clone(), zero])[0].clone();
+
+    sys.assert_eq(actual.0, public_input[0].clone());
+    sys.assert_eq(actual.1, public_input[1].clone());
+    sys.assert_eq(actual_hash, public_input[2].clone());
+
+    sys.zk()
+}
+
+const PUBLIC_INPUT_LENGTH: usize = 3;
+
+#[test]
+fn test_poseidon_circuit() {
+    // 2^8 = 256
+    let srs = {
+        let mut srs = SRS::<Affine>::create(1 << 8);
+        srs.add_lagrange_basis(D::new(srs.g.len()).unwrap());
+        Arc::new(srs)
+    };
+
+    let proof_system_constants = fp_constants();
+    let fq_poseidon = oracle::pasta::fq_kimchi::params();
+
+    let prover_index = generate_prover_index::<FpInner, _>(
+        srs,
+        &proof_system_constants,
+        &fq_poseidon,
+        PUBLIC_INPUT_LENGTH,
+        |sys, p| circuit::<_, Other, _>(&proof_system_constants, None, sys, p),
+    );
+
+    let group_map = <Affine as CommitmentCurve>::Map::setup();
+
+    let mut rng = rand::thread_rng();
+
+    // Example
+    let private_key = ScalarField::<Other>::rand(&mut rng);
+    let public_key = Other::prime_subgroup_generator()
+        .mul(private_key)
+        .into_affine();
+
+    let preimage = BaseField::<Other>::rand(&mut rng);
+
+    let witness = Witness {
+        s: private_key,
+        preimage,
+    };
+
+    let hash = {
+        let mut s: ArithmeticSponge<_, PlonkSpongeConstantsKimchi> =
+            ArithmeticSponge::new(proof_system_constants.poseidon.clone());
+        s.absorb(&[preimage]);
+        s.squeeze()
+    };
+
+    let proof = prove::<Affine, _, SpongeQ, SpongeR>(
+        &prover_index,
+        &group_map,
+        None,
+        vec![public_key.x, public_key.y, hash],
+        |sys, p| circuit::<Fp, Other, _>(&proof_system_constants, Some(&witness), sys, p),
+    );
+
+    let verifier_index = prover_index.verifier_index();
+
+    verify::<_, SpongeQ, SpongeR>(&group_map, &verifier_index, &proof).unwrap();
+}

--- a/circuit-construction/src/tests/poseidon.rs
+++ b/circuit-construction/src/tests/poseidon.rs
@@ -62,6 +62,13 @@ pub fn circuit<
     sys.assert_eq(actual.1, public_input[1].clone());
     sys.assert_eq(actual_hash, public_input[2].clone());
 
+    // test addition of vars
+    let x1 = sys.var(|| F::one());
+    let x2 = sys.var(|| F::one());
+    let x3 = x1 + x2;
+    let two = sys.constant(F::from(2u32));
+    sys.assert_eq(x3, two);
+
     sys.zk()
 }
 


### PR DESCRIPTION
This is a proposal to add `Sys: Cs` to `Var` in the circuit writer.

Essentially, we need to pass a main `sys` around all the time to do interesting things with our variables (like add two variables together). It's a bit annoying, so this PR adds a pointer to `sys` in vars so you can just do things like:

```rust
    let x1 = sys.var(|| F::one());
    let x2 = sys.var(|| F::one());
    let x3 = x1 + x2;
    let two = sys.constant(F::from(2u32));
    sys.assert_eq(x3, two);
```

instead of

```rust
    let x1 = sys.var(|| F::one());
    let x2 = sys.var(|| F::one());
    let x3 = sys.add(x1, x2);
    let two = sys.constant(F::from(2u32));
    sys.assert_eq(x3, two);
```

I'm actually not convinced that it's the best idea, as it makes the code a bit more complicated/verbose for a marginal gain. But perhaps it is still a good idea if we push this further. What do people think? Maybe I took a more complicated than necessary approach also.

The approach can be summarized as:

```diff
// a var now holds a Sys

- pub struct Var<F>
+ pub struct Var<Sys, F>
where
    Sys: Clone,
{
    /// A unique identifier for this variable.
    pub index: usize,
    /// ends up holding a value when generating the witness.
    pub value: Option<F>,
+    /// A pointer to the system.
+    pub sys: Sys,
}

// now Cs is implemented on a Rc<RefCell<Sys>>

- impl<F: PrimeField> Cs<F> forWitnessGenerator<F> {
+ impl<F: PrimeField> Cs<F> for Rc<RefCell<WitnessGenerator<F>>> {

// So these changes need to happen on Cs itself:

- pub trait Cs<F: PrimeField> {
+ pub trait Cs<F: PrimeField>: Sized + Clone {
-    fn var<G>(&mut self, g: G) -> Var<F>
+    fn var<G>(&self, g: G) -> Var<Self, F>

```

where 