### PR TITLE
FFAdd constraint and witness optimization

### DIFF
--- a/book/src/rfcs/ffadd.md
+++ b/book/src/rfcs/ffadd.md
@@ -148,6 +148,19 @@ Mathematically speaking, a subtraction within a field is no more than an additio
 
 Instead, our gate encodes subtractions and additions directly within the sign term that is multiplying the right input. This way, there is no need to check that the negated value is performed correctly (which would require an additional row for a potential `FFNeg` gate). 
 
+### Optimization
+
+Inspired by the halving approach in foreign field multiplication, an optimized version of the above gate results in a reduction by 2 in the number of constraints and by 1 in the number of witness cells needed. The main idea is to condense the claims about the low and middle limbs in one single larger limb of 176 bits, which fit in our native field. This way, we can get rid of the low carry flag, its corresponding carry check, and the three result checks become just two. These are the new equations:
+
+$$
+\begin{aligned}
+r_{bot} &= (a_0 + 2^{88}\cdot a_1) + s \cdot (b_0 + 2^88) - q \cdot (f_0 + 2^88 \cdot f_1) - c \cdot 2^{176} \\
+r_{top} &= a_2 + s \cdot b_2 - q \cdot f_2 + c 
+\end{aligned}
+$$
+
+with `r_top = r_2` and `c = c_1`. 
+
 ## Gadget
 
 The foreign field gadget will be composed by 4 sets of `RangeCheck` gadgets for witnesses $a, b, r, u$ accounting for 16 rows in total; followed by one row with `ForeignFieldAdd` gate type; a final `ForeignFieldAdd` with a `Zero` row. The first four rows constrain the range of the left input. The following four constrain the range of the right input. The next range check is for the result of the addition of left and right. Next, a final range check for the upper bound therm. Then the foreign field addition gate performs the actual addition. And the final foreign field addition gate (followed by a zero gate) takes care of the final upper bound operation. A total of 19 rows with 15 columns in Kimchi.

--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1274,6 +1274,11 @@ but where the result is larger than the modulus (yet smaller than 2^{264}). The 
  final bound check is to make sure that the final result (`min_result`) is indeed the minimum one
  (meaning less than the modulus).
 
+A more optimized version of these constraints is able to reduce by 2 the number of constraints and
+by 1 the number of witness cells needed. The idea is to condense the low and middle limbs in one longer
+limb of 176 bits (which fits inside our native field) and getting rid of the low carry flag.
+With this idea in mind, the sole carry flag we need is the one located between the middle and the high limbs.
+
 You could lay this out as a double-width gate for chained foreign additions and a final row, e.g.:
 
 | col | `ForeignFieldAdd`       | chain `ForeignFieldAdd` | final `ForeignFieldAdd` | final `Zero`      |
@@ -1286,8 +1291,8 @@ You could lay this out as a double-width gate for chained foreign additions and 
 |   5 | `right_input_hi` (copy) |                         |  2^88           (check) |                   |
 |   6 | `sign`           (copy) |                         |  1              (check) |                   |
 |   7 | `field_overflow`        |                         |  1              (check) |                   |
-|   8 | `carry_lo`              |                         | `bound_carry_lo`        |                   |
-|   9 | `carry_mi`              |                         | `bound_carry_mi`        |                   |
+|   8 | `carry`                 |                         | `bound_carry`           |                   |
+|   9 |                         |                         |                         |                   |
 |  10 |                         |                         |                         |                   |
 |  11 |                         |                         |                         |                   |
 |  12 |                         |                         |                         |                   |

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -8,7 +8,7 @@ use crate::{
         lookup::{index::LookupConstraintSystem, tables::LookupTable},
         polynomial::{WitnessEvals, WitnessOverDomains, WitnessShifts},
         polynomials::permutation::{Shifts, ZK_ROWS},
-        polynomials::{foreign_field_add, range_check},
+        polynomials::range_check,
         wires::*,
     },
     curve::KimchiCurve,
@@ -590,12 +590,15 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
         };
 
         // Foreign field addition constraint selector polynomial
