### PR TITLE
Compute 'chunked' Lagrange commitments

### DIFF
--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -265,15 +265,13 @@ where
                 // no blinders: blind the witness
                 None => index
                     .srs
-                    .commit_evaluations(index.cs.domain.d1, &witness_eval, None, rng),
+                    .commit_evaluations(index.cs.domain.d1, &witness_eval, rng),
                 // blinders: blind the witness with them
                 Some(blinder) => {
                     // TODO: make this a function rather no? mask_with_custom()
-                    let witness_com = index.srs.commit_evaluations_non_hiding(
-                        index.cs.domain.d1,
-                        &witness_eval,
-                        None,
-                    );
+                    let witness_com = index
+                        .srs
+                        .commit_evaluations_non_hiding(index.cs.domain.d1, &witness_eval);
                     index
                         .srs
                         .mask_custom(witness_com, blinder)
@@ -484,11 +482,7 @@ where
             //~~ - Commit each of the sorted polynomials.
             let sorted_comms: Vec<_> = sorted
                 .iter()
-                .map(|v| {
-                    index
-                        .srs
-                        .commit_evaluations(index.cs.domain.d1, v, None, rng)
-                })
+                .map(|v| index.srs.commit_evaluations(index.cs.domain.d1, v, rng))
                 .collect();
 
             //~~ - Absorb each commitments to the sorted polynomials.
@@ -542,7 +536,7 @@ where
             //~~ - Commit to the aggregation polynomial.
             let aggreg_comm = index
                 .srs
-                .commit_evaluations(index.cs.domain.d1, &aggreg, None, rng);
+                .commit_evaluations(index.cs.domain.d1, &aggreg, rng);
 
             //~~ - Absorb the commitment to the aggregation polynomial with the Fq-Sponge.
             fq_sponge.absorb_g(&aggreg_comm.commitment.unshifted);

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -471,6 +471,9 @@ where
             proof.prev_challenges.len(),
         ));
     }
+    if proof.public.len() != index.public {
+        return Err(VerifyError::IncorrectPubicInputLength(index.public));
+    }
 
     //~ 1. Commit to the negated public input polynomial.
     let lgr_comm = index
@@ -478,20 +481,9 @@ where
         .lagrange_bases
         .get(&index.domain.size())
         .expect("pre-computed committed lagrange bases not found");
-    let com: Vec<_> = lgr_comm
-        .iter()
-        .map(|c| PolyComm {
-            unshifted: vec![*c],
-            shifted: None,
-        })
-        .take(index.public)
-        .collect();
-    let com_ref: Vec<_> = com.iter().collect();
-    if proof.public.len() != index.public {
-        return Err(VerifyError::IncorrectPubicInputLength(index.public));
-    }
+    let com: Vec<_> = lgr_comm.iter().take(index.public).collect();
     let elm: Vec<_> = proof.public.iter().map(|s| -*s).collect();
-    let public_comm = PolyComm::<G>::multi_scalar_mul(&com_ref, &elm);
+    let public_comm = PolyComm::<G>::multi_scalar_mul(&com, &elm);
     let public_comm = {
         index
             .srs()

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -180,21 +180,20 @@ impl<G: KimchiCurve> ProverIndex<G> {
                     lookup_selectors: cs
                         .lookup_selectors
                         .as_ref()
-                        .map(|e| self.srs.commit_evaluations_non_hiding(domain, e, None)),
+                        .map(|e| self.srs.commit_evaluations_non_hiding(domain, e)),
                     lookup_table: cs
                         .lookup_table8
                         .iter()
-                        .map(|e| self.srs.commit_evaluations_non_hiding(domain, e, None))
+                        .map(|e| self.srs.commit_evaluations_non_hiding(domain, e))
                         .collect(),
                     table_ids: cs.table_ids8.as_ref().map(|table_ids8| {
-                        self.srs
-                            .commit_evaluations_non_hiding(domain, table_ids8, None)
+                        self.srs.commit_evaluations_non_hiding(domain, table_ids8)
                     }),
                     max_joint_size: cs.configuration.lookup_info.max_joint_size,
                     runtime_tables_selector: cs
                         .runtime_selector
                         .as_ref()
-                        .map(|e| self.srs.commit_evaluations_non_hiding(domain, e, None)),
+                        .map(|e| self.srs.commit_evaluations_non_hiding(domain, e)),
                 })
         };
 
