### PR TITLE
fix all-zeros public input for zkapps

### DIFF
--- a/kimchi/src/oracles.rs
+++ b/kimchi/src/oracles.rs
@@ -21,7 +21,7 @@ where
     /// the computed powers of alpha
     pub all_alphas: Alphas<G::ScalarField>,
     /// public polynomial evaluations
-    pub p_eval: Vec<Vec<G::ScalarField>>,
+    pub public_evals: [Vec<G::ScalarField>; 2],
     /// zeta^n and (zeta * omega)^n
     pub powers_of_eval_points_for_chunks: [G::ScalarField; 2],
     /// recursion data
@@ -50,7 +50,7 @@ pub mod caml {
     #[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
     pub struct CamlOracles<CamlF> {
         pub o: CamlRandomOracles<CamlF>,
-        pub p_eval: (CamlF, CamlF),
+        pub public_evals: (CamlF, CamlF),
         pub opening_prechallenges: Vec<CamlF>,
         pub digest_before_evaluations: CamlF,
     }
@@ -76,10 +76,10 @@ pub mod caml {
 
         let oracles_result = proof.oracles::<EFqSponge, EFrSponge>(&index, &p_comm)?;
 
-        let (mut sponge, combined_inner_product, p_eval, digest, oracles) = (
+        let (mut sponge, combined_inner_product, public_evals, digest, oracles) = (
             oracles_result.fq_sponge,
             oracles_result.combined_inner_product,
-            oracles_result.p_eval,
+            oracles_result.public_evals,
             oracles_result.digest,
             oracles_result.oracles,
         );
@@ -95,7 +95,7 @@ pub mod caml {
 
         Ok(CamlOracles {
             o: oracles.into(),
-            p_eval: (p_eval[0][0].into(), p_eval[1][0].into()),
+            public_evals: (public_evals[0][0].into(), public_evals[1][0].into()),
             opening_prechallenges,
             digest_before_evaluations: digest.into(),
         })

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -223,7 +223,7 @@ where
         // to make sure that the public commitment is never empty (in case all public inputs are zeros),
         // we make the public input the blinding factor
         // see https://github.com/o1-labs/proof-systems/issues/701
-        if public_comm.is_empty() {
+        if public_comm.is_empty() || public_comm.unshifted[0].is_zero() {
             public_comm.unshifted = vec![index.srs.h];
         }
 

--- a/kimchi/src/tests/generic.rs
+++ b/kimchi/src/tests/generic.rs
@@ -38,3 +38,21 @@ fn test_generic_gate_pub() {
         .setup()
         .prove_and_verify();
 }
+
+#[test]
+fn test_generic_gate_pub_all_zeros() {
+    let public = vec![Fp::from(0u8); 5];
+    let gates = create_circuit(0, public.len());
+
+    // create witness
+    let mut witness: [Vec<Fp>; COLUMNS] = array_init(|_| vec![Fp::zero(); gates.len()]);
+    fill_in_witness(0, &mut witness, &public);
+
+    // create and verify proof based on the witness
+    TestFramework::default()
+        .gates(gates)
+        .witness(witness)
+        .public_inputs(public)
+        .setup()
+        .prove_and_verify();
+}

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -476,7 +476,7 @@ where
     // to make sure that the public commitment is never empty (in case all public inputs are zeros),
     // we make the public input the blinding factor
     // see https://github.com/o1-labs/proof-systems/issues/701
-    if public_comm.unshifted[0].is_zero() {
+    if public_comm.is_empty() || public_comm.unshifted[0].is_zero() {
         public_comm.unshifted = vec![index.srs().h];
     }
 

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -473,6 +473,13 @@ where
     let elm: Vec<_> = proof.public.iter().map(|s| -*s).collect();
     let mut public_comm = PolyComm::<G>::multi_scalar_mul(&com_ref, &elm);
 
+    // to make sure that the public commitment is never empty (in case all public inputs are zeros),
+    // we make the public input the blinding factor
+    // see https://github.com/o1-labs/proof-systems/issues/701
+    if public_comm.unshifted[0].is_zero() {
+        public_comm.unshifted = vec![index.srs().h];
+    }
+
     //~ 1. Run the [Fiat-Shamir argument](#fiat-shamir-argument).
     let OraclesResult {
         fq_sponge,
@@ -670,7 +677,7 @@ where
     //~~ - public input commitment
     evaluations.push(Evaluation {
         commitment: public_comm,
-        evaluations: public_evals,
+        evaluations: public_evals.to_vec(),
         degree_bound: None,
     });
 

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -236,10 +236,8 @@ where
                 ],
             ]
         } else {
-            [Vec::<G::ScalarField>::new(), Vec::<G::ScalarField>::new()]
+            [vec![G::ScalarField::zero()], vec![G::ScalarField::zero()]]
         };
-
-        println!("verifier public eval: {:?}", public_evals);
 
         //~ 1. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
         fr_sponge.absorb(&self.ft_eval1);
@@ -478,6 +476,8 @@ where
     // see https://github.com/o1-labs/proof-systems/issues/701
     if public_comm.is_empty() || public_comm.unshifted[0].is_zero() {
         public_comm.unshifted = vec![index.srs().h];
+    } else {
+        public_comm.unshifted[0] = public_comm.unshifted[0].add(index.srs().h);
     }
 
     //~ 1. Run the [Fiat-Shamir argument](#fiat-shamir-argument).


### PR DESCRIPTION
This is a fix for https://github.com/o1-labs/snarkyjs/issues/344 that implements https://github.com/o1-labs/proof-systems/issues/701 for the public commitment/polynomial only

The mina PR associated with this is here https://github.com/MinaProtocol/mina/pull/11652

---

I think we should implement https://github.com/o1-labs/proof-systems/issues/701 next to generalize this pattern