### PR TITLE
Implement generic witness layout for custom gates

### DIFF
--- a/kimchi/src/circuits/mod.rs
+++ b/kimchi/src/circuits/mod.rs
@@ -13,3 +13,4 @@ pub mod polynomials;
 pub mod scalars;
 mod serialization_helper;
 pub mod wires;
+pub mod witness;

--- a/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
@@ -1,13 +1,15 @@
 //! This module computes the witness of a foreign field addition circuit.
 
-use crate::circuits::{
-    polynomial::COLUMNS,
-    polynomials::range_check::{
-        self,
-        witness::{extend_witness, handle_standard_witness_cell, CopyWitnessCell, ZeroWitnessCell},
+use crate::circuits::witness::Variables;
+use crate::{
+    circuits::{
+        polynomial::COLUMNS,
+        polynomials::range_check,
+        witness::{self, ConstantCell, CopyCell, VariableCell, WitnessCell},
     },
+    variable_map,
 };
-use ark_ff::{Field, PrimeField};
+use ark_ff::PrimeField;
 use num_bigint::BigUint;
 use o1_utils::foreign_field::{ForeignElement, HI, LO, MI, TWO_TO_LIMB};
 use std::array;
@@ -108,7 +110,7 @@ fn compute_subadd_values<F: PrimeField>(
 /// inputs: list of all inputs to the chain of additions/subtractions
 /// opcode: true for addition, false for subtraction
 /// modulus: modulus of the foreign field
-pub fn create_witness<F: PrimeField>(
+pub fn create<F: PrimeField>(
     inputs: &Vec<BigUint>,
     opcodes: &Vec<FFOps>,
     modulus: BigUint,
@@ -127,7 +129,7 @@ pub fn create_witness<F: PrimeField>(
 
     // Create multi-range-check witness for first left input
     let mut left = ForeignElement::from_biguint(inputs[LO].clone());
-    extend_witness(&mut witness, left.clone());
+    range_check::witness::extend(&mut witness, left.clone());
     let mut add_values: Vec<(F, F, F, F)> = vec![];
     for i in 0..num {
         let right = ForeignElement::from_biguint(inputs[i + 1].clone());
@@ -136,8 +138,8 @@ pub fn create_witness<F: PrimeField>(
         // Create multi-range-check witness for right_input (left_input was done in previous iteration) and output
         // We only obtain the 3 lower limbs of right because the range check takes only 264 bits now
         let right_3_limb = ForeignElement::new([right[LO], right[MI], right[HI]]);
-        extend_witness(&mut witness, right_3_limb);
-        extend_witness(&mut witness, output.clone());
+        range_check::witness::extend(&mut witness, right_3_limb);
+        range_check::witness::extend(&mut witness, output.clone());
 
         add_values.append(&mut vec![(sign, overflow, carry_lo, carry_mi)]);
         left = output; // output
@@ -153,7 +155,7 @@ pub fn create_witness<F: PrimeField>(
     assert_eq!(overflow, F::one());
 
     // Final RangeCheck for bound
-    extend_witness(&mut witness, bound);
+    range_check::witness::extend(&mut witness, bound);
     let mut offset = witness[LO].len(); // number of witness rows of the gadget before the first row of the addition gate
 
     // Include FFAdds gates for operations and final bound check
@@ -186,41 +188,6 @@ pub fn create_witness<F: PrimeField>(
     witness
 }
 
-// ==================
-// WITNESS CELL CODE
-// ==================
-
-// Extend standard WitnessCell to support foreign field addition
-// specific cell types
-//
-//     * ValueLimb := contiguous range of bits extracted from a value
-//
-// TODO: Currently located in range check, but could be moved elsewhere
-pub enum WitnessCell<F: Field> {
-    Standard(range_check::witness::WitnessCell),
-    FieldElement(FieldElementCell),
-    Constant(F),
-    Ignore,
-}
-
-/// Witness cell containing a type of value that is a field element
-pub enum FieldElementType {
-    Overflow,
-    Carry,
-    Sign,
-}
-
-pub struct FieldElementCell {
-    pub kind: FieldElementType,
-    pub limb_idx: usize,
-}
-
-impl FieldElementCell {
-    pub const fn create<F: Field>(kind: FieldElementType, limb_idx: usize) -> WitnessCell<F> {
-        WitnessCell::FieldElement(FieldElementCell { kind, limb_idx })
-    }
-}
-
 fn init_foreign_field_add_rows<F: PrimeField>(
     witness: &mut [Vec<F>; COLUMNS],
     offset: usize,
@@ -231,32 +198,33 @@ fn init_foreign_field_add_rows<F: PrimeField>(
 ) {
     let left_row = 8 * index;
     let right_row = 8 * index + 4;
-    let witness_shape: [[WitnessCell<F>; COLUMNS]; 1] = [
+    let witness_shape: [[Box<dyn WitnessCell<F>>; COLUMNS]; 1] = [
         // ForeignFieldAdd row
         [
-            WitnessCell::Standard(CopyWitnessCell::create(left_row, 0)), // left_input_lo
-            WitnessCell::Standard(CopyWitnessCell::create(left_row + 1, 0)), // left_input_mi
-            WitnessCell::Standard(CopyWitnessCell::create(left_row + 2, 0)), // left_input_hi
-            WitnessCell::Standard(CopyWitnessCell::create(right_row, 0)), // right_input_lo
-            WitnessCell::Standard(CopyWitnessCell::create(right_row + 1, 0)), // right_input_mi
-            WitnessCell::Standard(CopyWitnessCell::create(right_row + 2, 0)), // right_input_hi
-            FieldElementCell::create(FieldElementType::Sign, 0),         // sign
-            FieldElementCell::create(FieldElementType::Overflow, 0),     // field_overflow
-            FieldElementCell::create(FieldElementType::Carry, LO),       // carry_lo
-            FieldElementCell::create(FieldElementType::Carry, MI),       // carry_mi
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
+            CopyCell::create(left_row, 0),      // left_input_lo
+            CopyCell::create(left_row + 1, 0),  // left_input_mi
+            CopyCell::create(left_row + 2, 0),  // left_input_hi
+            CopyCell::create(right_row, 0),     // right_input_lo
+            CopyCell::create(right_row + 1, 0), // right_input_mi
+            CopyCell::create(right_row + 2, 0), // right_input_hi
+            VariableCell::create("sign"),
+            VariableCell::create("overflow"), // field_overflow
+            VariableCell::create("carry_lo"),
+            VariableCell::create("carry_mi"),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
         ],
     ];
 
-    for (row, wit) in witness_shape.iter().enumerate() {
-        for (col, cell) in wit.iter().enumerate() {
-            handle_ffadd_rows(witness, cell, (row, col), offset, sign, overflow, carry);
-        }
-    }
+    witness::init(
+        witness,
+        offset,
+        &witness_shape,
+        &variable_map!["sign" => sign, "overflow" => overflow, "carry_lo" => carry[0], "carry_mi" => carry[1]],
+    );
 }
 
 fn init_foreign_field_fin_rows<F: PrimeField>(
@@ -267,90 +235,49 @@ fn init_foreign_field_fin_rows<F: PrimeField>(
 ) {
     let out_row = 8 * num; // row where the final result is stored in RC
     let bound_row = 8 * num + 4; // row where the final bound is stored in RC
-    let witness_shape: [[WitnessCell<F>; COLUMNS]; 2] = [
+    let witness_shape: [[Box<dyn WitnessCell<F>>; COLUMNS]; 2] = [
         [
             // ForeignFieldFin row
-            WitnessCell::Standard(CopyWitnessCell::create(out_row, 0)), // result_lo
-            WitnessCell::Standard(CopyWitnessCell::create(out_row + 1, 0)), // result_mi
-            WitnessCell::Standard(CopyWitnessCell::create(out_row + 2, 0)), // result_hi
-            WitnessCell::Constant(F::zero()),                           // 0
-            WitnessCell::Constant(F::zero()),                           // 0
-            WitnessCell::Constant(F::from(TWO_TO_LIMB)),                // 2^88
-            WitnessCell::Constant(F::one()),                            // sign
-            WitnessCell::Constant(F::one()),                            // field_overflow
-            FieldElementCell::create(FieldElementType::Carry, LO),      // carry_lo
-            FieldElementCell::create(FieldElementType::Carry, MI),      // carry_mi
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
+            CopyCell::create(out_row, 0),               // result_lo
+            CopyCell::create(out_row + 1, 0),           // result_mi
+            CopyCell::create(out_row + 2, 0),           // result_hi
+            ConstantCell::create(F::zero()),            // 0
+            ConstantCell::create(F::zero()),            // 0
+            ConstantCell::create(F::from(TWO_TO_LIMB)), // 2^88
+            ConstantCell::create(F::one()),             // sign
+            ConstantCell::create(F::one()),             // field_overflow
+            VariableCell::create("carry_lo"),
+            VariableCell::create("carry_mi"),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
         ],
         [
             // Zero Row
-            WitnessCell::Standard(CopyWitnessCell::create(bound_row, 0)), // bound_lo
-            WitnessCell::Standard(CopyWitnessCell::create(bound_row + 1, 0)), // bound_mi
-            WitnessCell::Standard(CopyWitnessCell::create(bound_row + 2, 0)), // bound_hi
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
-            WitnessCell::Standard(ZeroWitnessCell::create()),
+            CopyCell::create(bound_row, 0),     // bound_lo
+            CopyCell::create(bound_row + 1, 0), // bound_mi
+            CopyCell::create(bound_row + 2, 0), // bound_hi
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
         ],
     ];
 
-    for (row, wit) in witness_shape.iter().enumerate() {
-        for (col, cell) in wit.iter().enumerate() {
-            handle_ffadd_rows(
-                witness,
-                cell,
-                (row, col),
-                offset,
-                F::zero(),
-                F::zero(),
-                carry,
-            );
-        }
-    }
-}
-
-fn handle_ffadd_rows<F: PrimeField>(
-    witness: &mut [Vec<F>; COLUMNS],
-    witness_cell: &WitnessCell<F>,
-    coordinates: (usize, usize), /* row, col */
-    offset: usize,
-    sign: F,
-    overflow: F,
-    carry: [F; 2],
-) {
-    let (row, col) = coordinates;
-    match witness_cell {
-        WitnessCell::Standard(standard_cell) => {
-            handle_standard_witness_cell(
-                witness,
-                standard_cell,
-                offset + row,
-                col,
-                F::zero(), /* unused by this gate */
-            )
-        }
-        WitnessCell::FieldElement(elem_cell) => {
-            witness[col][offset + row] = {
-                match elem_cell.kind {
-                    FieldElementType::Overflow => overflow,
-                    FieldElementType::Carry => carry[elem_cell.limb_idx],
-                    FieldElementType::Sign => sign,
-                }
-            }
-        }
-        WitnessCell::Constant(field_elem) => witness[col][offset + row] = *field_elem,
-        WitnessCell::Ignore => (),
-    }
+    witness::init(
+        witness,
+        offset,
+        &witness_shape,
+        &variable_map![ "carry_lo" => carry[0], "carry_mi" => carry[1]],
+    );
 }

--- a/kimchi/src/circuits/polynomials/range_check/witness.rs
+++ b/kimchi/src/circuits/polynomials/range_check/witness.rs
@@ -1,72 +1,17 @@
 //! Range check witness computation
 
 use ark_ff::PrimeField;
-use o1_utils::{FieldHelpers, ForeignElement};
+use o1_utils::ForeignElement;
 use std::array;
 
-use crate::circuits::polynomial::COLUMNS;
-
-/// Witness cell for range check gadget
-pub enum WitnessCell {
-    Copy(CopyWitnessCell),
-    Value,
-    Limb(LimbWitnessCell),
-    Zero,
-}
-
-/// Witness cell copied from another
-pub struct CopyWitnessCell {
-    row: usize,
-    col: usize,
-}
-
-impl CopyWitnessCell {
-    /// Create a copy witness cell
-    pub const fn create(row: usize, col: usize) -> WitnessCell {
-        WitnessCell::Copy(CopyWitnessCell { row, col })
-    }
-}
-
-/// Witness cell for a range check field element limb
-pub struct ValueWitnessCell;
-
-impl ValueWitnessCell {
-    /// Create a value witness cell
-    pub const fn create() -> WitnessCell {
-        WitnessCell::Value
-    }
-}
-
-/// Witness cell for a range check field element sub-limb
-pub struct LimbWitnessCell {
-    row: usize,   // Cell row
-    col: usize,   // Cell col
-    start: usize, // Starting bit offset
-    end: usize,   // Ending bit offset (exclusive)
-}
-
-impl LimbWitnessCell {
-    /// Creates a limb witness cell.
-    /// Params: source (row, col), starting bit offset and ending bit offset (exclusive)
-    pub const fn create(row: usize, col: usize, start: usize, end: usize) -> WitnessCell {
-        WitnessCell::Limb(LimbWitnessCell {
-            row,
-            col,
-            start,
-            end,
-        })
-    }
-}
-
-/// A cell containing zero
-pub struct ZeroWitnessCell;
-
-impl ZeroWitnessCell {
-    /// Create a zero witness cell
-    pub const fn create() -> WitnessCell {
-        WitnessCell::Zero
-    }
-}
+use crate::circuits::witness::Variables;
+use crate::{
+    circuits::{
+        polynomial::COLUMNS,
+        witness::{init_row, ConstantCell, CopyBitsCell, CopyCell, VariableCell, WitnessCell},
+    },
+    variables,
+};
 
 /// Witness layout
 ///   * The values and cell contents are in little-endian order.
@@ -79,152 +24,118 @@ impl ZeroWitnessCell {
 ///     For example, we can convert the `RangeCheck0` circuit gate into
 ///     a 64-bit lookup by adding two copy constraints to constrain
 ///     columns 1 and 2 to zero.
-pub const WITNESS_SHAPE: [[WitnessCell; COLUMNS]; 4] = [
-    /* row 1, RangeCheck0 row */
-    range_check_row(0),
-    /* row 2, RangeCheck0 row */
-    range_check_row(1),
-    /* row 3, RangeCheck1 row */
+fn layout<F: PrimeField>() -> [[Box<dyn WitnessCell<F>>; COLUMNS]; 4] {
     [
-        ValueWitnessCell::create(),
-        /* 2-bit crumbs (placed here to keep lookup pattern */
-        /*               the same as RangeCheck0) */
-        LimbWitnessCell::create(2, 0, 86, 88),
-        LimbWitnessCell::create(2, 0, 84, 86),
-        /* 12-bit plookups */
-        LimbWitnessCell::create(2, 0, 72, 84),
-        LimbWitnessCell::create(2, 0, 60, 72),
-        LimbWitnessCell::create(2, 0, 48, 60),
-        LimbWitnessCell::create(2, 0, 36, 48),
-        /* 2-bit crumbs */
-        LimbWitnessCell::create(2, 0, 34, 36),
-        LimbWitnessCell::create(2, 0, 32, 34),
-        LimbWitnessCell::create(2, 0, 30, 32),
-        LimbWitnessCell::create(2, 0, 28, 30),
-        LimbWitnessCell::create(2, 0, 26, 28),
-        LimbWitnessCell::create(2, 0, 24, 26),
-        LimbWitnessCell::create(2, 0, 22, 24),
-        LimbWitnessCell::create(2, 0, 20, 22),
-    ],
-    /* row 4, Zero row */
-    [
-        ZeroWitnessCell::create(),
-        /* 2-bit crumbs (placed here to keep lookup pattern */
-        /*               the same as RangeCheck0) */
-        LimbWitnessCell::create(2, 0, 18, 20),
-        LimbWitnessCell::create(2, 0, 16, 18),
-        /* 12-bit plookups (see note about copies in range_check_row) */
-        CopyWitnessCell::create(0, 1),
-        CopyWitnessCell::create(0, 2),
-        CopyWitnessCell::create(1, 1),
-        CopyWitnessCell::create(1, 2),
-        /* 2-bit crumbs */
-        LimbWitnessCell::create(2, 0, 14, 16),
-        LimbWitnessCell::create(2, 0, 12, 14),
-        LimbWitnessCell::create(2, 0, 10, 12),
-        LimbWitnessCell::create(2, 0, 8, 10),
-        LimbWitnessCell::create(2, 0, 6, 8),
-        LimbWitnessCell::create(2, 0, 4, 6),
-        LimbWitnessCell::create(2, 0, 2, 4),
-        LimbWitnessCell::create(2, 0, 0, 2),
-    ],
-];
+        /* row 1, RangeCheck0 row */
+        range_check_0_row("v0", 0),
+        /* row 2, RangeCheck0 row */
+        range_check_0_row("v1", 1),
+        /* row 3, RangeCheck1 row */
+        [
+            VariableCell::create("v2"),
+            /* 2-bit crumbs (placed here to keep lookup pattern */
+            /*               the same as RangeCheck0) */
+            CopyBitsCell::create(2, 0, 86, 88),
+            CopyBitsCell::create(2, 0, 84, 86),
+            /* 12-bit plookups */
+            CopyBitsCell::create(2, 0, 72, 84),
+            CopyBitsCell::create(2, 0, 60, 72),
+            CopyBitsCell::create(2, 0, 48, 60),
+            CopyBitsCell::create(2, 0, 36, 48),
+            /* 2-bit crumbs */
+            CopyBitsCell::create(2, 0, 34, 36),
+            CopyBitsCell::create(2, 0, 32, 34),
+            CopyBitsCell::create(2, 0, 30, 32),
+            CopyBitsCell::create(2, 0, 28, 30),
+            CopyBitsCell::create(2, 0, 26, 28),
+            CopyBitsCell::create(2, 0, 24, 26),
+            CopyBitsCell::create(2, 0, 22, 24),
+            CopyBitsCell::create(2, 0, 20, 22),
+        ],
+        /* row 4, Zero row */
+        [
+            ConstantCell::create(F::zero()),
+            /* 2-bit crumbs (placed here to keep lookup pattern */
+            /*               the same as RangeCheck0) */
+            CopyBitsCell::create(2, 0, 18, 20),
+            CopyBitsCell::create(2, 0, 16, 18),
+            /* 12-bit plookups (see note about copies in range_check_row) */
+            CopyCell::create(0, 1),
+            CopyCell::create(0, 2),
+            CopyCell::create(1, 1),
+            CopyCell::create(1, 2),
+            /* 2-bit crumbs */
+            CopyBitsCell::create(2, 0, 14, 16),
+            CopyBitsCell::create(2, 0, 12, 14),
+            CopyBitsCell::create(2, 0, 10, 12),
+            CopyBitsCell::create(2, 0, 8, 10),
+            CopyBitsCell::create(2, 0, 6, 8),
+            CopyBitsCell::create(2, 0, 4, 6),
+            CopyBitsCell::create(2, 0, 2, 4),
+            CopyBitsCell::create(2, 0, 0, 2),
+        ],
+    ]
+}
 
 /// The row layout for `RangeCheck0`
-const fn range_check_row(row: usize) -> [WitnessCell; COLUMNS] {
+fn range_check_0_row<F: PrimeField>(
+    limb_name: &'static str,
+    row: usize,
+) -> [Box<dyn WitnessCell<F>>; COLUMNS] {
     [
-        ValueWitnessCell::create(),
+        VariableCell::create(limb_name),
         /* 12-bit copies */
         // Copy cells are required because we have a limit
         // of 4 lookups per row.  These two lookups are moved to
         // the 4th row, which is a Zero circuit gate, and the
         // RangeCheck1 circuit gate triggers the lookup constraints.
-        LimbWitnessCell::create(row, 0, 76, 88),
-        LimbWitnessCell::create(row, 0, 64, 76),
+        CopyBitsCell::create(row, 0, 76, 88),
+        CopyBitsCell::create(row, 0, 64, 76),
         /* 12-bit plookups */
-        LimbWitnessCell::create(row, 0, 52, 64),
-        LimbWitnessCell::create(row, 0, 40, 52),
-        LimbWitnessCell::create(row, 0, 28, 40),
-        LimbWitnessCell::create(row, 0, 16, 28),
+        CopyBitsCell::create(row, 0, 52, 64),
+        CopyBitsCell::create(row, 0, 40, 52),
+        CopyBitsCell::create(row, 0, 28, 40),
+        CopyBitsCell::create(row, 0, 16, 28),
         /* 2-bit crumbs */
-        LimbWitnessCell::create(row, 0, 14, 16),
-        LimbWitnessCell::create(row, 0, 12, 14),
-        LimbWitnessCell::create(row, 0, 10, 12),
-        LimbWitnessCell::create(row, 0, 8, 10),
-        LimbWitnessCell::create(row, 0, 6, 8),
-        LimbWitnessCell::create(row, 0, 4, 6),
-        LimbWitnessCell::create(row, 0, 2, 4),
-        LimbWitnessCell::create(row, 0, 0, 2),
+        CopyBitsCell::create(row, 0, 14, 16),
+        CopyBitsCell::create(row, 0, 12, 14),
+        CopyBitsCell::create(row, 0, 10, 12),
+        CopyBitsCell::create(row, 0, 8, 10),
+        CopyBitsCell::create(row, 0, 6, 8),
+        CopyBitsCell::create(row, 0, 4, 6),
+        CopyBitsCell::create(row, 0, 2, 4),
+        CopyBitsCell::create(row, 0, 0, 2),
     ]
-}
-
-/// transforms a field to a limb from a start bit to an end bit
-pub fn value_to_limb<F: PrimeField>(fe: F, start: usize, end: usize) -> F {
-    F::from_bits(&fe.to_bits()[start..end]).expect("failed to deserialize field bits")
-}
-
-/// handles range-check witness cells
-pub fn handle_standard_witness_cell<F: PrimeField>(
-    witness: &mut [Vec<F>; COLUMNS],
-    witness_cell: &WitnessCell,
-    row: usize,
-    col: usize,
-    value: F,
-) {
-    match witness_cell {
-        WitnessCell::Copy(copy_cell) => {
-            witness[col][row] = witness[copy_cell.col][copy_cell.row];
-        }
-        WitnessCell::Value => {
-            witness[col][row] = value;
-        }
-        WitnessCell::Limb(limb_cell) => {
-            witness[col][row] = value_to_limb(
-                witness[limb_cell.col][limb_cell.row], // limb cell (row, col)
-                limb_cell.start,                       // starting bit
-                limb_cell.end,                         // ending bit (exclusive)
-            );
-        }
-        WitnessCell::Zero => {
-            witness[col][row] = F::zero();
-        }
-    }
-}
-
-/// initialize a range_check_row
-fn init_range_check_row<F: PrimeField>(witness: &mut [Vec<F>; COLUMNS], row: usize, value: F) {
-    for col in 0..COLUMNS {
-        handle_standard_witness_cell(witness, &WITNESS_SHAPE[row][col], row, col, value);
-    }
 }
 
 /// Create a multi range check witness
 /// Input: three 88-bit values: v0, v1 and v2
-pub fn create_multi_witness<F: PrimeField>(v0: F, v1: F, v2: F) -> [Vec<F>; COLUMNS] {
+pub fn create_multi<F: PrimeField>(v0: F, v1: F, v2: F) -> [Vec<F>; COLUMNS] {
+    let layout = layout();
     let mut witness: [Vec<F>; COLUMNS] = array::from_fn(|_| vec![F::zero(); 4]);
 
-    init_range_check_row(&mut witness, 0, v0);
-    init_range_check_row(&mut witness, 1, v1);
-    init_range_check_row(&mut witness, 2, v2);
-    init_range_check_row(&mut witness, 3, F::zero());
+    init_row(&mut witness, 0, 0, &layout, &variables!(v0));
+    init_row(&mut witness, 0, 1, &layout, &variables!(v1));
+    init_row(&mut witness, 0, 2, &layout, &variables!(v2));
+    init_row(&mut witness, 0, 3, &layout, &variables!());
 
     witness
 }
 
 /// Create a single range check witness
 /// Input: 88-bit value v0
-pub fn create_witness<F: PrimeField>(v0: F) -> [Vec<F>; COLUMNS] {
+pub fn create<F: PrimeField>(v0: F) -> [Vec<F>; COLUMNS] {
+    let layout = [range_check_0_row("v0", 0)];
     let mut witness: [Vec<F>; COLUMNS] = array::from_fn(|_| vec![F::zero(); 4]);
 
-    init_range_check_row(&mut witness, 0, v0);
+    init_row(&mut witness, 0, 0, &layout, &variables!(v0));
 
     witness
 }
 
-/// Extend an existing witness with a multi-range-check gate for foreign field
-/// elements fe
-pub fn extend_witness<F: PrimeField>(witness: &mut [Vec<F>; COLUMNS], fe: ForeignElement<F, 3>) {
-    let limbs_witness = create_multi_witness(fe[0], fe[1], fe[2]);
+/// Extend an existing witness with a multi-range-check gadget for foreign field element
+pub fn extend<F: PrimeField>(witness: &mut [Vec<F>; COLUMNS], fe: ForeignElement<F, 3>) {
+    let limbs_witness = create_multi(fe[0], fe[1], fe[2]);
     for col in 0..COLUMNS {
         witness[col].extend(limbs_witness[col].iter())
     }

--- a/kimchi/src/circuits/witness/constant_cell.rs
+++ b/kimchi/src/circuits/witness/constant_cell.rs
@@ -1,0 +1,21 @@
+use super::{variables::Variables, WitnessCell};
+use crate::circuits::polynomial::COLUMNS;
+use ark_ff::Field;
+
+/// Witness cell with constant value
+pub struct ConstantCell<F: Field> {
+    value: F,
+}
+
+impl<F: Field> ConstantCell<F> {
+    /// Create witness cell with constant value
+    pub fn create(value: F) -> Box<ConstantCell<F>> {
+        Box::new(ConstantCell { value })
+    }
+}
+
+impl<F: Field> WitnessCell<F> for ConstantCell<F> {
+    fn value(&self, _witness: &mut [Vec<F>; COLUMNS], _variables: &Variables<F>) -> F {
+        self.value
+    }
+}

--- a/kimchi/src/circuits/witness/copy_bits_cell.rs
+++ b/kimchi/src/circuits/witness/copy_bits_cell.rs
@@ -1,0 +1,32 @@
+use ark_ff::Field;
+use o1_utils::FieldHelpers;
+
+use super::{variables::Variables, WitnessCell};
+use crate::circuits::polynomial::COLUMNS;
+
+/// Witness cell copied from bits of another witness cell
+pub struct CopyBitsCell {
+    row: usize,
+    col: usize,
+    start: usize, // inclusive
+    end: usize,   // exclusive
+}
+
+impl CopyBitsCell {
+    /// Create witness cell copied from bits [start, end) of the witness cell at position (row, col)
+    pub fn create(row: usize, col: usize, start: usize, end: usize) -> Box<CopyBitsCell> {
+        Box::new(CopyBitsCell {
+            row,
+            col,
+            start,
+            end,
+        })
+    }
+}
+
+impl<F: Field> WitnessCell<F> for CopyBitsCell {
+    fn value(&self, witness: &mut [Vec<F>; COLUMNS], _variables: &Variables<F>) -> F {
+        F::from_bits(&witness[self.col][self.row].to_bits()[self.start..self.end])
+            .expect("failed to deserialize field bits for copy bits cell")
+    }
+}

--- a/kimchi/src/circuits/witness/copy_cell.rs
+++ b/kimchi/src/circuits/witness/copy_cell.rs
@@ -1,0 +1,23 @@
+use ark_ff::Field;
+
+use super::{variables::Variables, WitnessCell};
+use crate::circuits::polynomial::COLUMNS;
+
+/// Witness cell copied from another witness cell
+pub struct CopyCell {
+    row: usize,
+    col: usize,
+}
+
+impl CopyCell {
+    /// Create a witness cell copied from the witness cell at position (row, col)
+    pub fn create(row: usize, col: usize) -> Box<CopyCell> {
+        Box::new(CopyCell { row, col })
+    }
+}
+
+impl<F: Field> WitnessCell<F> for CopyCell {
+    fn value(&self, witness: &mut [Vec<F>; COLUMNS], _variables: &Variables<F>) -> F {
+        witness[self.col][self.row]
+    }
+}

--- a/kimchi/src/circuits/witness/copy_shift_cell.rs
+++ b/kimchi/src/circuits/witness/copy_shift_cell.rs
@@ -1,0 +1,23 @@
+use super::{variables::Variables, WitnessCell};
+use crate::circuits::polynomial::COLUMNS;
+use ark_ff::Field;
+
+/// Witness cell copied from another cell and shifted
+pub struct CopyShiftCell {
+    row: usize,
+    col: usize,
+    shift: u64,
+}
+
+impl CopyShiftCell {
+    /// Create witness cell copied from the witness cell at position (row, col) and then scaled by 2^shift
+    pub fn create(row: usize, col: usize, shift: u64) -> Box<CopyShiftCell> {
+        Box::new(CopyShiftCell { row, col, shift })
+    }
+}
+
+impl<F: Field> WitnessCell<F> for CopyShiftCell {
+    fn value(&self, witness: &mut [Vec<F>; COLUMNS], _variables: &Variables<F>) -> F {
+        F::from(2u32).pow([self.shift]) * witness[self.col][self.row]
+    }
+}

--- a/kimchi/src/circuits/witness/mod.rs
+++ b/kimchi/src/circuits/witness/mod.rs
@@ -17,7 +17,7 @@ pub use self::{
 
 use super::polynomial::COLUMNS;
 
-/// Interface for that all types of Witness cells
+/// Witness cell interface
 pub trait WitnessCell<F: Field> {
     fn value(&self, witness: &mut [Vec<F>; COLUMNS], variables: &Variables<F>) -> F;
 }

--- a/kimchi/src/circuits/witness/mod.rs
+++ b/kimchi/src/circuits/witness/mod.rs
@@ -1,0 +1,206 @@
+use ark_ff::{Field, PrimeField};
+mod constant_cell;
+mod copy_bits_cell;
+mod copy_cell;
+mod copy_shift_cell;
+mod variable_cell;
+mod variables;
+
+pub use self::{
+    constant_cell::ConstantCell,
+    copy_bits_cell::CopyBitsCell,
+    copy_cell::CopyCell,
+    copy_shift_cell::CopyShiftCell,
+    variable_cell::VariableCell,
+    variables::{variable_map, variables, Variables},
+};
+
+use super::polynomial::COLUMNS;
+
+/// Interface for that all types of Witness cells
+pub trait WitnessCell<F: Field> {
+    fn value(&self, witness: &mut [Vec<F>; COLUMNS], variables: &Variables<F>) -> F;
+}
+
+/// Initialize a witness cell based on layout and computed variables
+pub fn init_cell<F: PrimeField>(
+    witness: &mut [Vec<F>; COLUMNS],
+    offset: usize,
+    row: usize,
+    col: usize,
+    layout: &[[Box<dyn WitnessCell<F>>; COLUMNS]],
+    variables: &Variables<F>,
+) {
+    witness[col][row + offset] = layout[row][col].value(witness, variables);
+}
+
+/// Initialize a witness row based on layout and computed variables
+pub fn init_row<F: PrimeField>(
+    witness: &mut [Vec<F>; COLUMNS],
+    offset: usize,
+    row: usize,
+    layout: &[[Box<dyn WitnessCell<F>>; COLUMNS]],
+    variables: &Variables<F>,
+) {
+    for col in 0..COLUMNS {
+        init_cell(witness, offset, row, col, layout, variables);
+    }
+}
+
+/// Initialize a witness based on layout and computed variables
+pub fn init<F: PrimeField>(
+    witness: &mut [Vec<F>; COLUMNS],
+    offset: usize,
+    layout: &[[Box<dyn WitnessCell<F>>; COLUMNS]],
+    variables: &Variables<F>,
+) {
+    for row in 0..layout.len() {
+        init_row(witness, offset, row, layout, variables);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::array;
+
+    use super::*;
+
+    use ark_ec::AffineCurve;
+    use ark_ff::{Field, One, Zero};
+    use mina_curves::pasta::Pallas;
+    type PallasField = <Pallas as AffineCurve>::BaseField;
+
+    #[test]
+    fn zero_layout() {
+        let layout: [[Box<dyn WitnessCell<PallasField>>; COLUMNS]; 1] = [[
+            ConstantCell::create(PallasField::zero()),
+            ConstantCell::create(PallasField::zero()),
+            ConstantCell::create(PallasField::zero()),
+            ConstantCell::create(PallasField::zero()),
+            ConstantCell::create(PallasField::zero()),
+            ConstantCell::create(PallasField::zero()),
+            ConstantCell::create(PallasField::zero()),
+            ConstantCell::create(PallasField::zero()),
+            ConstantCell::create(PallasField::zero()),
+            ConstantCell::create(PallasField::zero()),
+            ConstantCell::create(PallasField::zero()),
+            ConstantCell::create(PallasField::zero()),
+            ConstantCell::create(PallasField::zero()),
+            ConstantCell::create(PallasField::zero()),
+            ConstantCell::create(PallasField::zero()),
+        ]];
+
+        let mut witness: [Vec<PallasField>; COLUMNS] =
+            array::from_fn(|_| vec![PallasField::one(); 1]);
+
+        for col in witness.clone() {
+            for field in col {
+                assert_eq!(field, PallasField::one());
+            }
+        }
+
+        // Set a single cell to zero
+        init_cell(&mut witness, 0, 0, 4, &layout, &variables!());
+        assert_eq!(witness[4][0], PallasField::zero());
+
+        // Set all the cells to zero
+        init_row(&mut witness, 0, 0, &layout, &variables!());
+
+        for col in witness {
+            for field in col {
+                assert_eq!(field, PallasField::zero());
+            }
+        }
+    }
+
+    #[test]
+    fn mixed_layout() {
+        let layout: [[Box<dyn WitnessCell<PallasField>>; COLUMNS]; 2] = [
+            [
+                ConstantCell::create(PallasField::from(12u32)),
+                ConstantCell::create(PallasField::from(0xa5a3u32)),
+                ConstantCell::create(PallasField::from(0x800u32)),
+                CopyCell::create(0, 0),
+                CopyBitsCell::create(0, 1, 0, 4),
+                CopyShiftCell::create(0, 2, 12),
+                VariableCell::create("sum_of_products"),
+                ConstantCell::create(PallasField::zero()),
+                ConstantCell::create(PallasField::zero()),
+                ConstantCell::create(PallasField::zero()),
+                ConstantCell::create(PallasField::zero()),
+                ConstantCell::create(PallasField::zero()),
+                ConstantCell::create(PallasField::zero()),
+                ConstantCell::create(PallasField::zero()),
+                ConstantCell::create(PallasField::zero()),
+            ],
+            [
+                CopyCell::create(0, 0),
+                CopyBitsCell::create(0, 1, 4, 8),
+                CopyShiftCell::create(0, 2, 8),
+                VariableCell::create("sum_of_products"),
+                ConstantCell::create(PallasField::zero()),
+                ConstantCell::create(PallasField::zero()),
+                ConstantCell::create(PallasField::zero()),
+                VariableCell::create("something_else"),
+                ConstantCell::create(PallasField::zero()),
+                ConstantCell::create(PallasField::zero()),
+                ConstantCell::create(PallasField::zero()),
+                ConstantCell::create(PallasField::zero()),
+                ConstantCell::create(PallasField::zero()),
+                ConstantCell::create(PallasField::zero()),
+                VariableCell::create("final_value"),
+            ],
+        ];
+
+        let mut witness: [Vec<PallasField>; COLUMNS] =
+            array::from_fn(|_| vec![PallasField::zero(); 2]);
+
+        // Local variable (witness computation) with same names as VariableCell above
+        let sum_of_products = PallasField::from(1337u32);
+        let something_else = sum_of_products * PallasField::from(5u32);
+        let final_value = (something_else + PallasField::one()).pow(&[2u64]);
+
+        init_row(
+            &mut witness,
+            0,
+            0,
+            &layout,
+            &variables!(sum_of_products, something_else, final_value),
+        );
+
+        assert_eq!(witness[3][0], PallasField::from(12u32));
+        assert_eq!(witness[4][0], PallasField::from(0x3u32));
+        assert_eq!(witness[5][0], PallasField::from(0x800000u32));
+        assert_eq!(witness[6][0], sum_of_products);
+
+        init_row(
+            &mut witness,
+            0,
+            1,
+            &layout,
+            &variables!(sum_of_products, something_else, final_value),
+        );
+
+        assert_eq!(witness[0][1], PallasField::from(12u32));
+        assert_eq!(witness[1][1], PallasField::from(0xau32));
+        assert_eq!(witness[2][1], PallasField::from(0x80000u32));
+        assert_eq!(witness[3][1], sum_of_products);
+        assert_eq!(witness[7][1], something_else);
+        assert_eq!(witness[14][1], final_value);
+
+        let mut witness2: [Vec<PallasField>; COLUMNS] =
+            array::from_fn(|_| vec![PallasField::zero(); 2]);
+        init(
+            &mut witness2,
+            0,
+            &layout,
+            &variables!(sum_of_products, something_else, final_value),
+        );
+
+        for row in 0..witness[0].len() {
+            for col in 0..witness.len() {
+                assert_eq!(witness[col][row], witness2[col][row]);
+            }
+        }
+    }
+}

--- a/kimchi/src/circuits/witness/variable_cell.rs
+++ b/kimchi/src/circuits/witness/variable_cell.rs
@@ -1,0 +1,22 @@
+use super::{variables::Variables, WitnessCell};
+use crate::circuits::polynomial::COLUMNS;
+use ark_ff::Field;
+
+/// Witness cell assigned from a variable
+/// See [Variables] for more details
+pub struct VariableCell<'a> {
+    name: &'a str,
+}
+
+impl<'a> VariableCell<'a> {
+    /// Create witness cell assigned from a variable name
+    pub fn create(name: &'a str) -> Box<VariableCell<'a>> {
+        Box::new(VariableCell { name })
+    }
+}
+
+impl<'a, F: Field> WitnessCell<F> for VariableCell<'a> {
+    fn value(&self, _witness: &mut [Vec<F>; COLUMNS], variables: &Variables<F>) -> F {
+        variables[self.name]
+    }
+}

--- a/kimchi/src/circuits/witness/variables.rs
+++ b/kimchi/src/circuits/witness/variables.rs
@@ -1,0 +1,100 @@
+use ark_ff::Field;
+/// Layout variable handling
+///
+///   First, you use "anchor" names for the variables when specifying
+///   the witness layout.
+///
+///     Ex.
+///
+///     let layout = [
+///         [
+///             &CopyShiftCell::create(0, 2, 8),
+///             &VariableCell::create("sum_of_products"),
+///             ...
+///             &VariableCell::create("final_value"),
+///         ]
+///      ;
+///
+///   Second, you use variables with the same names when performing the
+///   witness computation.
+///
+///     Ex.
+///
+///     let sum_of_products = carry1 * limb1 + pow1 * limb2;
+///     ...
+///     let final_value = middle_bits.pow(&[2u8]) * carry_flag
+///
+///   Third, when you're ready to generate the witness, you pass those
+///   variables to the witness creation functions using variables!(foo, bar)
+///   or variable_map!("foo" => 12, "bar" => blah).
+///
+///     Ex.
+///
+///     init_witness(
+///         &mut witness2,
+///         &layout,
+///         &variables!(sum_of_products, something_else, final_value),
+///     );
+///
+use std::{
+    collections::HashMap,
+    ops::{Index, IndexMut},
+};
+
+/// Layout variables mapping - these values are substituted
+/// into the witness layout when creating the witness instance.
+///
+///   Map of witness values (used by VariableCells)
+///     name (String) -> value (F)
+pub struct Variables<'a, F: Field>(HashMap<&'a str, F>);
+
+impl<'a, F: Field> Variables<'a, F> {
+    /// Create a layout variable map
+    pub fn create() -> Variables<'a, F> {
+        Variables(HashMap::new())
+    }
+
+    /// Insert a variable and corresponding value into the variable map
+    pub fn insert(&mut self, name: &'a str, value: F) {
+        self.0.insert(name, value);
+    }
+}
+
+impl<'a, F: Field> Index<&'a str> for Variables<'a, F> {
+    type Output = F;
+    fn index(&self, name: &'a str) -> &Self::Output {
+        &self.0[name]
+    }
+}
+
+impl<'a, F: Field> IndexMut<&'a str> for Variables<'a, F> {
+    fn index_mut(&mut self, name: &'a str) -> &mut Self::Output {
+        self.0.get_mut(name).expect("failed to get witness value")
+    }
+}
+
+/// Macro to simplify mapping of layout variable
+#[macro_export]
+macro_rules! variables {
+    () => {
+        Variables::create()
+    };
+    ($( $var: ident ),*) => {{
+         let mut vars = Variables::create();
+         $( vars.insert(stringify!{$var}, $var); )*
+         vars
+    }}
+}
+
+/// Macro to simplify creation of layout map
+#[macro_export]
+macro_rules! variable_map {
+    ($( $name: expr => $value: expr ),*) => {{
+        let mut vars = Variables::create();
+         $( vars.insert($name, $value); )*
+         vars
+    }}
+}
+
+pub use variable_map;
+pub use variables;

--- a/kimchi/src/tests/range_check.rs
+++ b/kimchi/src/tests/range_check.rs
@@ -128,7 +128,7 @@ fn verify_range_check0_one_invalid_witness() {
 fn verify_range_check0_valid_witness() {
     let cs = create_test_constraint_system();
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from_hex("115655443433221211ffef000000000000000000000000000000000000000000")
             .unwrap(),
         PallasField::from_hex("eeddcdccbbabaa99898877000000000000000000000000000000000000000000")
@@ -161,7 +161,7 @@ fn verify_range_check0_valid_witness() {
         Ok(())
     );
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from_hex("23d406ac800d1af73040dd000000000000000000000000000000000000000000")
             .unwrap(),
         PallasField::from_hex("a8fe8555371eb021469863000000000000000000000000000000000000000000")
@@ -199,7 +199,7 @@ fn verify_range_check0_valid_witness() {
 fn verify_range_check0_invalid_witness() {
     let cs = create_test_constraint_system();
 
-    let mut witness = range_check::witness::create_multi_witness::<PallasField>(
+    let mut witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from_hex("22f6b4e7ecb4488433ade7000000000000000000000000000000000000000000")
             .unwrap(),
         PallasField::from_hex("e20e9d80333f2fba463ffd000000000000000000000000000000000000000000")
@@ -230,7 +230,7 @@ fn verify_range_check0_invalid_witness() {
         ))
     );
 
-    let mut witness = range_check::witness::create_multi_witness::<PallasField>(
+    let mut witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from_hex("22cab5e27101eeafd2cbe1000000000000000000000000000000000000000000")
             .unwrap(),
         PallasField::from_hex("1ab61d31f4e27fe41a318c000000000000000000000000000000000000000000")
@@ -274,7 +274,7 @@ fn verify_range_check0_invalid_witness() {
 fn verify_range_check0_valid_v0_in_range() {
     let cs = create_test_constraint_system();
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from(PallasField::from(2u64).pow([88]) - PallasField::one()),
         PallasField::zero(),
         PallasField::zero(),
@@ -292,7 +292,7 @@ fn verify_range_check0_valid_v0_in_range() {
         Ok(())
     );
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from(PallasField::from(2u64).pow([64])),
         PallasField::zero(),
         PallasField::zero(),
@@ -310,7 +310,7 @@ fn verify_range_check0_valid_v0_in_range() {
         Ok(())
     );
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from(42u64),
         PallasField::zero(),
         PallasField::zero(),
@@ -328,7 +328,7 @@ fn verify_range_check0_valid_v0_in_range() {
         Ok(())
     );
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::one(),
         PallasField::zero(),
         PallasField::zero(),
@@ -351,7 +351,7 @@ fn verify_range_check0_valid_v0_in_range() {
 fn verify_range_check0_valid_v1_in_range() {
     let cs = create_test_constraint_system();
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::from(PallasField::from(2u64).pow([88]) - PallasField::one()),
         PallasField::zero(),
@@ -369,7 +369,7 @@ fn verify_range_check0_valid_v1_in_range() {
         Ok(())
     );
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::from(PallasField::from(2u64).pow([63])),
         PallasField::zero(),
@@ -387,7 +387,7 @@ fn verify_range_check0_valid_v1_in_range() {
         Ok(())
     );
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::from(48u64),
         PallasField::zero(),
@@ -405,7 +405,7 @@ fn verify_range_check0_valid_v1_in_range() {
         Ok(())
     );
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::one() + PallasField::one(),
         PallasField::zero(),
@@ -428,7 +428,7 @@ fn verify_range_check0_valid_v1_in_range() {
 fn verify_range_check0_invalid_v0_not_in_range() {
     let cs = create_test_constraint_system();
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from(2u64).pow([88]), // out of range
         PallasField::zero(),
         PallasField::zero(),
@@ -446,7 +446,7 @@ fn verify_range_check0_invalid_v0_not_in_range() {
         Err(CircuitGateError::Constraint(GateType::RangeCheck0, 8))
     );
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from(2u64).pow([96]), // out of range
         PallasField::zero(),
         PallasField::zero(),
@@ -469,7 +469,7 @@ fn verify_range_check0_invalid_v0_not_in_range() {
 fn verify_range_check0_invalid_v1_not_in_range() {
     let cs = create_test_constraint_system();
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::from(2u64).pow([88]), // out of range
         PallasField::zero(),
@@ -487,7 +487,7 @@ fn verify_range_check0_invalid_v1_not_in_range() {
         Err(CircuitGateError::Constraint(GateType::RangeCheck0, 8))
     );
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::from(2u64).pow([96]), // out of range
         PallasField::zero(),
@@ -513,7 +513,7 @@ fn verify_range_check0_test_copy_constraints() {
     for row in 0..=1 {
         for col in 1..=2 {
             // Copy constraints impact v0 and v1
-            let mut witness = range_check::witness::create_multi_witness::<PallasField>(
+            let mut witness = range_check::witness::create_multi::<PallasField>(
                 PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
                 PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
                 PallasField::zero(),
@@ -571,7 +571,7 @@ fn verify_range_check0_v0_test_lookups() {
 
     for i in 3..=6 {
         // Test ith lookup
-        let mut witness = range_check::witness::create_multi_witness::<PallasField>(
+        let mut witness = range_check::witness::create_multi::<PallasField>(
             PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
             PallasField::zero(),
             PallasField::zero(),
@@ -604,7 +604,7 @@ fn verify_range_check0_v1_test_lookups() {
 
     for i in 3..=6 {
         // Test ith lookup
-        let mut witness = range_check::witness::create_multi_witness::<PallasField>(
+        let mut witness = range_check::witness::create_multi::<PallasField>(
             PallasField::zero(),
             PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
             PallasField::zero(),
@@ -671,7 +671,7 @@ fn verify_range_check1_one_invalid_witness() {
 fn verify_range_check1_valid_witness() {
     let cs = create_test_constraint_system();
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from_hex("22cab5e27101eeafd2cbe1000000000000000000000000000000000000000000")
             .unwrap(),
         PallasField::from_hex("1ab61d31f4e27fe41a318c000000000000000000000000000000000000000000")
@@ -692,7 +692,7 @@ fn verify_range_check1_valid_witness() {
         Ok(())
     );
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from_hex("0d96f6fc210316c73bcc4d000000000000000000000000000000000000000000")
             .unwrap(),
         PallasField::from_hex("59c8e7b0ffb3cab6ce8d48000000000000000000000000000000000000000000")
@@ -718,7 +718,7 @@ fn verify_range_check1_valid_witness() {
 fn verify_range_check1_invalid_witness() {
     let cs = create_test_constraint_system();
 
-    let mut witness = range_check::witness::create_multi_witness::<PallasField>(
+    let mut witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from_hex("2ce2d3ac942f98d59e7e11000000000000000000000000000000000000000000")
             .unwrap(),
         PallasField::from_hex("52dd43524b95399f5d458d000000000000000000000000000000000000000000")
@@ -742,7 +742,7 @@ fn verify_range_check1_invalid_witness() {
         Err(CircuitGateError::Constraint(GateType::RangeCheck1, 20))
     );
 
-    let mut witness = range_check::witness::create_multi_witness::<PallasField>(
+    let mut witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from_hex("1bd50c94d2dc83d32f01c0000000000000000000000000000000000000000000")
             .unwrap(),
         PallasField::from_hex("e983d7cd9e28e440930f86000000000000000000000000000000000000000000")
@@ -771,7 +771,7 @@ fn verify_range_check1_invalid_witness() {
 fn verify_range_check1_valid_v2_in_range() {
     let cs = create_test_constraint_system();
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::zero(),
         PallasField::from(PallasField::from(2u64).pow([88]) - PallasField::one()),
@@ -789,7 +789,7 @@ fn verify_range_check1_valid_v2_in_range() {
         Ok(())
     );
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::zero(),
         PallasField::from(PallasField::from(2u64).pow([64])),
@@ -807,7 +807,7 @@ fn verify_range_check1_valid_v2_in_range() {
         Ok(())
     );
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::zero(),
         PallasField::from(42u64),
@@ -825,7 +825,7 @@ fn verify_range_check1_valid_v2_in_range() {
         Ok(())
     );
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::zero(),
         PallasField::one(),
@@ -848,7 +848,7 @@ fn verify_range_check1_valid_v2_in_range() {
 fn verify_range_check1_invalid_v2_not_in_range() {
     let cs = create_test_constraint_system();
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::zero(),
         PallasField::from(2u64).pow([88]), // out of range
@@ -866,7 +866,7 @@ fn verify_range_check1_invalid_v2_not_in_range() {
         Err(CircuitGateError::Constraint(GateType::RangeCheck1, 20))
     );
 
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::zero(),
         PallasField::from(2u64).pow([96]), // out of range
@@ -892,7 +892,7 @@ fn verify_range_check1_test_copy_constraints() {
     for row in 0..=1 {
         for col in 1..=2 {
             // Copy constraints impact v0 and v1
-            let mut witness = range_check::witness::create_multi_witness::<PallasField>(
+            let mut witness = range_check::witness::create_multi::<PallasField>(
                 PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
                 PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
                 PallasField::zero(),
@@ -954,7 +954,7 @@ fn verify_range_check1_test_curr_row_lookups() {
 
     for i in 3..=6 {
         // Test ith lookup (impacts v2)
-        let mut witness = range_check::witness::create_multi_witness::<PallasField>(
+        let mut witness = range_check::witness::create_multi::<PallasField>(
             PallasField::zero(),
             PallasField::zero(),
             PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
@@ -988,7 +988,7 @@ fn verify_range_check1_test_next_row_lookups() {
 
     for row in 0..=1 {
         for col in 1..=2 {
-            let mut witness = range_check::witness::create_multi_witness::<PallasField>(
+            let mut witness = range_check::witness::create_multi::<PallasField>(
                 PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
                 PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
                 PallasField::zero(),
@@ -1049,7 +1049,7 @@ fn verify_64_bit_range_check() {
     //   0   0 0 0 0 ... 0   GenericPub
     //   1   0 0 X X ... X   RangeCheck0
     let mut witness: [Vec<PallasField>; COLUMNS] = array::from_fn(|_| vec![PallasField::zero()]);
-    range_check::witness::create_witness::<PallasField>(
+    range_check::witness::create::<PallasField>(
         PallasField::from(2u64).pow([64]) - PallasField::one(), // in range
     )
     .iter_mut()
@@ -1073,7 +1073,7 @@ fn verify_64_bit_range_check() {
     //   0   0 0 0 0 ... 0   GenericPub
     //   1   0 X X X ... X   RangeCheck0
     let mut witness: [Vec<PallasField>; COLUMNS] = array::from_fn(|_| vec![PallasField::zero()]);
-    range_check::witness::create_witness::<PallasField>(
+    range_check::witness::create::<PallasField>(
         PallasField::from(2u64).pow([64]), // out of range
     )
     .iter_mut()
@@ -1095,7 +1095,7 @@ fn verify_range_check_valid_proof1() {
     let prover_index = create_test_prover_index(0);
 
     // Create witness
-    let witness = range_check::witness::create_multi_witness::<PallasField>(
+    let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from_hex("2bc0afaa2f6f50b1d1424b000000000000000000000000000000000000000000")
             .unwrap(),
         PallasField::from_hex("8b30889f3a39e297ac851a000000000000000000000000000000000000000000")


### PR DESCRIPTION
Extract common witness computation code from range-check and foreign-field-add gates into reusable generic kit for foreign field multiplication and other custom gates