@@ -222,7 +221,6 @@ impl<G: KimchiCurve> ProverIndex<G> {
                 self.srs.commit_evaluations_non_hiding(
                     domain,
                     &self.column_evaluations.coefficients8[i],
-                    None,
                 )
             }),
             generic_comm: mask_fixed(
@@ -238,35 +236,28 @@ impl<G: KimchiCurve> ProverIndex<G> {
             complete_add_comm: self.srs.commit_evaluations_non_hiding(
                 domain,
                 &self.column_evaluations.complete_add_selector4,
-                None,
             ),
-            mul_comm: self.srs.commit_evaluations_non_hiding(
-                domain,
-                &self.column_evaluations.mul_selector8,
-                None,
-            ),
-            emul_comm: self.srs.commit_evaluations_non_hiding(
-                domain,
-                &self.column_evaluations.emul_selector8,
-                None,
-            ),
+            mul_comm: self
+                .srs
+                .commit_evaluations_non_hiding(domain, &self.column_evaluations.mul_selector8),
+            emul_comm: self
+                .srs
+                .commit_evaluations_non_hiding(domain, &self.column_evaluations.emul_selector8),
 
             endomul_scalar_comm: self.srs.commit_evaluations_non_hiding(
                 domain,
                 &self.column_evaluations.endomul_scalar_selector8,
-                None,
             ),
 
-            chacha_comm: self.column_evaluations.chacha_selectors8.as_ref().map(|c| {
-                array::from_fn(|i| self.srs.commit_evaluations_non_hiding(domain, &c[i], None))
-            }),
+            chacha_comm: self
+                .column_evaluations
+                .chacha_selectors8
+                .as_ref()
+                .map(|c| array::from_fn(|i| self.srs.commit_evaluations_non_hiding(domain, &c[i]))),
 
             range_check_comm: self.column_evaluations.range_check_selectors8.as_ref().map(
                 |evals8| {
-                    array::from_fn(|i| {
-                        self.srs
-                            .commit_evaluations_non_hiding(domain, &evals8[i], None)
-                    })
+                    array::from_fn(|i| self.srs.commit_evaluations_non_hiding(domain, &evals8[i]))
                 },
             ),
 
@@ -274,13 +265,13 @@ impl<G: KimchiCurve> ProverIndex<G> {
                 .column_evaluations
                 .foreign_field_add_selector8
                 .as_ref()
-                .map(|eval8| self.srs.commit_evaluations_non_hiding(domain, eval8, None)),
+                .map(|eval8| self.srs.commit_evaluations_non_hiding(domain, eval8)),
 
             xor_comm: self
                 .column_evaluations
                 .xor_selector8
                 .as_ref()
-                .map(|eval8| self.srs.commit_evaluations_non_hiding(domain, eval8, None)),
+                .map(|eval8| self.srs.commit_evaluations_non_hiding(domain, eval8)),
 
             shift: self.cs.shift,
             zkpm: {

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -33,11 +33,9 @@ use super::evaluation_proof::*;
 
 /// A polynomial commitment.
 #[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PolyComm<C>
-where
-    C: CanonicalDeserialize + CanonicalSerialize,
-{
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(bound = "C: CanonicalDeserialize + CanonicalSerialize")]
+pub struct PolyComm<C> {
     #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
     pub unshifted: Vec<C>,
     #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -911,6 +911,58 @@ mod tests {
     }
 
     #[test]
+    fn test_chunked_lagrange_commitments() {
+        let n = 64;
+        let domain = D::<Fp>::new(n).unwrap();
+
+        let mut srs = SRS::<VestaG>::create(n / 2);
+        srs.add_lagrange_basis(domain);
+
+        let expected_lagrange_commitments: Vec<_> = (0..n)
+            .map(|i| {
+                let mut e = vec![Fp::zero(); n];
+                e[i] = Fp::one();
+                let p = Evaluations::<Fp, D<Fp>>::from_vec_and_domain(e, domain).interpolate();
+                srs.commit_non_hiding(&p, None)
+            })
+            .collect();
+
+        let computed_lagrange_commitments = srs.lagrange_bases.get(&domain.size()).unwrap();
+        for i in 0..n {
+            assert_eq!(
+                computed_lagrange_commitments[i],
+                expected_lagrange_commitments[i],
+            );
+        }
+    }
+
+    #[test]
+    fn test_offset_chunked_lagrange_commitments() {
+        let n = 64;
+        let domain = D::<Fp>::new(n).unwrap();
+
+        let mut srs = SRS::<VestaG>::create(n / 2 + 1);
+        srs.add_lagrange_basis(domain);
+
+        let expected_lagrange_commitments: Vec<_> = (0..n)
+            .map(|i| {
+                let mut e = vec![Fp::zero(); n];
+                e[i] = Fp::one();
+                let p = Evaluations::<Fp, D<Fp>>::from_vec_and_domain(e, domain).interpolate();
+                srs.commit_non_hiding(&p, Some(64))
+            })
+            .collect();
+
+        let computed_lagrange_commitments = srs.lagrange_bases.get(&domain.size()).unwrap();
+        for i in 0..n {
+            assert_eq!(
+                computed_lagrange_commitments[i],
+                expected_lagrange_commitments[i],
+            );
+        }
+    }
+
+    #[test]
     fn test_opening_proof() {
         // create two polynomials
         let coeffs: [Fp; 10] = array::from_fn(|i| Fp::from(i as u32));

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -606,11 +606,10 @@ impl<G: CommitmentCurve> SRS<G> {
         domain: D<G::ScalarField>,
         plnm: &Evaluations<G::ScalarField, D<G::ScalarField>>,
     ) -> PolyComm<G> {
-        let lagrange_basis = self.lagrange_bases.get(&domain.size());
-        let basis = match lagrange_basis.as_ref() {
-            None => panic!("lagrange bases for size {} not found", domain.size()),
-            Some(v) => v,
-        };
+        let basis = self
+            .lagrange_bases
+            .get(&domain.size())
+            .unwrap_or_else(|| panic!("lagrange bases for size {} not found", domain.size()));
         let commit_evaluations = |evals: &Vec<G::ScalarField>, basis: &Vec<PolyComm<G>>| {
             PolyComm::<G>::multi_scalar_mul(&basis.iter().collect::<Vec<_>>()[..], &evals[..])
         };

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -33,7 +33,7 @@ use super::evaluation_proof::*;
 
 /// A polynomial commitment.
 #[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(bound = "C: CanonicalDeserialize + CanonicalSerialize")]
 pub struct PolyComm<C> {
     #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]

--- a/poly-commitment/src/srs.rs
+++ b/poly-commitment/src/srs.rs
@@ -3,13 +3,14 @@
 use crate::commitment::CommitmentCurve;
 use crate::PolyComm;
 use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_ff::{BigInteger, PrimeField};
+use ark_ff::{BigInteger, PrimeField, Zero};
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as D};
 use blake2::{Blake2b512, Digest};
 use groupmap::GroupMap;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::array;
+use std::cmp::min;
 use std::collections::HashMap;
 
 #[serde_as]
@@ -84,13 +85,6 @@ where
     /// cache them in the SRS
     pub fn add_lagrange_basis(&mut self, domain: D<G::ScalarField>) {
         let n = domain.size();
-        if n > self.g.len() {
-            panic!(
-                "add_lagrange_basis: Domain size {} larger than SRS size {}",
-                n,
-                self.g.len()
-            );
-        }
 
         if self.lagrange_bases.contains_key(&n) {
             return;
@@ -151,13 +145,68 @@ where
         // because the commitment to the polynomial x^i is just self.g[i], we can obtain
         // commitments to the normalized Lagrange polynomials by applying IFFT to the
         // vector self.g[0..n].
-        let mut lg: Vec<<G as AffineCurve>::Projective> =
-            self.g[0..n].iter().map(|g| g.into_projective()).collect();
-        domain.ifft_in_place(&mut lg);
+        //
+        //
+        // Further still, we can do the same trick for 'chunked' polynomials.
+        //
+        // Recall that a chunked polynomial is some f of degree k*n - 1 with
+        // f(x) = f_0(x) + x^n f_1(x) + ... + x^{(k-1) n} f_{k-1}(x)
+        // where each f_i has degree n-1.
+        //
+        // In the above, if we set u = [ 1, x^2, ... x^{n-1}, 0, 0, .., 0 ]
+        // then we effectively 'zero out' any polynomial terms higher than x^{n-1}, leaving
+        // us with the 'partial Lagrange polynomials' that contribute to f_0.
+        //
+        // Similarly, u = [ 0, 0, ..., 0, 1, x^2, ..., x^{n-1}, 0, 0, ..., 0] with n leading
+        // zeros 'zeroes out' all terms except the 'partial Lagrange polynomials' that
+        // contribute to f_1, and likewise for each f_i.
+        //
+        // By computing each of these, and recollecting the terms as a vector of polynomial
+        // commitments, we obtain a chunked commitment to the L_i polynomials.
+        let srs_size = self.g.len();
+        let num_unshifteds = (n + srs_size - 1) / srs_size;
+        let mut unshifted = Vec::with_capacity(num_unshifteds);
 
-        <G as AffineCurve>::Projective::batch_normalization(lg.as_mut_slice());
-        let unshifted = vec![lg];
-        let shifted: Option<Vec<<G as AffineCurve>::Projective>> = None;
+        // For each chunk
+        for i in 0..num_unshifteds {
+            // Initialize the vector with zero curve points
+            let mut lg: Vec<<G as AffineCurve>::Projective> =
+                vec![<G as AffineCurve>::Projective::zero(); n];
+            // Overwrite the terms corresponding to that chunk with the SRS curve points
+            let start_offset = i * srs_size;
+            let num_terms = min((i + 1) * srs_size, n) - start_offset;
+            for j in 0..num_terms {
+                lg[start_offset + j] = self.g[j].into_projective()
+            }
+            // Apply the IFFT
+            domain.ifft_in_place(&mut lg);
+            <G as AffineCurve>::Projective::batch_normalization(lg.as_mut_slice());
+            // Append the 'partial Langrange polynomials' to the vector of unshifted chunks
+            unshifted.push(lg)
+        }
+
+        // If the srs size does not exactly divide the domain size
+        let shifted: Option<Vec<<G as AffineCurve>::Projective>> =
+            if num_unshifteds * self.g.len() == n {
+                None
+            } else {
+                // Initialize the vector to zero
+                let mut lg: Vec<<G as AffineCurve>::Projective> =
+                    vec![<G as AffineCurve>::Projective::zero(); n];
+                // Overwrite the terms corresponding to the final chunk with the SRS curve points
+                // shifted to the right
+                let start_offset = (num_unshifteds - 1) * srs_size;
+                let num_terms = n - start_offset;
+                let srs_start_offset = srs_size - num_terms;
+                for j in 0..num_terms {
+                    lg[start_offset + j] = self.g[srs_start_offset + j].into_projective()
+                }
+                // Apply the IFFT
+                domain.ifft_in_place(&mut lg);
+                <G as AffineCurve>::Projective::batch_normalization(lg.as_mut_slice());
+                Some(lg)
+            };
+
         let chunked_commitments: Vec<_> = (0..n)
             .map(|i| PolyComm {
                 unshifted: unshifted.iter().map(|v| v[i].into_affine()).collect(),


### PR DESCRIPTION
This PR tweaks the SRS precomputations to calculate a 'chunked' representation of the Lagrange commitments.

The lack of this prevented the 'chunked' approach from working with public inputs. This brings us closer to a working version of the chunked prover.