### PR TITLE
[easy] Fix BigUint converters

### DIFF
--- a/utils/src/field_helpers.rs
+++ b/utils/src/field_helpers.rs
@@ -13,6 +13,8 @@ pub enum FieldHelpersError {
     DeserializeBytes,
     #[error("failed to decode hex")]
     DecodeHex,
+    #[error("failed to convert BigUint into field element")]
+    FromBigToField,
 }
 
 /// Result alias using [FieldHelpersError]
@@ -102,23 +104,16 @@ impl<F: Field> FieldHelpers<F> for F {
     }
 }
 
-/// Field element helpers for [BigUint]
-pub trait BigFieldHelpers<F> {
+/// Field element wrapper for [BigUint]
+pub trait FieldFromBig<F> {
     /// Deserialize from big unsigned integer
     fn from_big(big: BigUint) -> Result<F>;
-
-    /// Serialize field element as a big unsigned integer
-    fn to_big(self) -> BigUint;
 }
 
-impl<F: PrimeField> BigFieldHelpers<F> for F {
+impl<F: PrimeField> FieldFromBig<F> for F {
     fn from_big(big: BigUint) -> Result<F> {
         big.try_into()
-            .map_err(|_| FieldHelpersError::DeserializeBytes)
-    }
-
-    fn to_big(self) -> BigUint {
-        self.into_repr().into()
+            .map_err(|_| FieldHelpersError::FromBigToField)
     }
 }
 
@@ -259,7 +254,7 @@ mod tests {
     #[test]
     fn field_big() {
         let fe_1024 = BaseField::from(1024u32);
-        let big_1024 = fe_1024.to_big();
+        let big_1024 = fe_1024.into();
         assert_eq!(big_1024, BigUint::new(vec![1024]));
 
         assert_eq!(

--- a/utils/src/field_helpers.rs
+++ b/utils/src/field_helpers.rs
@@ -1,7 +1,7 @@
 //! Useful helper methods to extend [ark_ff::Field].
 
 use ark_ff::{BigInteger, Field, FpParameters, PrimeField};
-use num_bigint::BigUint;
+use num_bigint::{BigUint, ToBigUint};
 use std::ops::Neg;
 use thiserror::Error;
 
@@ -113,7 +113,7 @@ impl<F: Field> FieldHelpers<F> for F {
         // Pad with zeros until multiple of 32 if necessary because the BigUint to_bytes_le function gives the smallest possible vector of bytes
         if bytes.len() % 32 != 0 {
             // smallest larger multiple of 32 bytes
-            let goal = 32 + bytes.len() / 32;
+            let goal = 32 * (1 + bytes.len() / 32);
             bytes.extend(std::iter::repeat(0).take(goal - bytes.len()));
         }
 
@@ -267,8 +267,19 @@ mod tests {
         assert_eq!(big, BigUint::new(vec![1024]));
 
         assert_eq!(
-            BaseField::from_big(big).expect("Failed to deserialize big integer"),
+            BaseField::from_big(big).expect("Failed to deserialize big uint"),
             BaseField::from(1024u32)
+        );
+
+        assert_eq!(
+            BigUint::from_bytes_be(&BaseField::from(0u32).into_repr().to_bytes_be()),
+            BigUint::from_bytes_be(&vec![0x00, 0x00, 0x00, 0x00, 0x00])
+        );
+
+        assert_eq!(
+            BaseField::from_big(BigUint::from_bytes_be(&vec![0x00, 0x00, 0x00, 0x00, 0x00]))
+                .expect("Failed to convert big uint"),
+            BaseField::from(0u32)
         );
     }
 }

--- a/utils/src/foreign_field.rs
+++ b/utils/src/foreign_field.rs
@@ -2,10 +2,7 @@
 
 use std::fmt::Display;
 
-use crate::{
-    field_helpers::{BigFieldHelpers, FieldHelpers},
-    serialization::SerdeAs,
-};
+use crate::{field_helpers::FieldHelpers, serialization::SerdeAs};
 use ark_ff::{FftField, Field, PrimeField};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
@@ -40,7 +37,7 @@ pub struct ForeignElement<F: Field, const N: usize> {
     pub len: usize,
 }
 
-impl<F: FftField, const N: usize> ForeignElement<F, N> {
+impl<F: PrimeField, const N: usize> ForeignElement<F, N> {
     /// Initializes a new foreign element from a big unsigned integer
     /// Panics if the BigUint is too large to fit in the `N` limbs
     pub fn new_from_big(big: BigUint) -> Self {
@@ -70,11 +67,8 @@ impl<F: FftField, const N: usize> ForeignElement<F, N> {
     }
 
     /// Initializes a new foreign element from an element in the native field
-    pub fn new_from_field(field: F) -> Self
-    where
-        F: PrimeField,
-    {
-        Self::new_from_big(field.to_big())
+    pub fn new_from_field(field: F) -> Self {
+        Self::new_from_big(field.into())
     }
 
     /// Obtains the big integer representation of the foreign field element
@@ -144,6 +138,7 @@ impl<F: FftField, const N: usize> Display for ForeignElement<F, N> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::field_helpers::FieldFromBig;
     use ark_ec::AffineCurve;
     use ark_ff::One;
     use mina_curves::pasta::pallas;

--- a/utils/src/foreign_field.rs
+++ b/utils/src/foreign_field.rs
@@ -3,7 +3,7 @@
 use std::fmt::Display;
 
 use crate::{
-    field_helpers::{BigUintFieldHelpers, FieldHelpers},
+    field_helpers::{BigFieldHelpers, FieldHelpers},
     serialization::SerdeAs,
 };
 use ark_ff::{FftField, Field, PrimeField};
@@ -74,7 +74,7 @@ impl<F: FftField, const N: usize> ForeignElement<F, N> {
     where
         F: PrimeField,
     {
-        Self::new_from_big(field.to_biguint())
+        Self::new_from_big(field.to_big())
     }
 
     /// Obtains the big integer representation of the foreign field element
@@ -173,15 +173,12 @@ mod tests {
     #[test]
     fn test_from_big() {
         let one = ForeignElement::<BaseField, 3>::new_from_be(&[0x01]);
-        assert_eq!(
-            BaseField::from_biguint(one.to_big()).unwrap(),
-            BaseField::one()
-        );
+        assert_eq!(BaseField::from_big(one.to_big()).unwrap(), BaseField::one());
 
         let max_big = BaseField::modulus_biguint() - 1u32;
         let max_fe = ForeignElement::<BaseField, 3>::new_from_big(max_big.clone());
         assert_eq!(
-            BaseField::from_biguint(max_fe.to_big()).unwrap(),
+            BaseField::from_big(max_fe.to_big()).unwrap(),
             BaseField::from_bytes(&max_big.to_bytes_le()).unwrap(),
         );
     }


### PR DESCRIPTION
This PR fixes the to/from_big functions for field elements that used our own functions inside and now just uses Into/From implementations in PrimeField as suggested by David.