### PR TITLE
Make the proof serialisable

### DIFF
--- a/kimchi/src/proof.rs
+++ b/kimchi/src/proof.rs
@@ -13,12 +13,12 @@ use serde_with::serde_as;
 //~ spec:startcode
 #[serde_as]
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "Vec<o1_utils::serialization::SerdeAs>: serde_with::SerializeAs<Field>",
+    deserialize = "Vec<o1_utils::serialization::SerdeAs>: serde_with::DeserializeAs<'de, Field>"
+))]
 pub struct LookupEvaluations<Field> {
     /// sorted lookup table polynomial
-    #[serde(bound(
-        serialize = "Vec<o1_utils::serialization::SerdeAs>: serde_with::SerializeAs<Field>",
-        deserialize = "Vec<o1_utils::serialization::SerdeAs>: serde_with::DeserializeAs<'de, Field>"
-    ))]
     #[serde_as(as = "Vec<Vec<o1_utils::serialization::SerdeAs>>")]
     pub sorted: Vec<Field>,
     /// lookup aggregation polynomial

--- a/kimchi/src/proof.rs
+++ b/kimchi/src/proof.rs
@@ -7,42 +7,65 @@ use ark_poly::univariate::DensePolynomial;
 use array_init::array_init;
 use commitment_dlog::{commitment::PolyComm, evaluation_proof::OpeningProof};
 use o1_utils::{types::fields::*, ExtendedDensePolynomial};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 //~ spec:startcode
-#[derive(Clone)]
+#[serde_as]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct LookupEvaluations<Field> {
     /// sorted lookup table polynomial
+    #[serde(bound(
+        serialize = "Vec<o1_utils::serialization::SerdeAs>: serde_with::SerializeAs<Field>",
+        deserialize = "Vec<o1_utils::serialization::SerdeAs>: serde_with::DeserializeAs<'de, Field>"
+    ))]
+    #[serde_as(as = "Vec<Vec<o1_utils::serialization::SerdeAs>>")]
     pub sorted: Vec<Field>,
     /// lookup aggregation polynomial
+    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
     pub aggreg: Field,
     // TODO: May be possible to optimize this away?
     /// lookup table polynomial
+    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
     pub table: Field,
 
     /// Optionally, a runtime table polynomial.
+    #[serde_as(as = "Option<Vec<o1_utils::serialization::SerdeAs>>")]
     pub runtime: Option<Field>,
 }
 
 // TODO: this should really be vectors here, perhaps create another type for chunked evaluations?
-#[derive(Clone)]
+#[serde_as]
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "Vec<o1_utils::serialization::SerdeAs>: serde_with::SerializeAs<Field>",
+    deserialize = "Vec<o1_utils::serialization::SerdeAs>: serde_with::DeserializeAs<'de, Field>"
+))]
 pub struct ProofEvaluations<Field> {
     /// witness polynomials
+    #[serde_as(as = "[Vec<o1_utils::serialization::SerdeAs>; COLUMNS]")]
     pub w: [Field; COLUMNS],
     /// permutation polynomial
+    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
     pub z: Field,
     /// permutation polynomials
     /// (PERMUTS-1 evaluations because the last permutation is only used in commitment form)
+    #[serde_as(as = "[Vec<o1_utils::serialization::SerdeAs>; PERMUTS - 1]")]
     pub s: [Field; PERMUTS - 1],
     /// lookup-related evaluations
     pub lookup: Option<LookupEvaluations<Field>>,
     /// evaluation of the generic selector polynomial
+    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
     pub generic_selector: Field,
     /// evaluation of the poseidon selector polynomial
+    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
     pub poseidon_selector: Field,
 }
 
 /// Commitments linked to the lookup feature
