### PR TITLE
Move polynomials out of ConstraintSystem

### DIFF
--- a/kimchi/src/alphas.rs
+++ b/kimchi/src/alphas.rs
@@ -324,15 +324,15 @@ mod tests {
         let gates = vec![CircuitGate::<Fp>::zero(Wire::for_row(0)); 2];
         let index = new_index_for_test(gates, 0);
         let (_linearization, powers_of_alpha) = expr_linearization(
-            index.cs.chacha8.is_some(),
-            index.cs.range_check_selector_polys.is_some(),
+            index.cs.column_evaluations.chacha_selectors8.is_some(),
+            index.cs.column_evaluations.range_check_selectors8.is_some(),
             index
                 .cs
                 .lookup_constraint_system
                 .as_ref()
                 .map(|lcs| &lcs.configuration),
-            index.cs.foreign_field_add_selector_poly.is_some(),
-            index.cs.xor_selector_poly.is_some(),
+            index.cs.column_evaluations.foreign_field_add_selector8.is_some(),
+            index.cs.column_evaluations.xor_selector8.is_some(),
             true,
         );
         // make sure this is present in the specification

--- a/kimchi/src/alphas.rs
+++ b/kimchi/src/alphas.rs
@@ -331,7 +331,11 @@ mod tests {
                 .lookup_constraint_system
                 .as_ref()
                 .map(|lcs| &lcs.configuration),
-            index.cs.column_evaluations.foreign_field_add_selector8.is_some(),
+            index
+                .cs
+                .column_evaluations
+                .foreign_field_add_selector8
+                .is_some(),
             index.cs.column_evaluations.xor_selector8.is_some(),
             true,
         );

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -88,9 +88,6 @@ pub struct ConstraintSystem<F: PrimeField> {
 
     // permutation polynomials
     // -----------------------
-    /// permutation polynomial array evaluations over domain d1
-    #[serde_as(as = "[o1_utils::serialization::SerdeAs; PERMUTS]")]
-    pub sigmal1: [E<F, D<F>>; PERMUTS],
     /// permutation polynomial array evaluations over domain d8
     #[serde_as(as = "[o1_utils::serialization::SerdeAs; PERMUTS]")]
     pub sigmal8: [E<F, D<F>>; PERMUTS],
@@ -654,7 +651,6 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
             public: self.public,
             prev_challenges: self.prev_challenges,
             sid,
-            sigmal1,
             sigmal8,
             generic4,
             coefficients8,

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -660,7 +660,7 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
             },
             column_evaluations: ColumnEvaluations {
                 permutation_coefficients8: sigmal8,
-                coefficients8: coefficients8,
+                coefficients8,
                 generic_selector4: generic4,
                 poseidon_selector8: ps8,
                 complete_add_selector4: complete_addl4,

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -2540,7 +2540,7 @@ pub mod test {
                 foreign_field_modulus: None,
             },
             witness: &domain_evals.d8.this.w,
-            coefficient: &constraint_system.coefficients8,
+            coefficient: &constraint_system.column_evaluations.coefficients8,
             vanishes_on_last_4_rows: &constraint_system.precomputations().vanishes_on_last_4_rows,
             z: &domain_evals.d8.this.z,
             l0_1: l0_1(constraint_system.domain.d1),

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -13,8 +13,6 @@ use crate::{
     curve::KimchiCurve,
 };
 use ark_ff::{bytes::ToBytes, PrimeField};
-use ark_poly::Evaluations;
-use ark_poly::Radix2EvaluationDomain as D;
 use num_traits::cast::ToPrimitive;
 use o1_utils::hasher::CryptoDigest;
 use serde::{Deserialize, Serialize};
@@ -113,15 +111,6 @@ pub enum GateType {
     //ForeignFieldMul = 26,
     // Gates for Keccak follow:
     Xor16 = 27,
-}
-
-/// Selector polynomial
-#[serde_as]
-#[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct SelectorPolynomial<F: PrimeField> {
-    /// Evaluation form (evaluated over domain d8)
-    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
-    pub eval8: Evaluations<F, D<F>>,
 }
 
 /// Gate error

--- a/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
@@ -188,7 +188,10 @@ impl<F: PrimeField> CircuitGate<F> {
         let mut index_evals = HashMap::new();
         index_evals.insert(
             self.typ,
-            &cs.foreign_field_add_selector_poly.as_ref().unwrap().eval8,
+            cs.column_evaluations
+                .foreign_field_add_selector8
+                .as_ref()
+                .unwrap(),
         );
 
         // Set up lookup environment
@@ -227,7 +230,7 @@ impl<F: PrimeField> CircuitGate<F> {
                     foreign_field_modulus: cs.foreign_field_modulus.clone(),
                 },
                 witness: &witness_evals.d8.this.w,
-                coefficient: &cs.coefficients8,
+                coefficient: &cs.column_evaluations.coefficients8,
                 vanishes_on_last_4_rows: &cs.precomputations().vanishes_on_last_4_rows,
                 z: &witness_evals.d8.this.z,
                 l0_1: l0_1(cs.domain.d1),

--- a/kimchi/src/circuits/polynomials/generic.rs
+++ b/kimchi/src/circuits/polynomials/generic.rs
@@ -284,8 +284,11 @@ pub mod testing {
             witness: &[DensePolynomial<F>; COLUMNS],
             public: &DensePolynomial<F>,
         ) -> bool {
-            let coefficientsm: [_; COLUMNS] =
-                array::from_fn(|i| self.coefficients8[i].clone().interpolate());
+            let coefficientsm: [_; COLUMNS] = array::from_fn(|i| {
+                self.column_evaluations.coefficients8[i]
+                    .clone()
+                    .interpolate()
+            });
 
             let generic_gate = |coeff_offset, register_offset| {
                 // addition (of left, right, output wires)

--- a/kimchi/src/circuits/polynomials/generic.rs
+++ b/kimchi/src/circuits/polynomials/generic.rs
@@ -310,7 +310,7 @@ pub mod testing {
             res += public;
 
             // selector poly
-            res = &res * &self.genericm;
+            res = &res * &self.evaluated_column_coefficients.generic_selector;
 
             // verify that it is divisible by Z_H
             match res.divide_by_vanishing_poly(self.domain.d1) {

--- a/kimchi/src/circuits/polynomials/permutation.rs
+++ b/kimchi/src/circuits/polynomials/permutation.rs
@@ -331,7 +331,7 @@ impl<F: PrimeField> ConstraintSystem<F> {
         //~
         let zkpm_zeta = self.precomputations().zkpm.evaluate(&zeta);
         let scalar = Self::perm_scalars(e, beta, gamma, alphas, zkpm_zeta);
-        self.sigmam[PERMUTS - 1].scale(scalar)
+        self.evaluated_column_coefficients.permutation_coefficients[PERMUTS - 1].scale(scalar)
     }
 
     pub fn perm_scalars(

--- a/kimchi/src/circuits/polynomials/permutation.rs
+++ b/kimchi/src/circuits/polynomials/permutation.rs
@@ -441,8 +441,8 @@ impl<F: PrimeField> ConstraintSystem<F> {
         for j in 0..n - 3 {
             z[j + 1] = witness
                 .iter()
-                .zip(self.sigmal1.iter())
-                .map(|(w, s)| w[j] + (s[j] * beta) + gamma)
+                .zip(self.sigmal8.iter())
+                .map(|(w, s)| w[j] + (s[8 * j] * beta) + gamma)
                 .fold(F::one(), |x, y| x * y);
         }
 

--- a/kimchi/src/circuits/polynomials/permutation.rs
+++ b/kimchi/src/circuits/polynomials/permutation.rs
@@ -263,7 +263,13 @@ impl<F: PrimeField> ConstraintSystem<F> {
             // (w8[6] + gamma + sigma[6] * beta)
             // in evaluation form in d8
             let mut sigmas = lagrange.d8.next.z.clone();
-            for (witness, sigma) in lagrange.d8.this.w.iter().zip(self.sigmal8.iter()) {
+            for (witness, sigma) in lagrange
+                .d8
+                .this
+                .w
+                .iter()
+                .zip(self.column_evaluations.permutation_coefficients8.iter())
+            {
                 let term = witness + &(gamma + &sigma.scale(beta));
                 sigmas = &sigmas * &term;
             }
@@ -441,7 +447,7 @@ impl<F: PrimeField> ConstraintSystem<F> {
         for j in 0..n - 3 {
             z[j + 1] = witness
                 .iter()
-                .zip(self.sigmal8.iter())
+                .zip(self.column_evaluations.permutation_coefficients8.iter())
                 .map(|(w, s)| w[j] + (s[8 * j] * beta) + gamma)
                 .fold(F::one(), |x, y| x * y);
         }

--- a/kimchi/src/circuits/polynomials/range_check/gadget.rs
+++ b/kimchi/src/circuits/polynomials/range_check/gadget.rs
@@ -126,8 +126,10 @@ impl<F: PrimeField> CircuitGate<F> {
         let mut index_evals = HashMap::new();
         index_evals.insert(
             self.typ,
-            &cs.range_check_selector_polys.as_ref().unwrap()[circuit_gate_selector_index(self.typ)]
-                .eval8,
+            &cs.column_evaluations
+                .range_check_selectors8
+                .as_ref()
+                .unwrap()[circuit_gate_selector_index(self.typ)],
         );
 
         // Set up lookup environment
@@ -166,7 +168,7 @@ impl<F: PrimeField> CircuitGate<F> {
                     foreign_field_modulus: None,
                 },
                 witness: &witness_evals.d8.this.w,
-                coefficient: &cs.coefficients8,
+                coefficient: &cs.column_evaluations.coefficients8,
                 vanishes_on_last_4_rows: &cs.precomputations().vanishes_on_last_4_rows,
                 z: &witness_evals.d8.this.z,
                 l0_1: l0_1(cs.domain.d1),

--- a/kimchi/src/circuits/polynomials/xor.rs
+++ b/kimchi/src/circuits/polynomials/xor.rs
@@ -100,7 +100,10 @@ impl<F: PrimeField> CircuitGate<F> {
         let witness_evals = cs.evaluate(&witness_poly, &z_poly);
 
         let mut index_evals = HashMap::new();
-        index_evals.insert(self.typ, &cs.xor_selector_poly.as_ref().unwrap().eval8);
+        index_evals.insert(
+            self.typ,
+            cs.column_evaluations.xor_selector8.as_ref().unwrap(),
+        );
 
         // Set up lookup environment
         let lcs = cs
@@ -138,7 +141,7 @@ impl<F: PrimeField> CircuitGate<F> {
                     foreign_field_modulus: None,
                 },
                 witness: &witness_evals.d8.this.w,
-                coefficient: &cs.coefficients8,
+                coefficient: &cs.column_evaluations.coefficients8,
                 vanishes_on_last_4_rows: &cs.precomputations().vanishes_on_last_4_rows,
                 z: &witness_evals.d8.this.z,
                 l0_1: l0_1(cs.domain.d1),

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -652,7 +652,7 @@ where
             }
 
             if let Some(selector) = index.cs.column_evaluations.xor_selector8.as_ref() {
-                index_evals.insert(GateType::Xor16, &selector);
+                index_evals.insert(GateType::Xor16, selector);
             }
 
             let mds = &G::sponge_params().mds;

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -940,12 +940,15 @@ where
         let chunked_evals = {
             let chunked_evals_zeta = ProofEvaluations::<Vec<G::ScalarField>> {
                 s: array::from_fn(|i| {
-                    index.cs.sigmam[0..PERMUTS - 1][i]
+                    index
+                        .cs
+                        .evaluated_column_coefficients
+                        .permutation_coefficients[0..PERMUTS - 1][i]
                         .to_chunked_polynomial(index.max_poly_size)
                         .evaluate_chunks(zeta)
                 }),
                 coefficients: array::from_fn(|i| {
-                    index.cs.coefficientsm[i]
+                    index.cs.evaluated_column_coefficients.coefficients[i]
                         .to_chunked_polynomial(index.max_poly_size)
                         .evaluate_chunks(zeta)
                 }),
@@ -963,24 +966,29 @@ where
 
                 generic_selector: index
                     .cs
-                    .genericm
+                    .evaluated_column_coefficients
+                    .generic_selector
                     .to_chunked_polynomial(index.max_poly_size)
                     .evaluate_chunks(zeta),
 
                 poseidon_selector: index
                     .cs
-                    .psm
+                    .evaluated_column_coefficients
+                    .poseidon_selector
                     .to_chunked_polynomial(index.max_poly_size)
                     .evaluate_chunks(zeta),
             };
             let chunked_evals_zeta_omega = ProofEvaluations::<Vec<G::ScalarField>> {
                 s: array::from_fn(|i| {
-                    index.cs.sigmam[0..PERMUTS - 1][i]
+                    index
+                        .cs
+                        .evaluated_column_coefficients
+                        .permutation_coefficients[0..PERMUTS - 1][i]
                         .to_chunked_polynomial(index.max_poly_size)
                         .evaluate_chunks(zeta_omega)
                 }),
                 coefficients: array::from_fn(|i| {
-                    index.cs.coefficientsm[i]
+                    index.cs.evaluated_column_coefficients.coefficients[i]
                         .to_chunked_polynomial(index.max_poly_size)
                         .evaluate_chunks(zeta_omega)
                 }),
@@ -999,13 +1007,15 @@ where
 
                 generic_selector: index
                     .cs
-                    .genericm
+                    .evaluated_column_coefficients
+                    .generic_selector
                     .to_chunked_polynomial(index.max_poly_size)
                     .evaluate_chunks(zeta_omega),
 
                 poseidon_selector: index
                     .cs
-                    .psm
+                    .evaluated_column_coefficients
+                    .poseidon_selector
                     .to_chunked_polynomial(index.max_poly_size)
                     .evaluate_chunks(zeta_omega),
             };
@@ -1197,8 +1207,16 @@ where
         polynomials.extend(vec![(&public_poly, None, fixed_hiding(1))]);
         polynomials.extend(vec![(&ft, None, blinding_ft)]);
         polynomials.extend(vec![(&z_poly, None, z_comm.blinders)]);
-        polynomials.extend(vec![(&index.cs.genericm, None, fixed_hiding(1))]);
-        polynomials.extend(vec![(&index.cs.psm, None, fixed_hiding(1))]);
+        polynomials.extend(vec![(
+            &index.cs.evaluated_column_coefficients.generic_selector,
+            None,
+            fixed_hiding(1),
+        )]);
+        polynomials.extend(vec![(
+            &index.cs.evaluated_column_coefficients.poseidon_selector,
+            None,
+            fixed_hiding(1),
+        )]);
         polynomials.extend(
             witness_poly
                 .iter()
@@ -1209,13 +1227,17 @@ where
         polynomials.extend(
             index
                 .cs
-                .coefficientsm
+                .evaluated_column_coefficients
+                .coefficients
                 .iter()
                 .map(|coefficientm| (coefficientm, None, non_hiding(1)))
                 .collect::<Vec<_>>(),
         );
         polynomials.extend(
-            index.cs.sigmam[0..PERMUTS - 1]
+            index
+                .cs
+                .evaluated_column_coefficients
+                .permutation_coefficients[0..PERMUTS - 1]
                 .iter()
                 .map(|w| (w, None, non_hiding(1)))
                 .collect::<Vec<_>>(),

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -77,13 +77,13 @@ impl<G: KimchiCurve> ProverIndex<G> {
 
         // pre-compute the linearization
         let (linearization, powers_of_alpha) = expr_linearization(
-            cs.chacha8.is_some(),
-            cs.range_check_selector_polys.is_some(),
+            cs.column_evaluations.chacha_selectors8.is_some(),
+            cs.column_evaluations.range_check_selectors8.is_some(),
             cs.lookup_constraint_system
                 .as_ref()
                 .map(|lcs| &lcs.configuration),
-            cs.foreign_field_add_selector_poly.is_some(),
-            cs.xor_selector_poly.is_some(),
+            cs.column_evaluations.foreign_field_add_selector8.is_some(),
+            cs.column_evaluations.xor_selector8.is_some(),
             true,
         );
 

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -212,14 +212,28 @@ impl<G: KimchiCurve> ProverIndex<G> {
                 cell
             },
 
-            sigma_comm: array::from_fn(|i| self.srs.commit_non_hiding(&self.cs.sigmam[i], None)),
+            sigma_comm: array::from_fn(|i| {
+                self.srs.commit_non_hiding(
+                    &self
+                        .cs
+                        .evaluated_column_coefficients
+                        .permutation_coefficients[i],
+                    None,
+                )
+            }),
             coefficients_comm: array::from_fn(|i| {
                 self.srs
                     .commit_evaluations_non_hiding(domain, &self.cs.coefficients8[i], None)
             }),
-            generic_comm: mask_fixed(self.srs.commit_non_hiding(&self.cs.genericm, None)),
+            generic_comm: mask_fixed(self.srs.commit_non_hiding(
+                &self.cs.evaluated_column_coefficients.generic_selector,
+                None,
+            )),
 
-            psm_comm: mask_fixed(self.srs.commit_non_hiding(&self.cs.psm, None)),
+            psm_comm: mask_fixed(self.srs.commit_non_hiding(
+                &self.cs.evaluated_column_coefficients.poseidon_selector,
+                None,
+            )),
 
             complete_add_comm: self.srs.commit_evaluations_non_hiding(
                 domain,

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -222,8 +222,11 @@ impl<G: KimchiCurve> ProverIndex<G> {
                 )
             }),
             coefficients_comm: array::from_fn(|i| {
-                self.srs
-                    .commit_evaluations_non_hiding(domain, &self.cs.coefficients8[i], None)
+                self.srs.commit_evaluations_non_hiding(
+                    domain,
+                    &self.cs.column_evaluations.coefficients8[i],
+                    None,
+                )
             }),
             generic_comm: mask_fixed(self.srs.commit_non_hiding(
                 &self.cs.evaluated_column_coefficients.generic_selector,
@@ -237,46 +240,60 @@ impl<G: KimchiCurve> ProverIndex<G> {
 
             complete_add_comm: self.srs.commit_evaluations_non_hiding(
                 domain,
-                &self.cs.complete_addl4,
+                &self.cs.column_evaluations.complete_add_selector4,
                 None,
             ),
-            mul_comm: self
-                .srs
-                .commit_evaluations_non_hiding(domain, &self.cs.mull8, None),
-            emul_comm: self
-                .srs
-                .commit_evaluations_non_hiding(domain, &self.cs.emull, None),
+            mul_comm: self.srs.commit_evaluations_non_hiding(
+                domain,
+                &self.cs.column_evaluations.mul_selector8,
+                None,
+            ),
+            emul_comm: self.srs.commit_evaluations_non_hiding(
+                domain,
+                &self.cs.column_evaluations.emul_selector8,
+                None,
+            ),
 
             endomul_scalar_comm: self.srs.commit_evaluations_non_hiding(
                 domain,
-                &self.cs.endomul_scalar8,
+                &self.cs.column_evaluations.endomul_scalar_selector8,
                 None,
             ),
 
-            chacha_comm: self.cs.chacha8.as_ref().map(|c| {
-                array::from_fn(|i| self.srs.commit_evaluations_non_hiding(domain, &c[i], None))
-            }),
+            chacha_comm: self
+                .cs
+                .column_evaluations
+                .chacha_selectors8
+                .as_ref()
+                .map(|c| {
+                    array::from_fn(|i| self.srs.commit_evaluations_non_hiding(domain, &c[i], None))
+                }),
 
-            range_check_comm: self.cs.range_check_selector_polys.as_ref().map(|poly| {
-                array::from_fn(|i| {
-                    self.srs
-                        .commit_evaluations_non_hiding(domain, &poly[i].eval8, None)
-                })
-            }),
+            range_check_comm: self
+                .cs
+                .column_evaluations
+                .range_check_selectors8
+                .as_ref()
+                .map(|evals8| {
+                    array::from_fn(|i| {
+                        self.srs
+                            .commit_evaluations_non_hiding(domain, &evals8[i], None)
+                    })
+                }),
 
             foreign_field_add_comm: self
                 .cs
-                .foreign_field_add_selector_poly
+                .column_evaluations
+                .foreign_field_add_selector8
                 .as_ref()
-                .map(|poly| {
-                    self.srs
-                        .commit_evaluations_non_hiding(domain, &poly.eval8, None)
-                }),
+                .map(|eval8| self.srs.commit_evaluations_non_hiding(domain, &eval8, None)),
 
-            xor_comm: self.cs.xor_selector_poly.as_ref().map(|poly| {
-                self.srs
-                    .commit_evaluations_non_hiding(domain, &poly.eval8, None)
-            }),
+            xor_comm: self
+                .cs
+                .column_evaluations
+                .xor_selector8
+                .as_ref()
+                .map(|eval8| self.srs.commit_evaluations_non_hiding(domain, &eval8, None)),
 
             shift: self.cs.shift,
             zkpm: {

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -286,14 +286,14 @@ impl<G: KimchiCurve> ProverIndex<G> {
                 .column_evaluations
                 .foreign_field_add_selector8
                 .as_ref()
-                .map(|eval8| self.srs.commit_evaluations_non_hiding(domain, &eval8, None)),
+                .map(|eval8| self.srs.commit_evaluations_non_hiding(domain, eval8, None)),
 
             xor_comm: self
                 .cs
                 .column_evaluations
                 .xor_selector8
                 .as_ref()
-                .map(|eval8| self.srs.commit_evaluations_non_hiding(domain, &eval8, None)),
+                .map(|eval8| self.srs.commit_evaluations_non_hiding(domain, eval8, None)),
 
             shift: self.cs.shift,
             zkpm: {


### PR DESCRIPTION
This PR moves the polynomials out of the `ConstraintSystem` structure, and into sub-structures.

This is part of a longer term plan to remove them from `ConstraintSystem` entirely, and to place them in `ProverIndex`. The constraint system should define the layout of the circuit; these precomputations don't contribute to that goal.