### PR TITLE
fn CompressedPubKey::empty()

### DIFF
--- a/signer/src/pubkey.rs
+++ b/signer/src/pubkey.rs
@@ -2,7 +2,7 @@
 //!
 //! Definition of public key structure and helpers
 
-use ark_ff::{BigInteger, PrimeField};
+use ark_ff::{BigInteger, PrimeField, Zero};
 use bs58;
 use core::fmt;
 use sha2::{Digest, Sha256};
@@ -148,6 +148,15 @@ pub struct CompressedPubKey {
 
     /// Parity of y-coordinate
     pub is_odd: bool,
+}
+
+impl Default for CompressedPubKey {
+    fn default() -> Self {
+        Self {
+            x: BaseField::zero(),
+            is_odd: false,
+        }
+    }
 }
 
 fn into_address(x: &BaseField, is_odd: bool) -> String {


### PR DESCRIPTION
The default value aligns with `empty` in [`non_zero_curve_point.ml`](https://github.com/MinaProtocol/mina/blob/develop/src/lib/non_zero_curve_point/non_zero_curve_point.ml#L90), it's useful for implementing default account etc.

```OCaml
let empty = Poly.{ x = Field.zero; is_odd = false }
```