### PR TITLE
Add feature flags for optional gates

### DIFF
--- a/kimchi/src/alphas.rs
+++ b/kimchi/src/alphas.rs
@@ -324,19 +324,7 @@ mod tests {
         let gates = vec![CircuitGate::<Fp>::zero(Wire::for_row(0)); 2];
         let index = new_index_for_test(gates, 0);
         let (_linearization, powers_of_alpha) = expr_linearization(
-            index.cs.column_evaluations.chacha_selectors8.is_some(),
-            index.cs.column_evaluations.range_check_selectors8.is_some(),
-            index
-                .cs
-                .lookup_constraint_system
-                .as_ref()
-                .map(|lcs| &lcs.configuration),
-            index
-                .cs
-                .column_evaluations
-                .foreign_field_add_selector8
-                .is_some(),
-            index.cs.column_evaluations.xor_selector8.is_some(),
+            &index.cs.feature_flags,
             true,
         );
         // make sure this is present in the specification

--- a/kimchi/src/alphas.rs
+++ b/kimchi/src/alphas.rs
@@ -323,10 +323,7 @@ mod tests {
     fn get_alphas_for_spec() {
         let gates = vec![CircuitGate::<Fp>::zero(Wire::for_row(0)); 2];
         let index = new_index_for_test(gates, 0);
-        let (_linearization, powers_of_alpha) = expr_linearization(
-            &index.cs.feature_flags,
-            true,
-        );
+        let (_linearization, powers_of_alpha) = expr_linearization(&index.cs.feature_flags, true);
         // make sure this is present in the specification
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let spec_path = Path::new(&manifest_dir)

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -27,7 +27,7 @@ use once_cell::sync::OnceCell;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
 use std::array;
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
 //
 // ConstraintSystem
@@ -457,11 +457,26 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
             .collect();
         gates.append(&mut padding);
 
-        // Record which gates are used by this constraint system
-        let mut circuit_gates_used = HashSet::<GateType>::default();
-        gates.iter().for_each(|gate| {
-            circuit_gates_used.insert(gate.typ);
-        });
+        let mut feature_flags = FeatureFlags {
+            chacha: false,
+            range_check: false,
+            lookup_configuration: None,
+            foreign_field_add: false,
+            xor: false,
+        };
+
+        for gate in &gates {
+            match gate.typ {
+                GateType::ChaCha0
+                | GateType::ChaCha1
+                | GateType::ChaCha2
+                | GateType::ChaChaFinal => feature_flags.chacha = true,
+                GateType::RangeCheck0 | GateType::RangeCheck1 => feature_flags.range_check = true,
+                GateType::ForeignFieldAdd => feature_flags.foreign_field_add = true,
+                GateType::Xor16 => feature_flags.range_check = true,
+                _ => (),
+            }
+        }
 
         //~ 4. sample the `PERMUTS` shifts.
         let shifts = Shifts::new(&domain.d1);
@@ -570,19 +585,15 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
 
         // chacha gate
         let chacha8 = {
-            use GateType::*;
-            let has_chacha_gate = gates
-                .iter()
-                .any(|gate| matches!(gate.typ, ChaCha0 | ChaCha1 | ChaCha2 | ChaChaFinal));
-            if !has_chacha_gate {
+            if !feature_flags.chacha {
                 None
             } else {
                 let a: [_; 4] = array::from_fn(|i| {
                     let g = match i {
-                        0 => ChaCha0,
-                        1 => ChaCha1,
-                        2 => ChaCha2,
-                        3 => ChaChaFinal,
+                        0 => GateType::ChaCha0,
+                        1 => GateType::ChaCha1,
+                        2 => GateType::ChaCha2,
+                        3 => GateType::ChaChaFinal,
                         _ => panic!("Invalid index"),
                     };
                     E::<F, D<F>>::from_vec_and_domain(
@@ -602,7 +613,7 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
         // Range check constraint selector polynomials
         let range_gates = range_check::gadget::circuit_gates();
         let range_check_selector_polys = {
-            if circuit_gates_used.is_disjoint(&range_gates.into_iter().collect()) {
+            if !feature_flags.range_check {
                 None
             } else {
                 Some(array::from_fn(|i| {
@@ -614,16 +625,15 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
         // Foreign field addition constraint selector polynomial
         let ffadd_gates = foreign_field_add::gadget::circuit_gates();
         let foreign_field_add_selector_poly = {
-            if circuit_gates_used.is_disjoint(&ffadd_gates.into_iter().collect()) {
+            if !feature_flags.foreign_field_add {
                 None
             } else {
                 Some(selector_polynomial(ffadd_gates[0], &gates, &domain))
             }
         };
 
-        let xor_gate = [GateType::Xor16];
         let xor_selector_poly = {
-            if circuit_gates_used.is_disjoint(&xor_gate.into_iter().collect()) {
+            if !feature_flags.xor {
                 None
             } else {
                 Some(selector_polynomial(GateType::Xor16, &gates, &domain))
@@ -654,6 +664,9 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
         let lookup_constraint_system =
             LookupConstraintSystem::create(&gates, lookup_tables, runtime_tables, &domain)
                 .map_err(|e| SetupError::ConstraintSystem(e.to_string()))?;
+        feature_flags.lookup_configuration = lookup_constraint_system
+            .as_ref()
+            .map(|lcs| lcs.configuration.clone());
 
         let sid = shifts.map[0].clone();
 
@@ -661,16 +674,6 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
         let endo = F::zero();
 
         let domain_constant_evaluation = OnceCell::new();
-
-        let feature_flags = FeatureFlags {
-            chacha: chacha8.is_some(),
-            range_check: range_check_selector_polys.is_some(),
-            lookup_configuration: lookup_constraint_system
-                .as_ref()
-                .map(|lcs| lcs.configuration.clone()),
-            foreign_field_add: foreign_field_add_selector_poly.is_some(),
-            xor: xor_selector_poly.is_some(),
-        };
 
         let constraints = ConstraintSystem {
             domain,

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -35,7 +35,8 @@ use std::{collections::HashSet, sync::Arc};
 
 /// Flags for optional features in the constraint system
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct FeatureFlags<F: PrimeField> {
+#[serde(bound = "F: ark_serialize::CanonicalSerialize + ark_serialize::CanonicalDeserialize")]
+pub struct FeatureFlags<F> {
     /// ChaCha gates
     pub chacha: bool,
     /// Range check gates

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -473,7 +473,7 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
                 | GateType::ChaChaFinal => feature_flags.chacha = true,
                 GateType::RangeCheck0 | GateType::RangeCheck1 => feature_flags.range_check = true,
                 GateType::ForeignFieldAdd => feature_flags.foreign_field_add = true,
-                GateType::Xor16 => feature_flags.range_check = true,
+                GateType::Xor16 => feature_flags.xor = true,
                 _ => (),
             }
         }

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -5,7 +5,9 @@ use crate::{
         domain_constant_evaluation::DomainConstantEvaluations,
         domains::EvaluationDomains,
         gate::{CircuitGate, GateType},
-        lookup::{index::LookupConstraintSystem, tables::LookupTable},
+        lookup::{
+            constraints::LookupConfiguration, index::LookupConstraintSystem, tables::LookupTable,
+        },
         polynomial::{WitnessEvals, WitnessOverDomains, WitnessShifts},
         polynomials::permutation::{Shifts, ZK_ROWS},
         polynomials::{foreign_field_add, range_check},
@@ -30,6 +32,21 @@ use std::{collections::HashSet, sync::Arc};
 //
 // ConstraintSystem
 //
+
+/// Flags for optional features in the constraint system
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct FeatureFlags<F: PrimeField> {
+    /// ChaCha gates
+    pub chacha: bool,
+    /// Range check gates
+    pub range_check: bool,
+    /// Foreign field addition gate
+    pub foreign_field_add: bool,
+    /// XOR gate
+    pub xor_selector: bool,
+    /// Lookups
+    pub lookup_configuration: Option<LookupConfiguration<F>>,
+}
 
 /// The polynomials representing evaluated columns, in coefficient form.
 #[serde_as]

--- a/kimchi/src/circuits/lookup/constraints.rs
+++ b/kimchi/src/circuits/lookup/constraints.rs
@@ -336,7 +336,8 @@ where
 // TODO: move to lookup::index
 #[serde_as]
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct LookupConfiguration<F: FftField> {
+#[serde(bound = "F: ark_serialize::CanonicalSerialize + ark_serialize::CanonicalDeserialize")]
+pub struct LookupConfiguration<F> {
     /// The kind of lookups used
     pub lookup_used: LookupsUsed,
 

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -14,6 +14,7 @@ use crate::circuits::polynomials::range_check;
 use crate::circuits::polynomials::varbasemul::VarbaseMul;
 use crate::circuits::polynomials::{generic, permutation, xor};
 use crate::circuits::{
+    constraints::FeatureFlags,
     expr::{Column, ConstantExpr, Expr, Linearization, PolishToken},
     gate::GateType,
     wires::COLUMNS,
@@ -26,11 +27,7 @@ use ark_ff::{FftField, PrimeField, SquareRootField};
 ///
 /// Will panic if `generic_gate` is not associate with `alpha^0`.
 pub fn constraints_expr<F: PrimeField + SquareRootField>(
-    chacha: bool,
-    range_check: bool,
-    lookup_constraint_system: Option<&LookupConfiguration<F>>,
-    foreign_field_add: bool,
-    xor: bool,
+    feature_flags: &FeatureFlags<F>,
     generic: bool,
 ) -> (Expr<ConstantExpr<F>>, Alphas<F>) {
     // register powers of alpha so that we don't reuse them across mutually inclusive constraints
@@ -49,22 +46,22 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
     expr += EndosclMul::combined_constraints(&powers_of_alpha);
     expr += EndomulScalar::combined_constraints(&powers_of_alpha);
 
-    if chacha {
+    if feature_flags.chacha {
         expr += ChaCha0::combined_constraints(&powers_of_alpha);
         expr += ChaCha1::combined_constraints(&powers_of_alpha);
         expr += ChaCha2::combined_constraints(&powers_of_alpha);
         expr += ChaChaFinal::combined_constraints(&powers_of_alpha);
     }
 
-    if range_check {
+    if feature_flags.range_check {
         expr += range_check::gadget::combined_constraints(&powers_of_alpha);
     }
 
-    if foreign_field_add {
+    if feature_flags.foreign_field_add {
         expr += ForeignFieldAdd::combined_constraints(&powers_of_alpha);
     }
 
-    if xor {
+    if feature_flags.xor {
         expr += xor::Xor16::combined_constraints(&powers_of_alpha);
     }
 
@@ -76,7 +73,7 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
     powers_of_alpha.register(ArgumentType::Permutation, permutation::CONSTRAINTS);
 
     // lookup
-    if let Some(lcs) = lookup_constraint_system.as_ref() {
+    if let Some(lcs) = feature_flags.lookup_configuration.as_ref() {
         let constraints = lookup::constraints::constraints(lcs);
 
         // note: the number of constraints depends on the lookup configuration,
@@ -149,23 +146,12 @@ pub fn linearization_columns<F: FftField + SquareRootField>(
 ///
 /// Will panic if the `linearization` process fails.
 pub fn expr_linearization<F: PrimeField + SquareRootField>(
-    chacha: bool,
-    range_check: bool,
-    lookup_constraint_system: Option<&LookupConfiguration<F>>,
-    foreign_field_addition: bool,
-    xor: bool,
+    feature_flags: &FeatureFlags<F>,
     generic: bool,
 ) -> (Linearization<Vec<PolishToken<F>>>, Alphas<F>) {
-    let evaluated_cols = linearization_columns::<F>(lookup_constraint_system);
+    let evaluated_cols = linearization_columns::<F>(feature_flags.lookup_configuration.as_ref());
 
-    let (expr, powers_of_alpha) = constraints_expr(
-        chacha,
-        range_check,
-        lookup_constraint_system,
-        foreign_field_addition,
-        xor,
-        generic,
-    );
+    let (expr, powers_of_alpha) = constraints_expr(feature_flags, generic);
 
     let linearization = expr
         .linearize(evaluated_cols)

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -76,10 +76,7 @@ impl<G: KimchiCurve> ProverIndex<G> {
         cs.endo = endo_q;
 
         // pre-compute the linearization
-        let (linearization, powers_of_alpha) = expr_linearization(
-            &cs.feature_flags,
-            true,
-        );
+        let (linearization, powers_of_alpha) = expr_linearization(&cs.feature_flags, true);
 
         // set `max_quot_size` to the degree of the quotient polynomial,
         // which is obtained by looking at the highest monomial in the sum

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -77,13 +77,7 @@ impl<G: KimchiCurve> ProverIndex<G> {
 
         // pre-compute the linearization
         let (linearization, powers_of_alpha) = expr_linearization(
-            cs.column_evaluations.chacha_selectors8.is_some(),
-            cs.column_evaluations.range_check_selectors8.is_some(),
-            cs.lookup_constraint_system
-                .as_ref()
-                .map(|lcs| &lcs.configuration),
-            cs.column_evaluations.foreign_field_add_selector8.is_some(),
-            cs.column_evaluations.xor_selector8.is_some(),
+            &cs.feature_flags,
             true,
         );
 


### PR DESCRIPTION
This PR adds a `FeatureFlag` structure, marking the 'optional features' used by the constraint system, and uses it for the linearization.