### PR TITLE
Update FieldHelper API to not claim ownership

### DIFF
--- a/cairo/src/helper.rs
+++ b/cairo/src/helper.rs
@@ -8,30 +8,30 @@ use o1_utils::FieldHelpers;
 /// Field element helpers for Cairo
 pub trait CairoFieldHelpers<F> {
     /// Return field element as byte, if it fits. Otherwise returns least significant byte
-    fn lsb(self) -> u8;
+    fn lsb(&self) -> u8;
 
     /// Return `pos`-th 16-bit chunk as another field element
-    fn u16_chunk(self, pos: usize) -> F;
+    fn u16_chunk(&self, pos: usize) -> F;
 
     /// Return first 64 bits of the field element
-    fn to_u64(self) -> u64;
+    fn to_u64(&self) -> u64;
 
     /// Return a field element in hexadecimal in big endian
-    fn to_hex_be(self) -> String;
+    fn to_hex_be(&self) -> String;
 }
 
 impl<F: Field> CairoFieldHelpers<F> for F {
-    fn lsb(self) -> u8 {
+    fn lsb(&self) -> u8 {
         self.to_bytes()[0]
     }
 
-    fn u16_chunk(self, pos: usize) -> F {
+    fn u16_chunk(&self, pos: usize) -> F {
         let bytes = self.to_bytes();
         let chunk = u16::from(bytes[2 * pos]) + u16::from(bytes[2 * pos + 1]) * 2u16.pow(8);
         F::from(chunk)
     }
 
-    fn to_u64(self) -> u64 {
+    fn to_u64(&self) -> u64 {
         let bytes = self.to_bytes();
         let mut acc: u64 = 0;
         for i in 0..8 {
@@ -40,7 +40,7 @@ impl<F: Field> CairoFieldHelpers<F> for F {
         acc
     }
 
-    fn to_hex_be(self) -> String {
+    fn to_hex_be(&self) -> String {
         let mut bytes = self.to_bytes();
         bytes.reverse();
         hex::encode(bytes)

--- a/curves/src/pasta/curves/pallas.rs
+++ b/curves/src/pasta/curves/pallas.rs
@@ -5,7 +5,7 @@ use ark_ec::{
 };
 use ark_ff::{field_new, Zero};
 
-#[derive(Copy, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PallasParameters;
 
 impl ModelParameters for PallasParameters {

--- a/curves/src/pasta/curves/vesta.rs
+++ b/curves/src/pasta/curves/vesta.rs
@@ -5,7 +5,7 @@ use ark_ec::{
 };
 use ark_ff::{field_new, Zero};
 
-#[derive(Copy, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct VestaParameters;
 
 impl ModelParameters for VestaParameters {

--- a/hasher/src/lib.rs
+++ b/hasher/src/lib.rs
@@ -15,7 +15,7 @@ use o1_utils::FieldHelpers;
 
 /// The domain parameter trait is used during hashing to convey extra
 /// arguments to domain string generation.  It is also used by generic signing code.
-pub trait DomainParameter: Clone + Copy {
+pub trait DomainParameter: Clone {
     /// Conversion into vector of bytes
     fn into_bytes(self) -> Vec<u8>;
 }

--- a/hasher/src/roinput.rs
+++ b/hasher/src/roinput.rs
@@ -834,7 +834,7 @@ mod tests {
 
     #[test]
     fn nested_roinput_test() {
-        #[derive(Clone, Copy, Debug)]
+        #[derive(Clone, Debug)]
         struct A {
             x: u32,
             y: bool,
@@ -858,7 +858,7 @@ mod tests {
             }
         }
 
-        #[derive(Clone, Copy, Debug)]
+        #[derive(Clone, Debug)]
         struct B1 {
             a: A,
             b: u64,
@@ -881,7 +881,7 @@ mod tests {
             }
         }
 
-        #[derive(Clone, Copy, Debug)]
+        #[derive(Clone, Debug)]
         struct B2 {
             a: A,
             b: u64,
@@ -919,7 +919,7 @@ mod tests {
             c: true,
         };
         let b2 = B2 {
-            a: b1.a,
+            a: b1.a.clone(),
             b: b1.b,
             c: b1.c,
         };
@@ -927,14 +927,14 @@ mod tests {
         assert_eq!(b1.to_roinput(), b2.to_roinput());
 
         let b2 = B2 {
-            a: b1.a,
-            b: b1.b,
+            a: b1.a.clone(),
+            b: b1.b.clone(),
             c: false,
         };
         assert_ne!(b1.to_roinput(), b2.to_roinput());
 
         let b2 = B2 {
-            a: b1.a,
+            a: b1.a.clone(),
             b: b1.b + 1,
             c: b1.c,
         };

--- a/kimchi/src/circuits/scalars.rs
+++ b/kimchi/src/circuits/scalars.rs
@@ -28,9 +28,9 @@ impl<F: Field> Default for RandomOracles<F> {
             zeta: F::zero(),
             v: F::zero(),
             u: F::zero(),
-            alpha_chal: c,
-            zeta_chal: c,
-            v_chal: c,
+            alpha_chal: c.clone(),
+            zeta_chal: c.clone(),
+            v_chal: c.clone(),
             u_chal: c,
             joint_combiner: None,
         }

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -166,7 +166,8 @@ where
             //~~ - Derive the scalar joint combiner challenge $j$ from $j'$ using the endomorphism.
             //~~   (TODO: specify endomorphism)
             let joint_combiner = ScalarChallenge(joint_combiner);
-            let joint_combiner = (joint_combiner, joint_combiner.to_field(&index.srs().endo_r));
+            let joint_combiner_field = joint_combiner.to_field(&index.srs().endo_r);
+            let joint_combiner = (joint_combiner, joint_combiner_field);
 
             //~~ - absorb the commitments to the sorted polynomials.
             for com in &lookup_commits.sorted {
@@ -367,7 +368,7 @@ where
                 alpha,
                 beta,
                 gamma,
-                joint_combiner: joint_combiner.map(|j| j.1),
+                joint_combiner: joint_combiner.clone().map(|j| j.1),
                 endo_coefficient: index.endo,
                 mds: index.fr_sponge_params.mds.clone(),
             };
@@ -575,7 +576,7 @@ where
                 alpha: oracles.alpha,
                 beta: oracles.beta,
                 gamma: oracles.gamma,
-                joint_combiner: oracles.joint_combiner.map(|j| j.1),
+                joint_combiner: oracles.joint_combiner.as_ref().map(|j| j.1),
                 endo_coefficient: index.endo,
                 mds: index.fr_sponge_params.mds.clone(),
             };

--- a/oracle/src/sponge.rs
+++ b/oracle/src/sponge.rs
@@ -11,7 +11,7 @@ const HIGH_ENTROPY_LIMBS: usize = 2;
 
 // TODO: move to a different file / module
 /// A challenge which is used as a scalar on a group element in the verifier
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct ScalarChallenge<F>(pub F);
 
 pub fn endo_coefficient<F: PrimeField>() -> F {

--- a/poly-commitment/src/combine.rs
+++ b/poly-commitment/src/combine.rs
@@ -441,7 +441,7 @@ pub fn affine_window_combine_one_endo<P: SWModelParameters>(
     let b: Vec<_> = g1.chunks(CHUNK_SIZE).zip(g2.chunks(CHUNK_SIZE)).collect();
     let v: Vec<_> = b
         .into_par_iter()
-        .map(|(v1, v2)| affine_window_combine_one_endo_base(endo_coeff, v1, v2, chal))
+        .map(|(v1, v2)| affine_window_combine_one_endo_base(endo_coeff, v1, v2, chal.clone()))
         .collect();
     v.concat()
 }

--- a/signer/README.md
+++ b/signer/README.md
@@ -22,7 +22,7 @@ use transaction::Transaction;
 let keypair = Keypair::rand(&mut rand::rngs::OsRng);
 
 let tx = Transaction::new_payment(
-                keypair.public,
+                keypair.public.clone(),
                 PubKey::from_address("B62qicipYxyEHu7QjUqS7QvBipTs5CzgkYZZZkPoKVYBu6tnDUcE9Zt").expect("invalid receiver address"),
                 1729000000000,
                 2000000000,

--- a/signer/src/keypair.rs
+++ b/signer/src/keypair.rs
@@ -26,7 +26,7 @@ pub enum KeypairError {
 pub type Result<T> = std::result::Result<T, KeypairError>;
 
 /// Keypair structure
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Keypair {
     /// Secret key
     pub(crate) secret: SecKey,
@@ -48,11 +48,11 @@ impl Keypair {
     pub fn rand(rng: &mut (impl RngCore + CryptoRng)) -> Self {
         let sec_key: SecKey = SecKey::rand(rng);
         let public: CurvePoint = CurvePoint::prime_subgroup_generator()
-            .mul(sec_key.into_scalar())
+            .mul(*sec_key.scalar())
             .into_affine();
 
         // Safe in this case b/c point must be on curve
-        Self::from_parts_unsafe(sec_key.into_scalar(), public)
+        Self::from_parts_unsafe(*sec_key.scalar(), public)
     }
 
     /// Deserialize a keypair from secret key hex

--- a/signer/src/keypair.rs
+++ b/signer/src/keypair.rs
@@ -10,7 +10,7 @@ use rand::{self, CryptoRng, RngCore};
 use thiserror::Error;
 
 /// Keypair error
-#[derive(Error, Debug, Clone, Copy, PartialEq)]
+#[derive(Error, Debug, Clone, PartialEq)]
 pub enum KeypairError {
     /// Invalid secret key hex
     #[error("invalid secret key hex")]
@@ -47,12 +47,13 @@ impl Keypair {
     /// Generate a random keypair
     pub fn rand(rng: &mut (impl RngCore + CryptoRng)) -> Self {
         let sec_key: SecKey = SecKey::rand(rng);
+        let scalar = sec_key.into_scalar();
         let public: CurvePoint = CurvePoint::prime_subgroup_generator()
-            .mul(*sec_key.scalar())
+            .mul(scalar)
             .into_affine();
 
         // Safe in this case b/c point must be on curve
-        Self::from_parts_unsafe(*sec_key.scalar(), public)
+        Self::from_parts_unsafe(scalar, public)
     }
 
     /// Deserialize a keypair from secret key hex

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -26,7 +26,7 @@ pub type BaseField = <CurvePoint as AffineCurve>::BaseField;
 pub type ScalarField = <CurvePoint as AffineCurve>::ScalarField;
 
 /// Mina network (or blockchain) identifier
-#[derive(Copy, Clone)]
+#[derive(Debug, Clone)]
 pub enum NetworkId {
     /// Id for all testnets
     TESTNET = 0x00,

--- a/signer/src/pubkey.rs
+++ b/signer/src/pubkey.rs
@@ -48,7 +48,7 @@ pub const MINA_ADDRESS_LEN: usize = 55;
 const MINA_ADDRESS_RAW_LEN: usize = 40;
 
 /// Public key
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PubKey(CurvePoint);
 
 impl PubKey {
@@ -102,14 +102,14 @@ impl PubKey {
         Ok(PubKey::from_point_unsafe(pt))
     }
 
-    /// Convert public key into curve point
-    pub fn into_point(self) -> CurvePoint {
-        self.0
+    /// Borrow public key as curve point
+    pub fn point(&self) -> &CurvePoint {
+        &self.0
     }
 
     /// Convert public key into compressed public key
-    pub fn into_compressed(self) -> CompressedPubKey {
-        let point = self.into_point();
+    pub fn into_compressed(&self) -> CompressedPubKey {
+        let point = self.0;
         CompressedPubKey {
             x: point.x,
             is_odd: point.y.into_repr().is_odd(),
@@ -117,15 +117,15 @@ impl PubKey {
     }
 
     /// Serialize public key into corresponding Mina address
-    pub fn into_address(self) -> String {
-        let point = self.into_point();
-        into_address(point.x, point.y.into_repr().is_odd())
+    pub fn into_address(&self) -> String {
+        let point = &self.0;
+        into_address(&point.x, point.y.into_repr().is_odd())
     }
 }
 
 impl fmt::Display for PubKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let point = self.into_point();
+        let point = self.point();
         let mut x_bytes = point.x.to_bytes();
         let mut y_bytes = point.y.to_bytes();
         x_bytes.reverse();
@@ -145,7 +145,7 @@ pub struct CompressedPubKey {
     pub is_odd: bool,
 }
 
-fn into_address(x: BaseField, is_odd: bool) -> String {
+fn into_address(x: &BaseField, is_odd: bool) -> String {
     let mut raw: Vec<u8> = vec![
         0xcb, // version for base58 check
         0x01, // non_zero_curve_point version
@@ -168,8 +168,8 @@ fn into_address(x: BaseField, is_odd: bool) -> String {
 
 impl CompressedPubKey {
     /// Serialize compressed public key into corresponding Mina address
-    pub fn into_address(self) -> String {
-        into_address(self.x, self.is_odd)
+    pub fn into_address(&self) -> String {
+        into_address(&self.x, self.is_odd)
     }
 
     /// Deserialize Mina address into compressed public key (via an uncompressed PubKey)

--- a/signer/src/pubkey.rs
+++ b/signer/src/pubkey.rs
@@ -13,7 +13,7 @@ use crate::{BaseField, CurvePoint};
 use o1_utils::FieldHelpers;
 
 /// Public key errors
-#[derive(Error, Debug, Clone, Copy, PartialEq)]
+#[derive(Error, Debug, Clone, PartialEq)]
 pub enum PubKeyError {
     /// Invalid address length
     #[error("invalid address length")]
@@ -107,6 +107,11 @@ impl PubKey {
         &self.0
     }
 
+    /// Convert public key into curve point
+    pub fn into_point(self) -> CurvePoint {
+        self.0
+    }
+
     /// Convert public key into compressed public key
     pub fn into_compressed(&self) -> CompressedPubKey {
         let point = self.0;
@@ -118,7 +123,7 @@ impl PubKey {
 
     /// Serialize public key into corresponding Mina address
     pub fn into_address(&self) -> String {
-        let point = &self.0;
+        let point = self.point();
         into_address(&point.x, point.y.into_repr().is_odd())
     }
 }
@@ -136,7 +141,7 @@ impl fmt::Display for PubKey {
 }
 
 /// Compressed public keys consist of x-coordinate and y-coordinate parity.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CompressedPubKey {
     /// X-coordinate
     pub x: BaseField,

--- a/signer/src/schnorr.rs
+++ b/signer/src/schnorr.rs
@@ -63,7 +63,7 @@ impl<H: 'static + Hashable> Signer<H> for Schnorr<H> {
         let k: ScalarField = if r.y.into_repr().is_even() { k } else { -k };
 
         let e: ScalarField = self.message_hash(&kp.public, r.x, input);
-        let s: ScalarField = k + e * kp.secret.into_scalar();
+        let s: ScalarField = k + e * kp.secret.scalar();
 
         Signature::new(r.x, s)
     }
@@ -75,7 +75,7 @@ impl<H: 'static + Hashable> Signer<H> for Schnorr<H> {
             .mul(sig.s)
             .into_affine();
         // Perform addition and infinity check in projective coordinates for performance
-        let rv = public.into_point().mul(ev).neg().add_mixed(&sv);
+        let rv = public.point().mul(ev).neg().add_mixed(&sv);
         if rv.is_zero() {
             return false;
         }
@@ -107,9 +107,9 @@ impl<H: 'static + Hashable> Schnorr<H> {
         let mut blake_hasher = Blake2bVar::new(32).unwrap();
 
         let mut roi: ROInput = input.to_roinput();
-        roi.append_field(kp.public.into_point().x);
-        roi.append_field(kp.public.into_point().y);
-        roi.append_scalar(kp.secret.into_scalar());
+        roi.append_field(kp.public.point().x);
+        roi.append_field(kp.public.point().y);
+        roi.append_scalar(*kp.secret.scalar());
         roi.append_bytes(&self.domain_param.into_bytes());
 
         blake_hasher.update(&roi.to_bytes());
@@ -135,8 +135,8 @@ impl<H: 'static + Hashable> Schnorr<H> {
     fn message_hash(&mut self, pub_key: &PubKey, rx: BaseField, input: &H) -> ScalarField {
         let schnorr_input = Message::<H> {
             input: input.clone(),
-            pub_key_x: pub_key.into_point().x,
-            pub_key_y: pub_key.into_point().y,
+            pub_key_x: pub_key.point().x,
+            pub_key_y: pub_key.point().y,
             rx,
         };
 

--- a/signer/src/schnorr.rs
+++ b/signer/src/schnorr.rs
@@ -87,14 +87,18 @@ impl<H: 'static + Hashable> Signer<H> for Schnorr<H> {
 
 pub(crate) fn create_legacy<H: 'static + Hashable>(domain_param: H::D) -> impl Signer<H> {
     Schnorr::<H> {
-        hasher: Box::new(mina_hasher::create_legacy::<Message<H>>(domain_param)),
+        hasher: Box::new(mina_hasher::create_legacy::<Message<H>>(
+            domain_param.clone(),
+        )),
         domain_param,
     }
 }
 
 pub(crate) fn create_kimchi<H: 'static + Hashable>(domain_param: H::D) -> impl Signer<H> {
     Schnorr::<H> {
-        hasher: Box::new(mina_hasher::create_kimchi::<Message<H>>(domain_param)),
+        hasher: Box::new(mina_hasher::create_kimchi::<Message<H>>(
+            domain_param.clone(),
+        )),
         domain_param,
     }
 }
@@ -110,7 +114,7 @@ impl<H: 'static + Hashable> Schnorr<H> {
         roi.append_field(kp.public.point().x);
         roi.append_field(kp.public.point().y);
         roi.append_scalar(*kp.secret.scalar());
-        roi.append_bytes(&self.domain_param.into_bytes());
+        roi.append_bytes(&self.domain_param.clone().into_bytes());
 
         blake_hasher.update(&roi.to_bytes());
 

--- a/signer/src/seckey.rs
+++ b/signer/src/seckey.rs
@@ -5,7 +5,7 @@ use ark_ff::UniformRand;
 use rand::{self, CryptoRng, RngCore};
 
 /// Secret key
-#[derive(Clone, Copy, PartialEq, Eq)] // No Debug nor Display
+#[derive(Clone, PartialEq, Eq)] // No Debug nor Display
 pub struct SecKey(ScalarField);
 
 impl SecKey {
@@ -21,8 +21,8 @@ impl SecKey {
         Self(scalar)
     }
 
-    /// Convert secret key into scalar field element
-    pub fn into_scalar(self) -> ScalarField {
-        self.0
+    /// Borrows secret key as scalar field element
+    pub fn scalar(&self) -> &ScalarField {
+        &self.0
     }
 }

--- a/signer/src/seckey.rs
+++ b/signer/src/seckey.rs
@@ -25,4 +25,9 @@ impl SecKey {
     pub fn scalar(&self) -> &ScalarField {
         &self.0
     }
+
+    /// Convert secret key into scalar field element
+    pub fn into_scalar(self) -> ScalarField {
+        self.0
+    }
 }

--- a/signer/src/signature.rs
+++ b/signer/src/signature.rs
@@ -5,7 +5,7 @@ use o1_utils::FieldHelpers;
 use std::fmt;
 
 /// Signature structure
-#[derive(Clone, Copy, Eq, fmt::Debug, PartialEq)]
+#[derive(Clone, Eq, fmt::Debug, PartialEq)]
 pub struct Signature {
     /// Base field component
     pub rx: BaseField,

--- a/signer/tests/signer.rs
+++ b/signer/tests/signer.rs
@@ -111,7 +111,7 @@ fn signer_zero_test() {
     assert_eq!(ctx.verify(&sig, &kp.public, &tx), true);
 
     // Zero some things
-    let mut sig2 = sig;
+    let mut sig2 = sig.clone();
     sig2.rx = BaseField::zero();
     assert_eq!(ctx.verify(&sig2, &kp.public, &tx), false);
     let mut sig3 = sig;

--- a/signer/tests/signer.rs
+++ b/signer/tests/signer.rs
@@ -65,7 +65,7 @@ fn signer_test_raw() {
     let kp = Keypair::from_hex("164244176fddb5d769b7de2027469d027ad428fadcc0c02396e6280142efb718")
         .expect("failed to create keypair");
     let tx = Transaction::new_payment(
-        kp.public,
+        kp.public.clone(),
         PubKey::from_address("B62qicipYxyEHu7QjUqS7QvBipTs5CzgkYZZZkPoKVYBu6tnDUcE9Zt")
             .expect("invalid address"),
         1729000000000,
@@ -97,7 +97,7 @@ fn signer_zero_test() {
     let kp = Keypair::from_hex("164244176fddb5d769b7de2027469d027ad428fadcc0c02396e6280142efb718")
         .expect("failed to create keypair");
     let tx = Transaction::new_payment(
-        kp.public,
+        kp.public.clone(),
         PubKey::from_address("B62qicipYxyEHu7QjUqS7QvBipTs5CzgkYZZZkPoKVYBu6tnDUcE9Zt")
             .expect("invalid address"),
         1729000000000,

--- a/signer/tests/transaction.rs
+++ b/signer/tests/transaction.rs
@@ -6,7 +6,7 @@ const TAG_BITS: usize = 3;
 const PAYMENT_TX_TAG: [bool; TAG_BITS] = [false, false, false];
 const DELEGATION_TX_TAG: [bool; TAG_BITS] = [false, false, true];
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Transaction {
     // Common
     pub fee: u64,

--- a/signer/tests/transaction.rs
+++ b/signer/tests/transaction.rs
@@ -143,7 +143,7 @@ fn transaction_memo() {
     let kp = Keypair::from_hex("164244176fddb5d769b7de2027469d027ad428fadcc0c02396e6280142efb718")
         .expect("failed to create keypair");
 
-    let tx = Transaction::new_payment(kp.public, kp.public, 0, 0, 0);
+    let tx = Transaction::new_payment(kp.public.clone(), kp.public, 0, 0, 0);
     assert_eq!(
         tx.memo,
         [
@@ -184,7 +184,7 @@ fn transaction_memo_str() {
     let kp = Keypair::from_hex("164244176fddb5d769b7de2027469d027ad428fadcc0c02396e6280142efb718")
         .expect("failed to create keypair");
 
-    let tx = Transaction::new_payment(kp.public, kp.public, 0, 0, 0);
+    let tx = Transaction::new_payment(kp.public.clone(), kp.public, 0, 0, 0);
     assert_eq!(
         tx.memo,
         [

--- a/utils/src/field_helpers.rs
+++ b/utils/src/field_helpers.rs
@@ -4,7 +4,7 @@ use std::ops::Neg;
 use thiserror::Error;
 
 // Field helpers error
-#[derive(Error, Debug, Clone, Copy, PartialEq)]
+#[derive(Error, Debug, Clone, PartialEq)]
 pub enum FieldHelpersError {
     #[error("failed to deserialize field bytes")]
     DeserializeBytes,

--- a/utils/src/field_helpers.rs
+++ b/utils/src/field_helpers.rs
@@ -26,13 +26,13 @@ pub trait FieldHelpers<F> {
     fn from_bits(bits: &[bool]) -> Result<F>;
 
     /// Serialize to bytes
-    fn to_bytes(self) -> Vec<u8>;
+    fn to_bytes(&self) -> Vec<u8>;
 
     /// Serialize to hex
-    fn to_hex(self) -> String;
+    fn to_hex(&self) -> String;
 
     /// Serialize to bits
-    fn to_bits(self) -> Vec<bool>;
+    fn to_bits(&self) -> Vec<bool>;
 
     /// Field size in bytes
     fn size_in_bytes() -> usize
@@ -73,7 +73,7 @@ impl<F: Field> FieldHelpers<F> for F {
         F::deserialize(&mut &bytes[..]).map_err(|_| FieldHelpersError::DeserializeBytes)
     }
 
-    fn to_bytes(self) -> Vec<u8> {
+    fn to_bytes(&self) -> Vec<u8> {
         let mut bytes: Vec<u8> = vec![];
         self.serialize(&mut bytes)
             .expect("Failed to serialize field");
@@ -81,11 +81,11 @@ impl<F: Field> FieldHelpers<F> for F {
         bytes
     }
 
-    fn to_hex(self) -> String {
+    fn to_hex(&self) -> String {
         hex::encode(self.to_bytes())
     }
 
-    fn to_bits(self) -> Vec<bool> {
+    fn to_bits(&self) -> Vec<bool> {
         self.to_bytes().iter().fold(vec![], |mut bits, byte| {
             let mut byte = *byte;
             for _ in 0..8 {
@@ -152,7 +152,7 @@ mod tests {
         let field_hex = "f2eee8d8f6e5fb182c610cae6c5393fce69dc4d900e7b4923b074e54ad00fb36";
         assert_eq!(
             BaseField::to_hex(
-                BaseField::from_hex(field_hex).expect("Failed to deserialize field hex")
+                &BaseField::from_hex(field_hex).expect("Failed to deserialize field hex")
             ),
             field_hex
         );
@@ -176,7 +176,7 @@ mod tests {
 
         assert_eq!(
             BaseField::to_hex(
-                BaseField::from_bytes(&[
+                &BaseField::from_bytes(&[
                     46, 174, 218, 228, 42, 116, 97, 213, 149, 45, 39, 185, 126, 202, 208, 104, 182,
                     152, 235, 185, 78, 138, 14, 76, 69, 56, 139, 182, 19, 222, 126, 8
                 ])


### PR DESCRIPTION
This PR updates the `FieldHelper` API to not claim ownership of `self` when not necessary so that the caller won't have to either give up the ownership or make unnecessary `clone`(s) 

It also tries to remove `Copy` derives in `signer` and `hasher` crates. I think in general it's not a good idea to derive `Copy` trait because it simply disables the powerful borrow checker and lifetime checker in the Rust compiler, and the combination of deriving `Copy` trait and overclaim of the ownership leads to unnecessary implicit copies which the rust compiler should have been capable of detecting.  I will tag some examples inline.