-        let ffadd_gates = foreign_field_add::gadget::circuit_gates();
         let foreign_field_add_selector_poly = {
-            if circuit_gates_used.is_disjoint(&ffadd_gates.into_iter().collect()) {
+            if !circuit_gates_used.contains(&GateType::ForeignFieldAdd) {
                 None
             } else {
-                Some(selector_polynomial(ffadd_gates[0], &gates, &domain))
+                Some(selector_polynomial(
+                    GateType::ForeignFieldAdd,
+                    &gates,
+                    &domain,
+                ))
             }
         };
 

--- a/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
@@ -25,18 +25,29 @@ pub enum FFOps {
     Mul,
 }
 
+// A Foreign Field Addition Values
+#[derive(PartialEq, Eq, Debug, Clone)]
+struct FFAddValues<F: PrimeField> {
+    left: ForeignElement<F, 3>,
+    right: ForeignElement<F, 4>,
+    output: ForeignElement<F, 3>,
+    sign: F,
+    ovf: F,
+    carry: F,
+}
+
 // Given a left and right inputs to an addition or subtraction, and a modulus, it computes
-// all necessary values needed for the witness layout. Meaning:
+// all necessary values needed for the witness layout. Meaning, it returns an [FFAddValues] instance
 // - the result of the addition/subtraction as a ForeignElement
 // - the sign of the operation
 // - the overflow flag
-// - the carry_lo and carry_mi values
-fn compute_subadd_values<F: PrimeField>(
+// - the carry value
+fn compute_ffadd_values<F: PrimeField>(
     left_input: &ForeignElement<F, 3>,
     right_input: &ForeignElement<F, 4>,
     opcode: FFOps,
     foreign_modulus: &ForeignElement<F, 3>,
-) -> (ForeignElement<F, 3>, F, F, F, F) {
+) -> FFAddValues<F> {
     assert_ne!(opcode, FFOps::Mul);
 
     let two_to_limb = F::from(TWO_TO_LIMB);
@@ -96,24 +107,46 @@ fn compute_subadd_values<F: PrimeField>(
         }
     });
 
-    // c1 = r2 - a2 - s*b2 + q*f2
-    let carry_mi =
+    // c = [ (a1 * 2^88 + a0) + s * (b1 * 2^88 + b0) - q * (f1 * 2^88 + f0) - (r1 * 2^88 + r0) ] / 2^176
+    //  <=>
+    // c = r2 - a2 - s*b2 + q*f2
+
+    let carry_bot: F = (bottom(&left_input[LO], &left_input[MI])
+        + bottom(&right_input[LO], &right_input[MI]) * sign
+        - bottom(&foreign_modulus[LO], &foreign_modulus[MI]) * field_overflow
+        - bottom(&result[LO], &result[MI]))
+        / (two_to_limb * two_to_limb);
+
+    let carry_top: F =
         result[HI] - left_input[HI] - sign * right_hi + field_overflow * foreign_modulus[HI];
-    // c0 = r1 - a1 - s*b1 + q*f1 + 2^88*c1
-    let carry_lo = result[MI] - left_input[MI] - sign * right_input[MI]
-        + field_overflow * foreign_modulus[MI]
-        + two_to_limb * carry_mi;
-    (result, sign, field_overflow, carry_lo, carry_mi)
+
+    // Check that both ways of computing the carry value are equal
+    assert_eq!(carry_top, carry_bot);
+
+    FFAddValues {
+        left: left_input.clone(),
+        right: right_input.clone(),
+        output: result,
+        sign,
+        ovf: field_overflow,
+        carry: carry_bot,
+    }
 }
 
-/// Creates a FFAdd witness (including range checks, `ForeignFieldAdd` rows, and one `ForeignFieldFin` row.)
+// Returns the bottom composition of an element from its low and middle limbs
+fn bottom<F: PrimeField>(lo: &F, mi: &F) -> F {
+    lo.clone() + mi.clone() * F::from(TWO_TO_LIMB)
+}
+
+/// Creates a FFAdd witness (including optional multi range checks, `ForeignFieldAdd` rows, and one `ForeignFieldFin` row.) starting in zero row
 /// inputs: list of all inputs to the chain of additions/subtractions
 /// opcode: true for addition, false for subtraction
 /// modulus: modulus of the foreign field
