### PR TITLE
[snarky] completing missing elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "disjoint-set"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d102f1a462fdcdddce88d6d46c06c074a2d2749b262230333726b06c52bb7585"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +763,7 @@ dependencies = [
  "colored",
  "commitment_dlog",
  "criterion",
+ "disjoint-set",
  "groupmap",
  "hex",
  "iai",

--- a/kimchi/src/snarky/constants.rs
+++ b/kimchi/src/snarky/constants.rs
@@ -1,0 +1,44 @@
+use ark_ec::AffineCurve;
+use ark_ff::{Field, PrimeField};
+use commitment_dlog::{commitment::CommitmentCurve, srs::endos};
+use mina_curves::pasta::{pallas::Affine as PallasAffine, vesta::Affine as VestaAffine, Fp, Fq};
+use oracle::poseidon::ArithmeticSpongeParams;
+
+#[derive(Clone)]
+pub struct Constants<F: Field> {
+    pub poseidon: ArithmeticSpongeParams<F>,
+    pub endo: F,
+    pub base: (F, F),
+}
+
+pub trait KimchiParams: PrimeField {
+    fn constants() -> Constants<Self>;
+}
+
+impl KimchiParams for Fp {
+    fn constants() -> Constants<Fp> {
+        let (endo_q, _endo_r) = endos::<PallasAffine>();
+        let base = PallasAffine::prime_subgroup_generator()
+            .to_coordinates()
+            .unwrap();
+        Constants {
+            poseidon: oracle::pasta::fp_kimchi::params(),
+            endo: endo_q,
+            base,
+        }
+    }
+}
+
+impl KimchiParams for Fq {
+    fn constants() -> Constants<Fq> {
+        let (endo_q, _endo_r) = endos::<VestaAffine>();
+        let base = VestaAffine::prime_subgroup_generator()
+            .to_coordinates()
+            .unwrap();
+        Constants {
+            poseidon: oracle::pasta::fq_kimchi::params(),
+            endo: endo_q,
+            base,
+        }
+    }
+}

--- a/kimchi/src/snarky/constraint_system.rs
+++ b/kimchi/src/snarky/constraint_system.rs
@@ -1091,7 +1091,25 @@ impl<Field: FftField, Gates: GateVector<Field>> SnarkyConstraintSystem<Field, Ga
                     vec![coeff(l), coeff(r), coeff(o), m, c],
                 )
             }
-            _ => unimplemented!(),
+            KimchiConstraint::Poseidon { state } => todo!(),
+            KimchiConstraint::EcAddComplete {
+                p1,
+                p2,
+                p3,
+                inf,
+                same_x,
+                slope,
+                inf_z,
+                x21_inv,
+            } => todo!(),
+            KimchiConstraint::EcScale { state } => todo!(),
+            KimchiConstraint::EcEndoscale {
+                state,
+                xs,
+                ys,
+                n_acc,
+            } => todo!(),
+            KimchiConstraint::EcEndoscalar { state } => todo!(),
         }
     }
 }

--- a/kimchi/src/snarky/constraint_system.rs
+++ b/kimchi/src/snarky/constraint_system.rs
@@ -1282,7 +1282,6 @@ impl<Field: FftField, Gates: GateVector<Field>> SnarkyConstraintSystem<Field, Ga
                 xs,
                 ys,
                 n_acc,
-            KimchiConstraint::EcEndoscalar { state } => todo!(),
             } => {
                 for round in state {
                     let vars = vec![
@@ -1317,6 +1316,27 @@ impl<Field: FftField, Gates: GateVector<Field>> SnarkyConstraintSystem<Field, Ga
                     Some(self.reduce_to_var(n_acc)),
                 ];
                 self.add_row(vars, GateType::Zero, vec![]);
+            }
+            KimchiConstraint::EcEndoscalar { state } => {
+                for round in state {
+                    let vars = vec![
+                        Some(self.reduce_to_var(round.n0)),
+                        Some(self.reduce_to_var(round.n8)),
+                        Some(self.reduce_to_var(round.a0)),
+                        Some(self.reduce_to_var(round.b0)),
+                        Some(self.reduce_to_var(round.a8)),
+                        Some(self.reduce_to_var(round.b8)),
+                        Some(self.reduce_to_var(round.x0)),
+                        Some(self.reduce_to_var(round.x1)),
+                        Some(self.reduce_to_var(round.x2)),
+                        Some(self.reduce_to_var(round.x3)),
+                        Some(self.reduce_to_var(round.x4)),
+                        Some(self.reduce_to_var(round.x5)),
+                        Some(self.reduce_to_var(round.x6)),
+                        Some(self.reduce_to_var(round.x7)),
+                    ];
+                    self.add_row(vars, GateType::EndoMulScalar, vec![]);
+                }
             }
         }
     }

--- a/kimchi/src/snarky/constraint_system.rs
+++ b/kimchi/src/snarky/constraint_system.rs
@@ -41,44 +41,6 @@ struct Position<Row> {
     col: usize,
 }
 
