### PR TITLE
introduce an ASM-like language for debugging

### DIFF
--- a/kimchi/src/alphas.rs
+++ b/kimchi/src/alphas.rs
@@ -321,7 +321,7 @@ mod tests {
 
     #[test]
     fn get_alphas_for_spec() {
-        let gates = vec![CircuitGate::<Fp>::zero(Wire::new(0)); 2];
+        let gates = vec![CircuitGate::<Fp>::zero(Wire::for_row(0)); 2];
         let index = new_index_for_test(gates, 0);
         let (_linearization, powers_of_alpha) = expr_linearization(
             index.cs.chacha8.is_some(),

--- a/kimchi/src/bench.rs
+++ b/kimchi/src/bench.rs
@@ -44,7 +44,7 @@ impl BenchmarkCtx {
 
         #[allow(clippy::explicit_counter_loop)]
         for row in 0..num_gates {
-            let wires = Wire::new(row);
+            let wires = Wire::for_row(row);
             gates.push(CircuitGate::create_generic_gadget(
                 wires,
                 GenericGateSpec::Const(1u32.into()),

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -2513,12 +2513,12 @@ pub mod test {
         let one = Fp::from(1u32);
         let mut gates = vec![];
         gates.push(CircuitGate::create_generic_gadget(
-            Wire::new(0),
+            Wire::for_row(0),
             GenericGateSpec::Const(1u32.into()),
             None,
         ));
         gates.push(CircuitGate::create_generic_gadget(
-            Wire::new(1),
+            Wire::for_row(1),
             GenericGateSpec::Const(1u32.into()),
             None,
         ));

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -405,14 +405,40 @@ impl<F: PrimeField> Connect for Vec<CircuitGate<F>> {
     }
 }
 
-/// A circuit is specified as a series of [`CircuitGate`].
+/// A circuit is specified as a public input size and a list of [`CircuitGate`].
 #[derive(Serialize)]
-pub struct Circuit<'a, F: PrimeField>(
-    #[serde(bound = "CircuitGate<F>: Serialize")] pub &'a [CircuitGate<F>],
-);
+#[serde(bound = "CircuitGate<F>: Serialize")]
+pub struct Circuit<'a, F: PrimeField> {
+    pub public_input_size: usize,
+    pub gates: &'a [CircuitGate<F>],
+}
+
+impl<'a, F> Circuit<'a, F>
+where
+    F: PrimeField,
+{
+    pub fn new(public_input_size: usize, gates: &'a [CircuitGate<F>]) -> Self {
+        Self {
+            public_input_size,
+            gates,
+        }
+    }
+}
 
 impl<'a, F: PrimeField> CryptoDigest for Circuit<'a, F> {
     const PREFIX: &'static [u8; 15] = b"kimchi-circuit0";
+}
+
+impl<'a, F> From<&'a ConstraintSystem<F>> for Circuit<'a, F>
+where
+    F: PrimeField,
+{
+    fn from(cs: &'a ConstraintSystem<F>) -> Self {
+        Self {
+            public_input_size: cs.public,
+            gates: &cs.gates,
+        }
+    }
 }
 
 #[cfg(feature = "ocaml_types")]

--- a/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
@@ -85,7 +85,7 @@ impl<F: PrimeField> CircuitGate<F> {
         for i in 0..num {
             circuit_gates.append(&mut vec![CircuitGate {
                 typ: GateType::ForeignFieldAdd,
-                wires: Wire::new(next_row + i),
+                wires: Wire::for_row(next_row + i),
                 coeffs: vec![],
             }]);
         }
@@ -93,12 +93,12 @@ impl<F: PrimeField> CircuitGate<F> {
         circuit_gates.append(&mut vec![
             CircuitGate {
                 typ: GateType::ForeignFieldAdd,
-                wires: Wire::new(next_row + num),
+                wires: Wire::for_row(next_row + num),
                 coeffs: vec![],
             },
             CircuitGate {
                 typ: GateType::Zero,
-                wires: Wire::new(next_row + num + 1),
+                wires: Wire::for_row(next_row + num + 1),
                 coeffs: vec![],
             },
         ]);

--- a/kimchi/src/circuits/polynomials/generic.rs
+++ b/kimchi/src/circuits/polynomials/generic.rs
@@ -429,7 +429,7 @@ pub mod testing {
         for _ in 0..public {
             let r = gates_row.next().unwrap();
             gates.push(CircuitGate::create_generic_gadget(
-                Wire::new(r),
+                Wire::for_row(r),
                 GenericGateSpec::Pub,
                 None,
             ));
@@ -448,7 +448,7 @@ pub mod testing {
                 mul_coeff: Some(2u32.into()),
             };
             gates.push(CircuitGate::create_generic_gadget(
-                Wire::new(r),
+                Wire::for_row(r),
                 g1,
                 Some(g2),
             ));
@@ -460,7 +460,7 @@ pub mod testing {
             let g1 = GenericGateSpec::Const(3u32.into());
             let g2 = GenericGateSpec::Const(5u32.into());
             gates.push(CircuitGate::create_generic_gadget(
-                Wire::new(r),
+                Wire::for_row(r),
                 g1,
                 Some(g2),
             ));

--- a/kimchi/src/circuits/polynomials/range_check/gadget.rs
+++ b/kimchi/src/circuits/polynomials/range_check/gadget.rs
@@ -38,10 +38,10 @@ impl<F: PrimeField> CircuitGate<F> {
     ///       `circuit_gates` - vector of circuit gates comprising this gate
     pub fn create_multi_range_check(start_row: usize) -> (usize, Vec<Self>) {
         let mut circuit_gates = vec![
-            CircuitGate::new(GateType::RangeCheck0, Wire::new(start_row), vec![]),
-            CircuitGate::new(GateType::RangeCheck0, Wire::new(start_row + 1), vec![]),
-            CircuitGate::new(GateType::RangeCheck1, Wire::new(start_row + 2), vec![]),
-            CircuitGate::new(GateType::Zero, Wire::new(start_row + 3), vec![]),
+            CircuitGate::new(GateType::RangeCheck0, Wire::for_row(start_row), vec![]),
+            CircuitGate::new(GateType::RangeCheck0, Wire::for_row(start_row + 1), vec![]),
+            CircuitGate::new(GateType::RangeCheck1, Wire::for_row(start_row + 2), vec![]),
+            CircuitGate::new(GateType::Zero, Wire::for_row(start_row + 3), vec![]),
         ];
 
         // copy v0p0
@@ -65,7 +65,7 @@ impl<F: PrimeField> CircuitGate<F> {
     ///       `next_row`      - next row after this gate
     ///       `circuit_gates` - vector of circuit gates comprising this gate
     pub fn create_range_check(start_row: usize) -> (usize, Vec<Self>) {
-        let gate = CircuitGate::new(GateType::RangeCheck0, Wire::new(start_row), vec![]);
+        let gate = CircuitGate::new(GateType::RangeCheck0, Wire::for_row(start_row), vec![]);
         (start_row + 1, vec![gate])
     }
 

--- a/kimchi/src/circuits/polynomials/turshi.rs
+++ b/kimchi/src/circuits/polynomials/turshi.rs
@@ -142,15 +142,15 @@ impl<F: PrimeField> CircuitGate<F> {
         // 4n-2: 1 row for Auxiliary argument (no constraints)
         let mut gates: Vec<CircuitGate<F>> = Vec::new();
         if num > 0 {
-            let claim_gate = Wire::new(row);
+            let claim_gate = Wire::for_row(row);
             gates.push(CircuitGate::create_cairo_claim(claim_gate));
         }
         let last = num - 1;
         for i in 0..last {
-            let ins_gate = Wire::new(row + 4 * i + 1);
-            let flg_gate = Wire::new(row + 4 * i + 2);
-            let tra_gate = Wire::new(row + 4 * i + 3);
-            let aux_gate = Wire::new(row + 4 * i + 4);
+            let ins_gate = Wire::for_row(row + 4 * i + 1);
+            let flg_gate = Wire::for_row(row + 4 * i + 2);
+            let tra_gate = Wire::for_row(row + 4 * i + 3);
+            let aux_gate = Wire::for_row(row + 4 * i + 4);
             gates.push(CircuitGate::create_cairo_instruction(ins_gate));
             gates.push(CircuitGate::create_cairo_flags(flg_gate));
             gates.push(CircuitGate::create_cairo_transition(tra_gate));
@@ -159,8 +159,8 @@ impl<F: PrimeField> CircuitGate<F> {
         // next available row after the full
         let next = row + 4 * last + 3;
         // the final instruction
-        let ins_gate = Wire::new(next - 2);
-        let aux_gate = Wire::new(next - 1);
+        let ins_gate = Wire::for_row(next - 2);
+        let aux_gate = Wire::for_row(next - 1);
         gates.push(CircuitGate::create_cairo_instruction(ins_gate));
         gates.push(CircuitGate::zero(aux_gate));
 

--- a/kimchi/src/circuits/polynomials/xor.rs
+++ b/kimchi/src/circuits/polynomials/xor.rs
@@ -42,14 +42,14 @@ impl<F: PrimeField> CircuitGate<F> {
         let mut gates = (0..num_xors)
             .map(|i| CircuitGate {
                 typ: GateType::Xor16,
-                wires: Wire::new(new_row + i),
+                wires: Wire::for_row(new_row + i),
                 coeffs: vec![],
             })
             .collect::<Vec<_>>();
         let zero_row = new_row + num_xors;
         gates.push(CircuitGate {
             typ: GateType::Generic,
-            wires: Wire::new(zero_row),
+            wires: Wire::for_row(zero_row),
             coeffs: vec![F::one()],
         });
         // check fin_in1, fin_in2, fin_out are zero

--- a/kimchi/src/circuits/wires.rs
+++ b/kimchi/src/circuits/wires.rs
@@ -27,9 +27,14 @@ pub struct Wire {
 }
 
 impl Wire {
+    /// Creates a new [Wire].
+    pub fn new(row: usize, col: usize) -> Self {
+        Self { row, col }
+    }
+
     /// Creates a new set of wires for a given row.
-    pub fn new(row: usize) -> [Self; PERMUTS] {
-        array::from_fn(|col| Self { row, col })
+    pub fn for_row(row: usize) -> [Self; PERMUTS] {
+        GateWires::new(row)
     }
 }
 
@@ -37,6 +42,19 @@ impl Wire {
 /// represents the same cell (row and column) or a different cell in another row.
 /// (This is to help the permutation argument.)
 pub type GateWires = [Wire; PERMUTS];
+
+/// Since we don't have a specific type for the wires of a row,
+/// we have to implement these convenience functions through a trait.
+pub trait Wirable: Sized {
+    /// Creates a new set of wires for a given row.
+    fn new(row: usize) -> Self;
+}
+
+impl Wirable for GateWires {
+    fn new(row: usize) -> Self {
+        array::from_fn(|col| Wire { row, col })
+    }
+}
 
 impl ToBytes for Wire {
     #[inline]

--- a/kimchi/src/circuits/wires.rs
+++ b/kimchi/src/circuits/wires.rs
@@ -48,11 +48,20 @@ pub type GateWires = [Wire; PERMUTS];
 pub trait Wirable: Sized {
     /// Creates a new set of wires for a given row.
     fn new(row: usize) -> Self;
+
+    /// Wire the cell at `col` to another cell (`to`).
+    fn wire(self, col: usize, to: Wire) -> Self;
 }
 
 impl Wirable for GateWires {
     fn new(row: usize) -> Self {
         array::from_fn(|col| Wire { row, col })
+    }
+
+    fn wire(mut self, col: usize, to: Wire) -> Self {
+        assert!(col < PERMUTS);
+        self[col] = to;
+        self
     }
 }
 

--- a/kimchi/src/snarky/asm.rs
+++ b/kimchi/src/snarky/asm.rs
@@ -67,7 +67,6 @@ where
 
             // wires
             {
-                let mut wires_str = vec![];
                 for (
                     col,
                     Wire {
@@ -76,33 +75,53 @@ where
                     },
                 ) in wires.iter().enumerate()
                 {
-                    if row != *to_row || col != *to_col {
-                        let col = if matches!(typ, GateType::Generic) {
-                            format!(".{}", Self::generic_cols(col))
-                        } else {
-                            format!("[{col}]")
-                        };
+                    // wiring
+                    let (wires1, wires2) = {
+                        let mut wires1 = vec![];
+                        let mut wires2 = vec![];
 
-                        let to_col = if matches!(self.gates[*to_row].typ, GateType::Generic) {
-                            format!(".{}", Self::generic_cols(*to_col))
-                        } else {
-                            format!("[{to_col}]")
-                        };
+                        if row != *to_row || col != *to_col {
+                            let col_str = if matches!(typ, GateType::Generic) {
+                                format!(".{}", Self::generic_cols(col))
+                            } else {
+                                format!("[{col}]")
+                            };
 
-                        wires_str.push(format!("{col} -> row{to_row}{to_col}"));
-                    }
-                }
+                            let to_col = if matches!(self.gates[*to_row].typ, GateType::Generic) {
+                                format!(".{}", Self::generic_cols(*to_col))
+                            } else {
+                                format!("[{to_col}]")
+                            };
 
-                if !wires_str.is_empty() {
-                    if matches!(typ, GateType::Generic) && wires_str.len() > GENERIC_REGISTERS {
-                        let (wires1, wires2) = wires_str.split_at(GENERIC_REGISTERS);
-                        res.push_str(&wires1.join(", "));
-                        res.push('\n');
-                        res.push_str(&wires2.join(", "));
-                    } else {
-                        res.push_str(&wires_str.join(", "));
-                    }
-                    res.push('\n');
+                            let res = format!("{col_str} -> row{to_row}{to_col}");
+
+                            if matches!(typ, GateType::Generic) && col < GENERIC_REGISTERS {
+                                wires1.push(res);
+                            } else {
+                                wires2.push(res);
+                            }
+                        }
+
+                        (wires1, wires2)
+                    };
+
+                    match (!wires1.is_empty(), !wires2.is_empty()) {
+                        (false, false) => (),
+                        (true, false) => {
+                            res.push_str(&wires1.join(", "));
+                            res.push('\n');
+                        }
+                        (false, true) => {
+                            res.push_str(&wires2.join(", "));
+                            res.push('\n');
+                        }
+                        (true, true) => {
+                            res.push_str(&wires1.join(", "));
+                            res.push('\n');
+                            res.push_str(&wires2.join(", "));
+                            res.push('\n');
+                        }
+                    };
                 }
             }
 
@@ -200,21 +219,23 @@ mod tests {
     fn test_simple_circuit_asm() {
         let public_input_size = 1;
         let gates: &Vec<CircuitGate<Fp>> = &vec![
-            CircuitGate {
-                typ: GateType::Generic,
-                wires: Wire::for_row(0),
-                coeffs: vec![1.into(), 2.into()],
-            },
-            CircuitGate {
-                typ: GateType::Poseidon,
-                wires: Wire::for_row(1).wire(0, Wire::new(0, 1)),
-                coeffs: vec![1.into(), 2.into()],
-            },
-            CircuitGate {
-                typ: GateType::Generic,
-                wires: Wire::for_row(2).wire(5, Wire::new(1, 1)),
-                coeffs: vec![1.into(), 2.into()],
-            },
+            CircuitGate::new(
+                GateType::Generic,
+                Wire::for_row(0),
+                vec![1.into(), 2.into()],
+            ),
+            CircuitGate::new(
+                GateType::Poseidon,
+                Wire::for_row(1).wire(0, Wire::new(0, 1)),
+                vec![1.into(), 2.into()],
+            ),
+            CircuitGate::new(
+                GateType::Generic,
+                Wire::for_row(2)
+                    .wire(0, Wire::new(1, 2))
+                    .wire(5, Wire::new(1, 1)),
+                vec![1.into(), 2.into()],
+            ),
         ];
 
         let circuit = Circuit::new(public_input_size, gates);
@@ -225,6 +246,7 @@ row1.Poseidon<1,2>
 [0] -> row0.r1
 
 row2.Generic<1,2>
+.l1 -> row1[2]
 .o2 -> row1[1]"#;
 
         let asm = circuit.generate_asm();

--- a/kimchi/src/snarky/asm.rs
+++ b/kimchi/src/snarky/asm.rs
@@ -1,0 +1,233 @@
+//! An ASM-like language to print a human-friendly version of a circuit.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
+use std::hash::Hash;
+
+use crate::circuits::gate::{Circuit, CircuitGate, GateType};
+use crate::circuits::polynomials::generic::{GENERIC_COEFFS, GENERIC_REGISTERS};
+use crate::circuits::wires::Wire;
+use ark_ff::PrimeField;
+
+/// Print a field in a negative form if it's past the half point.
+fn pretty<F: ark_ff::PrimeField>(ff: F) -> String {
+    let bigint: num_bigint::BigUint = ff.into();
+    let inv: num_bigint::BigUint = ff.neg().into(); // gettho way of splitting the field into positive and negative elements
+    if inv < bigint {
+        format!("-{}", inv)
+    } else {
+        bigint.to_string()
+    }
+}
+
+impl<'a, F> Circuit<'a, F>
+where
+    F: PrimeField,
+{
+    pub fn generate_asm(&self) -> String {
+        let mut res = String::new();
+
+        // vars
+        let mut vars = OrderedHashSet::default();
+
+        for CircuitGate { coeffs, .. } in self.gates {
+            Self::extract_vars_from_coeffs(&mut vars, coeffs);
+        }
+
+        for (idx, var) in vars.iter().enumerate() {
+            writeln!(res, "c{idx} = {}", pretty(*var)).unwrap();
+        }
+
+        // gates
+        for (row, CircuitGate { typ, coeffs, wires }) in self.gates.iter().enumerate() {
+            // gate
+            {
+                write!(res, "row{row}.").unwrap();
+                let coeffs = Self::parse_coeffs(&vars, coeffs);
+                write!(res, "{typ:?}").unwrap();
+                res.push('<');
+
+                if matches!(typ, GateType::Generic) && coeffs.len() > GENERIC_COEFFS {
+                    // for the double generic gate, split the coeffs in two parts
+                    let (gen1, gen2) = coeffs.split_at(GENERIC_COEFFS);
+                    res.push_str(&gen1.join(","));
+                    res.push_str("><");
+                    res.push_str(&gen2.join(","));
+                } else {
+                    res.push_str(&coeffs.join(","));
+                }
+
+                res.push_str(">\n");
+            }
+
+            // wires
+            {
+                let mut wires_str = vec![];
+                for (
+                    col,
+                    Wire {
+                        row: to_row,
+                        col: to_col,
+                    },
+                ) in wires.iter().enumerate()
+                {
+                    if row != *to_row || col != *to_col {
+                        let col = if matches!(typ, GateType::Generic) {
+                            format!(".{}", Self::generic_cols(col))
+                        } else {
+                            format!("[{col}]")
+                        };
+
+                        let to_col = if matches!(self.gates[*to_row].typ, GateType::Generic) {
+                            format!(".{}", Self::generic_cols(*to_col))
+                        } else {
+                            format!("[{to_col}]")
+                        };
+
+                        wires_str.push(format!("{col} -> row{to_row}{to_col}"));
+                    }
+                }
+
+                if !wires_str.is_empty() {
+                    if matches!(typ, GateType::Generic) && wires_str.len() > GENERIC_REGISTERS {
+                        let (wires1, wires2) = wires_str.split_at(GENERIC_REGISTERS);
+                        res.push_str(&wires1.join(", "));
+                        res.push('\n');
+                        res.push_str(&wires2.join(", "));
+                    } else {
+                        res.push_str(&wires_str.join(", "));
+                    }
+                    res.push('\n');
+                }
+            }
+
+            res.push('\n');
+        }
+
+        res
+    }
+
+    fn generic_cols(col: usize) -> &'static str {
+        match col {
+            0 => "l1",
+            1 => "r1",
+            2 => "o1",
+            3 => "l2",
+            4 => "r2",
+            5 => "o2",
+            x => panic!("invalid generic column: {x}"),
+        }
+    }
+
+    fn extract_vars_from_coeffs(vars: &mut OrderedHashSet<F>, coeffs: &[F]) {
+        for coeff in coeffs {
+            let s = pretty(*coeff);
+            if s.len() >= 5 {
+                vars.insert(*coeff);
+            }
+        }
+    }
+
+    fn parse_coeffs(vars: &OrderedHashSet<F>, coeffs: &[F]) -> Vec<String> {
+        coeffs
+            .iter()
+            .map(|x| {
+                let s = pretty(*x);
+                if s.len() < 5 {
+                    s
+                } else {
+                    let var_idx = vars.pos(x);
+                    format!("c{var_idx}")
+                }
+            })
+            .collect()
+    }
+}
+
+/// Very dumb way to write an ordered hash set.
+#[derive(Default)]
+pub struct OrderedHashSet<T> {
+    inner: HashSet<T>,
+    map: HashMap<T, usize>,
+    ordered: Vec<T>,
+}
+
+impl<T> OrderedHashSet<T>
+where
+    T: Eq + Hash + Clone,
+{
+    pub fn insert(&mut self, value: T) -> bool {
+        if self.inner.insert(value.clone()) {
+            self.map.insert(value.clone(), self.ordered.len());
+            self.ordered.push(value);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.ordered.iter()
+    }
+
+    pub fn pos(&self, value: &T) -> usize {
+        self.map[value]
+    }
+
+    pub fn len(&self) -> usize {
+        self.ordered.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ordered.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mina_curves::pasta::Fp;
+
+    use crate::circuits::wires::Wirable;
+
+    use super::*;
+
+    #[test]
+    fn test_simple_circuit_asm() {
+        let public_input_size = 0;
+        let gates: &Vec<CircuitGate<Fp>> = &vec![
+            CircuitGate {
+                typ: GateType::Generic,
+                wires: Wire::for_row(0),
+                coeffs: vec![1.into(), 2.into()],
+            },
+            CircuitGate {
+                typ: GateType::Poseidon,
+                wires: Wire::for_row(1).wire(0, Wire::new(0, 1)),
+                coeffs: vec![1.into(), 2.into()],
+            },
+            CircuitGate {
+                typ: GateType::Generic,
+                wires: Wire::for_row(2).wire(5, Wire::new(1, 1)),
+                coeffs: vec![1.into(), 2.into()],
+            },
+        ];
+
+        let circuit = Circuit::new(public_input_size, gates);
+
+        const EXPECTED: &str = r#"row0.Generic<1,2>
+
+row1.Poseidon<1,2>
+[0] -> row0.r1
+
+row2.Generic<1,2>
+.o2 -> row1[1]"#;
+
+        let asm = circuit.generate_asm();
+
+        if EXPECTED.trim() != asm.trim() {
+            eprintln!("expected:\n{EXPECTED}\n");
+            eprintln!("obtained:\n{asm}");
+            panic!("obtained asm does not match expected asm")
+        }
+    }
+}

--- a/kimchi/src/snarky/asm.rs
+++ b/kimchi/src/snarky/asm.rs
@@ -42,7 +42,12 @@ where
         for (row, CircuitGate { typ, coeffs, wires }) in self.gates.iter().enumerate() {
             // gate
             {
-                write!(res, "row{row}.").unwrap();
+                let is_pub = if row < self.public_input_size {
+                    "pub."
+                } else {
+                    ""
+                };
+                write!(res, "row{row}.{is_pub}").unwrap();
                 let coeffs = Self::parse_coeffs(&vars, coeffs);
                 write!(res, "{typ:?}").unwrap();
                 res.push('<');
@@ -193,7 +198,7 @@ mod tests {
 
     #[test]
     fn test_simple_circuit_asm() {
-        let public_input_size = 0;
+        let public_input_size = 1;
         let gates: &Vec<CircuitGate<Fp>> = &vec![
             CircuitGate {
                 typ: GateType::Generic,
@@ -214,7 +219,7 @@ mod tests {
 
         let circuit = Circuit::new(public_input_size, gates);
 
-        const EXPECTED: &str = r#"row0.Generic<1,2>
+        const EXPECTED: &str = r#"row0.pub.Generic<1,2>
 
 row1.Poseidon<1,2>
 [0] -> row0.r1

--- a/kimchi/src/snarky/constraint_system.rs
+++ b/kimchi/src/snarky/constraint_system.rs
@@ -518,7 +518,7 @@ impl<Field: PrimeField> SnarkyConstraintSystem<Field> {
 
         let digest = {
             use o1_utils::hasher::CryptoDigest as _;
-            let circuit = crate::circuits::gate::Circuit(&rust_gates);
+            let circuit = crate::circuits::gate::Circuit::new(public_input_size, &rust_gates);
             circuit.digest()
         };
 

--- a/kimchi/src/snarky/mod.rs
+++ b/kimchi/src/snarky/mod.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::all)]
 
+pub mod asm;
 pub mod constants;
 pub mod constraint_system;

--- a/kimchi/src/tests/chacha.rs
+++ b/kimchi/src/tests/chacha.rs
@@ -59,7 +59,7 @@ fn chacha_prover() {
     let gates: Vec<CircuitGate<Fp>> = gates
         .into_iter()
         .enumerate()
-        .map(|(i, typ)| CircuitGate::new(typ, Wire::new(i), vec![]))
+        .map(|(i, typ)| CircuitGate::new(typ, Wire::for_row(i), vec![]))
         .collect();
 
     // create the index
@@ -104,16 +104,16 @@ fn chacha_setup_bad_lookup(table_id: i32) {
         GateType::ChaCha0,
         GateType::Zero,
     ];
-    let gates: Vec<CircuitGate<Fp>> = gates
-        .into_iter()
-        .enumerate()
-        .map(|(i, typ)| CircuitGate::new(typ, Wire::new(i), vec![]))
-        // Pad with generic gates to get a sufficiently-large domain.
-        .chain(
-            (4..513)
-                .map(|i| CircuitGate::new(GateType::Generic, Wire::new(i), vec![Fp::zero(); 10])),
-        )
-        .collect();
+    let gates: Vec<CircuitGate<Fp>> =
+        gates
+            .into_iter()
+            .enumerate()
+            .map(|(i, typ)| CircuitGate::new(typ, Wire::for_row(i), vec![]))
+            // Pad with generic gates to get a sufficiently-large domain.
+            .chain((4..513).map(|i| {
+                CircuitGate::new(GateType::Generic, Wire::for_row(i), vec![Fp::zero(); 10])
+            }))
+            .collect();
 
     let mut rows = vec![];
 

--- a/kimchi/src/tests/ec.rs
+++ b/kimchi/src/tests/ec.rs
@@ -22,7 +22,7 @@ fn ec_test() {
     for row in 0..(num_doubles + num_additions + num_infs) {
         gates.push(CircuitGate::new(
             GateType::CompleteAdd,
-            Wire::new(row),
+            Wire::for_row(row),
             vec![],
         ));
     }

--- a/kimchi/src/tests/endomul.rs
+++ b/kimchi/src/tests/endomul.rs
@@ -29,11 +29,15 @@ fn endomul_test() {
     for s in 0..num_scalars {
         for i in 0..chunks {
             let row = rows_per_scalar * s + i;
-            gates.push(CircuitGate::new(GateType::EndoMul, Wire::new(row), vec![]));
+            gates.push(CircuitGate::new(
+                GateType::EndoMul,
+                Wire::for_row(row),
+                vec![],
+            ));
         }
 
         let row = rows_per_scalar * s + chunks;
-        gates.push(CircuitGate::new(GateType::Zero, Wire::new(row), vec![]));
+        gates.push(CircuitGate::new(GateType::Zero, Wire::for_row(row), vec![]));
     }
 
     let (endo_q, endo_r) = endos::<Other>();

--- a/kimchi/src/tests/endomul_scalar.rs
+++ b/kimchi/src/tests/endomul_scalar.rs
@@ -30,7 +30,7 @@ fn endomul_scalar_test() {
             let row = rows_per_scalar * s + i;
             gates.push(CircuitGate::new(
                 GateType::EndoMulScalar,
-                Wire::new(row),
+                Wire::for_row(row),
                 vec![],
             ));
         }

--- a/kimchi/src/tests/foreign_field_add.rs
+++ b/kimchi/src/tests/foreign_field_add.rs
@@ -134,7 +134,7 @@ fn create_test_constraint_system_ffadd(
 
     // Temporary workaround for lookup-table/domain-size issue
     for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::new(next_row)));
+        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
         next_row += 1;
     }
 
@@ -268,7 +268,7 @@ fn prove_and_verify(operation_count: usize) {
         CircuitGate::<PallasField>::create_foreign_field_add(0, operation_count);
     // Temporary workaround for lookup-table/domain-size issue
     for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::new(next_row)));
+        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
         next_row += 1;
     }
 

--- a/kimchi/src/tests/lookup.rs
+++ b/kimchi/src/tests/lookup.rs
@@ -33,7 +33,7 @@ fn setup_lookup_proof(use_values_from_table: bool, num_lookups: usize, table_siz
 
     // circuit gates
     let gates = (0..num_lookups)
-        .map(|i| CircuitGate::new(GateType::Lookup, Wire::new(i), vec![]))
+        .map(|i| CircuitGate::new(GateType::Lookup, Wire::for_row(i), vec![]))
         .collect();
 
     let witness = {
@@ -146,7 +146,11 @@ fn runtime_table(num: usize, indexed: bool) {
     // circuit
     let mut gates = vec![];
     for row in 0..20 {
-        gates.push(CircuitGate::new(GateType::Lookup, Wire::new(row), vec![]));
+        gates.push(CircuitGate::new(
+            GateType::Lookup,
+            Wire::for_row(row),
+            vec![],
+        ));
     }
 
     // witness

--- a/kimchi/src/tests/poseidon.rs
+++ b/kimchi/src/tests/poseidon.rs
@@ -44,9 +44,9 @@ fn test_poseidon() {
     // custom constraints for Poseidon hash function permutation
     // ROUNDS_FULL full rounds constraint gates
     for _ in 0..NUM_POS {
-        let first_wire = Wire::new(abs_row);
+        let first_wire = Wire::for_row(abs_row);
         let last_row = abs_row + POS_ROWS_PER_HASH;
-        let last_wire = Wire::new(last_row);
+        let last_wire = Wire::for_row(last_row);
         let (poseidon, row) = CircuitGate::<Fp>::create_poseidon_gadget(
             abs_row,
             [first_wire, last_wire],

--- a/kimchi/src/tests/range_check.rs
+++ b/kimchi/src/tests/range_check.rs
@@ -38,7 +38,7 @@ fn create_test_constraint_system() -> ConstraintSystem<Fp> {
 
     // Temporary workaround for lookup-table/domain-size issue
     for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::new(next_row)));
+        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
         next_row += 1;
     }
 
@@ -50,7 +50,7 @@ fn create_test_prover_index(public_size: usize) -> ProverIndex<Vesta> {
 
     // Temporary workaround for lookup-table/domain-size issue
     for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::new(next_row)));
+        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
         next_row += 1;
     }
 
@@ -1023,7 +1023,7 @@ fn verify_64_bit_range_check() {
     //      1 RangeCheck0 v0  0 0 ... Wire cells 1 and 2 to 1st cell 0 of GenericPub
     let mut gates = vec![];
     gates.push(CircuitGate::<Fp>::create_generic_gadget(
-        Wire::new(0),
+        Wire::for_row(0),
         GenericGateSpec::Pub,
         None,
     ));
@@ -1035,7 +1035,7 @@ fn verify_64_bit_range_check() {
     // Temporary workaround for lookup-table/domain-size issue
     let mut next_row = 2;
     for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::new(next_row)));
+        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
         next_row += 1;
     }
 

--- a/kimchi/src/tests/varbasemul.rs
+++ b/kimchi/src/tests/varbasemul.rs
@@ -28,10 +28,14 @@ fn varbase_mul_test() {
         let row = 2 * i;
         gates.push(CircuitGate::new(
             GateType::VarBaseMul,
-            Wire::new(row),
+            Wire::for_row(row),
             vec![],
         ));
-        gates.push(CircuitGate::new(GateType::Zero, Wire::new(row + 1), vec![]));
+        gates.push(CircuitGate::new(
+            GateType::Zero,
+            Wire::for_row(row + 1),
+            vec![],
+        ));
     }
 
     let mut witness: [Vec<F>; COLUMNS] =

--- a/kimchi/src/tests/xor.rs
+++ b/kimchi/src/tests/xor.rs
@@ -16,7 +16,7 @@ fn create_test_constraint_system(bits: usize) -> ConstraintSystem<Fp> {
 
     // Temporary workaround for lookup-table/domain-size issue
     for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::new(next_row)));
+        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
         next_row += 1;
     }
 
@@ -70,7 +70,7 @@ fn prove_and_verify(bits: usize) {
 
     // Temporary workaround for lookup-table/domain-size issue
     for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::new(next_row)));
+        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
         next_row += 1;
     }
 

--- a/tools/kimchi-visu/src/main.rs
+++ b/tools/kimchi-visu/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
         let row = {
             for i in 0..public {
                 let g = CircuitGate::<Fp>::create_generic_gadget(
-                    Wire::new(i),
+                    Wire::for_row(i),
                     GenericGateSpec::Pub,
                     None,
                 );
@@ -36,7 +36,7 @@ fn main() {
             let round_constants = &poseidon_params.round_constants;
             let (g, row) = CircuitGate::<Fp>::create_poseidon_gadget(
                 row,
-                [Wire::new(row), Wire::new(row + 11)],
+                [Wire::for_row(row), Wire::for_row(row + 11)],
                 round_constants,
             );
             gates.extend(g);


### PR DESCRIPTION
This PR adds an ASM-like language that's useful to inspect circuits and debug. (It also adds the public input size to the `Circuit` type, and adds some convenience functions, to make this work.)

It looks like this:

```
row0.pub.Generic<1,0,0,0,0>
.l1 -> row4.l1

row1.pub.Generic<1,0,0,0,0>
.l1 -> row2.l1

row2.Generic<-1,0,0,1,0><-1,0,0,1,0>
.l1 -> row4.r1, .r1 -> row1.l1
.l2 -> row0.l1, .r2 -> row2.l2

row3.Generic<-1,0,0,1,0><-1,0,0,1,0>
.l1 -> row4.r2, .r1 -> row3.l1
.l2 -> row4.l2, .r2 -> row3.l2

row4.Generic<0,0,1,-1,0><0,0,1,-1,0>
.l1 -> row2.r2, .r1 -> row2.r1, .o1 -> row5.l1
.l2 -> row3.r2, .r2 -> row3.r1, .o2 -> row4.o1

row5.Generic<1,0,0,0,-1>
.l1 -> row4.o2
```

See https://github.com/MinaProtocol/mina/pull/12125 to see it used in tests