### PR TITLE
Add a test for zeroed chunks inside chunked commitments

### DIFF
--- a/poly-commitment/src/tests/commitment.rs
+++ b/poly-commitment/src/tests/commitment.rs
@@ -352,3 +352,29 @@ fn test_commit_multiple_of_domain_size() {
         evalmask
     ))
 }
+
+#[test]
+fn test_commit_zero_chunk() {
+    use ark_ff::One;
+    let seed = [
+        17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0,
+    ];
+    let mut rng = <rand_chacha::ChaCha20Rng as SeedableRng>::from_seed(seed);
+
+    let eval_points = vec![Fp::one()];
+    let mut coefficients = vec![Fp::zero(); 256];
+    coefficients[255] = Fp::one();
+    let poly = DensePolynomial::from_coefficients_vec(coefficients);
+    let bound = Some(257);
+    let polymask = Fp::one();
+    let evalmask = Fp::one();
+    assert!(commit_and_open(
+        poly,
+        eval_points,
+        bound,
+        &mut rng,
+        polymask,
+        evalmask
+    ))
+}


### PR DESCRIPTION
This PR adds an additional explicit testcase for zeroed chunked commitments, designed to exercise one of the failing edge cases in https://github.com/o1-labs/proof-systems/pull/724.

This test also fails without the changes in #724; this can't be merged until those differences are fixed.