-impl<Row> Position<Row> {
-    /** Generates a full row of positions that each points to itself. */
-    fn create_cols(row: Row) -> Vec<Self>
-    where
-        Row: Clone,
-    {
-        (0..PERMUTS)
-            .map(|col| Position {
-                row: row.clone(),
-                col,
-            })
-            .collect()
-    }
-
-    /** Given a number of columns, append enough column wires to get an entire row.
-    The wire appended will simply point to themselves, so as to not take part in the
-    permutation argument. */
-    fn append_cols(row: Row, cols: &mut Vec<Position<Row>>)
-    where
-        Row: Clone,
-    {
-        let padding_offset = cols.len();
-        assert!(padding_offset <= PERMUTS);
-        let padding_len = PERMUTS - padding_offset;
-        cols.extend((0..padding_len).map(|i| Position {
-            row: row.clone(),
-            col: i + padding_offset,
-        }))
-    }
-
-    /** Converts an array of [Constants.columns] to [Constants.permutation_cols].
-    This is useful to truncate arrays of cells to the ones that only matter for the permutation argument.
-    */
-    fn cols_to_perms<A: Clone>(x: Vec<A>) -> Vec<A> {
-        x[0..PERMUTS].to_vec()
-    }
-}
-
 impl Position<usize> {
     fn to_rust_wire(self: Self) -> Wire {
         Wire {
@@ -1039,7 +1001,7 @@ impl<Field: FftField, Gates: GateVector<Field>> SnarkyConstraintSystem<Field, Ga
         }
     }
 
-    pub fn add_constraint<Cvar>(self: &mut Self, constraint: KimchiConstraint<Cvar, Field>)
+    pub fn add_constraint<Cvar>(&mut self, constraint: KimchiConstraint<Cvar, Field>)
     where
         Cvar: SnarkyCvar<Field = Field>,
     {
@@ -1224,17 +1186,14 @@ impl<Field: FftField, Gates: GateVector<Field>> SnarkyConstraintSystem<Field, Ga
                 self.add_row(vars, GateType::CompleteAdd, vec![]);
             }
             KimchiConstraint::EcScale { state } => {
-                for (
-                    round,
-                    ScaleRound {
-                        accs,
-                        bits,
-                        ss,
-                        base,
-                        n_prev,
-                        n_next,
-                    },
-                ) in state.into_iter().enumerate()
+                for ScaleRound {
+                    accs,
+                    bits,
+                    ss,
+                    base,
+                    n_prev,
+                    n_next,
+                } in state
                 {
                     // 0   1   2   3   4   5   6   7   8   9   10  11  12  13  14
                     // xT  yT  x0  y0  n   n'      x1  y1  x2  y2  x3  y3  x4  y4

--- a/kimchi/src/snarky/constraint_system.rs
+++ b/kimchi/src/snarky/constraint_system.rs
@@ -1282,8 +1282,42 @@ impl<Field: FftField, Gates: GateVector<Field>> SnarkyConstraintSystem<Field, Ga
                 xs,
                 ys,
                 n_acc,
-            } => todo!(),
             KimchiConstraint::EcEndoscalar { state } => todo!(),
+            } => {
+                for round in state {
+                    let vars = vec![
+                        Some(self.reduce_to_var(round.xt)),
+                        Some(self.reduce_to_var(round.yt)),
+                        None,
+                        None,
+                        Some(self.reduce_to_var(round.xp)),
+                        Some(self.reduce_to_var(round.yp)),
+                        Some(self.reduce_to_var(round.n_acc)),
+                        Some(self.reduce_to_var(round.xr)),
+                        Some(self.reduce_to_var(round.yr)),
+                        Some(self.reduce_to_var(round.s1)),
+                        Some(self.reduce_to_var(round.s3)),
+                        Some(self.reduce_to_var(round.b1)),
+                        Some(self.reduce_to_var(round.b2)),
+                        Some(self.reduce_to_var(round.b3)),
+                        Some(self.reduce_to_var(round.b4)),
+                    ];
+
+                    self.add_row(vars, GateType::EndoMul, vec![]);
+                }
+
+                // last row
+                let vars = vec![
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(self.reduce_to_var(xs)),
+                    Some(self.reduce_to_var(ys)),
+                    Some(self.reduce_to_var(n_acc)),
+                ];
+                self.add_row(vars, GateType::Zero, vec![]);
+            }
         }
     }
 }

--- a/kimchi/src/snarky/mod.rs
+++ b/kimchi/src/snarky/mod.rs
@@ -1,2 +1,4 @@
+#![allow(clippy::all)]
+
 pub mod constants;
 pub mod constraint_system;

--- a/kimchi/src/snarky/mod.rs
+++ b/kimchi/src/snarky/mod.rs
@@ -1,1 +1,2 @@
+pub mod constants;
 pub mod constraint_system;


### PR DESCRIPTION
from https://github.com/o1-labs/proof-systems/pull/542:

* [x] [`reduce_to_v`](https://github.com/MinaProtocol/mina/blob/7b0174549d5ee4255e1ab694d47597b599a325e3/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml#L731) helper in `add_constraint`
* [x] [`Poseidon` gate](https://github.com/MinaProtocol/mina/blob/develop/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml#L932)
* [x] [`EC_add_complete` gate](https://github.com/MinaProtocol/mina/blob/7b0174549d5ee4255e1ab694d47597b599a325e3/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml#L1012)
* [x] [`EC_scale` gate](https://github.com/MinaProtocol/mina/blob/7b0174549d5ee4255e1ab694d47597b599a325e3/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml#L1043)
* [x] [`EC_endoscale` gate](https://github.com/MinaProtocol/mina/blob/7b0174549d5ee4255e1ab694d47597b599a325e3/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml#L1096)
* [x] [`EC_endoscalar` gate](https://github.com/MinaProtocol/mina/blob/7b0174549d5ee4255e1ab694d47597b599a325e3/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml#L1141)