### PR TITLE
[kombucha] implement cached constants

### DIFF
--- a/circuit-construction/src/prover.rs
+++ b/circuit-construction/src/prover.rs
@@ -114,14 +114,8 @@ where
     EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
     EFrSponge: FrSponge<G::ScalarField>,
 {
-    // create the public rows
-    let mut gen: WitnessGenerator<G::ScalarField> = WitnessGenerator {
-        rows: public_input
-            .iter()
-            .map(|x| array_init(|i| if i == 0 { *x } else { G::ScalarField::zero() }))
-            .collect(),
-        generic_gate_queue: vec![],
-    };
+    // create the witness generator
+    let mut gen: WitnessGenerator<G::ScalarField> = WitnessGenerator::new(&public_input);
 
     // run the witness generation
     let public_vars = public_input
@@ -171,11 +165,7 @@ where
     H: FnOnce(&mut System<C::InnerField>, Vec<Var<C::InnerField>>),
     C: Cycle,
 {
-    let mut system: System<C::InnerField> = System {
-        next_variable: 0,
-        gates: vec![],
-        generic_gate_queue: vec![],
-    };
+    let mut system: System<C::InnerField> = System::default();
     let z = C::InnerField::zero();
 
     // create public input variables

--- a/circuit-construction/src/writer.rs
+++ b/circuit-construction/src/writer.rs
@@ -1,4 +1,4 @@
-use ark_ff::{BigInteger, FftField, PrimeField, Zero};
+use ark_ff::{BigInteger, FftField, PrimeField};
 use array_init::array_init;
 use kimchi::circuits::{
     gate::{CircuitGate, GateType},


### PR DESCRIPTION
Cache constants the same way the OCaml code does.

When writing this, and the double generic gate, it feels like I'm writing redundant or unnecessary code sometimes. It makes me think that if `Cs` was implemented on a single struct, combining both `System` and `WitnessGenerator`, it would be leaner. IIUC this is what the OCaml code is doing, but this is also what arkworks r1cs std is doing