-pub fn create<F: PrimeField>(
+pub fn create_ffadd_chain_witness<F: PrimeField>(
     inputs: &Vec<BigUint>,
     opcodes: &Vec<FFOps>,
     modulus: BigUint,
+    range_checks: bool,
 ) -> [Vec<F>; COLUMNS] {
     let num = inputs.len() - 1; // number of chained additions
 
@@ -127,74 +160,134 @@ pub fn create<F: PrimeField>(
 
     let foreign_modulus = ForeignElement::from_biguint(modulus);
 
-    // Create multi-range-check witness for first left input
     let mut left = ForeignElement::from_biguint(inputs[LO].clone());
-    range_check::witness::extend(&mut witness, left.clone());
-    let mut add_values: Vec<(F, F, F, F)> = vec![];
+    // Create multi-range-check witness for first left input
+    if range_checks {
+        range_check::witness::extend(&mut witness, left.clone());
+    }
+    let mut values: Vec<FFAddValues<F>> = vec![];
     for i in 0..num {
         let right = ForeignElement::from_biguint(inputs[i + 1].clone());
-        let (output, sign, overflow, carry_lo, carry_mi) =
-            compute_subadd_values(&left, &right, opcodes[i], &foreign_modulus);
-        // Create multi-range-check witness for right_input (left_input was done in previous iteration) and output
+        let add_values = compute_ffadd_values(&left, &right, opcodes[i], &foreign_modulus);
         // We only obtain the 3 lower limbs of right because the range check takes only 264 bits now
         let right_3_limb = ForeignElement::new([right[LO], right[MI], right[HI]]);
-        range_check::witness::extend(&mut witness, right_3_limb);
-        range_check::witness::extend(&mut witness, output.clone());
+        // Create multi-range-check witness for right_input (left_input was done in previous iteration) and output
+        if range_checks {
+            range_check::witness::extend(&mut witness, right_3_limb);
+            range_check::witness::extend(&mut witness, add_values.output.clone());
+        }
 
-        add_values.append(&mut vec![(sign, overflow, carry_lo, carry_mi)]);
-        left = output; // output
+        values.push(add_values.clone());
+        left = add_values.output.clone(); // output
     }
 
     // Compute values for final bound check, needs a 4 limb right input
     let right = ForeignElement::<F, 4>::from_biguint(BigUint::from(TWO_TO_LIMB).pow(3));
 
-    let (bound, sign, overflow, bound_carry_lo, bound_carry_mi) =
-        compute_subadd_values(&left, &right, FFOps::Add, &foreign_modulus);
+    let bound_values = compute_ffadd_values(&left, &right, FFOps::Add, &foreign_modulus);
     // Make sure they have the right value
-    assert_eq!(sign, F::one());
-    assert_eq!(overflow, F::one());
+    assert_eq!(bound_values.sign, F::one());
+    assert_eq!(bound_values.ovf, F::one());
 
     // Final RangeCheck for bound
-    range_check::witness::extend(&mut witness, bound);
-    let mut offset = witness[LO].len(); // number of witness rows of the gadget before the first row of the addition gate
+    if range_checks {
+        range_check::witness::extend(&mut witness, bound_values.output.clone());
+    }
+    let mut offset = if range_checks {
+        witness[LO].len() // number of witness rows of the gadget before the first row of the addition gate
+    } else {
+        0
+    };
 
     // Include FFAdds gates for operations and final bound check
 
-    for (i, value) in add_values.iter().enumerate() {
+    for (i, value) in values.iter().enumerate() {
         // Create foreign field addition row
         for w in &mut witness {
             w.extend(std::iter::repeat(F::zero()).take(1));
         }
 
-        let (sign, overflow, carry_lo, carry_mi) = *value;
-
         // ForeignFieldAdd row and Zero row
-        init_foreign_field_add_rows(
-            &mut witness,
-            offset,
-            i,
-            sign,
-            overflow,
-            [carry_lo, carry_mi],
-        );
+        if range_checks {
+            init_ff_add_rows_rc(&mut witness, offset, i, value.sign, value.ovf, value.carry);
+        } else {
+            let right = ForeignElement::new([value.right[LO], value.right[MI], value.right[HI]]);
+            init_ff_add_rows(
+                &mut witness,
+                offset,
+                value.left.clone(),
+                right,
+                value.sign,
+                value.ovf,
+                value.carry,
+            )
+        }
         offset += 1;
     }
 
     for w in &mut witness {
         w.extend(std::iter::repeat(F::zero()).take(2));
     }
-    init_foreign_field_fin_rows(&mut witness, offset, num, [bound_carry_lo, bound_carry_mi]);
+    if range_checks {
+        init_ff_fin_rows_rc(&mut witness, offset, num, bound_values.carry);
+    } else {
+        init_ff_fin_rows(
+            &mut witness,
+            offset,
+            bound_values.left,
+            bound_values.output.clone(),
+            bound_values.carry,
+        );
+    }
 
     witness
 }
 
-fn init_foreign_field_add_rows<F: PrimeField>(
+fn init_ff_add_rows<F: PrimeField>(
+    witness: &mut [Vec<F>; COLUMNS],
+    offset: usize,
+    left: ForeignElement<F, 3>,
+    right: ForeignElement<F, 3>,
+    sign: F,
+    overflow: F,
+    carry: F,
+) {
+    let witness_shape: Vec<[Box<dyn WitnessCell<F>>; COLUMNS]> = vec![
+        // ForeignFieldAdd row
+        [
+            VariableCell::create("left_lo"),
+            VariableCell::create("left_mi"),
+            VariableCell::create("left_hi"),
+            VariableCell::create("right_lo"),
+            VariableCell::create("right_mi"),
+            VariableCell::create("right_hi"),
+            VariableCell::create("sign"),
+            VariableCell::create("overflow"), // field_overflow
+            VariableCell::create("carry"),    // carry bit
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+        ],
+    ];
+
+    witness::init(
+        witness,
+        offset,
+        &witness_shape,
+        &variable_map!["left_lo" => left[LO], "left_mi" => left[MI], "left_hi" => left[HI], "right_lo" => right[LO], "right_mi" => right[MI], "right_hi" => right[HI], "sign" => sign, "overflow" => overflow, "carry" => carry],
+    );
+}
+
+fn init_ff_add_rows_rc<F: PrimeField>(
     witness: &mut [Vec<F>; COLUMNS],
     offset: usize,
     index: usize,
     sign: F,
     overflow: F,
-    carry: [F; 2],
+    carry: F,
 ) {
     let left_row = 8 * index;
     let right_row = 8 * index + 4;
@@ -209,8 +302,8 @@ fn init_foreign_field_add_rows<F: PrimeField>(
             CopyCell::create(right_row + 2, 0), // right_input_hi
             VariableCell::create("sign"),
             VariableCell::create("overflow"), // field_overflow
-            VariableCell::create("carry_lo"),
-            VariableCell::create("carry_mi"),
+            VariableCell::create("carry"),    // carry bit
+            ConstantCell::create(F::zero()),
             ConstantCell::create(F::zero()),
             ConstantCell::create(F::zero()),
             ConstantCell::create(F::zero()),
@@ -223,15 +316,15 @@ fn init_foreign_field_add_rows<F: PrimeField>(
         witness,
         offset,
         &witness_shape,
-        &variable_map!["sign" => sign, "overflow" => overflow, "carry_lo" => carry[0], "carry_mi" => carry[1]],
+        &variable_map!["sign" => sign, "overflow" => overflow, "carry" => carry],
     );
 }
 
-fn init_foreign_field_fin_rows<F: PrimeField>(
+fn init_ff_fin_rows_rc<F: PrimeField>(
     witness: &mut [Vec<F>; COLUMNS],
     offset: usize,
     num: usize,
-    carry: [F; 2],
+    carry: F,
 ) {
     let out_row = 8 * num; // row where the final result is stored in RC
     let bound_row = 8 * num + 4; // row where the final bound is stored in RC
@@ -246,8 +339,8 @@ fn init_foreign_field_fin_rows<F: PrimeField>(
             ConstantCell::create(F::from(TWO_TO_LIMB)), // 2^88
             ConstantCell::create(F::one()),             // sign
             ConstantCell::create(F::one()),             // field_overflow
-            VariableCell::create("carry_lo"),
-            VariableCell::create("carry_mi"),
+            VariableCell::create("carry"),
+            ConstantCell::create(F::zero()),
             ConstantCell::create(F::zero()),
             ConstantCell::create(F::zero()),
             ConstantCell::create(F::zero()),
@@ -278,6 +371,60 @@ fn init_foreign_field_fin_rows<F: PrimeField>(
         witness,
         offset,
         &witness_shape,
-        &variable_map![ "carry_lo" => carry[0], "carry_mi" => carry[1]],
+        &variable_map!["carry" => carry],
+    );
+}
+
+fn init_ff_fin_rows<F: PrimeField>(
+    witness: &mut [Vec<F>; COLUMNS],
+    offset: usize,
+    result: ForeignElement<F, 3>,
+    bound: ForeignElement<F, 3>,
+    carry: F,
+) {
+    let witness_shape: Vec<[Box<dyn WitnessCell<F>>; COLUMNS]> = vec![
+        [
+            // ForeignFieldFin row
+            VariableCell::create("result_lo"),
+            VariableCell::create("result_mi"),
+            VariableCell::create("result_hi"),
+            ConstantCell::create(F::zero()),            // 0
+            ConstantCell::create(F::zero()),            // 0
+            ConstantCell::create(F::from(TWO_TO_LIMB)), // 2^88
+            ConstantCell::create(F::one()),             // sign
+            ConstantCell::create(F::one()),             // field_overflow
+            VariableCell::create("carry"),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+        ],
+        [
+            // Zero Row
+            VariableCell::create("bound_lo"),
+            VariableCell::create("bound_mi"),
+            VariableCell::create("bound_hi"),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+            ConstantCell::create(F::zero()),
+        ],
+    ];
+
+    witness::init(
+        witness,
+        offset,
+        &witness_shape,
+        &variable_map!["carry" => carry, "result_lo" => result[LO], "result_mi" => result[MI], "result_hi" => result[HI], "bound_lo" => bound[LO], "bound_mi" => bound[MI], "bound_hi" => bound[HI]],
     );
 }

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -13,7 +13,8 @@ use crate::{
             complete_add::CompleteAdd,
             endomul_scalar::EndomulScalar,
             endosclmul::EndosclMul,
-            foreign_field_add, generic, permutation,
+            foreign_field_add::circuitgates::ForeignFieldAdd,
+            generic, permutation,
             permutation::ZK_ROWS,
             poseidon::Poseidon,
             range_check,
@@ -632,12 +633,7 @@ where
             }
 
             if let Some(selector) = index.cs.foreign_field_add_selector_poly.as_ref() {
-                index_evals.extend(
-                    foreign_field_add::gadget::circuit_gates()
-                        .iter()
-                        .enumerate()
-                        .map(|(_, gate_type)| (*gate_type, &selector.eval8)),
-                );
+                index_evals.insert(GateType::ForeignFieldAdd, &selector.eval8);
             }
 
             if let Some(selector) = index.cs.xor_selector_poly.as_ref() {
@@ -775,8 +771,8 @@ where
             // foreign field addition
             {
                 if index.cs.foreign_field_add_selector_poly.is_some() {
-                    let ffadd = foreign_field_add::gadget::combined_constraints(&all_alphas)
-                        .evaluations(&env);
+                    let ffadd =
+                        ForeignFieldAdd::combined_constraints(&all_alphas).evaluations(&env);
                     assert_eq!(ffadd.domain().size, t4.domain().size);
                     t4 += &ffadd;
                     check_constraint!(index, ffadd);


### PR DESCRIPTION
This PR brings an optimization to FFAdd reducing the number of constraints by 2 and reducing by 1 the number of witness cells needed. The idea is to condense claims about the low and high limbs in a longer 176-bit super-limb. This gets rid of the low carry flag (so only the old middle carry flag is in use now, together with its carry check constraint) and the three old result checks now become just 2.

I checked the tests and all works as it used to before. I added another helper to write FFAdd gadgets without leading rangecheck gates to allow for better chainability when we use this gate inside the ECDSA algorithm in combination with the others.