-#[derive(Clone)]
+#[serde_as]
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound = "G: ark_serialize::CanonicalDeserialize + ark_serialize::CanonicalSerialize")]
 pub struct LookupCommitments<G: AffineCurve> {
     pub sorted: Vec<PolyComm<G>>,
     pub aggreg: PolyComm<G>,
@@ -52,7 +75,9 @@ pub struct LookupCommitments<G: AffineCurve> {
 }
 
 /// All the commitments that the prover creates as part of the proof.
-#[derive(Clone)]
+#[serde_as]
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound = "G: ark_serialize::CanonicalDeserialize + ark_serialize::CanonicalSerialize")]
 pub struct ProverCommitments<G: AffineCurve> {
     /// The commitments to the witness (execution trace)
     pub w_comm: [PolyComm<G>; COLUMNS],
@@ -65,7 +90,9 @@ pub struct ProverCommitments<G: AffineCurve> {
 }
 
 /// The proof that the prover creates from a [ProverIndex](super::prover_index::ProverIndex) and a `witness`.
-#[derive(Clone)]
+#[serde_as]
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound = "G: ark_serialize::CanonicalDeserialize + ark_serialize::CanonicalSerialize")]
 pub struct ProverProof<G: AffineCurve> {
     /// All the polynomial commitments required in the proof
     pub commitments: ProverCommitments<G>,
@@ -78,12 +105,15 @@ pub struct ProverProof<G: AffineCurve> {
     pub evals: [ProofEvaluations<Vec<ScalarField<G>>>; 2],
 
     /// Required evaluation for [Maller's optimization](https://o1-labs.github.io/mina-book/crypto/plonk/maller_15.html#the-evaluation-of-l)
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub ft_eval1: ScalarField<G>,
 
     /// The public input
+    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
     pub public: Vec<ScalarField<G>>,
 
     /// The challenges underlying the optional polynomials folded into the proof
+    #[serde_as(as = "Vec<(Vec<o1_utils::serialization::SerdeAs>, serde_with::Same)>")]
     pub prev_challenges: Vec<(Vec<ScalarField<G>>, PolyComm<G>)>,
 }
 //~ spec:endcode

--- a/kimchi/src/tests/mod.rs
+++ b/kimchi/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod generic;
 mod lookup;
 mod poseidon;
 mod recursion;
+mod serde;
 mod serialization;
 mod turshi;
 mod varbasemul;

--- a/kimchi/src/tests/serde.rs
+++ b/kimchi/src/tests/serde.rs
@@ -1,0 +1,86 @@
+use crate::bench::BenchmarkCtx;
+use crate::circuits::polynomials::generic::testing::{create_circuit, fill_in_witness};
+use crate::circuits::wires::COLUMNS;
+use crate::proof::ProverProof;
+use crate::prover_index::testing::new_index_for_test;
+use crate::verifier::verify;
+use crate::verifier_index::VerifierIndex;
+use ark_ec::short_weierstrass_jacobian::GroupAffine;
+use ark_ff::Zero;
+use array_init::array_init;
+use commitment_dlog::commitment::CommitmentCurve;
+use commitment_dlog::srs::SRS;
+use groupmap::GroupMap;
+use mina_curves::pasta::fp::Fp;
+use mina_curves::pasta::vesta::{Affine, VestaParameters};
+use oracle::constants::PlonkSpongeConstantsKimchi;
+use oracle::sponge::{DefaultFqSponge, DefaultFrSponge};
+use std::time::Instant;
+
+type SpongeParams = PlonkSpongeConstantsKimchi;
+type BaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;
+type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_rmp_serde() {
+        let ctx = BenchmarkCtx::new(1 << 4);
+
+        let proof = ctx.create_proof();
+
+        // small check of proof being serializable
+        let ser_pf = rmp_serde::to_vec(&proof).unwrap();
+        println!("proof size: {} bytes", ser_pf.len());
+
+        let de_pf: ProverProof<Affine> = rmp_serde::from_slice(&ser_pf).unwrap();
+
+        ctx.batch_verification(vec![de_pf.clone()]);
+    }
+
+    #[test]
+    pub fn test_serialization() {
+        let public = vec![Fp::from(3u8); 5];
+        let gates = create_circuit(0, public.len());
+
+        // create witness
+        let mut witness: [Vec<Fp>; COLUMNS] = array_init(|_| vec![Fp::zero(); gates.len()]);
+        fill_in_witness(0, &mut witness, &public);
+
+        let index = new_index_for_test(gates, public.len());
+        let verifier_index = index.verifier_index();
+
+        let verifier_index_serialize =
+            serde_json::to_string(&verifier_index).expect("couldn't serialize index");
+
+        // verify the circuit satisfiability by the computed witness
+        index.cs.verify(&witness, &public).unwrap();
+
+        // add the proof to the batch
+        let group_map = <Affine as CommitmentCurve>::Map::setup();
+        let proof =
+            ProverProof::create::<BaseSponge, ScalarSponge>(&group_map, witness, &[], &index)
+                .unwrap();
+
+        // deserialize the verifier index
+        let mut verifier_index_deserialize: VerifierIndex<GroupAffine<VestaParameters>> =
+            serde_json::from_str(&verifier_index_serialize).unwrap();
+
+        // add srs with lagrange bases
+        let mut srs = SRS::<GroupAffine<VestaParameters>>::create(verifier_index.max_poly_size);
+        srs.add_lagrange_basis(verifier_index.domain);
+        verifier_index_deserialize.fq_sponge_params = oracle::pasta::fq_kimchi::params();
+        verifier_index_deserialize.fr_sponge_params = oracle::pasta::fp_kimchi::params();
+        verifier_index_deserialize.powers_of_alpha = index.powers_of_alpha;
+        verifier_index_deserialize.linearization = index.linearization;
+
+        // verify the proof
+        let start = Instant::now();
+        verify::<Affine, BaseSponge, ScalarSponge>(&group_map, &verifier_index_deserialize, &proof)
+            .unwrap();
+        println!("- time to verify: {}ms", start.elapsed().as_millis());
+    }
+}

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -10,6 +10,8 @@ use o1_utils::{
 use oracle::{sponge::ScalarChallenge, FqSponge};
 use rand_core::{CryptoRng, RngCore};
 use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use std::iter::Iterator;
 
 enum OptShiftedPolynomial<P> {
@@ -310,13 +312,20 @@ impl<G: CommitmentCurve> SRS<G> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "G: ark_serialize::CanonicalDeserialize + ark_serialize::CanonicalSerialize")]
 pub struct OpeningProof<G: AffineCurve> {
     /// vector of rounds of L & R commitments
+    #[serde_as(as = "Vec<(o1_utils::serialization::SerdeAs, o1_utils::serialization::SerdeAs)>")]
     pub lr: Vec<(G, G)>,
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub delta: G,
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub z1: G::ScalarField,
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub z2: G::ScalarField,
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub sg: G,
 }
 


### PR DESCRIPTION
This PR is proposed as an alternative to #570, which (IMO) is over-large and makes undesirable changes to some types.

This uses trait bounds in `serde` and `serde_as` to make proofs serialisable without modifying any types. Note in particular the bound on `LookupEvaluations`:
```
#[serde(bound(
    serialize = "Vec<o1_utils::serialization::SerdeAs>: serde_with::SerializeAs<Field>",
    deserialize = "Vec<o1_utils::serialization::SerdeAs>: serde_with::DeserializeAs<'de, Field>"
))]
```
which requires `Field` to be (de-/)serialisable by using the conversion `Field <-> Vec<ScalarField<G>>`. This means that e.g. `LookupEvaluations<Vec<ScalarField<G>>>` is serialisable but `LookupEvaluations<ScalarField<G>>` is not. Note that the explicit bounds set in the `#[serde(bound(...))]` attribute override the default `: Serialize` and `: Deserialize` bounds on generic arguments, which makes this PR possible.

This also includes @querolita's test from #570.

This fixes #434.