### PR TITLE
[ocaml] moving the oracle logic from stubs to proof-systems

### DIFF
--- a/kimchi/src/lib.rs
+++ b/kimchi/src/lib.rs
@@ -16,6 +16,7 @@ pub mod circuits;
 pub mod curve;
 pub mod error;
 pub mod linearization;
+pub mod oracles;
 pub mod plonk_sponge;
 pub mod proof;
 pub mod prover;

--- a/kimchi/src/oracles.rs
+++ b/kimchi/src/oracles.rs
@@ -1,0 +1,36 @@
+//! This type and logic only exists for the OCaml side.
+//! As we move more code to the Rust side,
+//! we hope to be able to remove this code in the future.
+
+use crate::{alphas::Alphas, circuits::scalars::RandomOracles};
+use commitment_dlog::commitment::{CommitmentCurve, PolyComm};
+use oracle::FqSponge;
+
+/// The result of running the oracle protocol
+pub struct OraclesResult<G, EFqSponge>
+where
+    G: CommitmentCurve,
+    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
+{
+    /// A sponge that acts on the base field of a curve
+    pub fq_sponge: EFqSponge,
+    /// the last evaluation of the Fq-Sponge in this protocol
+    pub digest: G::ScalarField,
+    /// the challenges produced in the protocol
+    pub oracles: RandomOracles<G::ScalarField>,
+    /// the computed powers of alpha
+    pub all_alphas: Alphas<G::ScalarField>,
+    /// public polynomial evaluations
+    pub p_eval: Vec<Vec<G::ScalarField>>,
+    /// zeta^n and (zeta * omega)^n
+    pub powers_of_eval_points_for_chunks: [G::ScalarField; 2],
+    /// recursion data
+    #[allow(clippy::type_complexity)]
+    pub polys: Vec<(PolyComm<G>, Vec<Vec<G::ScalarField>>)>,
+    /// pre-computed zeta^n
+    pub zeta1: G::ScalarField,
+    /// The evaluation f(zeta) - t(zeta) * Z_H(zeta)
+    pub ft_eval0: G::ScalarField,
+    /// Used by the OCaml side
+    pub combined_inner_product: G::ScalarField,
+}

--- a/kimchi/src/oracles.rs
+++ b/kimchi/src/oracles.rs
@@ -41,29 +41,30 @@ pub mod caml {
     use commitment_dlog::commitment::shift_scalar;
 
     use crate::{
-        circuits::scalars::caml::CamlRandomOracles, error::VerifyError, plonk_sponge::FrSponge,
-        proof::ProverProof, verifier_index::VerifierIndex,
+        circuits::scalars::caml::CamlRandomOracles, curve::KimchiCurve, error::VerifyError,
+        plonk_sponge::FrSponge, proof::ProverProof, verifier_index::VerifierIndex,
     };
 
     use super::*;
 
-    pub struct CamlOracles<F> {
-        pub o: CamlRandomOracles<F>,
-        pub p_eval: (F, F),
-        pub opening_prechallenges: Vec<F>,
-        pub digest_before_evaluations: F,
+    pub struct CamlOracles<CamlF> {
+        pub o: CamlRandomOracles<CamlF>,
+        pub p_eval: (CamlF, CamlF),
+        pub opening_prechallenges: Vec<CamlF>,
+        pub digest_before_evaluations: CamlF,
     }
 
-    pub fn create_caml_oracles<G, EFqSponge, EFrSponge, CurveParams>(
+    pub fn create_caml_oracles<G, CamlF, EFqSponge, EFrSponge, CurveParams>(
         lgr_comm: Vec<PolyComm<G>>,
         index: VerifierIndex<G>,
         proof: ProverProof<G>,
-    ) -> Result<CamlOracles<G::ScalarField>, VerifyError>
+    ) -> Result<CamlOracles<CamlF>, VerifyError>
     where
-        G: CommitmentCurve,
+        G: KimchiCurve,
         G::BaseField: PrimeField,
         EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
         EFrSponge: FrSponge<G::ScalarField>,
+        CamlF: From<G::ScalarField>,
     {
         let lgr_comm: Vec<PolyComm<G>> = lgr_comm.into_iter().take(proof.public.len()).collect();
         let lgr_comm_refs: Vec<_> = lgr_comm.iter().collect();

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -21,8 +21,7 @@ use crate::{
 use ark_ff::{Field, One, PrimeField, Zero};
 use ark_poly::{EvaluationDomain, Polynomial};
 use commitment_dlog::commitment::{
-    b_poly, b_poly_coefficients, combined_inner_product, BatchEvaluationProof, CommitmentCurve,
-    Evaluation, PolyComm,
+    b_poly, b_poly_coefficients, combined_inner_product, BatchEvaluationProof, Evaluation, PolyComm,
 };
 use itertools::izip;
 use oracle::{sponge::ScalarChallenge, FqSponge};

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -1,7 +1,6 @@
 //! This module implements zk-proof batch verifier functionality.
 
 use crate::{
-    alphas::Alphas,
     circuits::{
         argument::ArgumentType,
         constraints::ConstraintSystem,
@@ -14,6 +13,7 @@ use crate::{
     },
     curve::KimchiCurve,
     error::VerifyError,
+    oracles::OraclesResult,
     plonk_sponge::FrSponge,
     proof::{ProverProof, RecursionChallenge},
     verifier_index::VerifierIndex,
@@ -30,35 +30,6 @@ use rand::thread_rng;
 
 /// The result of a proof verification.
 pub type Result<T> = std::result::Result<T, VerifyError>;
-
-/// The result of running the oracle protocol
-pub struct OraclesResult<G, EFqSponge>
-where
-    G: CommitmentCurve,
-    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
-{
-    /// A sponge that acts on the base field of a curve
-    pub fq_sponge: EFqSponge,
-    /// the last evaluation of the Fq-Sponge in this protocol
-    pub digest: G::ScalarField,
-    /// the challenges produced in the protocol
-    pub oracles: RandomOracles<G::ScalarField>,
-    /// the computed powers of alpha
-    pub all_alphas: Alphas<G::ScalarField>,
-    /// public polynomial evaluations
-    pub p_eval: Vec<Vec<G::ScalarField>>,
-    /// zeta^n and (zeta * omega)^n
-    pub powers_of_eval_points_for_chunks: [G::ScalarField; 2],
-    /// recursion data
-    #[allow(clippy::type_complexity)]
-    pub polys: Vec<(PolyComm<G>, Vec<Vec<G::ScalarField>>)>,
-    /// pre-computed zeta^n
-    pub zeta1: G::ScalarField,
-    /// The evaluation f(zeta) - t(zeta) * Z_H(zeta)
-    pub ft_eval0: G::ScalarField,
-    /// Used by the OCaml side
-    pub combined_inner_product: G::ScalarField,
-}
 
 impl<G: KimchiCurve> ProverProof<G>
 where


### PR DESCRIPTION
this PR tries to get rid of that logic on the OCaml side: https://github.com/MinaProtocol/mina/blob/f01d3925a2/src/lib/crypto/kimchi_bindings/stubs/src/oracles.rs#L28

by moving the code here