### PR TITLE
[circuit-writer] remove Cs trait

### DIFF
--- a/circuit-construction/tests/example_proof.rs
+++ b/circuit-construction/tests/example_proof.rs
@@ -26,20 +26,16 @@ pub struct Witness<G: AffineCurve> {
 }
 
 // Prove knowledge of discrete log and poseidon preimage of a hash
-pub fn circuit<
-    F: PrimeField + FftField,
-    G: AffineCurve<BaseField = F> + CoordinateCurve,
-    Sys: Cs<F>,
->(
+pub fn circuit<F: PrimeField + FftField, G: AffineCurve<BaseField = F> + CoordinateCurve>(
     constants: &Constants<F>,
     // The witness
     witness: Option<&Witness<G>>,
-    sys: &mut Sys,
+    sys: &mut Sys<F>,
     public_input: Vec<Var<F>>,
 ) {
     let zero = sys.constant(F::zero());
 
-    let constant_curve_pt = |sys: &mut Sys, (x, y)| {
+    let constant_curve_pt = |sys: &mut Sys<F>, (x, y)| {
         let x = sys.constant(x);
         let y = sys.constant(y);
         (x, y)
@@ -79,7 +75,7 @@ fn test_example_circuit() {
         &proof_system_constants,
         &fq_poseidon,
         PUBLIC_INPUT_LENGTH,
-        |sys, p| circuit::<_, Other, _>(&proof_system_constants, None, sys, p),
+        |sys, p| circuit::<_, Other>(&proof_system_constants, None, sys, p),
     );
 
     let group_map = <Affine as CommitmentCurve>::Map::setup();
@@ -112,7 +108,7 @@ fn test_example_circuit() {
         &group_map,
         None,
         vec![public_key.x, public_key.y, hash],
-        |sys, p| circuit::<Fp, Other, _>(&proof_system_constants, Some(&witness), sys, p),
+        |sys, p| circuit::<Fp, Other>(&proof_system_constants, Some(&witness), sys, p),
     );
 
     // verify proof


### PR DESCRIPTION
turns out we don't need to be clever with the `Cs` trait implemented on two different structs, we can just have an enum and a single implementation. Removes a bunch of code and reduces complexity.