### PR TITLE
Add a deterministic version of the commitment unit test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,7 @@ dependencies = [
  "once_cell",
  "oracle",
  "rand",
+ "rand_chacha",
  "rand_core",
  "rayon",
  "serde",

--- a/poly-commitment/Cargo.toml
+++ b/poly-commitment/Cargo.toml
@@ -31,6 +31,7 @@ ocaml-gen = { path = "../ocaml/ocaml-gen", optional = true }
 
 [dev-dependencies]
 colored = "2.0.0"
+rand_chacha = { version = "0.3.0" }
 
 [features]
 ocaml_types = [ "ocaml", "ocaml-gen" ]

--- a/poly-commitment/src/tests/commitment.rs
+++ b/poly-commitment/src/tests/commitment.rs
@@ -15,7 +15,7 @@ use o1_utils::ExtendedDensePolynomial as _;
 use oracle::constants::PlonkSpongeConstantsKimchi as SC;
 use oracle::sponge::DefaultFqSponge;
 use oracle::FqSponge as _;
-use rand::Rng;
+use rand::{CryptoRng, Rng};
 use std::time::{Duration, Instant};
 
 // Note: Because the current API uses large tuples of types, I re-create types
@@ -95,15 +95,7 @@ impl AggregatedEvaluationProof {
     }
 }
 
-#[test]
-/// Tests polynomial commitments, batched openings and
-/// verification of a batch of batched opening proofs of polynomial commitments
-fn test_commit()
-where
-    <Fp as std::str::FromStr>::Err: std::fmt::Debug,
-{
-    // setup
-    let mut rng = rand::thread_rng();
+fn test_randomised<RNG: Rng + CryptoRng>(mut rng: &mut RNG) {
     let group_map = <Vesta as CommitmentCurve>::Map::setup();
     let fq_sponge =
         DefaultFqSponge::<VestaParameters, SC>::new(oracle::pasta::fq_kimchi::static_params());
@@ -229,4 +221,16 @@ where
         "batch verification time:".green(),
         timer.elapsed()
     );
+}
+
+#[test]
+/// Tests polynomial commitments, batched openings and
+/// verification of a batch of batched opening proofs of polynomial commitments
+fn test_commit()
+where
+    <Fp as std::str::FromStr>::Err: std::fmt::Debug,
+{
+    // setup
+    let mut rng = rand::thread_rng();
+    test_randomised(&mut rng)
 }

--- a/poly-commitment/src/tests/commitment.rs
+++ b/poly-commitment/src/tests/commitment.rs
@@ -15,7 +15,7 @@ use o1_utils::ExtendedDensePolynomial as _;
 use oracle::constants::PlonkSpongeConstantsKimchi as SC;
 use oracle::sponge::DefaultFqSponge;
 use oracle::FqSponge as _;
-use rand::{CryptoRng, Rng};
+use rand::{CryptoRng, Rng, SeedableRng};
 use std::time::{Duration, Instant};
 
 // Note: Because the current API uses large tuples of types, I re-create types
@@ -232,5 +232,22 @@ where
 {
     // setup
     let mut rng = rand::thread_rng();
+    test_randomised(&mut rng)
+}
+
+#[test]
+/// Deterministic tests of polynomial commitments, batched openings and
+/// verification of a batch of batched opening proofs of polynomial commitments
+fn test_commit_deterministic()
+where
+    <Fp as std::str::FromStr>::Err: std::fmt::Debug,
+{
+    // Seed deliberately chosen to exercise zero commitments
+    let seed = [
+        17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0,
+    ];
+
+    let mut rng = <rand_chacha::ChaCha20Rng as SeedableRng>::from_seed(seed);
     test_randomised(&mut rng)
 }


### PR DESCRIPTION
This PR adds a deterministic version of the commitment test, to ensure that we are reliably testing commitments that feature a 'zero' commitment.

This is part of the work on #724, but separated since it is orthogonal and good-to-have anyway.