### PR TITLE
Use 'fixed hiding' commitments for generic and poseidon selectors

### DIFF
--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -874,6 +874,11 @@ where
             .map(|(p, d1_size)| (p, None, non_hiding(*d1_size)))
             .collect::<Vec<_>>();
 
+        let fixed_hiding = |d1_size: usize| PolyComm {
+            unshifted: vec![G::ScalarField::one(); d1_size],
+            shifted: None,
+        };
+
         //~ 1. Then, include:
         //~~ - the negated public polynomial
         //~~ - the ft polynomial
@@ -886,8 +891,8 @@ where
         polynomials.extend(vec![(&public_poly, None, non_hiding(1))]);
         polynomials.extend(vec![(&ft, None, blinding_ft)]);
         polynomials.extend(vec![(&z_poly, None, z_comm.blinders)]);
-        polynomials.extend(vec![(&index.cs.genericm, None, non_hiding(1))]);
-        polynomials.extend(vec![(&index.cs.psm, None, non_hiding(1))]);
+        polynomials.extend(vec![(&index.cs.genericm, None, fixed_hiding(1))]);
+        polynomials.extend(vec![(&index.cs.psm, None, fixed_hiding(1))]);
         polynomials.extend(
             witness_poly
                 .iter()

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -16,7 +16,7 @@ use crate::{
     error::VerifierIndexError,
     prover_index::ProverIndex,
 };
-use ark_ff::PrimeField;
+use ark_ff::{One, PrimeField};
 use ark_poly::{univariate::DensePolynomial, Radix2EvaluationDomain as D};
 use array_init::array_init;
 use commitment_dlog::{
@@ -145,6 +145,14 @@ impl<G: KimchiCurve> ProverIndex<G> {
             return verifier_index.clone();
         }
 
+        let mask_fixed = |commitment: PolyComm<G>| {
+            let blinders = commitment.map(|_| G::ScalarField::one());
+            self.srs
+                .mask_custom(commitment, &blinders)
+                .unwrap()
+                .commitment
+        };
+
         let domain = self.cs.domain.d1;
 
         let lookup_index = {
@@ -193,9 +201,9 @@ impl<G: KimchiCurve> ProverIndex<G> {
                 self.srs
                     .commit_evaluations_non_hiding(domain, &self.cs.coefficients8[i], None)
             }),
-            generic_comm: self.srs.commit_non_hiding(&self.cs.genericm, None),
+            generic_comm: mask_fixed(self.srs.commit_non_hiding(&self.cs.genericm, None)),
 
-            psm_comm: self.srs.commit_non_hiding(&self.cs.psm, None),
+            psm_comm: mask_fixed(self.srs.commit_non_hiding(&self.cs.psm, None)),
 
             complete_add_comm: self.srs.commit_evaluations_non_hiding(
                 domain,


### PR DESCRIPTION
This PR introduces the concept of 'fixed hiding' for commitments. This is equivalent to using a blinding value of `1`, which we can use to transform zero commitments into non-zero commitments that can be consumed by pickles.

This PR only updates the generic and poseidon selectors; in order to convert the remaining commitments, we will need to propagate the blinding constants more carefully to unsure that the linearization works correctly. A PR implementing this will follow.