### PR TITLE
64-bit range check support

### DIFF
--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -409,9 +409,7 @@ impl LookupPattern {
             (ChaCha0 | ChaCha1 | ChaCha2, Curr | Next) => Some(LookupPattern::ChaCha),
             (ChaChaFinal, Curr | Next) => Some(LookupPattern::ChaChaFinal),
             (Lookup, Curr) => Some(LookupPattern::LookupGate),
-            (RangeCheck0, Curr) | (RangeCheck1, Curr | Next) => {
-                Some(LookupPattern::RangeCheckGate)
-            }
+            (RangeCheck0, Curr) | (RangeCheck1, Curr | Next) => Some(LookupPattern::RangeCheckGate),
             _ => None,
         }
     }

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -376,10 +376,10 @@ impl LookupPattern {
                     .collect()
             }
             LookupPattern::RangeCheckGate => {
-                (1..=4)
+                (3..=6)
                     .map(|column| {
                         //   0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
-                        //   - L L L L - - - - - -  -  -  -  -
+                        //   - - - L L L L - - - -  -  -  -  -
                         JointLookup {
                             table_id: LookupTableID::Constant(RANGE_CHECK_TABLE_ID),
                             entry: vec![SingleLookup {
@@ -410,6 +410,7 @@ impl LookupPattern {
             (ChaChaFinal, Curr | Next) => Some(LookupPattern::ChaChaFinal),
             (Lookup, Curr) => Some(LookupPattern::LookupGate),
             (RangeCheck0, Curr) | (RangeCheck1, Curr) | (RangeCheck1, Next) => {
+                ///////// TODO:: FIX THIS?????
                 Some(LookupPattern::RangeCheckGate)
             }
             _ => None,

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -409,8 +409,7 @@ impl LookupPattern {
             (ChaCha0 | ChaCha1 | ChaCha2, Curr | Next) => Some(LookupPattern::ChaCha),
             (ChaChaFinal, Curr | Next) => Some(LookupPattern::ChaChaFinal),
             (Lookup, Curr) => Some(LookupPattern::LookupGate),
-            (RangeCheck0, Curr) | (RangeCheck1, Curr) | (RangeCheck1, Next) => {
-                ///////// TODO:: FIX THIS?????
+            (RangeCheck0, Curr) | (RangeCheck1, Curr | Next) => {
                 Some(LookupPattern::RangeCheckGate)
             }
             _ => None,

--- a/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
@@ -3,11 +3,18 @@
 ///
 ///    The range check gate is comprised of three circuit gates (RangeCheck0, RangeCheck1
 ///    and Zero) and can perform range checks on up to three 88-bit values: v0, v1 and v2.
-///    Each value is in little-endian byte order.
+///
+///    Byte-order:
+///      * Each value is in big-endian byte order
+///      * Limbs are mapped to columns in big-endian order (i.e. the lowest columns
+///        contain the highest bits)
+///      * We also have the highest bits covered by copy constraints and plookups, so that
+///        we can copy the highest two constraints to zero and get a 64-bit lookup, which
+///        are envisioned as a common case
 ///
 ///    The values are decomposed into limbs as follows.
 ///
-///    L is a 12-bit lookup limb,
+///    L is a 12-bit lookup (or copy) limb,
 ///    C is a 2-bit "crumb" limb.
 ///
 ///         <----6----> <------8------>
@@ -38,27 +45,27 @@
 ///
 ///  This is how three 88-bit inputs v0, v1 and v2 are layed out and constrained.
 ///
-///   * vipj is the jth 12-bit limb of vi
-///   * vicj is the jth 2-bit crumb limb of vi
+///   * vipj is the jth 12-bit limb of value vi
+///   * vicj is the jth 2-bit crumb limb of value vi
 ///
 /// Gate:   RangeCheck0    RangeCheck0    RangeCheck1    Zero
-///   Rows -->
+///    Rows -->
 ///         0              1              2              3
-///  C  0 | v0           | v1           | v2           | 0
-///  o  1 | plookup v0p0 | plookup v1p0 | plookup v2p0 | plookup v0p4
-///  l  2 | plookup v0p1 | plookup v1p1 | plookup v2p1 | plookup v0p5
-///  s  3 | plookup v0p2 | plookup v1p2 | plookup v2p2 | plookup v1p4
-///  |  4 | plookup v0p3 | plookup v1p3 | plookup v2p3 | plookup v1p5
-/// \ / 5 | copy v0p4    | copy v1p4    | crumb v2c0   | crumb v2c10
-///  '  6 | copy v0p5    | copy v1p5    | crumb v2c1   | crumb v2c11
-///     7 | crumb v0c0   | crumb v1c0   | crumb v2c2   | crumb v2c12
-///     8 | crumb v0c1   | crumb v1c1   | crumb v2c3   | crumb v2c13
-///     9 | crumb v0c2   | crumb v1c2   | crumb v2c4   | crumb v2c14
-///    10 | crumb v0c3   | crumb v1c3   | crumb v2c5   | crumb v2c15
-///    11 | crumb v0c4   | crumb v1c4   | crumb v2c6   | crumb v2c16
-///    12 | crumb v0c5   | crumb v1c5   | crumb v2c7   | crumb v2c17
-///    13 | crumb v0c6   | crumb v1c6   | crumb v2c8   | crumb v2c18
-///    14 | crumb v0c7   | crumb v1c7   | crumb v2c9   | crumb v2c19
+///    0 | v0           | v1           | v2           | 0
+///    1 | copy    v0p0 | copy    v1p0 | crumb   v2c0 | crumb   v2c10
+///    2 | copy    v0p1 | copy    v1p1 | crumb   v2c1 | crumb   v2c11
+///    3 | plookup v0p2 | plookup v1p2 | plookup v2p0 | plookup  v0p0
+///    4 | plookup v0p3 | plookup v1p3 | plookup v2p1 | plookup  v0p1
+///    5 | plookup v0p4 | plookup v1p4 | plookup v2p2 | plookup  v1p0
+///    6 | plookup v0p5 | plookup v1p5 | plookup v2p3 | plookup  v1p1
+///    7 | crumb   v0c0 | crumb   v1c0 | crumb   v2c2 | crumb   v2c12
+///    8 | crumb   v0c1 | crumb   v1c1 | crumb   v2c3 | crumb   v2c13
+///    9 | crumb   v0c2 | crumb   v1c2 | crumb   v2c4 | crumb   v2c14
+///   10 | crumb   v0c3 | crumb   v1c3 | crumb   v2c5 | crumb   v2c15
+///   11 | crumb   v0c4 | crumb   v1c4 | crumb   v2c6 | crumb   v2c16
+///   12 | crumb   v0c5 | crumb   v1c5 | crumb   v2c7 | crumb   v2c17
+///   13 | crumb   v0p6 | copy    v1c6 | crumb   v2c8 | crumb   v2c18
+///   14 | crumb   v0p7 | copy    v1c7 | crumb   v2c9 | crumb   v2c19
 ///
 ///   The 12-bit chunks are constrained with plookups and the 2-bit crumbs constrained with
 ///   degree-4 constraints of the form x*(x - 1)*(x - 2)*(x - 3).
@@ -97,28 +104,28 @@ use ark_ff::{FftField, One, Zero};
 ///   * This gate operates on the Curr row
 ///
 /// It uses three different types of constraints
-///   * plookup - plookup (12-bits)
 ///   * copy    - copy to another cell (12-bits)
+///   * plookup - plookup (12-bits)
 ///   * crumb   - degree-4 constraint (2-bits)
 ///
 /// Given value v the layout looks like this
 ///
 /// Column | Curr
 ///      0 | v
-///      1 | plookup vp0
-///      2 | plookup vp1
+///      1 | copy    vp0
+///      2 | copy    vp1
 ///      3 | plookup vp2
 ///      4 | plookup vp3
-///      5 | copy vp4
-///      6 | copy vp5
-///      7 | crumb vc0
-///      8 | crumb vc1
-///      9 | crumb vc2
-///     10 | crumb vc3
-///     11 | crumb vc4
-///     12 | crumb vc5
-///     13 | crumb vc6
-///     14 | crumb vc7
+///      5 | plookup vp4
+///      6 | plookup vp5
+///      7 | crumb   vc0
+///      8 | crumb   vc1
+///      9 | crumb   vc2
+///     10 | crumb   vc3
+///     11 | crumb   vc4
+///     12 | crumb   vc5
+///     13 | crumb   vc6
+///     14 | crumb   vc7
 ///
 /// where the notation vpi and vci defined in the "Layout" section above.
 
@@ -134,12 +141,16 @@ where
 
     // Constraints for RangeCheck0
     //   * Operates on Curr row
-    //   * Range constrain all limbs except vp4 and vp5 (barring plookup constraints, which are done elsewhere)
+    //   * Range constrain all limbs except vp0 and vp1 (barring plookup constraints, which are done elsewhere)
     //   * Constrain that combining all limbs equals the limb stored in column 0
     fn constraints() -> Vec<E<F>> {
         // 1) Apply range constraints on limbs
-        // Columns 1-4 are 12-bit plookup range constraints (these are specified elsewhere)
-        // Create 8 2-bit chunk range constraints
+        //    * Columns 1-2 are 12-bit copy constraints
+        //        * They are copied to 3 rows ahead and are constrained by plookups
+        //          triggered by RangeCheck1 on its Next row
+        //        * They can be constrained to zero to obtain a 64-bit range check
+        //    * Columns 3-6 are 12-bit plookup range constraints (these are specified in the lookup gate)
+        //    * Columns 7-14 are 2-bit crumb range constraints
         let mut constraints = (7..COLUMNS)
             .map(|i| crumb(&witness_curr(i)))
             .collect::<Vec<E<F>>>();
@@ -154,13 +165,13 @@ where
         //
         // Check v    =  vp0*2^0 + vp1*2^{12}  + ... + p5*2^{60}   + vc0*2^{72}  + vc1*2^{74}  + ... + vc7*2^{86}
         //       w(0) = w(1)*2^0 + w(2)*2^{12} + ... + w(6)*2^{60} + w(7)*2^{72} + w(8)*2^{74} + ... + w(14)*2^{86}
-        //            = \sum i \in [1,7] 2^{12*(i - 1)}*w(i) + \sum i \in [8,14] 2^{2*(i - 7) + 6*12}*w(i)
+        //            = \sum i \in [1,6] 2^{12*(i - 1)} * w(i) + \sum i \in [7,14] 2^{2*(i - 7) + 6*12} * w(i)
 
         let mut power_of_2 = E::one();
         let mut sum_of_limbs = E::zero();
 
         // Sum 12-bit limbs
-        for i in 1..7 {
+        for i in 1..=6 {
             sum_of_limbs += power_of_2.clone() * witness_curr(i);
             power_of_2 *= 4096u64.into(); // 12 bits
         }
@@ -223,17 +234,32 @@ where
     //   * Range constrain all limbs (barring plookup constraints, which are done elsewhere)
     //   * Constrain that combining all limbs equals the value v2 stored in row Curr, column 0
     fn constraints() -> Vec<E<F>> {
-        // 1) Apply range constraints on limbs
-        // Columns 1-4 are 12-bit plookup range constraints (these are specified elsewhere)
-
-        // Create 10 2-bit chunk range constraints using Curr row
-        let mut constraints = (5..COLUMNS)
+        // 1) Apply range constraints on limbs for Curr row
+        //    * Columns 1-2 are 2-bit crumbs
+        let mut constraints = (1..=2)
             .map(|i| crumb(&witness_curr(i)))
             .collect::<Vec<E<F>>>();
-
-        // Create 10 more 2-bit chunk range constraints using Next row
+        //    * Columns 3-6 are 12-bit plookup range constraints (these are specified
+        //      in the lookup gate)
+        //    * Columns 7-14 are 2-bit crumb range constraints
         constraints.append(
-            &mut (5..COLUMNS)
+            &mut (7..COLUMNS)
+                .map(|i| crumb(&witness_curr(i)))
+                .collect::<Vec<E<F>>>(),
+        );
+
+        // 2) Apply range constraints on limbs for Next row
+        //    * Columns 1-2 are 2-bit crumbs
+        constraints.append(
+            &mut (1..=2)
+                .map(|i| crumb(&witness_next(i)))
+                .collect::<Vec<E<F>>>(),
+        );
+        //    * Columns 3-6 are 12-bit plookup range constraints for v0 and v1 (these
+        //      are specified in the lookup gate)
+        //    * Columns 7-14 are more 2-bit crumbs
+        constraints.append(
+            &mut (7..COLUMNS)
                 .map(|i| crumb(&witness_next(i)))
                 .collect::<Vec<E<F>>>(),
         );
@@ -244,32 +270,44 @@ where
         //
         //          Columns
         //          0    1   2   3   4   5    6    7    8    9    10   11   12   13   14
-        //    Curr  v2   vp0 vp1 vp2 vp3 vc0  vc1  vc2  vc3  vc4  vc5  vc6  vc7  vc8  vc9
+        //    Curr  v2   vc0 vc1 vp0 vp1 vp2 vp3 vc2  vc3  vc4  vc5  vc6  vc7  vc8  vc9
         //    Next                       vc10 vc11 vc12 vc13 vc14 vc15 vc16 vc17 vc18 vc19
         //
         // Check   v2 = vp0*2^0          + vp1*2^{12}       + ... + vp3*2^{36}       + vc0*2^{48}     + vc1*2^{50}     + ... + vc19*2^{66}
         //       w(0) = w_curr(1)*2^0    + w_curr(2)*2^{12} + ... + w_curr(4)*2^{36} + w_curr(5)*2^48 + w_curr(6)*2^50 + ... + w_curr(14)*2^66
         //            + w_next(5)*2^{68} + w_next(6)*2^{70} + ... + w_next(14)*2^{86}
-        // (1st part) = \sum i \in [1,5] 2^{12*(i - 1)}*w_curr(i) + \sum i \in [6,14] 2^{2*(i - 5) + 4*12}*w_curr(i)
+        // (1st part) = \sum i \in [1,4] 2^{12*(i - 1)}*w_curr(i) + \sum i \in [5,14] 2^{2*(i - 5) + 4*12}*w_curr(i)
         // (2nd part) + \sum i \in [5,14] 2^{2*(i - 5} + 68)*w_next(i)
 
         let mut power_of_2 = E::one();
         let mut sum_of_limbs = E::zero();
 
-        // 1st part: Sum 12-bit limbs (row Curr)
-        for i in 1..5 {
-            sum_of_limbs += power_of_2.clone() * witness_curr(i);
-            power_of_2 *= 4096u64.into(); // 12 bits
-        }
-
-        // 1st part:  Sum 2-bit limbs (row Curr)
-        for i in 5..COLUMNS {
+        // 1st part:  Sum 2-bit limbs vc0 and vc1 (row Curr)
+        for i in 1..=2 {
             sum_of_limbs += power_of_2.clone() * witness_curr(i);
             power_of_2 *= 4u64.into(); // 2 bits
         }
 
-        // 2nd part: Sum 2-bit limbs (row Next)
-        for i in 5..COLUMNS {
+        // 1st part: Sum 12-bit limbs (row Curr)
+        for i in 3..=6 {
+            sum_of_limbs += power_of_2.clone() * witness_curr(i);
+            power_of_2 *= 4096u64.into(); // 12 bits
+        }
+
+        // 1st part:  Sum remaining 2-bit limbs (row Curr)
+        for i in 7..COLUMNS {
+            sum_of_limbs += power_of_2.clone() * witness_curr(i);
+            power_of_2 *= 4u64.into(); // 2 bits
+        }
+
+        // 2nd part:  Sum 2-bit limbs vc10 and vc11 (row Next)
+        for i in 1..=2 {
+            sum_of_limbs += power_of_2.clone() * witness_next(i);
+            power_of_2 *= 4u64.into(); // 2 bits
+        }
+
+        // 2nd part: Sum remaining 2-bit limbs (row Next)
+        for i in 7..COLUMNS {
             sum_of_limbs += power_of_2.clone() * witness_next(i);
             power_of_2 *= 4u64.into(); // 2 bits
         }

--- a/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
@@ -158,7 +158,7 @@ where
             .map(|i| crumb(&witness_curr(i)))
             .collect::<Vec<E<F>>>();
 
-        // 2) Constrain that the combined limbs equals the limb stored in w(0):
+        // 2) Constrain that the combined limbs equals the value v stored in w(0):
         //
         //        w(0) = v = vp0 vp1 vp2 vp3 vp4 vp5 vc0 vc1 vc2 vc3 vc4 vc5 vc6 vc7
         //

--- a/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
@@ -5,7 +5,7 @@
 ///    and Zero) and can perform range checks on up to three 88-bit values: v0, v1 and v2.
 ///
 ///    Byte-order:
-///      * Each value is in big-endian byte order
+///      * Each value is in little-endian byte order
 ///      * Limbs are mapped to columns in big-endian order (i.e. the lowest columns
 ///        contain the highest bits)
 ///      * We also have the highest bits covered by copy constraints and plookups, so that
@@ -31,9 +31,12 @@
 ///     2   v2
 ///     3   v0,v1,v2
 ///
-///   * The first 2 rows contain v0 and v1 and their respective decompositions into 12-bit and 2-bit limbs
-///   * The 3rd row contains v2 and part of its decomposition: four 12-bit limbs and the 1st 10 crumbs
-///   * The final row contains v0's and v1's 5th and 6th 12-bit limbs as well as the remaining 10 crumbs of v2
+///   * The first 2 rows contain v0 and v1 and their respective decompositions
+///     into 12-bit and 2-bit limbs
+///   * The 3rd row contains v2 and part of its decomposition: four 12-bit limbs and
+///     the 1st 10 crumbs
+///   * The final row contains v0's and v1's 5th and 6th 12-bit limbs as well as the
+///     remaining 10 crumbs of v2
 ///
 /// Constraints:
 ///
@@ -52,7 +55,7 @@
 ///    Rows -->
 ///         0              1              2              3
 ///    0 | v0           | v1           | v2           | 0
-///    1 | copy    v0p0 | copy    v1p0 | crumb   v2c0 | crumb   v2c10
+///    1 | copy    v0p0 | copy    v1p0 | crumb   v2c0 | crumb   v2c10 <- MSB
 ///    2 | copy    v0p1 | copy    v1p1 | crumb   v2c1 | crumb   v2c11
 ///    3 | plookup v0p2 | plookup v1p2 | plookup v2p0 | plookup  v0p0
 ///    4 | plookup v0p3 | plookup v1p3 | plookup v2p1 | plookup  v0p1
@@ -65,10 +68,10 @@
 ///   11 | crumb   v0c4 | crumb   v1c4 | crumb   v2c6 | crumb   v2c16
 ///   12 | crumb   v0c5 | crumb   v1c5 | crumb   v2c7 | crumb   v2c17
 ///   13 | crumb   v0p6 | copy    v1c6 | crumb   v2c8 | crumb   v2c18
-///   14 | crumb   v0p7 | copy    v1c7 | crumb   v2c9 | crumb   v2c19
+///   14 | crumb   v0p7 | copy    v1c7 | crumb   v2c9 | crumb   v2c19 <- LSB
 ///
-///   The 12-bit chunks are constrained with plookups and the 2-bit crumbs constrained with
-///   degree-4 constraints of the form x*(x - 1)*(x - 2)*(x - 3).
+///   The 12-bit chunks are constrained with plookups and the 2-bit crumbs
+///   constrained with degree-4 constraints of the form x*(x - 1)*(x - 2)*(x - 3).
 ///
 ///   Note that copy denotes a plookup that is deferred to the 4th gate (i.e. Zero).
 ///   This is because of the limitation that we have at most 4 lookups per row.
@@ -82,7 +85,7 @@
 ///     0   RangeCheck0   Partially constrain v0
 ///     1   RangeCheck0   Partially constrain v1
 ///     2   RangeCheck1   Fully constrain v2 (and trigger plookups constraints on row 3)
-///     3   Zero          Complete the constraining of v0 and v1
+///     3   Zero          Complete the constraining of v0 and v1 using lookups
 ///
 ///  Nb. each CircuitGate type corresponds to a unique polynomial and thus
 ///       is assigned its own unique powers of alpha
@@ -155,31 +158,29 @@ where
             .map(|i| crumb(&witness_curr(i)))
             .collect::<Vec<E<F>>>();
 
-        // 2) Constrain that the combined limbs equals the limb stored in w(0) where
-        //    v = vp0 vp1 vp2 vp3 vp4 vp5 vc0 vc1 vc2 vc3 vc4 vc5 vc6 vc7
-        //    in big-endian byte order.
+        // 2) Constrain that the combined limbs equals the limb stored in w(0):
         //
-        //          Columns
-        //          0      1    2    3    4    5    6    7    8    9    10   11   12   13   14
-        //    Curr  v      vp0  vp1  vp2  vp3  vp4  vp5  vc0  vc1  vc2  vc3  vc4  vc5  vc6  vc7  <- LSB
+        //        w(0) = v = vp0 vp1 vp2 vp3 vp4 vp5 vc0 vc1 vc2 vc3 vc4 vc5 vc6 vc7
         //
-        // Check v    =  vp0*2^0 + vp1*2^{12}  + ... + p5*2^{60}   + vc0*2^{72}  + vc1*2^{74}  + ... + vc7*2^{86}
-        //       w(0) = w(1)*2^0 + w(2)*2^{12} + ... + w(6)*2^{60} + w(7)*2^{72} + w(8)*2^{74} + ... + w(14)*2^{86}
-        //            = \sum i \in [1,6] 2^{12*(i - 1)} * w(i) + \sum i \in [7,14] 2^{2*(i - 7) + 6*12} * w(i)
+        //    where the value and limbs are stored in little-endian byte order, but mapped
+        //    to cells in big-endian order.
+        //
+        //    Cols: 0  1   2   3   4   5   6   7   8   9   10  11  12  13  14
+        //    Curr: v  vp0 vp1 vp2 vp3 vp4 vp5 vc0 vc1 vc2 vc3 vc4 vc5 vc6 vc7  <- LSB
 
         let mut power_of_2 = E::one();
         let mut sum_of_limbs = E::zero();
 
-        // Sum 12-bit limbs
-        for i in 1..=6 {
-            sum_of_limbs += power_of_2.clone() * witness_curr(i);
-            power_of_2 *= 4096u64.into(); // 12 bits
-        }
-
         // Sum 2-bit limbs
-        for i in 7..COLUMNS {
+        for i in (7..COLUMNS).rev() {
             sum_of_limbs += power_of_2.clone() * witness_curr(i);
             power_of_2 *= 4u64.into(); // 2 bits
+        }
+
+        // Sum 12-bit limbs
+        for i in (1..=6).rev() {
+            sum_of_limbs += power_of_2.clone() * witness_curr(i);
+            power_of_2 *= 4096u64.into(); // 12 bits
         }
 
         // Check value v against the sum of limbs
@@ -202,20 +203,20 @@ where
 ///
 /// Column | Curr         | Next
 ///      0 | v2           | (ignored)
-///      1 | plookup v2p0 | (ignored)
-///      2 | plookup v2p1 | (ignored)
-///      3 | plookup v2p2 | (ignored)
-///      4 | plookup v2p3 | (ignored)
-///      5 | crumb v2c0   | crumb v2c10
-///      6 | crumb v2c1   | crumb v2c11
-///      7 | crumb v2c2   | crumb v2c12
-///      8 | crumb v2c3   | crumb v2c13
-///      9 | crumb v2c4   | crumb v2c14
-///     10 | crumb v2c5   | crumb v2c15
-///     11 | crumb v2c6   | crumb v2c16
-///     12 | crumb v2c7   | crumb v2c17
-///     13 | crumb v2c8   | crumb v2c18
-///     14 | crumb v2c9   | crumb v2c19
+///      1 | crumb   v2c0 | crumb v2c10
+///      2 | crumb   v2c1 | crumb v2c11
+///      3 | plookup v2p0 | (ignored)
+///      4 | plookup v2p1 | (ignored)
+///      5 | plookup v2p2 | (ignored)
+///      6 | plookup v2p3 | (ignored)
+///      7 | crumb   v2c2 | crumb v2c12
+///      8 | crumb   v2c3 | crumb v2c13
+///      9 | crumb   v2c4 | crumb v2c14
+///     10 | crumb   v2c5 | crumb v2c15
+///     11 | crumb   v2c6 | crumb v2c16
+///     12 | crumb   v2c7 | crumb v2c17
+///     13 | crumb   v2c8 | crumb v2c18
+///     14 | crumb   v2c9 | crumb v2c19
 ///
 /// where the notation v2i and v2i defined in the "Layout" section above.
 
@@ -265,50 +266,47 @@ where
         );
 
         // 2) Constrain that the combined limbs equals the value v2 stored in w(0) where
-        //    v2 = vp0 vp1 vp2 vp3 vc0 vc1 vc2 vc3 vc4 vc5 vc6 vc7 vc8 vc9 vc10 vc11 vc12 vc13 vc14 vc15 vc16 vc17 vc18 vc19
-        //    in little-endian byte order.
         //
-        //          Columns
-        //          0    1   2   3   4   5    6    7    8    9    10   11   12   13   14
-        //    Curr  v2   vc0 vc1 vp0 vp1 vp2 vp3 vc2  vc3  vc4  vc5  vc6  vc7  vc8  vc9
-        //    Next                       vc10 vc11 vc12 vc13 vc14 vc15 vc16 vc17 vc18 vc19
+        //    w(0) = v2 = vc0 vc1 vp0 vp1 vp2 vp3 vc2 vc3 vc4 vc5 vc6 vc7 vc8 vc9 vc10 vc11 vc12
+        //                vc13 vc14 vc15 vc16 vc17 vc18 vc19
         //
-        // Check   v2 = vp0*2^0          + vp1*2^{12}       + ... + vp3*2^{36}       + vc0*2^{48}     + vc1*2^{50}     + ... + vc19*2^{66}
-        //       w(0) = w_curr(1)*2^0    + w_curr(2)*2^{12} + ... + w_curr(4)*2^{36} + w_curr(5)*2^48 + w_curr(6)*2^50 + ... + w_curr(14)*2^66
-        //            + w_next(5)*2^{68} + w_next(6)*2^{70} + ... + w_next(14)*2^{86}
-        // (1st part) = \sum i \in [1,4] 2^{12*(i - 1)}*w_curr(i) + \sum i \in [5,14] 2^{2*(i - 5) + 4*12}*w_curr(i)
-        // (2nd part) + \sum i \in [5,14] 2^{2*(i - 5} + 68)*w_next(i)
+        //    where the value and limbs are stored in little-endian byte order, but mapped
+        //    to cells in big-endian order.
+        //
+        //          0  1   2   3   4   5    6    7    8    9    10   11   12   13   14
+        //    Curr  v2 vc0 vc1 vp0 vp1 vp2  vp3  vc2  vc3  vc4  vc5  vc6  vc7  vc8  vc9
+        //    Next                     vc10 vc11 vc12 vc13 vc14 vc15 vc16 vc17 vc18 vc19 <- LSB
 
         let mut power_of_2 = E::one();
         let mut sum_of_limbs = E::zero();
 
-        // 1st part:  Sum 2-bit limbs vc0 and vc1 (row Curr)
-        for i in 1..=2 {
+        // Next row: Sum 2-bit limbs
+        for i in (7..COLUMNS).rev() {
+            sum_of_limbs += power_of_2.clone() * witness_next(i);
+            power_of_2 *= 4u64.into(); // 2 bits
+        }
+
+        // Next row:  Sum remaining 2-bit limbs vc10 and vc11
+        for i in (1..=2).rev() {
+            sum_of_limbs += power_of_2.clone() * witness_next(i);
+            power_of_2 *= 4u64.into(); // 2 bits
+        }
+
+        // Curr row:  Sum 2-bit limbs
+        for i in (7..COLUMNS).rev() {
             sum_of_limbs += power_of_2.clone() * witness_curr(i);
             power_of_2 *= 4u64.into(); // 2 bits
         }
 
-        // 1st part: Sum 12-bit limbs (row Curr)
-        for i in 3..=6 {
+        // Curr row: Sum 12-bit limbs
+        for i in (3..=6).rev() {
             sum_of_limbs += power_of_2.clone() * witness_curr(i);
             power_of_2 *= 4096u64.into(); // 12 bits
         }
 
-        // 1st part:  Sum remaining 2-bit limbs (row Curr)
-        for i in 7..COLUMNS {
+        // Curr row:  Sum remaining 2-bit limbs: vc0 and vc1
+        for i in (1..=2).rev() {
             sum_of_limbs += power_of_2.clone() * witness_curr(i);
-            power_of_2 *= 4u64.into(); // 2 bits
-        }
-
-        // 2nd part:  Sum 2-bit limbs vc10 and vc11 (row Next)
-        for i in 1..=2 {
-            sum_of_limbs += power_of_2.clone() * witness_next(i);
-            power_of_2 *= 4u64.into(); // 2 bits
-        }
-
-        // 2nd part: Sum remaining 2-bit limbs (row Next)
-        for i in 7..COLUMNS {
-            sum_of_limbs += power_of_2.clone() * witness_next(i);
             power_of_2 *= 4u64.into(); // 2 bits
         }
 

--- a/kimchi/src/circuits/polynomials/range_check/mod.rs
+++ b/kimchi/src/circuits/polynomials/range_check/mod.rs
@@ -7,4 +7,4 @@ pub mod witness;
 
 pub use circuitgates::{RangeCheck0, RangeCheck1};
 pub use gate::*;
-pub use witness::create_witness;
+pub use witness::*;

--- a/kimchi/src/circuits/polynomials/range_check/witness.rs
+++ b/kimchi/src/circuits/polynomials/range_check/witness.rs
@@ -64,16 +64,16 @@ const WITNESS_SHAPE: [[WitnessCell; COLUMNS]; 4] = [
     /* row 1, RangeCheck0 row */
     [
         ValueWitnessCell::create(),
-        /* 12-bit plookups */
-        LimbWitnessCell::create(0, 0, 0, 12),
-        LimbWitnessCell::create(0, 0, 12, 24),
-        LimbWitnessCell::create(0, 0, 24, 36),
-        LimbWitnessCell::create(0, 0, 36, 48),
         /* 12-bit copies */
         // Copy cells are required because we have a limit
         // of 4 lookups per row.  These two lookups are moved to
         // the 4th row (i.e. Zero circuit gate) and the RangeCheck1
         // circuit gate triggers the lookup constraints.
+        LimbWitnessCell::create(0, 0, 0, 12),
+        LimbWitnessCell::create(0, 0, 12, 24),
+        /* 12-bit plookups */
+        LimbWitnessCell::create(0, 0, 24, 36),
+        LimbWitnessCell::create(0, 0, 36, 48),
         LimbWitnessCell::create(0, 0, 48, 60),
         LimbWitnessCell::create(0, 0, 60, 72),
         /* 2-bit crumbs */
@@ -89,12 +89,12 @@ const WITNESS_SHAPE: [[WitnessCell; COLUMNS]; 4] = [
     /* row 2, RangeCheck0 row */
     [
         ValueWitnessCell::create(),
-        /* 12-bit plookups */
+        /* 12-bit copies (see note about copies above) */
         LimbWitnessCell::create(1, 0, 0, 12),
         LimbWitnessCell::create(1, 0, 12, 24),
+        /* 12-bit plookups */
         LimbWitnessCell::create(1, 0, 24, 36),
         LimbWitnessCell::create(1, 0, 36, 48),
-        /* 12-bit copies (see note about copies above) */
         LimbWitnessCell::create(1, 0, 48, 60),
         LimbWitnessCell::create(1, 0, 60, 72),
         /* 2-bit crumbs */
@@ -110,14 +110,16 @@ const WITNESS_SHAPE: [[WitnessCell; COLUMNS]; 4] = [
     /* row 3, RangeCheck1 row */
     [
         ValueWitnessCell::create(),
+        /* 2-bit crumbs (placed here to keep lookup pattern */
+        /*               the same as RangeCheck0) */
+        LimbWitnessCell::create(2, 0, 0, 2),
+        LimbWitnessCell::create(2, 0, 2, 4),
         /* 12-bit plookups */
-        LimbWitnessCell::create(2, 0, 0, 12),
-        LimbWitnessCell::create(2, 0, 12, 24),
-        LimbWitnessCell::create(2, 0, 24, 36),
-        LimbWitnessCell::create(2, 0, 36, 48),
+        LimbWitnessCell::create(2, 0, 4, 16),
+        LimbWitnessCell::create(2, 0, 16, 28),
+        LimbWitnessCell::create(2, 0, 28, 40),
+        LimbWitnessCell::create(2, 0, 40, 52),
         /* 2-bit crumbs */
-        LimbWitnessCell::create(2, 0, 48, 50),
-        LimbWitnessCell::create(2, 0, 50, 52),
         LimbWitnessCell::create(2, 0, 52, 54),
         LimbWitnessCell::create(2, 0, 54, 56),
         LimbWitnessCell::create(2, 0, 56, 58),
@@ -130,14 +132,16 @@ const WITNESS_SHAPE: [[WitnessCell; COLUMNS]; 4] = [
     /* row 4, Zero row */
     [
         ZeroWitnessCell::create(),
-        /* 12-bit plookups (see note about copies above) */
-        CopyWitnessCell::create(0, 5),
-        CopyWitnessCell::create(0, 6),
-        CopyWitnessCell::create(1, 5),
-        CopyWitnessCell::create(1, 6),
-        /* 2-bit crumbs */
+        /* 2-bit crumbs (placed here to keep lookup pattern */
+        /*               the same as RangeCheck0) */
         LimbWitnessCell::create(2, 0, 68, 70),
         LimbWitnessCell::create(2, 0, 70, 72),
+        /* 12-bit plookups (see note about copies above) */
+        CopyWitnessCell::create(0, 1),
+        CopyWitnessCell::create(0, 2),
+        CopyWitnessCell::create(1, 1),
+        CopyWitnessCell::create(1, 2),
+        /* 2-bit crumbs */
         LimbWitnessCell::create(2, 0, 72, 74),
         LimbWitnessCell::create(2, 0, 74, 76),
         LimbWitnessCell::create(2, 0, 76, 78),

--- a/kimchi/src/circuits/polynomials/range_check/witness.rs
+++ b/kimchi/src/circuits/polynomials/range_check/witness.rs
@@ -178,15 +178,25 @@ fn init_range_check_row<F: PrimeField>(witness: &mut [Vec<F>; COLUMNS], row: usi
     }
 }
 
-/// Create a range check witness
+/// Create a multi range check witness
 /// Input: three values: v0, v1 and v2
-pub fn create_witness<F: PrimeField>(v0: F, v1: F, v2: F) -> [Vec<F>; COLUMNS] {
+pub fn create_multi_witness<F: PrimeField>(v0: F, v1: F, v2: F) -> [Vec<F>; COLUMNS] {
     let mut witness: [Vec<F>; COLUMNS] = array_init(|_| vec![F::zero(); 4]);
 
     init_range_check_row(&mut witness, 0, v0);
     init_range_check_row(&mut witness, 1, v1);
     init_range_check_row(&mut witness, 2, v2);
     init_range_check_row(&mut witness, 3, F::zero());
+
+    witness
+}
+
+/// Create a single range check witness
+/// Input: three values: v0, v1 and v2
+pub fn create_witness<F: PrimeField>(v0: F) -> [Vec<F>; COLUMNS] {
+    let mut witness: [Vec<F>; COLUMNS] = array_init(|_| vec![F::zero(); 4]);
+
+    init_range_check_row(&mut witness, 0, v0);
 
     witness
 }

--- a/kimchi/src/circuits/polynomials/range_check/witness.rs
+++ b/kimchi/src/circuits/polynomials/range_check/witness.rs
@@ -18,6 +18,7 @@ struct CopyWitnessCell {
     row: usize,
     col: usize,
 }
+
 impl CopyWitnessCell {
     const fn create(row: usize, col: usize) -> WitnessCell {
         WitnessCell::Copy(CopyWitnessCell { row, col })
@@ -39,6 +40,7 @@ struct LimbWitnessCell {
     start: usize, // Starting bit offset
     end: usize,   // Ending bit offset (exclusive)
 }
+
 impl LimbWitnessCell {
     // Params: source (row, col), starting bit offset and ending bit offset (exclusive)
     const fn create(row: usize, col: usize, start: usize, end: usize) -> WitnessCell {
@@ -59,99 +61,95 @@ impl ZeroWitnessCell {
     }
 }
 
-// Generate witness in shape that constraints expect (TODO: static for now, make dynamic)
+// Witness layout
+//   * The values and cell contents are in little-endian order.
+//     This is important for compatibility with other gates, where
+//     elements of the first 7 columns could be copied and reused by them.
+//     So they should be in the usual little-endian witness byte order.
+//   * Limbs are mapped to columns so that those containing the MSBs
+//     are in lower numbered columns (i.e. big-endian column mapping).
+//     This is important so that copy constraints are possible on the MSBs.
+//     For example, we can convert the RangeCheck0 circuit gate into
+//     a 64-bit lookup by adding two copy constraints to constrain
+//     columns 1 and 2 to zero.
 const WITNESS_SHAPE: [[WitnessCell; COLUMNS]; 4] = [
     /* row 1, RangeCheck0 row */
-    [
-        ValueWitnessCell::create(),
-        /* 12-bit copies */
-        // Copy cells are required because we have a limit
-        // of 4 lookups per row.  These two lookups are moved to
-        // the 4th row (i.e. Zero circuit gate) and the RangeCheck1
-        // circuit gate triggers the lookup constraints.
-        LimbWitnessCell::create(0, 0, 0, 12),
-        LimbWitnessCell::create(0, 0, 12, 24),
-        /* 12-bit plookups */
-        LimbWitnessCell::create(0, 0, 24, 36),
-        LimbWitnessCell::create(0, 0, 36, 48),
-        LimbWitnessCell::create(0, 0, 48, 60),
-        LimbWitnessCell::create(0, 0, 60, 72),
-        /* 2-bit crumbs */
-        LimbWitnessCell::create(0, 0, 72, 74),
-        LimbWitnessCell::create(0, 0, 74, 76),
-        LimbWitnessCell::create(0, 0, 76, 78),
-        LimbWitnessCell::create(0, 0, 78, 80),
-        LimbWitnessCell::create(0, 0, 80, 82),
-        LimbWitnessCell::create(0, 0, 82, 84),
-        LimbWitnessCell::create(0, 0, 84, 86),
-        LimbWitnessCell::create(0, 0, 86, 88),
-    ],
+    range_check_row(0),
     /* row 2, RangeCheck0 row */
-    [
-        ValueWitnessCell::create(),
-        /* 12-bit copies (see note about copies above) */
-        LimbWitnessCell::create(1, 0, 0, 12),
-        LimbWitnessCell::create(1, 0, 12, 24),
-        /* 12-bit plookups */
-        LimbWitnessCell::create(1, 0, 24, 36),
-        LimbWitnessCell::create(1, 0, 36, 48),
-        LimbWitnessCell::create(1, 0, 48, 60),
-        LimbWitnessCell::create(1, 0, 60, 72),
-        /* 2-bit crumbs */
-        LimbWitnessCell::create(1, 0, 72, 74),
-        LimbWitnessCell::create(1, 0, 74, 76),
-        LimbWitnessCell::create(1, 0, 76, 78),
-        LimbWitnessCell::create(1, 0, 78, 80),
-        LimbWitnessCell::create(1, 0, 80, 82),
-        LimbWitnessCell::create(1, 0, 82, 84),
-        LimbWitnessCell::create(1, 0, 84, 86),
-        LimbWitnessCell::create(1, 0, 86, 88),
-    ],
+    range_check_row(1),
     /* row 3, RangeCheck1 row */
     [
         ValueWitnessCell::create(),
         /* 2-bit crumbs (placed here to keep lookup pattern */
         /*               the same as RangeCheck0) */
-        LimbWitnessCell::create(2, 0, 0, 2),
-        LimbWitnessCell::create(2, 0, 2, 4),
+        LimbWitnessCell::create(2, 0, 86, 88),
+        LimbWitnessCell::create(2, 0, 84, 86),
         /* 12-bit plookups */
-        LimbWitnessCell::create(2, 0, 4, 16),
-        LimbWitnessCell::create(2, 0, 16, 28),
-        LimbWitnessCell::create(2, 0, 28, 40),
-        LimbWitnessCell::create(2, 0, 40, 52),
+        LimbWitnessCell::create(2, 0, 72, 84),
+        LimbWitnessCell::create(2, 0, 60, 72),
+        LimbWitnessCell::create(2, 0, 48, 60),
+        LimbWitnessCell::create(2, 0, 36, 48),
         /* 2-bit crumbs */
-        LimbWitnessCell::create(2, 0, 52, 54),
-        LimbWitnessCell::create(2, 0, 54, 56),
-        LimbWitnessCell::create(2, 0, 56, 58),
-        LimbWitnessCell::create(2, 0, 58, 60),
-        LimbWitnessCell::create(2, 0, 60, 62),
-        LimbWitnessCell::create(2, 0, 62, 64),
-        LimbWitnessCell::create(2, 0, 64, 66),
-        LimbWitnessCell::create(2, 0, 66, 68),
+        LimbWitnessCell::create(2, 0, 34, 36),
+        LimbWitnessCell::create(2, 0, 32, 34),
+        LimbWitnessCell::create(2, 0, 30, 32),
+        LimbWitnessCell::create(2, 0, 28, 30),
+        LimbWitnessCell::create(2, 0, 26, 28),
+        LimbWitnessCell::create(2, 0, 24, 26),
+        LimbWitnessCell::create(2, 0, 22, 24),
+        LimbWitnessCell::create(2, 0, 20, 22),
     ],
     /* row 4, Zero row */
     [
         ZeroWitnessCell::create(),
         /* 2-bit crumbs (placed here to keep lookup pattern */
         /*               the same as RangeCheck0) */
-        LimbWitnessCell::create(2, 0, 68, 70),
-        LimbWitnessCell::create(2, 0, 70, 72),
-        /* 12-bit plookups (see note about copies above) */
+        LimbWitnessCell::create(2, 0, 18, 20),
+        LimbWitnessCell::create(2, 0, 16, 18),
+        /* 12-bit plookups (see note about copies in range_check_row) */
         CopyWitnessCell::create(0, 1),
         CopyWitnessCell::create(0, 2),
         CopyWitnessCell::create(1, 1),
         CopyWitnessCell::create(1, 2),
         /* 2-bit crumbs */
-        LimbWitnessCell::create(2, 0, 72, 74),
-        LimbWitnessCell::create(2, 0, 74, 76),
-        LimbWitnessCell::create(2, 0, 76, 78),
-        LimbWitnessCell::create(2, 0, 78, 80),
-        LimbWitnessCell::create(2, 0, 80, 82),
-        LimbWitnessCell::create(2, 0, 82, 84),
-        LimbWitnessCell::create(2, 0, 84, 86),
-        LimbWitnessCell::create(2, 0, 86, 88),
+        LimbWitnessCell::create(2, 0, 14, 16),
+        LimbWitnessCell::create(2, 0, 12, 14),
+        LimbWitnessCell::create(2, 0, 10, 12),
+        LimbWitnessCell::create(2, 0, 8, 10),
+        LimbWitnessCell::create(2, 0, 6, 8),
+        LimbWitnessCell::create(2, 0, 4, 6),
+        LimbWitnessCell::create(2, 0, 2, 4),
+        LimbWitnessCell::create(2, 0, 0, 2),
     ],
 ];
+
+// The row layout for RangeCheck0
+const fn range_check_row(row: usize) -> [WitnessCell; COLUMNS] {
+    [
+        ValueWitnessCell::create(),
+        /* 12-bit copies */
+        // Copy cells are required because we have a limit
+        // of 4 lookups per row.  These two lookups are moved to
+        // the 4th row, which is a Zero circuit gate, and the
+        // RangeCheck1 circuit gate triggers the lookup constraints.
+        LimbWitnessCell::create(row, 0, 76, 88),
+        LimbWitnessCell::create(row, 0, 64, 76),
+        /* 12-bit plookups */
+        LimbWitnessCell::create(row, 0, 52, 64),
+        LimbWitnessCell::create(row, 0, 40, 52),
+        LimbWitnessCell::create(row, 0, 28, 40),
+        LimbWitnessCell::create(row, 0, 16, 28),
+        /* 2-bit crumbs */
+        LimbWitnessCell::create(row, 0, 14, 16),
+        LimbWitnessCell::create(row, 0, 12, 14),
+        LimbWitnessCell::create(row, 0, 10, 12),
+        LimbWitnessCell::create(row, 0, 8, 10),
+        LimbWitnessCell::create(row, 0, 6, 8),
+        LimbWitnessCell::create(row, 0, 4, 6),
+        LimbWitnessCell::create(row, 0, 2, 4),
+        LimbWitnessCell::create(row, 0, 0, 2),
+    ]
+}
 
 fn value_to_limb<F: PrimeField>(fe: F, start: usize, end: usize) -> F {
     F::from_bits(&fe.to_bits()[start..end]).expect("failed to deserialize field bits")


### PR DESCRIPTION
This adds 64-bit range check support.  This can be done with a single `RangeCheck0` circuit gate / row by copying the cells in columns 1 and 2 to zero, i.e. by adding two copy constraints.

Closes #592 