### PR TITLE
Absorb previous challenge commitments at the start of proving / verification

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1541,6 +1541,7 @@ The prover then follows the following steps to create the proof:
 1. Pad the witness columns with Zero gates to make them the same length as the domain.
    Then, randomize the last `ZK_ROWS` of each columns.
 1. Setup the Fq-Sponge.
+1. Absorb the commitments of the previous challenges with the Fq-sponge.
 1. Compute the negated public input polynomial as
    the polynomial that evaluates to $-p_i$ for the first `public_input_size` values of the domain,
    and $0$ for the rest.
@@ -1669,6 +1670,7 @@ We define two helper algorithms below, used in the batch verification of proofs.
 We run the following algorithm:
 
 1. Setup the Fq-Sponge.
+1. Absorb the commitments of the previous challenges with the Fq-sponge.
 1. Absorb the commitment of the public input polynomial with the Fq-Sponge.
 1. Absorb the commitments to the registers / witness columns with the Fq-Sponge.
 1. If lookup is used:

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -195,6 +195,11 @@ where
         //~ 1. Setup the Fq-Sponge.
         let mut fq_sponge = EFqSponge::new(index.fq_sponge_params.clone());
 
+        //~ 1. Absorb the commitments of the previous challenges with the Fq-sponge.
+        for RecursionChallenge { comm, .. } in prev_challenges.iter() {
+            fq_sponge.absorb_g(&comm.unshifted);
+        }
+
         //~ 1. Compute the negated public input polynomial as
         //~    the polynomial that evaluates to $-p_i$ for the first `public_input_size` values of the domain,
         //~    and $0$ for the rest.

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -127,6 +127,11 @@ where
         //~ 1. Setup the Fq-Sponge.
         let mut fq_sponge = EFqSponge::new(index.fq_sponge_params.clone());
 
+        //~ 1. Absorb the commitments of the previous challenges with the Fq-sponge.
+        for RecursionChallenge { comm, .. } in self.prev_challenges.iter() {
+            fq_sponge.absorb_g(&comm.unshifted);
+        }
+
         //~ 1. Absorb the commitment of the public input polynomial with the Fq-Sponge.
         fq_sponge.absorb_g(&p_comm.unshifted);
 


### PR DESCRIPTION
This PR tweaks the prover and verifier to absorb the previous challenge commitments at the beginning of proving and verification. This ensures that these previous challenge commitments are involved with the Fiat-Shamir non-interactivity modification, so that Kimchi is sound without the use of pickles.