### PR TITLE
[SRS] encode bound on basefield of commitmentcurve in trait

### DIFF
--- a/circuit-construction/src/lib.rs
+++ b/circuit-construction/src/lib.rs
@@ -13,7 +13,7 @@ mod tests;
 /// This contains the Kimchi dependencies being used
 pub mod prologue {
     pub use super::constants::{fp_constants, fq_constants, Constants};
-    pub use super::prover::{generate_prover_index, prove, CoordinateCurve, FpInner};
+    pub use super::prover::{generate_prover_index, prove, CoordinateCurve};
     pub use super::writer::{Cs, Var};
     pub use ark_ec::{AffineCurve, ProjectiveCurve};
     pub use ark_ff::{FftField, PrimeField, UniformRand};

--- a/circuit-construction/src/prover.rs
+++ b/circuit-construction/src/prover.rs
@@ -1,6 +1,6 @@
 use crate::writer::{Cs, GateSpec, System, Var, WitnessGenerator};
-use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_ff::{FftField, One, PrimeField, SquareRootField, Zero};
+use ark_ec::AffineCurve;
+use ark_ff::{One, PrimeField, Zero};
 use commitment_dlog::{
     commitment::{CommitmentCurve, PolyComm},
     srs::{endos, SRS},
@@ -12,93 +12,8 @@ use kimchi::{
     proof::ProverProof,
     prover_index::ProverIndex,
 };
-use mina_curves::pasta::{Fp, Fq, Pallas as Other, Vesta};
 use oracle::FqSponge;
 use std::array;
-
-/// A [Cycle] represents the algebraic structure that
-/// allows for recursion using elliptic curves.
-pub trait Cycle {
-    type InnerField: FftField
-        + PrimeField
-        + SquareRootField
-        + From<u128>
-        + From<u64>
-        + From<u32>
-        + From<u16>
-        + From<u8>;
-    type OuterField: FftField
-        + PrimeField
-        + SquareRootField
-        + From<u128>
-        + From<u64>
-        + From<u32>
-        + From<u16>
-        + From<u8>;
-
-    type InnerMap: groupmap::GroupMap<Self::InnerField>;
-    type OuterMap: groupmap::GroupMap<Self::OuterField>;
-
-    type InnerProj: ProjectiveCurve<
-            Affine = Self::Inner,
-            ScalarField = Self::OuterField,
-            BaseField = Self::InnerField,
-        > + From<Self::Inner>
-        + Into<Self::Inner>
-        + std::ops::MulAssign<Self::OuterField>;
-
-    type Inner: CommitmentCurve<
-            Projective = Self::InnerProj,
-            Map = Self::InnerMap,
-            BaseField = Self::InnerField,
-            ScalarField = Self::OuterField,
-        > + From<Self::InnerProj>
-        + Into<Self::InnerProj>;
-
-    type OuterProj: ProjectiveCurve<
-            Affine = Self::Outer,
-            ScalarField = Self::InnerField,
-            BaseField = Self::OuterField,
-        > + From<Self::Outer>
-        + Into<Self::Outer>
-        + std::ops::MulAssign<Self::InnerField>;
-
-    type Outer: CommitmentCurve<
-            Projective = Self::OuterProj,
-            Map = Self::OuterMap,
-            ScalarField = Self::InnerField,
-            BaseField = Self::OuterField,
-        > + KimchiCurve;
-}
-
-/// Used to configure the base curve of Pallas
-pub struct FpInner;
-/// Used to configure the base curve of Vesta
-pub struct FqInner;
-
-impl Cycle for FpInner {
-    type InnerMap = <Other as CommitmentCurve>::Map;
-    type OuterMap = <Vesta as CommitmentCurve>::Map;
-
-    type InnerField = Fp;
-    type OuterField = Fq;
-    type Inner = Other;
-    type Outer = Vesta;
-    type InnerProj = <Other as AffineCurve>::Projective;
-    type OuterProj = <Vesta as AffineCurve>::Projective;
-}
-
-impl Cycle for FqInner {
-    type InnerMap = <Vesta as CommitmentCurve>::Map;
-    type OuterMap = <Other as CommitmentCurve>::Map;
-
-    type InnerField = Fq;
-    type OuterField = Fp;
-    type Inner = Vesta;
-    type Outer = Other;
-    type InnerProj = <Vesta as AffineCurve>::Projective;
-    type OuterProj = <Other as AffineCurve>::Projective;
-}
 
 /// Given an index, a group map, custom blinders for the witness, a public input vector, and a circuit `main`, it creates a proof.
 ///
@@ -164,20 +79,20 @@ where
 /// # Panics
 ///
 /// Will panic if `constraint_system` is not built with `public` input.
-pub fn generate_prover_index<C, H>(
-    srs: std::sync::Arc<SRS<C::Outer>>,
+pub fn generate_prover_index<Curve, Circuit>(
+    srs: std::sync::Arc<SRS<Curve>>,
     public: usize,
-    main: H,
-) -> ProverIndex<C::Outer>
+    main: Circuit,
+) -> ProverIndex<Curve>
 where
-    H: FnOnce(&mut System<C::InnerField>, Vec<Var<C::InnerField>>),
-    C: Cycle,
+    Circuit: FnOnce(&mut System<Curve::ScalarField>, Vec<Var<Curve::ScalarField>>),
+    Curve: KimchiCurve,
 {
-    let mut system: System<C::InnerField> = System::default();
-    let z = C::InnerField::zero();
+    let mut system: System<Curve::ScalarField> = System::default();
+    let z = Curve::ScalarField::zero();
 
     // create public input variables
-    let public_input_row = vec![C::InnerField::one(), z, z, z, z, z, z, z, z, z];
+    let public_input_row = vec![Curve::ScalarField::one(), z, z, z, z, z, z, z, z, z];
     let public_input: Vec<_> = (0..public)
         .map(|_| {
             let v = system.var(|| panic!("fail"));
@@ -196,15 +111,16 @@ where
     let gates = system.gates();
 
     // Other base field = self scalar field
-    let (endo_q, _endo_r) = endos::<C::Inner>();
+    let (endo_q, _endo_r) = endos::<Curve::OtherCurve>();
+    //let (endo_q, _endo_r) = Curve::endos();
 
-    let constraint_system = ConstraintSystem::<C::InnerField>::create(gates)
+    let constraint_system = ConstraintSystem::<Curve::ScalarField>::create(gates)
         .public(public)
         .build()
         // TODO: return a Result instead of panicking
         .expect("couldn't construct constraint system");
 
-    ProverIndex::<C::Outer>::create(constraint_system, endo_q, srs)
+    ProverIndex::<Curve>::create(constraint_system, endo_q, srs)
 }
 
 /// Handling coordinates in an affine curve

--- a/circuit-construction/src/tests/example_proof.rs
+++ b/circuit-construction/src/tests/example_proof.rs
@@ -59,7 +59,7 @@ fn test_example_circuit() {
     let proof_system_constants = fp_constants();
 
     // generate circuit and index
-    let prover_index = generate_prover_index::<FpInner, _>(srs, PUBLIC_INPUT_LENGTH, |sys, p| {
+    let prover_index = generate_prover_index::<_, _>(srs, PUBLIC_INPUT_LENGTH, |sys, p| {
         circuit::<_, Pallas, _>(&proof_system_constants, None, sys, p)
     });
 

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -321,7 +321,8 @@ pub fn squeeze_challenge<
     squeeze_prechallenge(sponge).to_field(endo_r)
 }
 
-pub trait CommitmentCurve: AffineCurve {
+pub trait CommitmentCurve: AffineCurve<BaseField = Self::CommitmentField> {
+    type CommitmentField: PrimeField;
     type Params: SWModelParameters;
     type Map: GroupMap<Self::BaseField>;
 
@@ -358,6 +359,7 @@ impl<P: SWModelParameters> CommitmentCurve for SWJAffine<P>
 where
     P::BaseField: PrimeField,
 {
+    type CommitmentField = P::BaseField;
     type Params = P;
     type Map = BWParameters<P>;
 

--- a/poly-commitment/src/srs.rs
+++ b/poly-commitment/src/srs.rs
@@ -34,8 +34,6 @@ pub struct SRS<G: CommitmentCurve> {
 }
 
 pub fn endos<G: CommitmentCurve>() -> (G::BaseField, G::ScalarField)
-where
-    G::BaseField: PrimeField,
 {
     let endo_q: G::BaseField = oracle::sponge::endo_coefficient();
     let endo_r = {
@@ -53,8 +51,6 @@ where
 }
 
 fn point_of_random_bytes<G: CommitmentCurve>(map: &G::Map, random_bytes: &[u8]) -> G
-where
-    G::BaseField: PrimeField,
 {
     // packing in bit-representation
     const N: usize = 31;
@@ -71,10 +67,7 @@ where
     G::of_coordinates(x, y)
 }
 
-impl<G: CommitmentCurve> SRS<G>
-where
-    G::BaseField: PrimeField,
-{
+impl<G: CommitmentCurve> SRS<G> {
     pub fn max_degree(&self) -> usize {
         self.g.len()
     }

--- a/poly-commitment/src/srs.rs
+++ b/poly-commitment/src/srs.rs
@@ -33,8 +33,7 @@ pub struct SRS<G: CommitmentCurve> {
     pub endo_q: G::BaseField,
 }
 
-pub fn endos<G: CommitmentCurve>() -> (G::BaseField, G::ScalarField)
-{
+pub fn endos<G: CommitmentCurve>() -> (G::BaseField, G::ScalarField) {
     let endo_q: G::BaseField = oracle::sponge::endo_coefficient();
     let endo_r = {
         let potential_endo_r: G::ScalarField = oracle::sponge::endo_coefficient();
@@ -50,8 +49,7 @@ pub fn endos<G: CommitmentCurve>() -> (G::BaseField, G::ScalarField)
     (endo_q, endo_r)
 }
 
-fn point_of_random_bytes<G: CommitmentCurve>(map: &G::Map, random_bytes: &[u8]) -> G
-{
+fn point_of_random_bytes<G: CommitmentCurve>(map: &G::Map, random_bytes: &[u8]) -> G {
     // packing in bit-representation
     const N: usize = 31;
     let mut bits = [false; 8 * N];


### PR DESCRIPTION
Ideally we shouldn't need to add additional bounds when we use a `KimchiCurve` type. It looks like I can't write `trait KimchiCurve : CommitmentCurve<BaseField: PrimeField>` so this is another way to encode that in the trait. It seems to work.