### PR TITLE
Fix cargo clippy warnings in rust 1.62.0

### DIFF
--- a/kimchi/src/circuits/polynomials/range_check/gate.rs
+++ b/kimchi/src/circuits/polynomials/range_check/gate.rs
@@ -198,8 +198,7 @@ impl<F: FftField + SquareRootField> CircuitGate<F> {
             &beta,
             &gamma,
             &lcs.configuration.lookup_info,
-        )
-        .map_err(|e| e)?;
+        )?;
         let lookup_env = Some(LookupEnvironment {
             aggreg: &lookup_env_data.aggreg8,
             sorted: &lookup_env_data.sorted8,

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -48,7 +48,7 @@ pub struct ProverIndex<G: CommitmentCurve> {
 }
 //~spec:endcode
 
-impl<'a, G: CommitmentCurve> ProverIndex<G>
+impl<G: CommitmentCurve> ProverIndex<G>
 where
     G::BaseField: PrimeField,
 {

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -138,7 +138,7 @@ pub struct VerifierIndex<G: CommitmentCurve> {
 }
 //~spec:endcode
 
-impl<'a, G: CommitmentCurve> ProverIndex<G>
+impl<G: CommitmentCurve> ProverIndex<G>
 where
     G::BaseField: PrimeField,
 {

--- a/tools/kimchi-visu/src/lib.rs
+++ b/tools/kimchi-visu/src/lib.rs
@@ -85,7 +85,7 @@ where
     // serialize witness
     if let Some(witness) = witness {
         let witness = serde_json::to_string(&witness).expect("couldn't serialize witness");
-        data.push_str(&format!("const witness = {witness};"));
+        data = format!("{data}const witness = {witness};");
     } else {
         data.push_str("const witness = null;");
     }
@@ -93,7 +93,7 @@ where
     // serialize constraints
     let constraints = latex_constraints::<G>();
     let constraints = serde_json::to_string(&constraints).expect("couldn't serialize constraints");
-    data.push_str(&format!("const constraints = {constraints};"));
+    data = format!("{data}const constraints = {constraints};");
 
     // create template
     let template_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/assets/template.html");


### PR DESCRIPTION
This PR fixes the Cargo Clippy warnings detected by rust 1.62.0 and it's compatible with current fixed rust 1.58.0.
