### PR TITLE
Use kimchi/README.md in the kimchi crate rustdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,58 +9,6 @@ You can read more about this project on the [Kimchi book](https://o1-labs.github
 
 [See here for the rust documentation](https://o1-labs.github.io/proof-systems/rustdoc).
 
-## Example
-
-We assume that you already have:
-
-* `gates`: a circuit, which can be expressed as a vector of [CircuitGate](https://o1-labs.github.io/proof-systems/rustdoc/kimchi/circuits/gate/struct.CircuitGate.html)
-* a way to produce a `witness`, which can be expressed as a `[Vec<F>; COLUMNS]` (for `F` some field of your chosing)
-* `public_size`: the size of the public input
-
-Then, you can create an URS for your circuit in the following way:
-
-```rust,ignore
-use kimchi::{circuits::constraints, verifier::verify};
-use mina_curves::pasta::{fp::Fp, vesta::{Affine, VestaParameters}, pallas::Affine as Other};
-use oracle::{
-    constants::PlonkSpongeConstantsKimchi,
-    sponge::{DefaultFqSponge, DefaultFrSponge},
-};
-use commitment_dlog::commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve};
-
-type SpongeParams = PlonkSpongeConstantsKimchi;
-type BaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;
-type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
-
-// compile the circuit
-let fp_sponge_params = oracle::pasta::fp_kimchi::params();
-let cs = ConstraintSystem::<Fp>::create(gates, vec![], fp_sponge_params, public_size).unwrap();
-
-// create an URS
-let mut urs = SRS::<Affine>::create(cs.domain.d1.size as usize);
-srs.add_lagrange_basis(cs.domain.d1);
-
-// obtain a prover index
-let prover_index = {
-    let fq_sponge_params = oracle::pasta::fq_kimchi::params();
-    let (endo_q, _endo_r) = endos::<Other>();
-    Index::<Affine>::create(cs, fq_sponge_params, endo_q, srs)
-};
-
-// obtain a verifier index
-let verifier_index = prover_index.verifier_index();
-
-// create a proof
-let group_map = <Affine as CommitmentCurve>::Map::setup();
-let proof =  ProverProof::create::<BaseSponge, ScalarSponge>(
-    &group_map, witness, &prover_index);
-
-// verify a proof
-verify::<Affine, BaseSponge, ScalarSponge>(&group_map, verifier_index, proof).unwrap();
-```
-
-Note that kimchi is specifically designed for use in a recursion proof system, like [pickles](https://medium.com/minaprotocol/meet-pickles-snark-enabling-smart-contract-on-coda-protocol-7ede3b54c250), but can also be used a stand alone for normal proofs.
-
 ## Organization
 
 The project is organized in the following way:

--- a/kimchi/README.md
+++ b/kimchi/README.md
@@ -2,6 +2,58 @@
 
 Kimchi is based on [plonk](https://eprint.iacr.org/2019/953.pdf), a zk-SNARK protocol.
 
+## Example
+
+We assume that you already have:
+
+* `gates`: a circuit, which can be expressed as a vector of [CircuitGate](https://o1-labs.github.io/proof-systems/rustdoc/kimchi/circuits/gate/struct.CircuitGate.html)
+* a way to produce a `witness`, which can be expressed as a `[Vec<F>; COLUMNS]` (for `F` some field of your chosing)
+* `public_size`: the size of the public input
+
+Then, you can create an URS for your circuit in the following way:
+
+```rust,ignore
+use kimchi::{circuits::constraints, verifier::verify};
+use mina_curves::pasta::{fp::Fp, vesta::{Affine, VestaParameters}, pallas::Affine as Other};
+use oracle::{
+    constants::PlonkSpongeConstantsKimchi,
+    sponge::{DefaultFqSponge, DefaultFrSponge},
+};
+use commitment_dlog::commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve};
+
+type SpongeParams = PlonkSpongeConstantsKimchi;
+type BaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;
+type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
+
+// compile the circuit
+let fp_sponge_params = oracle::pasta::fp_kimchi::params();
+let cs = ConstraintSystem::<Fp>::create(gates, vec![], fp_sponge_params, public_size).unwrap();
+
+// create an URS
+let mut urs = SRS::<Affine>::create(cs.domain.d1.size as usize);
+srs.add_lagrange_basis(cs.domain.d1);
+
+// obtain a prover index
+let prover_index = {
+    let fq_sponge_params = oracle::pasta::fq_kimchi::params();
+    let (endo_q, _endo_r) = endos::<Other>();
+    Index::<Affine>::create(cs, fq_sponge_params, endo_q, srs)
+};
+
+// obtain a verifier index
+let verifier_index = prover_index.verifier_index();
+
+// create a proof
+let group_map = <Affine as CommitmentCurve>::Map::setup();
+let proof =  ProverProof::create::<BaseSponge, ScalarSponge>(
+    &group_map, witness, &prover_index);
+
+// verify a proof
+verify::<Affine, BaseSponge, ScalarSponge>(&group_map, verifier_index, proof).unwrap();
+```
+
+Note that kimchi is specifically designed for use in a recursion proof system, like [pickles](https://medium.com/minaprotocol/meet-pickles-snark-enabling-smart-contract-on-coda-protocol-7ede3b54c250), but can also be used a stand alone for normal proofs.
+
 ## Benchmarks
 
 To bench kimchi, we have two types of benchmark engines. 

--- a/kimchi/src/lib.rs
+++ b/kimchi/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../../README.md")]
+#![doc = include_str!("../README.md")]
 
 #[macro_use]
 extern crate num_derive;


### PR DESCRIPTION
As part of MinaProtocol/mina#11212, I'm moving some rust deps from a git submodule to a cargo git dep. However, the `kimchi` crate fails to build, since it can't find ../../README.md in this case.

I've moved the example into the kimchi crate README.md and used that.