### PR TITLE
Allow an all-zero public input

### DIFF
--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -827,7 +827,7 @@ where
 
         //~ 1. Evaluate the negated public polynomial (if present) at $\zeta$ and $\zeta\omega$.
         let public_evals = if public_poly.is_zero() {
-            [Vec::new(), Vec::new()]
+            [vec![G::ScalarField::zero()], vec![G::ScalarField::zero()]]
         } else {
             [
                 vec![public_poly.evaluate(&zeta)],

--- a/kimchi/src/tests/generic.rs
+++ b/kimchi/src/tests/generic.rs
@@ -38,3 +38,21 @@ fn test_generic_gate_pub() {
         .setup()
         .prove_and_verify();
 }
+
+#[test]
+fn test_generic_gate_pub_all_zeros() {
+    let public = vec![Fp::from(0u8); 5];
+    let gates = create_circuit(0, public.len());
+
+    // create witness
+    let mut witness: [Vec<Fp>; COLUMNS] = array_init(|_| vec![Fp::zero(); gates.len()]);
+    fill_in_witness(0, &mut witness, &public);
+
+    // create and verify proof based on the witness
+    TestFramework::default()
+        .gates(gates)
+        .witness(witness)
+        .public_inputs(public)
+        .setup()
+        .prove_and_verify();
+}

--- a/kimchi/src/tests/generic.rs
+++ b/kimchi/src/tests/generic.rs
@@ -56,3 +56,21 @@ fn test_generic_gate_pub_all_zeros() {
         .setup()
         .prove_and_verify();
 }
+
+#[test]
+fn test_generic_gate_pub_empty() {
+    let public = vec![];
+    let gates = create_circuit(0, public.len());
+
+    // create witness
+    let mut witness: [Vec<Fp>; COLUMNS] = array_init(|_| vec![Fp::zero(); gates.len()]);
+    fill_in_witness(0, &mut witness, &public);
+
+    // create and verify proof based on the witness
+    TestFramework::default()
+        .gates(gates)
+        .witness(witness)
+        .public_inputs(public)
+        .setup()
+        .prove_and_verify();
+}

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -236,7 +236,7 @@ where
                 ],
             ]
         } else {
-            vec![Vec::<G::ScalarField>::new(), Vec::<G::ScalarField>::new()]
+            vec![vec![G::ScalarField::zero()], vec![G::ScalarField::zero()]]
         };
 
         //~ 1. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -232,7 +232,7 @@ impl<C: AffineCurve> PolyComm<C> {
             },
             unshifted: {
                 if com.is_empty() || elm.is_empty() {
-                    Vec::new()
+                    vec![C::zero()]
                 } else {
                     let n = Iterator::max(com.iter().map(|c| c.unshifted.len())).unwrap();
                     (0..n)

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -563,7 +563,7 @@ impl<G: CommitmentCurve> SRS<G> {
 
         // committing all the segments without shifting
         let unshifted = if is_zero {
-            Vec::new()
+            vec![G::zero()]
         } else {
             (0..p / n + if p % n != 0 { 1 } else { 0 })
                 .map(|i| {

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -435,7 +435,7 @@ pub fn combined_inner_product<F: PrimeField>(
 
         if let Some(m) = shifted {
             // polyscale^i sum_j evalscale^j elm_j^{N - m} f(elm_j)
-            let last_evals = if *m > evals.len() * srs_length {
+            let last_evals = if *m >= evals.len() * srs_length {
                 vec![F::zero(); evaluation_points.len()]
             } else {
                 evals[evals.len() - 1].clone()

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -518,15 +518,9 @@ impl<G: CommitmentCurve> SRS<G> {
             .zip(blinders)
             .ok_or_else(|| CommitmentError::BlindersDontMatch(blinders.len(), com.len()))?
             .map(|(g, b)| {
-                if g.is_zero() {
-                    // TODO: This leaks information when g is the identity!
-                    // We should change this so that we still mask in this case
-                    g
-                } else {
-                    let mut g_masked = self.h.mul(b);
-                    g_masked.add_assign_mixed(&g);
-                    g_masked.into_affine()
-                }
+                let mut g_masked = self.h.mul(b);
+                g_masked.add_assign_mixed(&g);
+                g_masked.into_affine()
             });
         Ok(BlindedCommitment {
             commitment,

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -112,7 +112,7 @@ impl<G: CommitmentCurve> SRS<G> {
             let mut scale = G::ScalarField::one();
 
             // iterating over polynomials in the batch
-            for (p_i, degree_bound, omegas) in plnms.iter() {
+            for (p_i, degree_bound, omegas) in plnms {
                 let mut offset = 0;
                 // iterating over chunks of the polynomial
                 if let Some(m) = degree_bound {

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -130,9 +130,11 @@ impl<G: CommitmentCurve> SRS<G> {
                     scale *= &polyscale;
                     offset += self.g.len();
                     if let Some(m) = degree_bound {
-                        if offset > *m {
-                            // mixing in the shifted segment since degree is bounded
-                            plnm.add_shifted(scale, self.g.len() - m % self.g.len(), segment);
+                        if offset >= *m {
+                            if offset > *m {
+                                // mixing in the shifted segment since degree is bounded
+                                plnm.add_shifted(scale, self.g.len() - m % self.g.len(), segment);
+                            }
                             omega += &(omegas.shifted.unwrap() * scale);
                             scale *= &polyscale;
                         }

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -112,7 +112,7 @@ impl<G: CommitmentCurve> SRS<G> {
             let mut scale = G::ScalarField::one();
 
             // iterating over polynomials in the batch
-            for (p_i, degree_bound, omegas) in plnms.iter().filter(|p| !p.0.is_zero()) {
+            for (p_i, degree_bound, omegas) in plnms.iter() {
                 let mut offset = 0;
                 let mut j = 0;
                 // iterating over chunks of the polynomial

--- a/utils/src/dense_polynomial.rs
+++ b/utils/src/dense_polynomial.rs
@@ -22,6 +22,7 @@ pub trait ExtendedDensePolynomial<F: Field> {
     fn eval_polynomial(coeffs: &[F], x: F) -> F;
 
     /// Convert a polynomial into chunks.
+    /// Implementors must ensure that the result contains at least 1 chunk.
     fn to_chunked_polynomial(&self, size: usize) -> ChunkedPolynomial<F>;
 }
 
@@ -52,6 +53,14 @@ impl<F: Field> ExtendedDensePolynomial<F> for DensePolynomial<F> {
     }
 
     fn to_chunked_polynomial(&self, chunk_size: usize) -> ChunkedPolynomial<F> {
+        // Ensure that there is always at least 1 polynomial in the resulting chunked polynomial.
+        if self.coeffs.is_empty() {
+            return ChunkedPolynomial {
+                polys: vec![DensePolynomial::from_coefficients_vec(vec![])],
+                size: chunk_size,
+            };
+        }
+
         let mut chunk_polys: Vec<DensePolynomial<F>> = vec![];
         for chunk in self.coeffs.chunks(chunk_size) {
             chunk_polys.push(DensePolynomial::from_coefficients_slice(chunk));


### PR DESCRIPTION
This PR tweaks the handling of public inputs, so that the public input commitment can be allowed to be all-zero.

The handling of zero polynomials and commitments is special-cased in lots of places in the code, so this was a rather tricky change to make. In particular, the 'commitments' test is still broken (via a probabilistic flake), since it depends more closely on some of those special cases.

This is ready for review, but should not be merged until the flaking test is fixed.