### PR TITLE
Use `selector_polynomial` helper for all unevaluated selectors

### DIFF
--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -10,7 +10,7 @@ use crate::{
         },
         polynomial::{WitnessEvals, WitnessOverDomains, WitnessShifts},
         polynomials::permutation::{Shifts, ZK_ROWS},
-        polynomials::{foreign_field_add, range_check},
+        polynomials::range_check,
         wires::*,
     },
     curve::KimchiCurve,


### PR DESCRIPTION
This PR simplifies the logic in `constraints::Builder::build`, using the `selector_polynomial` helper wherever possible.

This PR builds upon #867.