### PR TITLE
Iterate over gates in prover instead of calling them all manually

### DIFF
--- a/kimchi/src/circuits/argument.rs
+++ b/kimchi/src/circuits/argument.rs
@@ -174,3 +174,21 @@ pub trait Argument<F: PrimeField> {
         }
     }
 }
+
+pub trait DynArgument<F: PrimeField> {
+    fn constraints(&self) -> Vec<E<F>>;
+    fn combined_constraints(&self, alphas: &Alphas<F>) -> E<F>;
+    fn argument_type(&self) -> ArgumentType;
+}
+
+impl<F: PrimeField, T: Argument<F>> DynArgument<F> for T {
+    fn constraints(&self) -> Vec<E<F>> {
+        <Self as Argument<F>>::constraints()
+    }
+    fn combined_constraints(&self, alphas: &Alphas<F>) -> E<F> {
+        <Self as Argument<F>>::combined_constraints(alphas)
+    }
+    fn argument_type(&self) -> ArgumentType {
+        <Self as Argument<F>>::ARGUMENT_TYPE
+    }
+}

--- a/kimchi/src/circuits/polynomials/chacha.rs
+++ b/kimchi/src/circuits/polynomials/chacha.rs
@@ -214,6 +214,12 @@ fn line<F: PrimeField, T: ExprOps<F>>(env: &ArgumentEnv<F, T>, nybble_rotation: 
 /// Implementation of the `ChaCha0` gate
 pub struct ChaCha0<F>(PhantomData<F>);
 
+impl<F: PrimeField> ChaCha0<F> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
 impl<F> Argument<F> for ChaCha0<F>
 where
     F: PrimeField,
@@ -229,6 +235,12 @@ where
 
 /// Implementation of the `ChaCha1` gate
 pub struct ChaCha1<F>(PhantomData<F>);
+
+impl<F: PrimeField> ChaCha1<F> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
 
 impl<F> Argument<F> for ChaCha1<F>
 where
@@ -246,6 +258,12 @@ where
 /// Implementation of the `ChaCha2` gate
 pub struct ChaCha2<F>(PhantomData<F>);
 
+impl<F: PrimeField> ChaCha2<F> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
 impl<F> Argument<F> for ChaCha2<F>
 where
     F: PrimeField,
@@ -261,6 +279,12 @@ where
 
 /// Implementation of the `ChaChaFinal` gate
 pub struct ChaChaFinal<F>(PhantomData<F>);
+
+impl<F: PrimeField> ChaChaFinal<F> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
 
 impl<F> Argument<F> for ChaChaFinal<F>
 where

--- a/kimchi/src/circuits/polynomials/complete_add.rs
+++ b/kimchi/src/circuits/polynomials/complete_add.rs
@@ -88,6 +88,12 @@ fn zero_check<F: Field, T: ExprOps<F>>(z: T, z_inv: T, r: T) -> Vec<T> {
 /// See [here](https://en.wikipedia.org/wiki/Elliptic_curve#The_group_law) for the formulas used.
 pub struct CompleteAdd<F>(PhantomData<F>);
 
+impl<F: PrimeField> CompleteAdd<F> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
 impl<F> Argument<F> for CompleteAdd<F>
 where
     F: PrimeField,

--- a/kimchi/src/circuits/polynomials/endomul_scalar.rs
+++ b/kimchi/src/circuits/polynomials/endomul_scalar.rs
@@ -156,6 +156,12 @@ fn polynomial<F: Field, T: ExprOps<F>>(coeffs: &[F], x: &T) -> T {
 
 pub struct EndomulScalar<F>(PhantomData<F>);
 
+impl<F: PrimeField> EndomulScalar<F> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
 impl<F> Argument<F> for EndomulScalar<F>
 where
     F: PrimeField,

--- a/kimchi/src/circuits/polynomials/endosclmul.rs
+++ b/kimchi/src/circuits/polynomials/endosclmul.rs
@@ -175,6 +175,12 @@ impl<F: PrimeField> CircuitGate<F> {
 /// Implementation of the `EndosclMul` gate.
 pub struct EndosclMul<F>(PhantomData<F>);
 
+impl<F: PrimeField> EndosclMul<F> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
 impl<F> Argument<F> for EndosclMul<F>
 where
     F: PrimeField,

--- a/kimchi/src/circuits/polynomials/foreign_field_add/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/circuitgates.rs
@@ -113,6 +113,12 @@ use std::{array, marker::PhantomData};
 /// - Operates on Curr and Next rows.
 pub struct ForeignFieldAdd<F>(PhantomData<F>);
 
+impl<F: PrimeField> ForeignFieldAdd<F> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
 impl<F> Argument<F> for ForeignFieldAdd<F>
 where
     F: PrimeField,

--- a/kimchi/src/circuits/polynomials/poseidon.rs
+++ b/kimchi/src/circuits/polynomials/poseidon.rs
@@ -329,6 +329,12 @@ const ROUND_EQUATIONS: [RoundEquation; ROUNDS_PER_ROW] = [
 /// constrain the values of the (r+1)th state.
 pub struct Poseidon<F>(PhantomData<F>);
 
+impl<F: PrimeField> Poseidon<F> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
 impl<F> Poseidon<F> where F: Field {}
 
 impl<F> Argument<F> for Poseidon<F>

--- a/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
@@ -150,6 +150,12 @@ use ark_ff::PrimeField;
 #[derive(Default)]
 pub struct RangeCheck0<F>(PhantomData<F>);
 
+impl<F: PrimeField> RangeCheck0<F> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
 impl<F> Argument<F> for RangeCheck0<F>
 where
     F: PrimeField,
@@ -240,6 +246,12 @@ where
 
 #[derive(Default)]
 pub struct RangeCheck1<F>(PhantomData<F>);
+
+impl<F: PrimeField> RangeCheck1<F> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
 
 impl<F> Argument<F> for RangeCheck1<F>
 where

--- a/kimchi/src/circuits/polynomials/varbasemul.rs
+++ b/kimchi/src/circuits/polynomials/varbasemul.rs
@@ -397,6 +397,12 @@ pub fn witness<F: FftField + std::fmt::Display>(
 /// Implementation of the `VarbaseMul` gate
 pub struct VarbaseMul<F>(PhantomData<F>);
 
+impl<F: PrimeField> VarbaseMul<F> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
 impl<F> Argument<F> for VarbaseMul<F>
 where
     F: PrimeField,

--- a/kimchi/src/circuits/polynomials/xor.rs
+++ b/kimchi/src/circuits/polynomials/xor.rs
@@ -395,6 +395,12 @@ pub fn lookup_table<F: PrimeField>() -> LookupTable<F> {
 #[derive(Default)]
 pub struct Xor16<F>(PhantomData<F>);
 
+impl<F: PrimeField> Xor16<F> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
 impl<F> Argument<F> for Xor16<F>
 where
     F: PrimeField,

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -666,16 +666,20 @@ where
 
         let quotient_poly = {
             // generic
-            let alphas =
-                all_alphas.get_alphas(ArgumentType::Gate(GateType::Generic), generic::CONSTRAINTS);
-            let mut t4 = index.cs.gnrc_quot(alphas, &lagrange.d4.this.w);
+            let mut t4 = {
+                let alphas = all_alphas
+                    .get_alphas(ArgumentType::Gate(GateType::Generic), generic::CONSTRAINTS);
+                let t4 = index.cs.gnrc_quot(alphas, &lagrange.d4.this.w);
 
-            if cfg!(debug_assertions) {
-                let p4 = public_poly.evaluate_over_domain_by_ref(index.cs.domain.d4);
-                let gen_minus_pub = &t4 + &p4;
+                if cfg!(debug_assertions) {
+                    let p4 = public_poly.evaluate_over_domain_by_ref(index.cs.domain.d4);
+                    let gen_minus_pub = &t4 + &p4;
 
-                check_constraint!(index, gen_minus_pub);
-            }
+                    check_constraint!(index, gen_minus_pub);
+                }
+
+                t4
+            };
 
             // complete addition
             {


### PR DESCRIPTION
This PR is built upon #838.

This PR adds a new trait `DynArgument` to work around an incompatibility between `dyn` trait implementations and the `Argument` trait. It then uses this trait to remove the boilerplate for adding gates from the prover, replacing it with a loop over an iterator.