### PR TITLE
[Trivial] Rename function parameters to be consistent between different functions

### DIFF
--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -851,8 +851,8 @@ where
         sponge: fq_sponge,
         evaluations,
         evaluation_points,
-        xi: oracles.v,
-        r: oracles.u,
+        polyscale: oracles.v,
+        evalscale: oracles.u,
         opening: &proof.proof,
     })
 }

--- a/poly-commitment/src/tests/batch_15_wires.rs
+++ b/poly-commitment/src/tests/batch_15_wires.rs
@@ -114,8 +114,8 @@ where
         .map(|proof| BatchEvaluationProof {
             sponge: proof.0.clone(),
             evaluation_points: proof.1.clone(),
-            xi: proof.2,
-            r: proof.3,
+            polyscale: proof.2,
+            evalscale: proof.3,
             evaluations: proof
                 .4
                 .iter()

--- a/poly-commitment/src/tests/commitment.rs
+++ b/poly-commitment/src/tests/commitment.rs
@@ -87,8 +87,8 @@ impl AggregatedEvaluationProof {
         BatchEvaluationProof {
             sponge: self.fq_sponge.clone(),
             evaluation_points: self.eval_points.clone(),
-            xi: self.polymask,
-            r: self.evalmask,
+            polyscale: self.polymask,
+            evalscale: self.evalmask,
             evaluations: coms,
             opening: &self.proof,
         }


### PR DESCRIPTION
This PR renames `xi` and `r` to `polyscale` and `evalscale` respectively, so that the same descriptive names are used for `open` in `evaluation_proof.rs` and `verify` in `commitment.rs`.