### PR TITLE
[crypto] parallelize witness commitment and interpolation

### DIFF
--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -239,8 +239,6 @@ where
             [vec![G::ScalarField::zero()], vec![G::ScalarField::zero()]]
         };
 
-        println!("verifier public eval: {:?}", public_evals);
-
         //~ 1. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
         fr_sponge.absorb(&self.ft_eval1);
 


### PR DESCRIPTION
did some experiments following discussion with @imeckler : 

use par_iter to parallelize commitment of witness columns (and interpolation)

## some bench

without par_iter in the codebase:

```
Proof creation/proof creation (SRS size 2^11)                        
                        time:   [481.88 ms 483.59 ms 485.32 ms]

Proof creation/proof creation (SRS size 2^15)                        
                        time:   [6.2940 s 6.3487 s 6.4120 s]
```

with par_iter (current master):

```
Proof creation/proof creation (SRS size 2^11)                        
                        time:   [409.67 ms 413.74 ms 417.99 ms]
Benchmarking Proof creation/proof creation (SRS size 2^15): Warming up for 3.0000 s

Proof creation/proof creation (SRS size 2^15)                        
                        time:   [3.2189 s 3.3084 s 3.4077 s]
```

with par_iter for witnesses (this PR):

```
Proof creation/proof creation (SRS size 2^11)                        
                        time:   [398.51 ms 410.01 ms 424.46 ms]

Proof creation/proof creation (SRS size 2^15)                        
                        time:   [3.1958 s 3.2787 s 3.3728 s]
```

not the greatest improvement, perhaps someone will see something I didn't