### PR TITLE
Move prover precomputations into `ProverIndex`

### DIFF
--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -545,7 +545,6 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
             let eval = E::from_vec_and_domain(padded, domain.d1);
             eval.interpolate()
         });
-        // TODO: This doesn't need to be degree 8 but that would require some changes in expr
         let column_evaluations = {
             let permutation_coefficients8 =
                 array::from_fn(|i| sigmam[i].evaluate_over_domain_by_ref(domain.d8));
@@ -619,6 +618,8 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
                     ))
                 }
             };
+
+            // TODO: This doesn't need to be degree 8 but that would require some changes in expr
             let coefficients8 =
                 array::from_fn(|i| coefficientsm[i].evaluate_over_domain_by_ref(domain.d8));
 

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -500,8 +500,6 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
 
         let sigmam: [DP<F>; PERMUTS] = array::from_fn(|i| sigmal1[i].clone().interpolate());
 
-        let sigmal8 = array::from_fn(|i| sigmam[i].evaluate_over_domain_by_ref(domain.d8));
-
         // Gates
         // -----
         //
@@ -549,23 +547,28 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
         });
         // TODO: This doesn't need to be degree 8 but that would require some changes in expr
         let column_evaluations = {
-            let ps8 = psm.evaluate_over_domain_by_ref(domain.d8);
+            let permutation_coefficients8 =
+                array::from_fn(|i| sigmam[i].evaluate_over_domain_by_ref(domain.d8));
+
+            let poseidon_selector8 = psm.evaluate_over_domain_by_ref(domain.d8);
 
             // ECC gates
-            let complete_addl4 =
+            let complete_add_selector4 =
                 selector_polynomial(GateType::CompleteAdd, &gates, &domain, &domain.d4);
 
-            let mull8 = selector_polynomial(GateType::VarBaseMul, &gates, &domain, &domain.d8);
+            let mul_selector8 =
+                selector_polynomial(GateType::VarBaseMul, &gates, &domain, &domain.d8);
 
-            let emull = selector_polynomial(GateType::EndoMul, &gates, &domain, &domain.d8);
+            let emul_selector8 =
+                selector_polynomial(GateType::EndoMul, &gates, &domain, &domain.d8);
 
-            let endomul_scalar8 =
+            let endomul_scalar_selector8 =
                 selector_polynomial(GateType::EndoMulScalar, &gates, &domain, &domain.d8);
 
-            let generic4 = genericm.evaluate_over_domain_by_ref(domain.d4);
+            let generic_selector4 = genericm.evaluate_over_domain_by_ref(domain.d4);
 
             // chacha gate
-            let chacha8 = {
+            let chacha_selectors8 = {
                 if !feature_flags.chacha {
                     None
                 } else {
@@ -579,7 +582,7 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
             };
 
             // Range check constraint selector polynomials
-            let range_check_selector_polys = {
+            let range_check_selectors8 = {
                 if !feature_flags.range_check {
                     None
                 } else {
@@ -591,7 +594,7 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
             };
 
             // Foreign field addition constraint selector polynomial
-            let foreign_field_add_selector_poly = {
+            let foreign_field_add_selector8 = {
                 if !feature_flags.foreign_field_add {
                     None
                 } else {
@@ -604,7 +607,7 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
                 }
             };
 
-            let xor_selector_poly = {
+            let xor_selector8 = {
                 if !feature_flags.xor {
                     None
                 } else {
@@ -620,18 +623,18 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
                 array::from_fn(|i| coefficientsm[i].evaluate_over_domain_by_ref(domain.d8));
 
             ColumnEvaluations {
-                permutation_coefficients8: sigmal8,
-                coefficients8: coefficients8,
-                generic_selector4: generic4,
-                poseidon_selector8: ps8,
-                complete_add_selector4: complete_addl4,
-                mul_selector8: mull8,
-                emul_selector8: emull,
-                chacha_selectors8: chacha8,
-                endomul_scalar_selector8: endomul_scalar8,
-                range_check_selectors8: range_check_selector_polys,
-                foreign_field_add_selector8: foreign_field_add_selector_poly,
-                xor_selector8: xor_selector_poly,
+                permutation_coefficients8,
+                coefficients8,
+                generic_selector4,
+                poseidon_selector8,
+                complete_add_selector4,
+                mul_selector8,
+                emul_selector8,
+                chacha_selectors8,
+                endomul_scalar_selector8,
+                range_check_selectors8,
+                foreign_field_add_selector8,
+                xor_selector8,
             }
         };
 

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -496,17 +496,18 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
                 ]
             };
 
-            let sigmam: [DP<F>; PERMUTS] = array::from_fn(|i| sigmal1[i].clone().interpolate());
+            let permutation_coefficients: [DP<F>; PERMUTS] =
+                array::from_fn(|i| sigmal1[i].clone().interpolate());
 
             // poseidon gate
-            let psm = E::<F, D<F>>::from_vec_and_domain(
+            let poseidon_selector = E::<F, D<F>>::from_vec_and_domain(
                 gates.iter().map(|gate| gate.ps()).collect(),
                 domain.d1,
             )
             .interpolate();
 
             // double generic gate
-            let genericm = E::<F, D<F>>::from_vec_and_domain(
+            let generic_selector = E::<F, D<F>>::from_vec_and_domain(
                 gates
                     .iter()
                     .map(|gate| {
@@ -522,7 +523,7 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
             .interpolate();
 
             // coefficient polynomial
-            let coefficientsm: [_; COLUMNS] = array::from_fn(|i| {
+            let coefficients: [_; COLUMNS] = array::from_fn(|i| {
                 let padded = gates
                     .iter()
                     .map(|gate| gate.coeffs.get(i).cloned().unwrap_or_else(F::zero))
@@ -532,10 +533,10 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
             });
 
             EvaluatedColumnCoefficients {
-                permutation_coefficients: sigmam,
-                coefficients: coefficientsm,
-                generic_selector: genericm,
-                poseidon_selector: psm,
+                permutation_coefficients,
+                coefficients,
+                generic_selector,
+                poseidon_selector,
             }
         };
 

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -617,6 +617,21 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
         let coefficients8 =
             array::from_fn(|i| coefficientsm[i].evaluate_over_domain_by_ref(domain.d8));
 
+        let column_evaluations = ColumnEvaluations {
+            permutation_coefficients8: sigmal8,
+            coefficients8: coefficients8,
+            generic_selector4: generic4,
+            poseidon_selector8: ps8,
+            complete_add_selector4: complete_addl4,
+            mul_selector8: mull8,
+            emul_selector8: emull,
+            chacha_selectors8: chacha8,
+            endomul_scalar_selector8: endomul_scalar8,
+            range_check_selectors8: range_check_selector_polys,
+            foreign_field_add_selector8: foreign_field_add_selector_poly,
+            xor_selector8: xor_selector_poly,
+        };
+
         //
         // Lookup
         // ------
@@ -653,20 +668,7 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
                 generic_selector: genericm,
                 poseidon_selector: psm,
             },
-            column_evaluations: ColumnEvaluations {
-                permutation_coefficients8: sigmal8,
-                coefficients8: coefficients8,
-                generic_selector4: generic4,
-                poseidon_selector8: ps8,
-                complete_add_selector4: complete_addl4,
-                mul_selector8: mull8,
-                emul_selector8: emull,
-                chacha_selectors8: chacha8,
-                endomul_scalar_selector8: endomul_scalar8,
-                range_check_selectors8: range_check_selector_polys,
-                foreign_field_add_selector8: foreign_field_add_selector_poly,
-                xor_selector8: xor_selector_poly,
-            },
+            column_evaluations,
         };
 
         match self.precomputations {

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -2480,11 +2480,14 @@ pub mod test {
             wires::Wire,
         },
         curve::KimchiCurve,
+        prover_index::ProverIndex,
     };
     use ark_ff::UniformRand;
-    use mina_curves::pasta::{Fp, Vesta};
+    use commitment_dlog::srs::{endos, SRS};
+    use mina_curves::pasta::{Fp, Pallas, Vesta};
     use rand::{prelude::StdRng, SeedableRng};
     use std::array;
+    use std::sync::Arc;
 
     #[test]
     #[should_panic]
@@ -2523,11 +2526,19 @@ pub mod test {
             GenericGateSpec::Const(1u32.into()),
             None,
         ));
-        let constraint_system = ConstraintSystem::fp_for_testing(gates);
+        let index = {
+            let constraint_system = ConstraintSystem::fp_for_testing(gates);
+            let mut srs = SRS::<Vesta>::create(constraint_system.domain.d1.size());
+            srs.add_lagrange_basis(constraint_system.domain.d1);
+            let srs = Arc::new(srs);
+
+            let (endo_q, _endo_r) = endos::<Pallas>();
+            ProverIndex::<Vesta>::create(constraint_system, endo_q, srs)
+        };
 
         let witness_cols: [_; COLUMNS] = array::from_fn(|_| DensePolynomial::zero());
         let permutation = DensePolynomial::zero();
-        let domain_evals = constraint_system.evaluate(&witness_cols, &permutation);
+        let domain_evals = index.cs.evaluate(&witness_cols, &permutation);
 
         let env = Environment {
             constants: Constants {
@@ -2540,11 +2551,11 @@ pub mod test {
                 foreign_field_modulus: None,
             },
             witness: &domain_evals.d8.this.w,
-            coefficient: &constraint_system.column_evaluations.coefficients8,
-            vanishes_on_last_4_rows: &constraint_system.precomputations().vanishes_on_last_4_rows,
+            coefficient: &index.column_evaluations.coefficients8,
+            vanishes_on_last_4_rows: &index.cs.precomputations().vanishes_on_last_4_rows,
             z: &domain_evals.d8.this.z,
-            l0_1: l0_1(constraint_system.domain.d1),
-            domain: constraint_system.domain,
+            l0_1: l0_1(index.cs.domain.d1),
+            domain: index.cs.domain,
             index: HashMap::new(),
             lookup: None,
         };

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -11,6 +11,7 @@ use crate::{
         wires::*,
     },
     curve::KimchiCurve,
+    prover_index::ProverIndex,
 };
 use ark_ff::{bytes::ToBytes, PrimeField};
 use num_traits::cast::ToPrimitive;
@@ -208,7 +209,7 @@ impl<F: PrimeField> CircuitGate<F> {
         &self,
         row: usize,
         witness: &[Vec<F>; COLUMNS],
-        cs: &ConstraintSystem<F>,
+        index: &ProverIndex<G>,
         public: &[F],
     ) -> Result<(), String> {
         use GateType::*;
@@ -218,23 +219,23 @@ impl<F: PrimeField> CircuitGate<F> {
             Poseidon => self.verify_poseidon::<G>(row, witness),
             CompleteAdd => self.verify_complete_add(row, witness),
             VarBaseMul => self.verify_vbmul(row, witness),
-            EndoMul => self.verify_endomul::<G>(row, witness, cs),
-            EndoMulScalar => self.verify_endomul_scalar::<G>(row, witness, cs),
+            EndoMul => self.verify_endomul::<G>(row, witness, &index.cs),
+            EndoMulScalar => self.verify_endomul_scalar::<G>(row, witness, &index.cs),
             // TODO: implement the verification for chacha
             ChaCha0 | ChaCha1 | ChaCha2 | ChaChaFinal => Ok(()),
             // TODO: implement the verification for the lookup gate
             Lookup => Ok(()),
             CairoClaim | CairoInstruction | CairoFlags | CairoTransition => {
-                self.verify_cairo_gate::<G>(row, witness, cs)
+                self.verify_cairo_gate::<G>(row, witness, &index.cs)
             }
             RangeCheck0 | RangeCheck1 => self
-                .verify_range_check::<G>(row, witness, cs)
+                .verify_range_check::<G>(row, witness, index)
                 .map_err(|e| e.to_string()),
             Xor16 => self
-                .verify_xor::<G>(row, witness, cs)
+                .verify_xor::<G>(row, witness, index)
                 .map_err(|e| e.to_string()),
             ForeignFieldAdd => self
-                .verify_foreign_field_add::<G>(row, witness, cs)
+                .verify_foreign_field_add::<G>(row, witness, index)
                 .map_err(|e| e.to_string()),
         }
     }

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -13,7 +13,7 @@ use crate::{
     curve::KimchiCurve,
     prover_index::ProverIndex,
 };
-use ark_ff::{bytes::ToBytes, PrimeField};
+use ark_ff::{bytes::ToBytes, PrimeField, SquareRootField};
 use num_traits::cast::ToPrimitive;
 use o1_utils::hasher::CryptoDigest;
 use serde::{Deserialize, Serialize};
@@ -193,7 +193,7 @@ impl<F: PrimeField> ToBytes for CircuitGate<F> {
     }
 }
 
-impl<F: PrimeField> CircuitGate<F> {
+impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     /// this function creates "empty" circuit gate
     pub fn zero(wires: GateWires) -> Self {
         CircuitGate::new(GateType::Zero, wires, vec![])

--- a/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
@@ -25,6 +25,7 @@ use crate::{
         wires::Wire,
     },
     curve::KimchiCurve,
+    prover_index::ProverIndex,
 };
 
 use super::circuitgates::ForeignFieldAdd;
@@ -150,14 +151,15 @@ impl<F: PrimeField> CircuitGate<F> {
         &self,
         _: usize,
         witness: &[Vec<F>; COLUMNS],
-        cs: &ConstraintSystem<F>,
+        index: &ProverIndex<G>,
     ) -> CircuitGateResult<()> {
         if !circuit_gates().contains(&self.typ) {
             return Err(CircuitGateError::InvalidCircuitGateType(self.typ));
         }
 
         // Pad the witness to domain d1 size
-        let padding_length = cs
+        let padding_length = index
+            .cs
             .domain
             .d1
             .size
@@ -170,7 +172,7 @@ impl<F: PrimeField> CircuitGate<F> {
 
         // Compute witness polynomial
         let witness_poly: [DensePolynomial<F>; COLUMNS] = array::from_fn(|i| {
-            Evaluations::<F, D<F>>::from_vec_and_domain(witness[i].clone(), cs.domain.d1)
+            Evaluations::<F, D<F>>::from_vec_and_domain(witness[i].clone(), index.cs.domain.d1)
                 .interpolate()
         });
 
@@ -178,31 +180,33 @@ impl<F: PrimeField> CircuitGate<F> {
         let rng = &mut StdRng::from_seed([0u8; 32]);
         let beta = F::rand(rng);
         let gamma = F::rand(rng);
-        let z_poly = cs
+        let z_poly = index
             .perm_aggreg(&witness, &beta, &gamma, rng)
             .map_err(|_| CircuitGateError::InvalidCopyConstraint(self.typ))?;
 
         // Compute witness polynomial evaluations
-        let witness_evals = cs.evaluate(&witness_poly, &z_poly);
+        let witness_evals = index.cs.evaluate(&witness_poly, &z_poly);
 
         let mut index_evals = HashMap::new();
         index_evals.insert(
             self.typ,
-            cs.column_evaluations
+            index
+                .column_evaluations
                 .foreign_field_add_selector8
                 .as_ref()
                 .unwrap(),
         );
 
         // Set up lookup environment
-        let lcs = cs
+        let lcs = index
+            .cs
             .lookup_constraint_system
             .as_ref()
             .ok_or(CircuitGateError::MissingLookupConstraintSystem(self.typ))?;
 
         let lookup_env_data = set_up_lookup_env_data(
             self.typ,
-            cs,
+            &index.cs,
             &witness,
             &beta,
             &gamma,
@@ -225,16 +229,16 @@ impl<F: PrimeField> CircuitGate<F> {
                     beta: F::rand(rng),
                     gamma: F::rand(rng),
                     joint_combiner: Some(F::rand(rng)),
-                    endo_coefficient: cs.endo,
+                    endo_coefficient: index.cs.endo,
                     mds: &G::sponge_params().mds,
-                    foreign_field_modulus: cs.foreign_field_modulus.clone(),
+                    foreign_field_modulus: index.cs.foreign_field_modulus.clone(),
                 },
                 witness: &witness_evals.d8.this.w,
-                coefficient: &cs.column_evaluations.coefficients8,
-                vanishes_on_last_4_rows: &cs.precomputations().vanishes_on_last_4_rows,
+                coefficient: &index.column_evaluations.coefficients8,
+                vanishes_on_last_4_rows: &index.cs.precomputations().vanishes_on_last_4_rows,
                 z: &witness_evals.d8.this.z,
-                l0_1: l0_1(cs.domain.d1),
-                domain: cs.domain,
+                l0_1: l0_1(index.cs.domain.d1),
+                domain: index.cs.domain,
                 index: index_evals,
                 lookup: lookup_env,
             }
@@ -254,7 +258,7 @@ impl<F: PrimeField> CircuitGate<F> {
         if constraints
             .evaluations(&env)
             .interpolate()
-            .divide_by_vanishing_poly(cs.domain.d1)
+            .divide_by_vanishing_poly(index.cs.domain.d1)
             .unwrap()
             .1
             .is_zero()

--- a/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use ark_ff::{PrimeField, Zero};
+use ark_ff::{PrimeField, SquareRootField, Zero};
 use ark_poly::{
     univariate::DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as D,
 };
@@ -33,7 +33,7 @@ use super::circuitgates::ForeignFieldAdd;
 /// Number of gates used by the foreign field addition gadget
 pub const GATE_COUNT: usize = 1;
 
-impl<F: PrimeField> CircuitGate<F> {
+impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     /// Outputs next row
     fn append_multi_range_check_rows(next_row: &mut usize, gates: &mut Vec<CircuitGate<F>>) {
         let (subsequent_row, mut range_check_circuit_gates) =

--- a/kimchi/src/circuits/polynomials/generic.rs
+++ b/kimchi/src/circuits/polynomials/generic.rs
@@ -35,12 +35,12 @@
 
 use crate::circuits::{
     argument::{Argument, ArgumentEnv, ArgumentType},
-    constraints::ConstraintSystem,
     expr::constraints::ExprOps,
     gate::{CircuitGate, GateType},
     polynomial::COLUMNS,
     wires::GateWires,
 };
+use crate::{curve::KimchiCurve, prover_index::ProverIndex};
 use ark_ff::{FftField, PrimeField, Zero};
 use ark_poly::univariate::DensePolynomial;
 use std::array;
@@ -277,7 +277,7 @@ pub mod testing {
         }
     }
 
-    impl<F: PrimeField> ConstraintSystem<F> {
+    impl<F: PrimeField, G: KimchiCurve<ScalarField = F>> ProverIndex<G> {
         /// Function to verify the generic polynomials with a witness.
         pub fn verify_generic(
             &self,
@@ -313,10 +313,10 @@ pub mod testing {
             res += public;
 
             // selector poly
-            res = &res * &self.evaluated_column_coefficients.generic_selector;
+            res = &res * &self.cs.evaluated_column_coefficients.generic_selector;
 
             // verify that it is divisible by Z_H
-            match res.divide_by_vanishing_poly(self.domain.d1) {
+            match res.divide_by_vanishing_poly(self.cs.domain.d1) {
                 Some((_quotient, rest)) => rest.is_zero(),
                 None => false,
             }

--- a/kimchi/src/circuits/polynomials/generic.rs
+++ b/kimchi/src/circuits/polynomials/generic.rs
@@ -313,7 +313,7 @@ pub mod testing {
             res += public;
 
             // selector poly
-            res = &res * &self.cs.evaluated_column_coefficients.generic_selector;
+            res = &res * &self.evaluated_column_coefficients.generic_selector;
 
             // verify that it is divisible by Z_H
             match res.divide_by_vanishing_poly(self.cs.domain.d1) {

--- a/kimchi/src/circuits/polynomials/permutation.rs
+++ b/kimchi/src/circuits/polynomials/permutation.rs
@@ -339,10 +339,7 @@ impl<F: PrimeField, G: KimchiCurve<ScalarField = F>> ProverIndex<G> {
         //~
         let zkpm_zeta = self.cs.precomputations().zkpm.evaluate(&zeta);
         let scalar = ConstraintSystem::<F>::perm_scalars(e, beta, gamma, alphas, zkpm_zeta);
-        self.cs
-            .evaluated_column_coefficients
-            .permutation_coefficients[PERMUTS - 1]
-            .scale(scalar)
+        self.evaluated_column_coefficients.permutation_coefficients[PERMUTS - 1].scale(scalar)
     }
 
     /// permutation aggregation polynomial computation

--- a/kimchi/src/circuits/polynomials/permutation.rs
+++ b/kimchi/src/circuits/polynomials/permutation.rs
@@ -46,8 +46,10 @@ use crate::{
         polynomial::WitnessOverDomains,
         wires::{Wire, COLUMNS, PERMUTS},
     },
+    curve::KimchiCurve,
     error::ProverError,
     proof::ProofEvaluations,
+    prover_index::ProverIndex,
 };
 use ark_ff::{FftField, PrimeField, SquareRootField, Zero};
 use ark_poly::{
@@ -190,7 +192,7 @@ where
     }
 }
 
-impl<F: PrimeField> ConstraintSystem<F> {
+impl<F: PrimeField, G: KimchiCurve<ScalarField = F>> ProverIndex<G> {
     /// permutation quotient poly contribution computation
     ///
     /// # Errors
@@ -214,7 +216,7 @@ impl<F: PrimeField> ConstraintSystem<F> {
         let alpha2 = alphas.next().expect("missing power of alpha");
 
         // constant gamma in evaluation form (in domain d8)
-        let gamma = &self.precomputations().constant_1_d8.scale(gamma);
+        let gamma = &self.cs.precomputations().constant_1_d8.scale(gamma);
 
         //~ The quotient contribution of the permutation is split into two parts $perm$ and $bnd$.
         //~ They will be used by the prover.
@@ -251,9 +253,9 @@ impl<F: PrimeField> ConstraintSystem<F> {
             // (w[6](x) + gamma + x * beta * shift[6])
             // in evaluation form in d8
             let mut shifts = lagrange.d8.this.z.clone();
-            for (witness, shift) in lagrange.d8.this.w.iter().zip(self.shift.iter()) {
+            for (witness, shift) in lagrange.d8.this.w.iter().zip(self.cs.shift.iter()) {
                 let term =
-                    &(witness + gamma) + &self.precomputations().poly_x_d1.scale(beta * shift);
+                    &(witness + gamma) + &self.cs.precomputations().poly_x_d1.scale(beta * shift);
                 shifts = &shifts * &term;
             }
 
@@ -274,7 +276,7 @@ impl<F: PrimeField> ConstraintSystem<F> {
                 sigmas = &sigmas * &term;
             }
 
-            &(&shifts - &sigmas).scale(alpha0) * &self.precomputations().zkpl
+            &(&shifts - &sigmas).scale(alpha0) * &self.cs.precomputations().zkpl
         };
 
         //~ and `bnd`:
@@ -302,7 +304,7 @@ impl<F: PrimeField> ConstraintSystem<F> {
 
             // accumulator end := (z(x) - 1) / (x - sid[n-3])
             let denominator = DensePolynomial::from_coefficients_slice(&[
-                -self.sid[self.domain.d1.size() - 3],
+                -self.cs.sid[self.cs.domain.d1.size() - 3],
                 F::one(),
             ]);
             let (bnd2, res) = DenseOrSparsePolynomial::divide_with_q_and_r(
@@ -335,50 +337,12 @@ impl<F: PrimeField> ConstraintSystem<F> {
         //~
         //~ $\text{scalar} \cdot \sigma_6(x)$
         //~
-        let zkpm_zeta = self.precomputations().zkpm.evaluate(&zeta);
-        let scalar = Self::perm_scalars(e, beta, gamma, alphas, zkpm_zeta);
-        self.evaluated_column_coefficients.permutation_coefficients[PERMUTS - 1].scale(scalar)
-    }
-
-    pub fn perm_scalars(
-        e: &[ProofEvaluations<F>],
-        beta: F,
-        gamma: F,
-        mut alphas: impl Iterator<Item = F>,
-        zkp_zeta: F,
-    ) -> F {
-        let alpha0 = alphas
-            .next()
-            .expect("not enough powers of alpha for permutation");
-        let _alpha1 = alphas
-            .next()
-            .expect("not enough powers of alpha for permutation");
-        let _alpha2 = alphas
-            .next()
-            .expect("not enough powers of alpha for permutation");
-
-        //~ where $\text{scalar}$ is computed as:
-        //~
-        //~ $$
-        //~ \begin{align}
-        //~ z(\zeta \omega) \beta \alpha^{PERM0} zkpl(\zeta) \cdot \\
-        //~ (\gamma + \beta \sigma_0(\zeta) + w_0(\zeta)) \cdot \\
-        //~ (\gamma + \beta \sigma_1(\zeta) + w_1(\zeta)) \cdot \\
-        //~ (\gamma + \beta \sigma_2(\zeta) + w_2(\zeta)) \cdot \\
-        //~ (\gamma + \beta \sigma_3(\zeta) + w_3(\zeta)) \cdot \\
-        //~ (\gamma + \beta \sigma_4(\zeta) + w_4(\zeta)) \cdot \\
-        //~ (\gamma + \beta \sigma_5(\zeta) + w_5(\zeta)) \cdot \\
-        //~ \end{align}
-        //~$$
-        //~
-        let init = e[1].z * beta * alpha0 * zkp_zeta;
-        let res = e[0]
-            .w
-            .iter()
-            .zip(e[0].s.iter())
-            .map(|(w, s)| gamma + (beta * s) + w)
-            .fold(init, |x, y| x * y);
-        -res
+        let zkpm_zeta = self.cs.precomputations().zkpm.evaluate(&zeta);
+        let scalar = ConstraintSystem::<F>::perm_scalars(e, beta, gamma, alphas, zkpm_zeta);
+        self.cs
+            .evaluated_column_coefficients
+            .permutation_coefficients[PERMUTS - 1]
+            .scale(scalar)
     }
 
     /// permutation aggregation polynomial computation
@@ -397,10 +361,10 @@ impl<F: PrimeField> ConstraintSystem<F> {
         gamma: &F,
         rng: &mut (impl RngCore + CryptoRng),
     ) -> Result<DensePolynomial<F>, ProverError> {
-        let n = self.domain.d1.size();
+        let n = self.cs.domain.d1.size();
 
         // only works if first element is 1
-        assert_eq!(self.domain.d1.elements().next(), Some(F::one()));
+        assert_eq!(self.cs.domain.d1.elements().next(), Some(F::one()));
 
         //~ To compute the permutation aggregation polynomial,
         //~ the prover interpolates the polynomial that has the following evaluations.
@@ -458,8 +422,8 @@ impl<F: PrimeField> ConstraintSystem<F> {
             let x = z[j];
             z[j + 1] *= witness
                 .iter()
-                .zip(self.shift.iter())
-                .map(|(w, s)| w[j] + (self.sid[j] * beta * s) + gamma)
+                .zip(self.cs.shift.iter())
+                .map(|(w, s)| w[j] + (self.cs.sid[j] * beta * s) + gamma)
                 .fold(x, |z, y| z * y);
         }
 
@@ -474,7 +438,50 @@ impl<F: PrimeField> ConstraintSystem<F> {
         z[n - 2] = F::rand(rng);
         z[n - 1] = F::rand(rng);
 
-        let res = Evaluations::<F, D<F>>::from_vec_and_domain(z, self.domain.d1).interpolate();
+        let res = Evaluations::<F, D<F>>::from_vec_and_domain(z, self.cs.domain.d1).interpolate();
         Ok(res)
+    }
+}
+
+impl<F: PrimeField> ConstraintSystem<F> {
+    pub fn perm_scalars(
+        e: &[ProofEvaluations<F>],
+        beta: F,
+        gamma: F,
+        mut alphas: impl Iterator<Item = F>,
+        zkp_zeta: F,
+    ) -> F {
+        let alpha0 = alphas
+            .next()
+            .expect("not enough powers of alpha for permutation");
+        let _alpha1 = alphas
+            .next()
+            .expect("not enough powers of alpha for permutation");
+        let _alpha2 = alphas
+            .next()
+            .expect("not enough powers of alpha for permutation");
+
+        //~ where $\text{scalar}$ is computed as:
+        //~
+        //~ $$
+        //~ \begin{align}
+        //~ z(\zeta \omega) \beta \alpha^{PERM0} zkpl(\zeta) \cdot \\
+        //~ (\gamma + \beta \sigma_0(\zeta) + w_0(\zeta)) \cdot \\
+        //~ (\gamma + \beta \sigma_1(\zeta) + w_1(\zeta)) \cdot \\
+        //~ (\gamma + \beta \sigma_2(\zeta) + w_2(\zeta)) \cdot \\
+        //~ (\gamma + \beta \sigma_3(\zeta) + w_3(\zeta)) \cdot \\
+        //~ (\gamma + \beta \sigma_4(\zeta) + w_4(\zeta)) \cdot \\
+        //~ (\gamma + \beta \sigma_5(\zeta) + w_5(\zeta)) \cdot \\
+        //~ \end{align}
+        //~$$
+        //~
+        let init = e[1].z * beta * alpha0 * zkp_zeta;
+        let res = e[0]
+            .w
+            .iter()
+            .zip(e[0].s.iter())
+            .map(|(w, s)| gamma + (beta * s) + w)
+            .fold(init, |x, y| x * y);
+        -res
     }
 }

--- a/kimchi/src/circuits/polynomials/poseidon.rs
+++ b/kimchi/src/circuits/polynomials/poseidon.rs
@@ -35,7 +35,7 @@ use crate::{
     },
     curve::KimchiCurve,
 };
-use ark_ff::{Field, PrimeField};
+use ark_ff::{Field, PrimeField, SquareRootField};
 use mina_poseidon::{
     constants::{PlonkSpongeConstantsKimchi, SpongeConstants},
     poseidon::{sbox, ArithmeticSponge, ArithmeticSpongeParams, Sponge},
@@ -77,7 +77,7 @@ pub const fn round_to_cols(i: usize) -> Range<usize> {
     start..(start + SPONGE_WIDTH)
 }
 
-impl<F: PrimeField> CircuitGate<F> {
+impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     pub fn create_poseidon(
         wires: GateWires,
         // Coefficients are passed in in the logical order

--- a/kimchi/src/circuits/polynomials/range_check/gadget.rs
+++ b/kimchi/src/circuits/polynomials/range_check/gadget.rs
@@ -24,6 +24,7 @@ use crate::{
         wires::Wire,
     },
     curve::KimchiCurve,
+    prover_index::ProverIndex,
 };
 
 use super::circuitgates::{RangeCheck0, RangeCheck1};
@@ -88,14 +89,15 @@ impl<F: PrimeField> CircuitGate<F> {
         &self,
         _: usize,
         witness: &[Vec<F>; COLUMNS],
-        cs: &ConstraintSystem<G::ScalarField>,
+        index: &ProverIndex<G>,
     ) -> CircuitGateResult<()> {
         if !circuit_gates().contains(&self.typ) {
             return Err(CircuitGateError::InvalidCircuitGateType(self.typ));
         }
 
         // Pad the witness to domain d1 size
-        let padding_length = cs
+        let padding_length = index
+            .cs
             .domain
             .d1
             .size
@@ -108,7 +110,7 @@ impl<F: PrimeField> CircuitGate<F> {
 
         // Compute witness polynomial
         let witness_poly: [DensePolynomial<F>; COLUMNS] = array::from_fn(|i| {
-            Evaluations::<F, D<F>>::from_vec_and_domain(witness[i].clone(), cs.domain.d1)
+            Evaluations::<F, D<F>>::from_vec_and_domain(witness[i].clone(), index.cs.domain.d1)
                 .interpolate()
         });
 
@@ -116,31 +118,33 @@ impl<F: PrimeField> CircuitGate<F> {
         let rng = &mut StdRng::from_seed([0u8; 32]);
         let beta = F::rand(rng);
         let gamma = F::rand(rng);
-        let z_poly = cs
+        let z_poly = index
             .perm_aggreg(&witness, &beta, &gamma, rng)
             .map_err(|_| CircuitGateError::InvalidCopyConstraint(self.typ))?;
 
         // Compute witness polynomial evaluations
-        let witness_evals = cs.evaluate(&witness_poly, &z_poly);
+        let witness_evals = index.cs.evaluate(&witness_poly, &z_poly);
 
         let mut index_evals = HashMap::new();
         index_evals.insert(
             self.typ,
-            &cs.column_evaluations
+            &index
+                .column_evaluations
                 .range_check_selectors8
                 .as_ref()
                 .unwrap()[circuit_gate_selector_index(self.typ)],
         );
 
         // Set up lookup environment
-        let lcs = cs
+        let lcs = index
+            .cs
             .lookup_constraint_system
             .as_ref()
             .ok_or(CircuitGateError::MissingLookupConstraintSystem(self.typ))?;
 
         let lookup_env_data = set_up_lookup_env_data(
             self.typ,
-            cs,
+            &index.cs,
             &witness,
             &beta,
             &gamma,
@@ -163,16 +167,16 @@ impl<F: PrimeField> CircuitGate<F> {
                     beta: F::rand(rng),
                     gamma: F::rand(rng),
                     joint_combiner: Some(F::rand(rng)),
-                    endo_coefficient: cs.endo,
+                    endo_coefficient: index.cs.endo,
                     mds: &G::sponge_params().mds,
                     foreign_field_modulus: None,
                 },
                 witness: &witness_evals.d8.this.w,
-                coefficient: &cs.column_evaluations.coefficients8,
-                vanishes_on_last_4_rows: &cs.precomputations().vanishes_on_last_4_rows,
+                coefficient: &index.column_evaluations.coefficients8,
+                vanishes_on_last_4_rows: &index.cs.precomputations().vanishes_on_last_4_rows,
                 z: &witness_evals.d8.this.z,
-                l0_1: l0_1(cs.domain.d1),
-                domain: cs.domain,
+                l0_1: l0_1(index.cs.domain.d1),
+                domain: index.cs.domain,
                 index: index_evals,
                 lookup: lookup_env,
             }
@@ -192,7 +196,7 @@ impl<F: PrimeField> CircuitGate<F> {
         if constraints
             .evaluations(&env)
             .interpolate()
-            .divide_by_vanishing_poly(cs.domain.d1)
+            .divide_by_vanishing_poly(index.cs.domain.d1)
             .unwrap()
             .1
             .is_zero()

--- a/kimchi/src/circuits/polynomials/range_check/gadget.rs
+++ b/kimchi/src/circuits/polynomials/range_check/gadget.rs
@@ -1,6 +1,6 @@
 //! Range check gate
 
-use ark_ff::{FftField, PrimeField, Zero};
+use ark_ff::{FftField, PrimeField, SquareRootField, Zero};
 use ark_poly::{
     univariate::DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as D,
 };
@@ -31,7 +31,7 @@ use super::circuitgates::{RangeCheck0, RangeCheck1};
 
 pub const GATE_COUNT: usize = 2;
 
-impl<F: PrimeField> CircuitGate<F> {
+impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     /// Create range check gate for constraining three 88-bit values.
     ///     Inputs the starting row
     ///     Outputs tuple (`next_row`, `circuit_gates`) where

--- a/kimchi/src/circuits/polynomials/turshi.rs
+++ b/kimchi/src/circuits/polynomials/turshi.rs
@@ -90,7 +90,7 @@ use crate::{
     curve::KimchiCurve,
     proof::ProofEvaluations,
 };
-use ark_ff::{FftField, Field, PrimeField};
+use ark_ff::{FftField, Field, PrimeField, SquareRootField};
 use rand::{prelude::StdRng, SeedableRng};
 use std::array;
 use std::marker::PhantomData;
@@ -104,7 +104,7 @@ pub const CIRCUIT_GATE_COUNT: usize = 4;
 
 // GATE-RELATED
 
-impl<F: PrimeField> CircuitGate<F> {
+impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     /// This function creates a `CairoClaim` gate
     pub fn create_cairo_claim(wires: GateWires) -> Self {
         CircuitGate::new(GateType::CairoClaim, wires, vec![])

--- a/kimchi/src/circuits/polynomials/xor.rs
+++ b/kimchi/src/circuits/polynomials/xor.rs
@@ -21,7 +21,7 @@ use crate::{
     prover_index::ProverIndex,
     variable_map,
 };
-use ark_ff::{PrimeField, Zero};
+use ark_ff::{PrimeField, SquareRootField, Zero};
 use ark_poly::{
     univariate::DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as D,
 };
@@ -30,7 +30,7 @@ use std::{array, collections::HashMap, marker::PhantomData};
 
 pub const GATE_COUNT: usize = 1;
 
-impl<F: PrimeField> CircuitGate<F> {
+impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     /// Creates a XOR gadget for `bits` length
     /// Includes:
     /// - num_xors Xor16 gates

--- a/kimchi/src/circuits/polynomials/xor.rs
+++ b/kimchi/src/circuits/polynomials/xor.rs
@@ -18,6 +18,7 @@ use crate::{
         witness::{self, ConstantCell, CopyBitsCell, CrumbCell, Variables, WitnessCell},
     },
     curve::KimchiCurve,
+    prover_index::ProverIndex,
     variable_map,
 };
 use ark_ff::{PrimeField, Zero};
@@ -64,14 +65,15 @@ impl<F: PrimeField> CircuitGate<F> {
         &self,
         _: usize,
         witness: &[Vec<F>; COLUMNS],
-        cs: &ConstraintSystem<F>,
+        index: &ProverIndex<G>,
     ) -> CircuitGateResult<()> {
         if !circuit_gates().contains(&self.typ) {
             return Err(CircuitGateError::InvalidCircuitGateType(self.typ));
         }
 
         // Pad the witness to domain d1 size
-        let padding_length = cs
+        let padding_length = index
+            .cs
             .domain
             .d1
             .size
@@ -84,7 +86,7 @@ impl<F: PrimeField> CircuitGate<F> {
 
         // Compute witness polynomial
         let witness_poly: [DensePolynomial<F>; COLUMNS] = array::from_fn(|i| {
-            Evaluations::<F, D<F>>::from_vec_and_domain(witness[i].clone(), cs.domain.d1)
+            Evaluations::<F, D<F>>::from_vec_and_domain(witness[i].clone(), index.cs.domain.d1)
                 .interpolate()
         });
 
@@ -92,28 +94,29 @@ impl<F: PrimeField> CircuitGate<F> {
         let rng = &mut StdRng::from_seed([0u8; 32]);
         let beta = F::rand(rng);
         let gamma = F::rand(rng);
-        let z_poly = cs
+        let z_poly = index
             .perm_aggreg(&witness, &beta, &gamma, rng)
             .map_err(|_| CircuitGateError::InvalidCopyConstraint(self.typ))?;
 
         // Compute witness polynomial evaluations
-        let witness_evals = cs.evaluate(&witness_poly, &z_poly);
+        let witness_evals = index.cs.evaluate(&witness_poly, &z_poly);
 
         let mut index_evals = HashMap::new();
         index_evals.insert(
             self.typ,
-            cs.column_evaluations.xor_selector8.as_ref().unwrap(),
+            index.column_evaluations.xor_selector8.as_ref().unwrap(),
         );
 
         // Set up lookup environment
-        let lcs = cs
+        let lcs = index
+            .cs
             .lookup_constraint_system
             .as_ref()
             .ok_or(CircuitGateError::MissingLookupConstraintSystem(self.typ))?;
 
         let lookup_env_data = set_up_lookup_env_data(
             self.typ,
-            cs,
+            &index.cs,
             &witness,
             &beta,
             &gamma,
@@ -136,16 +139,16 @@ impl<F: PrimeField> CircuitGate<F> {
                     beta: F::rand(rng),
                     gamma: F::rand(rng),
                     joint_combiner: Some(F::rand(rng)),
-                    endo_coefficient: cs.endo,
+                    endo_coefficient: index.cs.endo,
                     mds: &G::sponge_params().mds,
                     foreign_field_modulus: None,
                 },
                 witness: &witness_evals.d8.this.w,
-                coefficient: &cs.column_evaluations.coefficients8,
-                vanishes_on_last_4_rows: &cs.precomputations().vanishes_on_last_4_rows,
+                coefficient: &index.column_evaluations.coefficients8,
+                vanishes_on_last_4_rows: &index.cs.precomputations().vanishes_on_last_4_rows,
                 z: &witness_evals.d8.this.z,
-                l0_1: l0_1(cs.domain.d1),
-                domain: cs.domain,
+                l0_1: l0_1(index.cs.domain.d1),
+                domain: index.cs.domain,
                 index: index_evals,
                 lookup: lookup_env,
             }
@@ -165,7 +168,7 @@ impl<F: PrimeField> CircuitGate<F> {
         if constraints
             .evaluations(&env)
             .interpolate()
-            .divide_by_vanishing_poly(cs.domain.d1)
+            .divide_by_vanishing_poly(index.cs.domain.d1)
             .unwrap()
             .1
             .is_zero()

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -173,10 +173,7 @@ where
         // double-check the witness
         if cfg!(debug_assertions) {
             let public = witness[0][0..index.cs.public].to_vec();
-            index
-                .cs
-                .verify::<G>(&witness, &public)
-                .expect("incorrect witness");
+            index.verify(&witness, &public).expect("incorrect witness");
         }
 
         //~ 1. Ensure we have room in the witness for the zero-knowledge rows.
@@ -562,7 +559,7 @@ where
         }
 
         //~ 1. Compute the permutation aggregation polynomial $z$.
-        let z_poly = index.cs.perm_aggreg(&witness, &beta, &gamma, rng)?;
+        let z_poly = index.perm_aggreg(&witness, &beta, &gamma, rng)?;
 
         //~ 1. Commit (hidding) to the permutation aggregation polynomial $z$.
         let z_comm = index.srs.commit(&z_poly, None, rng);
@@ -607,28 +604,28 @@ where
         let env = {
             let mut index_evals = HashMap::new();
             use GateType::*;
-            index_evals.insert(Generic, &index.cs.column_evaluations.generic_selector4);
-            index_evals.insert(Poseidon, &index.cs.column_evaluations.poseidon_selector8);
+            index_evals.insert(Generic, &index.column_evaluations.generic_selector4);
+            index_evals.insert(Poseidon, &index.column_evaluations.poseidon_selector8);
             index_evals.insert(
                 CompleteAdd,
-                &index.cs.column_evaluations.complete_add_selector4,
+                &index.column_evaluations.complete_add_selector4,
             );
-            index_evals.insert(VarBaseMul, &index.cs.column_evaluations.mul_selector8);
-            index_evals.insert(EndoMul, &index.cs.column_evaluations.emul_selector8);
+            index_evals.insert(VarBaseMul, &index.column_evaluations.mul_selector8);
+            index_evals.insert(EndoMul, &index.column_evaluations.emul_selector8);
             index_evals.insert(
                 EndoMulScalar,
-                &index.cs.column_evaluations.endomul_scalar_selector8,
+                &index.column_evaluations.endomul_scalar_selector8,
             );
             [ChaCha0, ChaCha1, ChaCha2, ChaChaFinal]
                 .iter()
                 .enumerate()
                 .for_each(|(i, g)| {
-                    if let Some(c) = &index.cs.column_evaluations.chacha_selectors8 {
+                    if let Some(c) = &index.column_evaluations.chacha_selectors8 {
                         index_evals.insert(*g, &c[i]);
                     }
                 });
 
-            if let Some(polys) = &index.cs.column_evaluations.range_check_selectors8 {
+            if let Some(polys) = &index.column_evaluations.range_check_selectors8 {
                 index_evals.extend(
                     range_check::gadget::circuit_gates()
                         .iter()
@@ -638,7 +635,6 @@ where
             }
 
             if let Some(selector) = index
-                .cs
                 .column_evaluations
                 .foreign_field_add_selector8
                 .as_ref()
@@ -651,7 +647,7 @@ where
                 );
             }
 
-            if let Some(selector) = index.cs.column_evaluations.xor_selector8.as_ref() {
+            if let Some(selector) = index.column_evaluations.xor_selector8.as_ref() {
                 index_evals.insert(GateType::Xor16, &selector);
             }
 
@@ -667,7 +663,7 @@ where
                     foreign_field_modulus: index.cs.foreign_field_modulus.clone(),
                 },
                 witness: &lagrange.d8.this.w,
-                coefficient: &index.cs.column_evaluations.coefficients8,
+                coefficient: &index.column_evaluations.coefficients8,
                 vanishes_on_last_4_rows: &index.cs.precomputations().vanishes_on_last_4_rows,
                 z: &lagrange.d8.this.z,
                 l0_1: l0_1(index.cs.domain.d1),
@@ -706,9 +702,7 @@ where
             let (mut t8, bnd) = {
                 let alphas =
                     all_alphas.get_alphas(ArgumentType::Permutation, permutation::CONSTRAINTS);
-                let (perm, bnd) = index
-                    .cs
-                    .perm_quot(&lagrange, beta, gamma, &z_poly, alphas)?;
+                let (perm, bnd) = index.perm_quot(&lagrange, beta, gamma, &z_poly, alphas)?;
 
                 check_constraint!(index, perm);
 
@@ -751,7 +745,6 @@ where
             // chacha
             {
                 if index
-                    .cs
                     .column_evaluations
                     .chacha_selectors8
                     .as_ref()
@@ -778,7 +771,7 @@ where
             }
 
             // range check gates
-            if index.cs.column_evaluations.range_check_selectors8.is_some() {
+            if index.column_evaluations.range_check_selectors8.is_some() {
                 for gate_type in range_check::gadget::circuit_gates() {
                     let range_check_constraint =
                         range_check::gadget::circuit_gate_constraints(gate_type, &all_alphas)
@@ -792,7 +785,6 @@ where
             // foreign field addition
             {
                 if index
-                    .cs
                     .column_evaluations
                     .foreign_field_add_selector8
                     .is_some()
@@ -807,7 +799,7 @@ where
 
             // xor
             {
-                if index.cs.column_evaluations.xor_selector8.is_some() {
+                if index.column_evaluations.xor_selector8.is_some() {
                     let xor = xor::combined_constraints(&all_alphas).evaluations(&env);
                     assert_eq!(xor.domain().size, t4.domain().size);
                     t4 += &xor;
@@ -1093,7 +1085,7 @@ where
                 // permutation (not part of linearization yet)
                 let alphas =
                     all_alphas.get_alphas(ArgumentType::Permutation, permutation::CONSTRAINTS);
-                let f = index.cs.perm_lnrz(evals, zeta, beta, gamma, alphas);
+                let f = index.perm_lnrz(evals, zeta, beta, gamma, alphas);
 
                 // the circuit polynomial
                 let f = {

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -954,15 +954,12 @@ where
         let chunked_evals = {
             let chunked_evals_zeta = ProofEvaluations::<Vec<G::ScalarField>> {
                 s: array::from_fn(|i| {
-                    index
-                        .cs
-                        .evaluated_column_coefficients
-                        .permutation_coefficients[0..PERMUTS - 1][i]
+                    index.evaluated_column_coefficients.permutation_coefficients[0..PERMUTS - 1][i]
                         .to_chunked_polynomial(index.max_poly_size)
                         .evaluate_chunks(zeta)
                 }),
                 coefficients: array::from_fn(|i| {
-                    index.cs.evaluated_column_coefficients.coefficients[i]
+                    index.evaluated_column_coefficients.coefficients[i]
                         .to_chunked_polynomial(index.max_poly_size)
                         .evaluate_chunks(zeta)
                 }),
@@ -979,14 +976,12 @@ where
                 lookup: lookup_context.eval_zeta.take(),
 
                 generic_selector: index
-                    .cs
                     .evaluated_column_coefficients
                     .generic_selector
                     .to_chunked_polynomial(index.max_poly_size)
                     .evaluate_chunks(zeta),
 
                 poseidon_selector: index
-                    .cs
                     .evaluated_column_coefficients
                     .poseidon_selector
                     .to_chunked_polynomial(index.max_poly_size)
@@ -994,15 +989,12 @@ where
             };
             let chunked_evals_zeta_omega = ProofEvaluations::<Vec<G::ScalarField>> {
                 s: array::from_fn(|i| {
-                    index
-                        .cs
-                        .evaluated_column_coefficients
-                        .permutation_coefficients[0..PERMUTS - 1][i]
+                    index.evaluated_column_coefficients.permutation_coefficients[0..PERMUTS - 1][i]
                         .to_chunked_polynomial(index.max_poly_size)
                         .evaluate_chunks(zeta_omega)
                 }),
                 coefficients: array::from_fn(|i| {
-                    index.cs.evaluated_column_coefficients.coefficients[i]
+                    index.evaluated_column_coefficients.coefficients[i]
                         .to_chunked_polynomial(index.max_poly_size)
                         .evaluate_chunks(zeta_omega)
                 }),
@@ -1020,14 +1012,12 @@ where
                 lookup: lookup_context.eval_zeta_omega.take(),
 
                 generic_selector: index
-                    .cs
                     .evaluated_column_coefficients
                     .generic_selector
                     .to_chunked_polynomial(index.max_poly_size)
                     .evaluate_chunks(zeta_omega),
 
                 poseidon_selector: index
-                    .cs
                     .evaluated_column_coefficients
                     .poseidon_selector
                     .to_chunked_polynomial(index.max_poly_size)
@@ -1222,12 +1212,12 @@ where
         polynomials.extend(vec![(&ft, None, blinding_ft)]);
         polynomials.extend(vec![(&z_poly, None, z_comm.blinders)]);
         polynomials.extend(vec![(
-            &index.cs.evaluated_column_coefficients.generic_selector,
+            &index.evaluated_column_coefficients.generic_selector,
             None,
             fixed_hiding(1),
         )]);
         polynomials.extend(vec![(
-            &index.cs.evaluated_column_coefficients.poseidon_selector,
+            &index.evaluated_column_coefficients.poseidon_selector,
             None,
             fixed_hiding(1),
         )]);
@@ -1240,7 +1230,6 @@ where
         );
         polynomials.extend(
             index
-                .cs
                 .evaluated_column_coefficients
                 .coefficients
                 .iter()
@@ -1248,10 +1237,7 @@ where
                 .collect::<Vec<_>>(),
         );
         polynomials.extend(
-            index
-                .cs
-                .evaluated_column_coefficients
-                .permutation_coefficients[0..PERMUTS - 1]
+            index.evaluated_column_coefficients.permutation_coefficients[0..PERMUTS - 1]
                 .iter()
                 .map(|w| (w, None, non_hiding(1)))
                 .collect::<Vec<_>>(),

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -3,7 +3,7 @@
 use crate::{
     alphas::Alphas,
     circuits::{
-        constraints::ConstraintSystem,
+        constraints::{ColumnEvaluations, ConstraintSystem},
         expr::{Linearization, PolishToken},
         wires::PERMUTS,
     },
@@ -45,6 +45,9 @@ pub struct ProverIndex<G: KimchiCurve> {
     /// maximal size of the quotient polynomial according to the supported constraints
     pub max_quot_size: usize,
 
+    #[serde(bound = "ColumnEvaluations<G::ScalarField>: Serialize + DeserializeOwned")]
+    pub column_evaluations: ColumnEvaluations<G::ScalarField>,
+
     /// The verifier index corresponding to this prover index
     #[serde(skip)]
     pub verifier_index: Option<VerifierIndex<G>>,
@@ -84,6 +87,8 @@ impl<G: KimchiCurve> ProverIndex<G> {
         // where the $w_i(x)$ are of degree the size of the domain.
         let max_quot_size = PERMUTS * cs.domain.d1.size();
 
+        let column_evaluations = cs.column_evaluations();
+
         ProverIndex {
             cs,
             linearization,
@@ -91,6 +96,7 @@ impl<G: KimchiCurve> ProverIndex<G> {
             srs,
             max_poly_size,
             max_quot_size,
+            column_evaluations,
             verifier_index: None,
             verifier_index_digest: None,
         }

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -3,7 +3,7 @@
 use crate::{
     alphas::Alphas,
     circuits::{
-        constraints::{ColumnEvaluations, ConstraintSystem},
+        constraints::{ColumnEvaluations, ConstraintSystem, EvaluatedColumnCoefficients},
         expr::{Linearization, PolishToken},
         wires::PERMUTS,
     },
@@ -44,6 +44,9 @@ pub struct ProverIndex<G: KimchiCurve> {
 
     /// maximal size of the quotient polynomial according to the supported constraints
     pub max_quot_size: usize,
+
+    #[serde(bound = "EvaluatedColumnCoefficients<G::ScalarField>: Serialize + DeserializeOwned")]
+    pub evaluated_column_coefficients: EvaluatedColumnCoefficients<G::ScalarField>,
 
     #[serde(bound = "ColumnEvaluations<G::ScalarField>: Serialize + DeserializeOwned")]
     pub column_evaluations: ColumnEvaluations<G::ScalarField>,
@@ -87,7 +90,9 @@ impl<G: KimchiCurve> ProverIndex<G> {
         // where the $w_i(x)$ are of degree the size of the domain.
         let max_quot_size = PERMUTS * cs.domain.d1.size();
 
-        let column_evaluations = cs.column_evaluations();
+        let evaluated_column_coefficients = cs.evaluated_column_coefficients();
+
+        let column_evaluations = cs.column_evaluations(&evaluated_column_coefficients);
 
         ProverIndex {
             cs,
@@ -96,6 +101,7 @@ impl<G: KimchiCurve> ProverIndex<G> {
             srs,
             max_poly_size,
             max_quot_size,
+            evaluated_column_coefficients,
             column_evaluations,
             verifier_index: None,
             verifier_index_digest: None,

--- a/kimchi/src/tests/foreign_field_add.rs
+++ b/kimchi/src/tests/foreign_field_add.rs
@@ -9,8 +9,11 @@ use crate::circuits::{
     },
     wires::Wire,
 };
+use crate::prover_index::ProverIndex;
 use ark_ec::AffineCurve;
 use ark_ff::{One, Zero};
+use ark_poly::EvaluationDomain;
+use commitment_dlog::srs::{endos, SRS};
 use mina_curves::pasta::{Pallas, Vesta};
 use num_bigint::BigUint;
 use num_traits::FromPrimitive;
@@ -19,6 +22,7 @@ use o1_utils::{
     FieldHelpers,
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::sync::Arc;
 
 type PallasField = <Pallas as AffineCurve>::BaseField;
 type VestaField = <Vesta as AffineCurve>::BaseField;
@@ -126,10 +130,7 @@ static ZERO: &[u8] = &[0x00];
 // The one byte
 static ONE: &[u8] = &[0x01];
 
-fn create_test_constraint_system_ffadd(
-    num: usize,
-    modulus: BigUint,
-) -> ConstraintSystem<PallasField> {
+fn create_test_constraint_system_ffadd(num: usize, modulus: BigUint) -> ProverIndex<Vesta> {
     let (mut next_row, mut gates) = CircuitGate::<PallasField>::create_foreign_field_add(0, num);
 
     // Temporary workaround for lookup-table/domain-size issue
@@ -138,10 +139,16 @@ fn create_test_constraint_system_ffadd(
         next_row += 1;
     }
 
-    ConstraintSystem::create(gates)
+    let cs = ConstraintSystem::create(gates)
         .foreign_field_modulus(&Some(modulus))
         .build()
-        .unwrap()
+        .unwrap();
+    let mut srs = SRS::<Vesta>::create(cs.domain.d1.size());
+    srs.add_lagrange_basis(cs.domain.d1);
+    let srs = Arc::new(srs);
+
+    let (endo_q, _endo_r) = endos::<Pallas>();
+    ProverIndex::<Vesta>::create(cs, endo_q, srs)
 }
 
 // returns the maximum value for a field of modulus size
@@ -154,10 +161,10 @@ fn test_ffadd(
     fmod: &[u8],
     inputs: Vec<Vec<u8>>,
     ops: &Vec<FFOps>,
-) -> ([Vec<PallasField>; COLUMNS], ConstraintSystem<PallasField>) {
+) -> ([Vec<PallasField>; COLUMNS], ProverIndex<Vesta>) {
     let nops = ops.len();
     let foreign_modulus = BigUint::from_bytes_be(fmod);
-    let cs = create_test_constraint_system_ffadd(nops, foreign_modulus.clone());
+    let index = create_test_constraint_system_ffadd(nops, foreign_modulus.clone());
     let inputs = inputs
         .iter()
         .map(|x| BigUint::from_bytes_be(x))
@@ -168,11 +175,11 @@ fn test_ffadd(
 
     for row in 0..all_rows {
         assert_eq!(
-            cs.gates[row].verify_witness::<Vesta>(
+            index.cs.gates[row].verify_witness::<Vesta>(
                 row,
                 &witness,
-                &cs,
-                &witness[0][0..cs.public].to_vec()
+                &index.cs,
+                &witness[0][0..index.cs.public].to_vec()
             ),
             Ok(())
         );
@@ -183,12 +190,12 @@ fn test_ffadd(
 
     for row in add_row..all_rows {
         assert_eq!(
-            cs.gates[row].verify::<Vesta>(row, &witness, &cs, &[]),
+            index.cs.gates[row].verify::<Vesta>(row, &witness, &index, &[]),
             Ok(())
         );
     }
 
-    (witness, cs)
+    (witness, index)
 }
 
 // checks that the result cells of the witness are computed as expected
@@ -310,7 +317,7 @@ fn test_zero_add() {
 #[test]
 // Adding terms that are zero modulo the foreign field
 fn test_zero_sum_foreign() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![FOR_MOD_BOT.to_vec(), FOR_MOD_TOP.to_vec()],
         &vec![FFOps::Add],
@@ -324,7 +331,7 @@ fn test_zero_sum_native() {
     let native_modulus = PallasField::modulus_biguint();
     let one = BigUint::new(vec![1u32]);
     let mod_minus_one = native_modulus.clone() - one.clone();
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![ONE.to_vec(), mod_minus_one.to_bytes_be()],
         &vec![FFOps::Add],
@@ -337,7 +344,7 @@ fn test_zero_sum_native() {
 
 #[test]
 fn test_one_plus_one() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![ONE.to_vec(), ONE.to_vec()],
         &vec![FFOps::Add],
@@ -350,7 +357,7 @@ fn test_one_plus_one() {
 #[test]
 // Adds two terms that are the maximum value in the foreign field
 fn test_max_number() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![MAX_SECP256K1.to_vec(), MAX_SECP256K1.to_vec()],
         &vec![FFOps::Add],
@@ -377,7 +384,7 @@ fn test_zero_minus_one() {
         .to_big()
         .to_bytes_be();
     let right_for_neg: ForeignElement<PallasField, 3> = ForeignElement::from_be(&right_be_neg);
-    let (witness_neg, _cs) = test_ffadd(
+    let (witness_neg, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![ZERO.to_vec(), right_be_neg],
         &vec![FFOps::Add],
@@ -385,7 +392,7 @@ fn test_zero_minus_one() {
     check_result(witness_neg, vec![right_for_neg.clone()]);
 
     // NEXT AS SUB
-    let (witness_sub, _cs) = test_ffadd(
+    let (witness_sub, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![ZERO.to_vec(), ONE.to_vec()],
         &vec![FFOps::Sub],
@@ -403,7 +410,7 @@ fn test_one_minus_one_plus_one() {
         .neg(&foreign_modulus)
         .to_big()
         .to_bytes_be();
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![ONE.to_vec(), ONE.to_vec(), neg_neg_one],
         &vec![FFOps::Sub, FFOps::Add],
@@ -427,14 +434,14 @@ fn test_minus_minus() {
     let neg_one = neg_one_for.to_big().to_bytes_be();
     let neg_two = ForeignElement::<PallasField, 3>::from_biguint(BigUint::from_u32(2).unwrap())
         .neg(&foreign_modulus);
-    let (witness_neg, _cs) = test_ffadd(
+    let (witness_neg, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![neg_one.to_vec(), neg_one.to_vec()],
         &vec![FFOps::Add],
     );
     check_result(witness_neg, vec![neg_two.clone()]);
 
-    let (witness_sub, _cs) = test_ffadd(
+    let (witness_sub, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![ZERO.to_vec(), ONE.to_vec(), ONE.to_vec()],
         &vec![FFOps::Sub, FFOps::Sub],
@@ -445,7 +452,7 @@ fn test_minus_minus() {
 #[test]
 // test when the low carry is minus one
 fn test_neg_carry_lo() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![OVF_NEG_LO.to_vec(), OVF_NEG_LO.to_vec()],
         &vec![FFOps::Add],
@@ -456,7 +463,7 @@ fn test_neg_carry_lo() {
 #[test]
 // test when the middle carry is minus one
 fn test_neg_carry_mi() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![OVF_NEG_MI.to_vec(), OVF_NEG_MI.to_vec()],
         &vec![FFOps::Add],
@@ -467,7 +474,7 @@ fn test_neg_carry_mi() {
 #[test]
 // test when there is negative low carry and 0 middle limb (carry bit propagates)
 fn test_propagate_carry() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![OVF_ZERO_MI_NEG_LO.to_vec(), OVF_ZERO_MI_NEG_LO.to_vec()],
         &vec![FFOps::Add],
@@ -478,7 +485,7 @@ fn test_propagate_carry() {
 #[test]
 // test when the both carries are minus one
 fn test_neg_carries() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![OVF_NEG_BOTH.to_vec(), OVF_ZERO_MI_NEG_LO.to_vec()],
         &vec![FFOps::Add],
@@ -499,7 +506,7 @@ fn test_upperbound() {
 #[test]
 // test a carry that nullifies in the low limb
 fn test_null_lo_carry() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![MAX_SECP256K1.to_vec(), NULL_CARRY_LO.to_vec()],
         &vec![FFOps::Add],
@@ -510,7 +517,7 @@ fn test_null_lo_carry() {
 #[test]
 // test a carry that nullifies in the mid limb
 fn test_null_mi_carry() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![MAX_SECP256K1.to_vec(), NULL_CARRY_MI.to_vec()],
         &vec![FFOps::Add],
@@ -521,7 +528,7 @@ fn test_null_mi_carry() {
 #[test]
 // test a carry that nullifies in the mid limb
 fn test_null_both_carry() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![MAX_SECP256K1.to_vec(), NULL_CARRY_BOTH.to_vec()],
         &vec![FFOps::Add],
@@ -532,7 +539,7 @@ fn test_null_both_carry() {
 #[test]
 // test sums without carry bits in any limb
 fn test_no_carry_limbs() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![TIC.to_vec(), TOC.to_vec()],
         &vec![FFOps::Add],
@@ -546,7 +553,7 @@ fn test_no_carry_limbs() {
 #[test]
 // test sum with carry only in low part
 fn test_pos_carry_limb_lo() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![TIC.to_vec(), TOC_LO.to_vec()],
         &vec![FFOps::Add],
@@ -556,7 +563,7 @@ fn test_pos_carry_limb_lo() {
 
 #[test]
 fn test_pos_carry_limb_mid() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![TIC.to_vec(), TOC_MI.to_vec()],
         &vec![FFOps::Add],
@@ -566,7 +573,7 @@ fn test_pos_carry_limb_mid() {
 
 #[test]
 fn test_pos_carry_limb_lo_mid() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![TIC.to_vec(), TOC_TWO.to_vec()],
         &vec![FFOps::Add],
@@ -577,7 +584,7 @@ fn test_pos_carry_limb_lo_mid() {
 #[test]
 // Check it fails if given a wrong result (sum)
 fn test_wrong_sum() {
-    let (mut witness, cs) = test_ffadd(
+    let (mut witness, index) = test_ffadd(
         SECP256K1_MOD,
         vec![TIC.to_vec(), TOC.to_vec()],
         &vec![FFOps::Add],
@@ -588,7 +595,7 @@ fn test_wrong_sum() {
     witness[0][17] = all_ones_limb.clone();
 
     assert_eq!(
-        cs.gates[16].verify_foreign_field_add::<Vesta>(0, &witness, &cs),
+        index.cs.gates[16].verify_foreign_field_add(0, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(
             GateType::ForeignFieldAdd
         )),
@@ -598,7 +605,7 @@ fn test_wrong_sum() {
 #[test]
 // Check it fails if given a wrong result (difference)
 fn test_wrong_dif() {
-    let (mut witness, cs) = test_ffadd(
+    let (mut witness, index) = test_ffadd(
         SECP256K1_MOD,
         vec![TIC.to_vec(), TOC.to_vec()],
         &vec![FFOps::Sub],
@@ -608,7 +615,7 @@ fn test_wrong_dif() {
     witness[0][17] = PallasField::zero();
 
     assert_eq!(
-        cs.gates[16].verify_foreign_field_add::<Vesta>(0, &witness, &cs),
+        index.cs.gates[16].verify_foreign_field_add(0, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(
             GateType::ForeignFieldAdd
         )),
@@ -618,7 +625,7 @@ fn test_wrong_dif() {
 #[test]
 // Test subtraction of the foreign field
 fn test_zero_sub_fmod() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![ZERO.to_vec(), SECP256K1_MOD.to_vec()],
         &vec![FFOps::Sub],
@@ -630,7 +637,7 @@ fn test_zero_sub_fmod() {
 #[test]
 // Test subtraction of the foreign field maximum value
 fn test_zero_sub_fmax() {
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![ZERO.to_vec(), MAX_SECP256K1.to_vec()],
         &vec![FFOps::Sub],
@@ -649,7 +656,7 @@ fn test_pasta_add_max_vesta() {
     let vesta_modulus = VestaField::modulus_biguint();
     let vesta_mod_be = vesta_modulus.to_bytes_be();
     let right_input = field_max(vesta_modulus.clone());
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         &vesta_mod_be,
         vec![ZERO.to_vec(), right_input.to_bytes_be()],
         &vec![FFOps::Add],
@@ -665,7 +672,7 @@ fn test_pasta_sub_max_vesta() {
     let vesta_modulus = VestaField::modulus_biguint();
     let vesta_mod_be = vesta_modulus.to_bytes_be();
     let right_input = field_max(vesta_modulus.clone());
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         &vesta_mod_be,
         vec![ZERO.to_vec(), right_input.to_bytes_be()],
         &vec![FFOps::Sub],
@@ -681,7 +688,7 @@ fn test_pasta_add_max_pallas() {
     let vesta_modulus = VestaField::modulus_biguint();
     let vesta_mod_be = vesta_modulus.to_bytes_be();
     let right_input = field_max(PallasField::modulus_biguint());
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         &vesta_mod_be,
         vec![ZERO.to_vec(), right_input.to_bytes_be()],
         &vec![FFOps::Add],
@@ -697,7 +704,7 @@ fn test_pasta_sub_max_pallas() {
     let vesta_modulus = VestaField::modulus_biguint();
     let vesta_mod_be = vesta_modulus.to_bytes_be();
     let right_input = field_max(PallasField::modulus_biguint());
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         &vesta_mod_be,
         vec![ZERO.to_vec(), right_input.to_bytes_be()],
         &vec![FFOps::Sub],
@@ -713,7 +720,7 @@ fn test_random_add() {
     let foreign_mod = BigUint::from_bytes_be(SECP256K1_MOD);
     let left_input = random_input(foreign_mod.clone(), true);
     let right_input = random_input(foreign_mod.clone(), true);
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![left_input.clone(), right_input.clone()],
         &vec![FFOps::Add],
@@ -731,7 +738,7 @@ fn test_random_sub() {
     let foreign_mod = BigUint::from_bytes_be(SECP256K1_MOD);
     let left_input = random_input(foreign_mod.clone(), true);
     let right_input = random_input(foreign_mod.clone(), true);
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         SECP256K1_MOD,
         vec![left_input.clone(), right_input.clone()],
         &vec![FFOps::Sub],
@@ -752,7 +759,7 @@ fn test_foreign_is_native_add() {
     let pallas = PallasField::modulus_biguint();
     let left_input = random_input(pallas.clone(), true);
     let right_input = random_input(pallas.clone(), true);
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         &pallas.to_bytes_be(),
         vec![left_input.clone(), right_input.clone()],
         &vec![FFOps::Add],
@@ -780,7 +787,7 @@ fn test_foreign_is_native_sub() {
     let pallas = PallasField::modulus_biguint();
     let left_input = random_input(pallas.clone(), true);
     let right_input = random_input(pallas.clone(), true);
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         &pallas.to_bytes_be(),
         vec![left_input.clone(), right_input.clone()],
         &vec![FFOps::Sub],
@@ -811,7 +818,7 @@ fn test_random_small_add() {
     let foreign_mod = BigUint::from_bytes_be(&prime_be);
     let left_input = random_input(foreign_mod.clone(), false);
     let right_input = random_input(foreign_mod.clone(), false);
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         &prime_be,
         vec![left_input.clone(), right_input.clone()],
         &vec![FFOps::Add],
@@ -832,7 +839,7 @@ fn test_random_small_sub() {
     let foreign_mod = BigUint::from_bytes_be(&prime_be);
     let left_input = random_input(foreign_mod.clone(), false);
     let right_input = random_input(foreign_mod.clone(), false);
-    let (witness, _cs) = test_ffadd(
+    let (witness, _index) = test_ffadd(
         &prime_be,
         vec![left_input.clone(), right_input.clone()],
         &vec![FFOps::Sub],
@@ -850,7 +857,7 @@ fn test_random_bad_input() {
     let foreign_mod = BigUint::from_bytes_be(&SECP256K1_MOD);
     let left_input = random_input(foreign_mod.clone(), false);
     let right_input = random_input(foreign_mod.clone(), false);
-    let (mut witness, cs) = test_ffadd(
+    let (mut witness, index) = test_ffadd(
         SECP256K1_MOD,
         vec![left_input.clone(), right_input.clone()],
         &vec![FFOps::Sub],
@@ -858,7 +865,7 @@ fn test_random_bad_input() {
     // First modify left input only to cause an invalid copy constraint
     witness[0][16] = witness[0][16] + PallasField::one();
     assert_eq!(
-        cs.gates[16].verify_foreign_field_add::<Vesta>(0, &witness, &cs),
+        index.cs.gates[16].verify_foreign_field_add(0, &witness, &index),
         Err(CircuitGateError::InvalidCopyConstraint(
             GateType::ForeignFieldAdd
         )),
@@ -866,7 +873,7 @@ fn test_random_bad_input() {
     // then modify the value in the range check to cause an invalid FFAdd constraint
     witness[0][0] = witness[0][0] + PallasField::one();
     assert_eq!(
-        cs.gates[16].verify_foreign_field_add::<Vesta>(0, &witness, &cs),
+        index.cs.gates[16].verify_foreign_field_add(0, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(
             GateType::ForeignFieldAdd
         )),
@@ -879,7 +886,7 @@ fn test_random_bad_parameters() {
     let foreign_mod = BigUint::from_bytes_be(&SECP256K1_MOD);
     let left_input = random_input(foreign_mod.clone(), false);
     let right_input = random_input(foreign_mod.clone(), false);
-    let (mut witness, cs) = test_ffadd(
+    let (mut witness, index) = test_ffadd(
         SECP256K1_MOD,
         vec![left_input.clone(), right_input.clone()],
         &vec![FFOps::Add],
@@ -887,7 +894,7 @@ fn test_random_bad_parameters() {
     // Modify low carry
     witness[8][16] = witness[8][16] + PallasField::one();
     assert_eq!(
-        cs.gates[16].verify_foreign_field_add::<Vesta>(0, &witness, &cs),
+        index.cs.gates[16].verify_foreign_field_add(0, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(
             GateType::ForeignFieldAdd
         )),
@@ -896,7 +903,7 @@ fn test_random_bad_parameters() {
     // Modify high carry
     witness[9][16] = witness[9][16] - PallasField::one();
     assert_eq!(
-        cs.gates[16].verify_foreign_field_add::<Vesta>(0, &witness, &cs),
+        index.cs.gates[16].verify_foreign_field_add(0, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(
             GateType::ForeignFieldAdd
         )),
@@ -905,7 +912,7 @@ fn test_random_bad_parameters() {
     // Modify overflow
     witness[7][16] = witness[7][16] + PallasField::one();
     assert_eq!(
-        cs.gates[16].verify_foreign_field_add::<Vesta>(0, &witness, &cs),
+        index.cs.gates[16].verify_foreign_field_add(0, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(
             GateType::ForeignFieldAdd
         )),
@@ -914,7 +921,7 @@ fn test_random_bad_parameters() {
     // Modify sign
     witness[6][16] = PallasField::zero() - witness[6][16];
     assert_eq!(
-        cs.gates[16].verify_foreign_field_add::<Vesta>(0, &witness, &cs),
+        index.cs.gates[16].verify_foreign_field_add(0, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(
             GateType::ForeignFieldAdd
         )),
@@ -922,7 +929,7 @@ fn test_random_bad_parameters() {
     witness[6][16] = PallasField::zero() - witness[6][16];
     // Check back to normal
     assert_eq!(
-        cs.gates[16].verify_foreign_field_add::<Vesta>(0, &witness, &cs),
+        index.cs.gates[16].verify_foreign_field_add(0, &witness, &index),
         Ok(()),
     );
 }
@@ -945,7 +952,7 @@ fn test_random_chain() {
         .into_iter()
         .map(|_| random_operation(rng))
         .collect::<Vec<_>>();
-    let (witness, _cs) = test_ffadd(SECP256K1_MOD, inputs.clone(), &operations);
+    let (witness, _index) = test_ffadd(SECP256K1_MOD, inputs.clone(), &operations);
     let mut left = vec![inputs[0].clone()];
     let results: Vec<ForeignElement<PallasField, 3>> = operations
         .iter()

--- a/kimchi/src/tests/framework.rs
+++ b/kimchi/src/tests/framework.rs
@@ -147,10 +147,7 @@ impl TestRunner {
         let witness = self.0.witness.unwrap();
 
         // verify the circuit satisfiability by the computed witness
-        prover
-            .cs
-            .verify::<Vesta>(&witness, &self.0.public_inputs)
-            .unwrap();
+        prover.verify(&witness, &self.0.public_inputs).unwrap();
 
         // add the proof to the batch
         let start = Instant::now();

--- a/kimchi/src/tests/range_check.rs
+++ b/kimchi/src/tests/range_check.rs
@@ -15,13 +15,18 @@ use crate::{
 
 use ark_ec::AffineCurve;
 use ark_ff::{Field, One, Zero};
+use ark_poly::EvaluationDomain;
 use mina_curves::pasta::{Fp, Pallas, Vesta, VestaParameters};
 use o1_utils::FieldHelpers;
 
 use std::array;
+use std::sync::Arc;
 
 use crate::{prover_index::ProverIndex, verifier::verify};
-use commitment_dlog::commitment::CommitmentCurve;
+use commitment_dlog::{
+    commitment::CommitmentCurve,
+    srs::{endos, SRS},
+};
 use groupmap::GroupMap;
 use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi,
@@ -32,18 +37,6 @@ type BaseSponge = DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>;
 type ScalarSponge = DefaultFrSponge<Fp, PlonkSpongeConstantsKimchi>;
 
 type PallasField = <Pallas as AffineCurve>::BaseField;
-
-fn create_test_constraint_system() -> ConstraintSystem<Fp> {
-    let (mut next_row, mut gates) = CircuitGate::<Fp>::create_multi_range_check(0);
-
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
-    }
-
-    ConstraintSystem::create(gates).build().unwrap()
-}
 
 fn create_test_prover_index(public_size: usize) -> ProverIndex<Vesta> {
     let (mut next_row, mut gates) = CircuitGate::<Fp>::create_multi_range_check(0);
@@ -66,67 +59,87 @@ fn create_test_prover_index(public_size: usize) -> ProverIndex<Vesta> {
 
 #[test]
 fn verify_range_check0_zero_valid_witness() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
     let witness: [Vec<PallasField>; COLUMNS] = array::from_fn(|_| vec![PallasField::from(0); 4]);
 
     // gates[0] is RangeCheck0
     assert_eq!(
-        cs.gates[0].verify_range_check::<Vesta>(0, &witness, &cs),
+        index.cs.gates[0].verify_range_check::<Vesta>(0, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[0].verify_witness::<Vesta>(0, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[0].verify_witness::<Vesta>(
+            0,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 
     // gates[1] is RangeCheck0
     assert_eq!(
-        cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+        index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[1].verify_witness::<Vesta>(1, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[1].verify_witness::<Vesta>(
+            1,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 }
 
 #[test]
 fn verify_range_check0_one_invalid_witness() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
     let witness: [Vec<PallasField>; COLUMNS] = array::from_fn(|_| vec![PallasField::from(1); 4]);
 
     // gates[0] is RangeCheck0
     assert_eq!(
-        cs.gates[0].verify_range_check::<Vesta>(0, &witness, &cs),
+        index.cs.gates[0].verify_range_check::<Vesta>(0, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(GateType::RangeCheck0))
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[0].verify_witness::<Vesta>(0, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[0].verify_witness::<Vesta>(
+            0,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Err(CircuitGateError::Constraint(GateType::RangeCheck0, 8))
     );
 
     // gates[1] is RangeCheck0
     assert_eq!(
-        cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+        index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(GateType::RangeCheck0))
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[1].verify_witness::<Vesta>(1, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[1].verify_witness::<Vesta>(
+            1,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Err(CircuitGateError::Constraint(GateType::RangeCheck0, 8))
     );
 }
 
 #[test]
 fn verify_range_check0_valid_witness() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from_hex("115655443433221211ffef000000000000000000000000000000000000000000")
@@ -139,25 +152,35 @@ fn verify_range_check0_valid_witness() {
 
     // gates[0] is RangeCheck0
     assert_eq!(
-        cs.gates[0].verify_range_check::<Vesta>(0, &witness, &cs),
+        index.cs.gates[0].verify_range_check::<Vesta>(0, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[0].verify_witness::<Vesta>(0, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[0].verify_witness::<Vesta>(
+            0,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 
     // gates[1] is RangeCheck0
     assert_eq!(
-        cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+        index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[1].verify_witness::<Vesta>(1, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[1].verify_witness::<Vesta>(
+            1,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 
@@ -172,32 +195,42 @@ fn verify_range_check0_valid_witness() {
 
     // gates[0] is RangeCheck0
     assert_eq!(
-        cs.gates[0].verify_range_check::<Vesta>(0, &witness, &cs),
+        index.cs.gates[0].verify_range_check::<Vesta>(0, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[0].verify_witness::<Vesta>(0, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[0].verify_witness::<Vesta>(
+            0,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 
     // gates[1] is RangeCheck0
     assert_eq!(
-        cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+        index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[1].verify_witness::<Vesta>(1, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[1].verify_witness::<Vesta>(
+            1,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 }
 
 #[test]
 fn verify_range_check0_invalid_witness() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     let mut witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from_hex("22f6b4e7ecb4488433ade7000000000000000000000000000000000000000000")
@@ -213,7 +246,7 @@ fn verify_range_check0_invalid_witness() {
 
     // gates[0] is RangeCheck0
     assert_eq!(
-        cs.gates[0].verify_range_check::<Vesta>(0, &witness, &cs),
+        index.cs.gates[0].verify_range_check::<Vesta>(0, &witness, &index),
         Err(CircuitGateError::InvalidCopyConstraint(
             GateType::RangeCheck0
         ))
@@ -224,7 +257,7 @@ fn verify_range_check0_invalid_witness() {
 
     // gates[1] is RangeCheck0
     assert_eq!(
-        cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+        index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
         Err(CircuitGateError::InvalidCopyConstraint(
             GateType::RangeCheck0
         ))
@@ -244,13 +277,18 @@ fn verify_range_check0_invalid_witness() {
 
     // gates[0] is RangeCheck0
     assert_eq!(
-        cs.gates[0].verify_range_check::<Vesta>(0, &witness, &cs),
+        index.cs.gates[0].verify_range_check::<Vesta>(0, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(GateType::RangeCheck0))
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[0].verify_witness::<Vesta>(0, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[0].verify_witness::<Vesta>(
+            0,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Err(CircuitGateError::Constraint(GateType::RangeCheck0, 1))
     );
 
@@ -259,20 +297,25 @@ fn verify_range_check0_invalid_witness() {
 
     // gates[1] is RangeCheck0
     assert_eq!(
-        cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+        index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(GateType::RangeCheck0))
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[1].verify_witness::<Vesta>(1, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[1].verify_witness::<Vesta>(
+            1,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Err(CircuitGateError::Constraint(GateType::RangeCheck0, 2))
     );
 }
 
 #[test]
 fn verify_range_check0_valid_v0_in_range() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from(PallasField::from(2u64).pow([88]) - PallasField::one()),
@@ -282,13 +325,18 @@ fn verify_range_check0_valid_v0_in_range() {
 
     // gates[0] is RangeCheck0 and contains v0
     assert_eq!(
-        cs.gates[0].verify_range_check::<Vesta>(0, &witness, &cs),
+        index.cs.gates[0].verify_range_check::<Vesta>(0, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[0].verify_witness::<Vesta>(0, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[0].verify_witness::<Vesta>(
+            0,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 
@@ -300,13 +348,18 @@ fn verify_range_check0_valid_v0_in_range() {
 
     // gates[0] is RangeCheck0 and contains v0
     assert_eq!(
-        cs.gates[0].verify_range_check::<Vesta>(0, &witness, &cs),
+        index.cs.gates[0].verify_range_check::<Vesta>(0, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[0].verify_witness::<Vesta>(0, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[0].verify_witness::<Vesta>(
+            0,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 
@@ -318,13 +371,18 @@ fn verify_range_check0_valid_v0_in_range() {
 
     // gates[0] is RangeCheck0 and contains v0
     assert_eq!(
-        cs.gates[0].verify_range_check::<Vesta>(0, &witness, &cs),
+        index.cs.gates[0].verify_range_check::<Vesta>(0, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[0].verify_witness::<Vesta>(0, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[0].verify_witness::<Vesta>(
+            0,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 
@@ -336,20 +394,25 @@ fn verify_range_check0_valid_v0_in_range() {
 
     // gates[0] is RangeCheck0 and contains v0
     assert_eq!(
-        cs.gates[0].verify_range_check::<Vesta>(0, &witness, &cs),
+        index.cs.gates[0].verify_range_check::<Vesta>(0, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[0].verify_witness::<Vesta>(0, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[0].verify_witness::<Vesta>(
+            0,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 }
 
 #[test]
 fn verify_range_check0_valid_v1_in_range() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
@@ -359,13 +422,18 @@ fn verify_range_check0_valid_v1_in_range() {
 
     // gates[1] is RangeCheck0 and contains v1
     assert_eq!(
-        cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+        index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[1].verify_witness::<Vesta>(1, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[1].verify_witness::<Vesta>(
+            1,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 
@@ -377,13 +445,18 @@ fn verify_range_check0_valid_v1_in_range() {
 
     // gates[1] is RangeCheck0 and contains v1
     assert_eq!(
-        cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+        index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[1].verify_witness::<Vesta>(1, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[1].verify_witness::<Vesta>(
+            1,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 
@@ -395,13 +468,18 @@ fn verify_range_check0_valid_v1_in_range() {
 
     // gates[1] is RangeCheck0 and contains v1
     assert_eq!(
-        cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+        index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[1].verify_witness::<Vesta>(1, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[1].verify_witness::<Vesta>(
+            1,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 
@@ -413,20 +491,25 @@ fn verify_range_check0_valid_v1_in_range() {
 
     // gates[1] is RangeCheck0 and contains v1
     assert_eq!(
-        cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+        index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[1].verify_witness::<Vesta>(1, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[1].verify_witness::<Vesta>(
+            1,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 }
 
 #[test]
 fn verify_range_check0_invalid_v0_not_in_range() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from(2u64).pow([88]), // out of range
@@ -436,13 +519,18 @@ fn verify_range_check0_invalid_v0_not_in_range() {
 
     // gates[0] is RangeCheck0 and contains v0
     assert_eq!(
-        cs.gates[0].verify_range_check::<Vesta>(0, &witness, &cs),
+        index.cs.gates[0].verify_range_check::<Vesta>(0, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(GateType::RangeCheck0))
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[0].verify_witness::<Vesta>(0, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[0].verify_witness::<Vesta>(
+            0,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Err(CircuitGateError::Constraint(GateType::RangeCheck0, 8))
     );
 
@@ -454,20 +542,25 @@ fn verify_range_check0_invalid_v0_not_in_range() {
 
     // gates[0] is RangeCheck0 and contains v0
     assert_eq!(
-        cs.gates[0].verify_range_check::<Vesta>(0, &witness, &cs),
+        index.cs.gates[0].verify_range_check::<Vesta>(0, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(GateType::RangeCheck0))
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[0].verify_witness::<Vesta>(0, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[0].verify_witness::<Vesta>(
+            0,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Err(CircuitGateError::Constraint(GateType::RangeCheck0, 8))
     );
 }
 
 #[test]
 fn verify_range_check0_invalid_v1_not_in_range() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
@@ -477,13 +570,18 @@ fn verify_range_check0_invalid_v1_not_in_range() {
 
     // gates[1] is RangeCheck0 and contains v1
     assert_eq!(
-        cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+        index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(GateType::RangeCheck0))
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[1].verify_witness::<Vesta>(1, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[1].verify_witness::<Vesta>(
+            1,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Err(CircuitGateError::Constraint(GateType::RangeCheck0, 8))
     );
 
@@ -495,20 +593,25 @@ fn verify_range_check0_invalid_v1_not_in_range() {
 
     // gates[1] is RangeCheck0 and contains v1
     assert_eq!(
-        cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+        index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(GateType::RangeCheck0))
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[1].verify_witness::<Vesta>(1, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[1].verify_witness::<Vesta>(
+            1,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Err(CircuitGateError::Constraint(GateType::RangeCheck0, 8))
     );
 }
 
 #[test]
 fn verify_range_check0_test_copy_constraints() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     for row in 0..=1 {
         for col in 1..=2 {
@@ -521,17 +624,17 @@ fn verify_range_check0_test_copy_constraints() {
 
             // Positive test case (gates[row] is a RangeCheck0 circuit gate)
             assert_eq!(
-                cs.gates[row].verify_range_check::<Vesta>(row, &witness, &cs),
+                index.cs.gates[row].verify_range_check::<Vesta>(row, &witness, &index),
                 Ok(())
             );
 
             // Generic witness verification test
             assert_eq!(
-                cs.gates[row].verify_witness::<Vesta>(
+                index.cs.gates[row].verify_witness::<Vesta>(
                     row,
                     &witness,
-                    &cs,
-                    &witness[0][0..cs.public].to_vec()
+                    &index.cs,
+                    &witness[0][0..index.cs.public].to_vec()
                 ),
                 Ok(())
             );
@@ -540,20 +643,22 @@ fn verify_range_check0_test_copy_constraints() {
             assert_ne!(witness[col][row], PallasField::zero());
             witness[col][row] = PallasField::zero();
             assert_eq!(
-                cs.gates[row].verify_range_check::<Vesta>(row, &witness, &cs),
-                Err(CircuitGateError::InvalidCopyConstraint(cs.gates[row].typ))
+                index.cs.gates[row].verify_range_check::<Vesta>(row, &witness, &index),
+                Err(CircuitGateError::InvalidCopyConstraint(
+                    index.cs.gates[row].typ
+                ))
             );
 
             // Generic witness verification test
             assert_eq!(
-                cs.gates[row].verify_witness::<Vesta>(
+                index.cs.gates[row].verify_witness::<Vesta>(
                     row,
                     &witness,
-                    &cs,
-                    &witness[0][0..cs.public].to_vec()
+                    &index.cs,
+                    &witness[0][0..index.cs.public].to_vec()
                 ),
                 Err(CircuitGateError::CopyConstraint {
-                    typ: cs.gates[row].typ,
+                    typ: index.cs.gates[row].typ,
                     src: Wire { row, col },
                     dst: Wire {
                         row: 3,
@@ -567,7 +672,7 @@ fn verify_range_check0_test_copy_constraints() {
 
 #[test]
 fn verify_range_check0_v0_test_lookups() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     for i in 3..=6 {
         // Test ith lookup
@@ -580,7 +685,7 @@ fn verify_range_check0_v0_test_lookups() {
         // Positive test
         // gates[0] is RangeCheck0 and constrains some of v0
         assert_eq!(
-            cs.gates[0].verify_range_check::<Vesta>(0, &witness, &cs),
+            index.cs.gates[0].verify_range_check::<Vesta>(0, &witness, &index),
             Ok(())
         );
 
@@ -590,7 +695,7 @@ fn verify_range_check0_v0_test_lookups() {
 
         // gates[0] is RangeCheck0 and constrains some of v0
         assert_eq!(
-            cs.gates[0].verify_range_check::<Vesta>(0, &witness, &cs),
+            index.cs.gates[0].verify_range_check::<Vesta>(0, &witness, &index),
             Err(CircuitGateError::InvalidLookupConstraintSorted(
                 GateType::RangeCheck0
             ))
@@ -600,7 +705,7 @@ fn verify_range_check0_v0_test_lookups() {
 
 #[test]
 fn verify_range_check0_v1_test_lookups() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     for i in 3..=6 {
         // Test ith lookup
@@ -613,7 +718,7 @@ fn verify_range_check0_v1_test_lookups() {
         // Positive test
         // gates[1] is RangeCheck0 and constrains some of v1
         assert_eq!(
-            cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+            index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
             Ok(())
         );
 
@@ -623,7 +728,7 @@ fn verify_range_check0_v1_test_lookups() {
 
         // gates[1] is RangeCheck0 and constrains some of v1
         assert_eq!(
-            cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+            index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
             Err(CircuitGateError::InvalidLookupConstraintSorted(
                 GateType::RangeCheck0
             ))
@@ -633,43 +738,53 @@ fn verify_range_check0_v1_test_lookups() {
 
 #[test]
 fn verify_range_check1_zero_valid_witness() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
     let witness: [Vec<PallasField>; COLUMNS] = array::from_fn(|_| vec![PallasField::from(0); 4]);
 
     // gates[2] is RangeCheck1
     assert_eq!(
-        cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+        index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[2].verify_witness::<Vesta>(2, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[2].verify_witness::<Vesta>(
+            2,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 }
 
 #[test]
 fn verify_range_check1_one_invalid_witness() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
     let witness: [Vec<PallasField>; COLUMNS] = array::from_fn(|_| vec![PallasField::from(1); 4]);
 
     // gates[2] is RangeCheck1
     assert_eq!(
-        cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+        index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(GateType::RangeCheck1))
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[2].verify_witness::<Vesta>(2, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[2].verify_witness::<Vesta>(
+            2,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Err(CircuitGateError::Constraint(GateType::RangeCheck1, 20))
     );
 }
 
 #[test]
 fn verify_range_check1_valid_witness() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from_hex("22cab5e27101eeafd2cbe1000000000000000000000000000000000000000000")
@@ -682,13 +797,18 @@ fn verify_range_check1_valid_witness() {
 
     // gates[2] is RangeCheck1
     assert_eq!(
-        cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+        index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[2].verify_witness::<Vesta>(2, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[2].verify_witness::<Vesta>(
+            2,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 
@@ -703,20 +823,25 @@ fn verify_range_check1_valid_witness() {
 
     // gates[2] is RangeCheck1
     assert_eq!(
-        cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+        index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[2].verify_witness::<Vesta>(2, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[2].verify_witness::<Vesta>(
+            2,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 }
 
 #[test]
 fn verify_range_check1_invalid_witness() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     let mut witness = range_check::witness::create_multi::<PallasField>(
         PallasField::from_hex("2ce2d3ac942f98d59e7e11000000000000000000000000000000000000000000")
@@ -732,13 +857,18 @@ fn verify_range_check1_invalid_witness() {
 
     // gates[2] is RangeCheck1
     assert_eq!(
-        cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+        index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(GateType::RangeCheck1))
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[2].verify_witness::<Vesta>(2, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[2].verify_witness::<Vesta>(
+            2,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Err(CircuitGateError::Constraint(GateType::RangeCheck1, 20))
     );
 
@@ -756,20 +886,25 @@ fn verify_range_check1_invalid_witness() {
 
     // gates[2] is RangeCheck1
     assert_eq!(
-        cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+        index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(GateType::RangeCheck1))
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[2].verify_witness::<Vesta>(2, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[2].verify_witness::<Vesta>(
+            2,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Err(CircuitGateError::Constraint(GateType::RangeCheck1, 8))
     );
 }
 
 #[test]
 fn verify_range_check1_valid_v2_in_range() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
@@ -779,13 +914,18 @@ fn verify_range_check1_valid_v2_in_range() {
 
     // gates[2] is RangeCheck1 and constrains v2
     assert_eq!(
-        cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+        index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[2].verify_witness::<Vesta>(2, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[2].verify_witness::<Vesta>(
+            2,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 
@@ -797,13 +937,18 @@ fn verify_range_check1_valid_v2_in_range() {
 
     // gates[2] is RangeCheck1 and constrains v2
     assert_eq!(
-        cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+        index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[2].verify_witness::<Vesta>(2, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[2].verify_witness::<Vesta>(
+            2,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 
@@ -815,13 +960,18 @@ fn verify_range_check1_valid_v2_in_range() {
 
     // gates[2] is RangeCheck1 and constrains v2
     assert_eq!(
-        cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+        index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[2].verify_witness::<Vesta>(2, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[2].verify_witness::<Vesta>(
+            2,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 
@@ -833,20 +983,25 @@ fn verify_range_check1_valid_v2_in_range() {
 
     // gates[2] is RangeCheck1 and constrains v2
     assert_eq!(
-        cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+        index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[2].verify_witness::<Vesta>(2, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[2].verify_witness::<Vesta>(
+            2,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 }
 
 #[test]
 fn verify_range_check1_invalid_v2_not_in_range() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
@@ -856,13 +1011,18 @@ fn verify_range_check1_invalid_v2_not_in_range() {
 
     // gates[2] is RangeCheck1 and constrains v2
     assert_eq!(
-        cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+        index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(GateType::RangeCheck1))
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[2].verify_witness::<Vesta>(2, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[2].verify_witness::<Vesta>(
+            2,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Err(CircuitGateError::Constraint(GateType::RangeCheck1, 20))
     );
 
@@ -874,20 +1034,25 @@ fn verify_range_check1_invalid_v2_not_in_range() {
 
     // gates[2] is RangeCheck1 and constrains v2
     assert_eq!(
-        cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+        index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
         Err(CircuitGateError::InvalidConstraint(GateType::RangeCheck1))
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[2].verify_witness::<Vesta>(2, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[2].verify_witness::<Vesta>(
+            2,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Err(CircuitGateError::Constraint(GateType::RangeCheck1, 20))
     );
 }
 
 #[test]
 fn verify_range_check1_test_copy_constraints() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     for row in 0..=1 {
         for col in 1..=2 {
@@ -900,7 +1065,7 @@ fn verify_range_check1_test_copy_constraints() {
 
             // Positive test case (gates[2] is a RangeCheck1 circuit gate)
             assert_eq!(
-                cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+                index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
                 Ok(())
             );
 
@@ -908,7 +1073,7 @@ fn verify_range_check1_test_copy_constraints() {
             assert_ne!(witness[col][row], PallasField::zero());
             witness[col][row] = PallasField::zero();
             assert_eq!(
-                cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+                index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
                 Err(CircuitGateError::InvalidCopyConstraint(
                     GateType::RangeCheck1
                 ))
@@ -917,11 +1082,11 @@ fn verify_range_check1_test_copy_constraints() {
             // Generic witness verification test
             // RangeCheck1's current row doesn't have any copy constraints
             assert_eq!(
-                cs.gates[2].verify_witness::<Vesta>(
+                index.cs.gates[2].verify_witness::<Vesta>(
                     2,
                     &witness,
-                    &cs,
-                    &witness[0][0..cs.public].to_vec()
+                    &index.cs,
+                    &witness[0][0..index.cs.public].to_vec()
                 ),
                 Ok(())
             );
@@ -929,11 +1094,11 @@ fn verify_range_check1_test_copy_constraints() {
             // Generic witness verification test
             // RangeCheck1's next row has copy constraints, but it's a Zero gate
             assert_eq!(
-                cs.gates[3].verify_witness::<Vesta>(
+                index.cs.gates[3].verify_witness::<Vesta>(
                     3,
                     &witness,
-                    &cs,
-                    &witness[0][0..cs.public].to_vec()
+                    &index.cs,
+                    &witness[0][0..index.cs.public].to_vec()
                 ),
                 Err(CircuitGateError::CopyConstraint {
                     typ: GateType::Zero,
@@ -950,7 +1115,7 @@ fn verify_range_check1_test_copy_constraints() {
 
 #[test]
 fn verify_range_check1_test_curr_row_lookups() {
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     for i in 3..=6 {
         // Test ith lookup (impacts v2)
@@ -963,7 +1128,7 @@ fn verify_range_check1_test_curr_row_lookups() {
         // Positive test
         // gates[2] is RangeCheck1 and constrains v2
         assert_eq!(
-            cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+            index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
             Ok(())
         );
 
@@ -973,7 +1138,7 @@ fn verify_range_check1_test_curr_row_lookups() {
 
         // gates[2] is RangeCheck1 and constrains v2
         assert_eq!(
-            cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+            index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
             Err(CircuitGateError::InvalidLookupConstraintSorted(
                 GateType::RangeCheck1
             ))
@@ -984,7 +1149,7 @@ fn verify_range_check1_test_curr_row_lookups() {
 #[test]
 fn verify_range_check1_test_next_row_lookups() {
     // TODO
-    let cs = create_test_constraint_system();
+    let index = create_test_prover_index(0);
 
     for row in 0..=1 {
         for col in 1..=2 {
@@ -997,7 +1162,7 @@ fn verify_range_check1_test_next_row_lookups() {
             // Positive test case (gates[2] is RangeCheck1 and constrains
             // both v0's and v1's lookups that are deferred to 4th row)
             assert_eq!(
-                cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+                index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
                 Ok(())
             );
 
@@ -1006,7 +1171,7 @@ fn verify_range_check1_test_next_row_lookups() {
             witness[col][row] = PallasField::from(2u64.pow(12));
             witness[col - 1 + 2 * row + 3][3] = PallasField::from(2u64.pow(12));
             assert_eq!(
-                cs.gates[2].verify_range_check::<Vesta>(2, &witness, &cs),
+                index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
                 Err(CircuitGateError::InvalidLookupConstraintSorted(
                     GateType::RangeCheck1
                 ))
@@ -1045,6 +1210,15 @@ fn verify_64_bit_range_check() {
             .build()
             .unwrap();
 
+    let index = {
+        let mut srs = SRS::<Vesta>::create(cs.domain.d1.size());
+        srs.add_lagrange_basis(cs.domain.d1);
+        let srs = Arc::new(srs);
+
+        let (endo_q, _endo_r) = endos::<Pallas>();
+        ProverIndex::<Vesta>::create(cs, endo_q, srs)
+    };
+
     // Witness layout (positive test case)
     //   Row 0 1 2 3 ... 14  Gate
     //   0   0 0 0 0 ... 0   GenericPub
@@ -1059,13 +1233,18 @@ fn verify_64_bit_range_check() {
 
     // Positive test case
     assert_eq!(
-        cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+        index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
         Ok(())
     );
 
     // Generic witness verification test
     assert_eq!(
-        cs.gates[1].verify_witness::<Vesta>(1, &witness, &cs, &witness[0][0..cs.public].to_vec()),
+        index.cs.gates[1].verify_witness::<Vesta>(
+            1,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public].to_vec()
+        ),
         Ok(())
     );
 
@@ -1083,7 +1262,7 @@ fn verify_64_bit_range_check() {
 
     // Negative test case
     assert_eq!(
-        cs.gates[1].verify_range_check::<Vesta>(1, &witness, &cs),
+        index.cs.gates[1].verify_range_check::<Vesta>(1, &witness, &index),
         Err(CircuitGateError::InvalidCopyConstraint(
             GateType::RangeCheck0
         ))
@@ -1106,7 +1285,7 @@ fn verify_range_check_valid_proof1() {
     );
 
     // Verify computed witness satisfies the circuit
-    prover_index.cs.verify::<Vesta>(&witness, &[]).unwrap();
+    prover_index.verify(&witness, &[]).unwrap();
 
     // Generate proof
     let group_map = <Vesta as CommitmentCurve>::Map::setup();

--- a/kimchi/src/tests/serde.rs
+++ b/kimchi/src/tests/serde.rs
@@ -64,7 +64,7 @@ mod tests {
             serde_json::to_string(&verifier_index).expect("couldn't serialize index");
 
         // verify the circuit satisfiability by the computed witness
-        index.cs.verify::<Vesta>(&witness, &public).unwrap();
+        index.verify(&witness, &public).unwrap();
 
         // add the proof to the batch
         let group_map = <Vesta as CommitmentCurve>::Map::setup();

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -224,7 +224,7 @@ impl<G: KimchiCurve> ProverIndex<G> {
             coefficients_comm: array::from_fn(|i| {
                 self.srs.commit_evaluations_non_hiding(
                     domain,
-                    &self.cs.column_evaluations.coefficients8[i],
+                    &self.column_evaluations.coefficients8[i],
                     None,
                 )
             }),
@@ -240,56 +240,46 @@ impl<G: KimchiCurve> ProverIndex<G> {
 
             complete_add_comm: self.srs.commit_evaluations_non_hiding(
                 domain,
-                &self.cs.column_evaluations.complete_add_selector4,
+                &self.column_evaluations.complete_add_selector4,
                 None,
             ),
             mul_comm: self.srs.commit_evaluations_non_hiding(
                 domain,
-                &self.cs.column_evaluations.mul_selector8,
+                &self.column_evaluations.mul_selector8,
                 None,
             ),
             emul_comm: self.srs.commit_evaluations_non_hiding(
                 domain,
-                &self.cs.column_evaluations.emul_selector8,
+                &self.column_evaluations.emul_selector8,
                 None,
             ),
 
             endomul_scalar_comm: self.srs.commit_evaluations_non_hiding(
                 domain,
-                &self.cs.column_evaluations.endomul_scalar_selector8,
+                &self.column_evaluations.endomul_scalar_selector8,
                 None,
             ),
 
-            chacha_comm: self
-                .cs
-                .column_evaluations
-                .chacha_selectors8
-                .as_ref()
-                .map(|c| {
-                    array::from_fn(|i| self.srs.commit_evaluations_non_hiding(domain, &c[i], None))
-                }),
+            chacha_comm: self.column_evaluations.chacha_selectors8.as_ref().map(|c| {
+                array::from_fn(|i| self.srs.commit_evaluations_non_hiding(domain, &c[i], None))
+            }),
 
-            range_check_comm: self
-                .cs
-                .column_evaluations
-                .range_check_selectors8
-                .as_ref()
-                .map(|evals8| {
+            range_check_comm: self.column_evaluations.range_check_selectors8.as_ref().map(
+                |evals8| {
                     array::from_fn(|i| {
                         self.srs
                             .commit_evaluations_non_hiding(domain, &evals8[i], None)
                     })
-                }),
+                },
+            ),
 
             foreign_field_add_comm: self
-                .cs
                 .column_evaluations
                 .foreign_field_add_selector8
                 .as_ref()
                 .map(|eval8| self.srs.commit_evaluations_non_hiding(domain, &eval8, None)),
 
             xor_comm: self
-                .cs
                 .column_evaluations
                 .xor_selector8
                 .as_ref()

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -214,10 +214,7 @@ impl<G: KimchiCurve> ProverIndex<G> {
 
             sigma_comm: array::from_fn(|i| {
                 self.srs.commit_non_hiding(
-                    &self
-                        .cs
-                        .evaluated_column_coefficients
-                        .permutation_coefficients[i],
+                    &self.evaluated_column_coefficients.permutation_coefficients[i],
                     None,
                 )
             }),
@@ -228,15 +225,15 @@ impl<G: KimchiCurve> ProverIndex<G> {
                     None,
                 )
             }),
-            generic_comm: mask_fixed(self.srs.commit_non_hiding(
-                &self.cs.evaluated_column_coefficients.generic_selector,
-                None,
-            )),
+            generic_comm: mask_fixed(
+                self.srs
+                    .commit_non_hiding(&self.evaluated_column_coefficients.generic_selector, None),
+            ),
 
-            psm_comm: mask_fixed(self.srs.commit_non_hiding(
-                &self.cs.evaluated_column_coefficients.poseidon_selector,
-                None,
-            )),
+            psm_comm: mask_fixed(
+                self.srs
+                    .commit_non_hiding(&self.evaluated_column_coefficients.poseidon_selector, None),
+            ),
 
             complete_add_comm: self.srs.commit_evaluations_non_hiding(
                 domain,


### PR DESCRIPTION
This PR builds upon https://github.com/o1-labs/proof-systems/pull/868, moving the polynomial precomputation structures in `ConstraintSystem` into `ProverIndex`.