### PR TITLE
Absorb shifted commitments

### DIFF
--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -215,7 +215,7 @@ where
 
         //~ 1. Absorb the commitments of the previous challenges with the Fq-sponge.
         for RecursionChallenge { comm, .. } in &prev_challenges {
-            absorb_commitment(&mut fq_sponge, &comm)
+            absorb_commitment(&mut fq_sponge, comm)
         }
 
         //~ 1. Compute the negated public input polynomial as

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -38,7 +38,7 @@ use ark_poly::{
     Radix2EvaluationDomain as D, UVPolynomial,
 };
 use commitment_dlog::commitment::{
-    b_poly_coefficients, BlindedCommitment, CommitmentCurve, PolyComm,
+    absorb_commitment, b_poly_coefficients, BlindedCommitment, CommitmentCurve, PolyComm,
 };
 use itertools::Itertools;
 use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
@@ -215,7 +215,7 @@ where
 
         //~ 1. Absorb the commitments of the previous challenges with the Fq-sponge.
         for RecursionChallenge { comm, .. } in &prev_challenges {
-            fq_sponge.absorb_g(&comm.unshifted);
+            absorb_commitment(&mut fq_sponge, &comm)
         }
 
         //~ 1. Compute the negated public input polynomial as
@@ -246,7 +246,7 @@ where
         //~    Note: unlike the original PLONK protocol,
         //~    the prover also provides evaluations of the public polynomial to help the verifier circuit.
         //~    This is why we need to absorb the commitment to the public polynomial at this point.
-        fq_sponge.absorb_g(&public_comm.unshifted);
+        absorb_commitment(&mut fq_sponge, &public_comm);
 
         //~ 1. Commit to the witness columns by creating `COLUMNS` hidding commitments.
         //~
@@ -291,7 +291,7 @@ where
         //~ 1. Absorb the witness commitments with the Fq-Sponge.
         w_comm
             .iter()
-            .for_each(|c| fq_sponge.absorb_g(&c.commitment.unshifted));
+            .for_each(|c| absorb_commitment(&mut fq_sponge, &c.commitment));
 
         //~ 1. Compute the witness polynomials by interpolating each `COLUMNS` of the witness.
         //~    TODO: why not do this first, and then commit? Why commit from evaluation directly?
@@ -357,7 +357,7 @@ where
                 let runtime_table_comm = index.srs.commit(&runtime_table_contribution, None, rng);
 
                 // absorb the commitment
-                fq_sponge.absorb_g(&runtime_table_comm.commitment.unshifted);
+                absorb_commitment(&mut fq_sponge, &runtime_table_comm.commitment);
 
                 // pre-compute the updated second column of the lookup table
                 let mut second_column_d8 = runtime_table_contribution_d8.clone();
@@ -494,7 +494,7 @@ where
             //~~ - Absorb each commitments to the sorted polynomials.
             sorted_comms
                 .iter()
-                .for_each(|c| fq_sponge.absorb_g(&c.commitment.unshifted));
+                .for_each(|c| absorb_commitment(&mut fq_sponge, &c.commitment));
 
             // precompute different forms of the sorted polynomials for later
             // TODO: We can avoid storing these coefficients.
@@ -545,7 +545,7 @@ where
                 .commit_evaluations(index.cs.domain.d1, &aggreg, None, rng);
 
             //~~ - Absorb the commitment to the aggregation polynomial with the Fq-Sponge.
-            fq_sponge.absorb_g(&aggreg_comm.commitment.unshifted);
+            absorb_commitment(&mut fq_sponge, &aggreg_comm.commitment);
 
             // precompute different forms of the aggregation polynomial for later
             let aggreg_coeffs = aggreg.interpolate();
@@ -565,7 +565,7 @@ where
         let z_comm = index.srs.commit(&z_poly, None, rng);
 
         //~ 1. Absorb the permutation aggregation polynomial $z$ with the Fq-Sponge.
-        fq_sponge.absorb_g(&z_comm.commitment.unshifted);
+        absorb_commitment(&mut fq_sponge, &z_comm.commitment);
 
         //~ 1. Sample $\alpha'$ with the Fq-Sponge.
         let alpha_chal = ScalarChallenge(fq_sponge.challenge());
@@ -877,7 +877,7 @@ where
         };
 
         //~ 1. Absorb the the commitment of the quotient polynomial with the Fq-Sponge.
-        fq_sponge.absorb_g(&t_comm.commitment.unshifted);
+        absorb_commitment(&mut fq_sponge, &t_comm.commitment);
 
         //~ 1. Sample $\zeta'$ with the Fq-Sponge.
         let zeta_chal = ScalarChallenge(fq_sponge.challenge());

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -68,17 +68,17 @@ where
 
         //~ 1. Absorb the commitments of the previous challenges with the Fq-sponge.
         for RecursionChallenge { comm, .. } in &self.prev_challenges {
-            absorb_commitment(&mut fq_sponge, &comm);
+            absorb_commitment(&mut fq_sponge, comm);
         }
 
         //~ 1. Absorb the commitment of the public input polynomial with the Fq-Sponge.
-        absorb_commitment(&mut fq_sponge, &public_comm);
+        absorb_commitment(&mut fq_sponge, public_comm);
 
         //~ 1. Absorb the commitments to the registers / witness columns with the Fq-Sponge.
         self.commitments
             .w_comm
             .iter()
-            .for_each(|c| absorb_commitment(&mut fq_sponge, &c));
+            .for_each(|c| absorb_commitment(&mut fq_sponge, c));
 
         //~ 1. If lookup is used:
         let joint_combiner = if let Some(l) = &index.lookup_index {
@@ -94,7 +94,7 @@ where
                     .runtime
                     .as_ref()
                     .ok_or(VerifyError::IncorrectRuntimeProof)?;
-                absorb_commitment(&mut fq_sponge, &runtime_commit);
+                absorb_commitment(&mut fq_sponge, runtime_commit);
             }
 
             //~~ - If it involves queries to a multiple-column lookup table,
@@ -115,7 +115,7 @@ where
 
             //~~ - absorb the commitments to the sorted polynomials.
             for com in &lookup_commits.sorted {
-                absorb_commitment(&mut fq_sponge, &com);
+                absorb_commitment(&mut fq_sponge, com);
             }
 
             Some(joint_combiner)

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -21,7 +21,7 @@ use crate::{
 use ark_ff::{Field, One, PrimeField, Zero};
 use ark_poly::{EvaluationDomain, Polynomial};
 use commitment_dlog::commitment::{
-    combined_inner_product, BatchEvaluationProof, Evaluation, PolyComm,
+    absorb_commitment, combined_inner_product, BatchEvaluationProof, Evaluation, PolyComm,
 };
 use itertools::izip;
 use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
@@ -68,17 +68,17 @@ where
 
         //~ 1. Absorb the commitments of the previous challenges with the Fq-sponge.
         for RecursionChallenge { comm, .. } in &self.prev_challenges {
-            fq_sponge.absorb_g(&comm.unshifted);
+            absorb_commitment(&mut fq_sponge, &comm);
         }
 
         //~ 1. Absorb the commitment of the public input polynomial with the Fq-Sponge.
-        fq_sponge.absorb_g(&public_comm.unshifted);
+        absorb_commitment(&mut fq_sponge, &public_comm);
 
         //~ 1. Absorb the commitments to the registers / witness columns with the Fq-Sponge.
         self.commitments
             .w_comm
             .iter()
-            .for_each(|c| fq_sponge.absorb_g(&c.unshifted));
+            .for_each(|c| absorb_commitment(&mut fq_sponge, &c));
 
         //~ 1. If lookup is used:
         let joint_combiner = if let Some(l) = &index.lookup_index {
@@ -94,7 +94,7 @@ where
                     .runtime
                     .as_ref()
                     .ok_or(VerifyError::IncorrectRuntimeProof)?;
-                fq_sponge.absorb_g(&runtime_commit.unshifted);
+                absorb_commitment(&mut fq_sponge, &runtime_commit);
             }
 
             //~~ - If it involves queries to a multiple-column lookup table,
@@ -115,7 +115,7 @@ where
 
             //~~ - absorb the commitments to the sorted polynomials.
             for com in &lookup_commits.sorted {
-                fq_sponge.absorb_g(&com.unshifted);
+                absorb_commitment(&mut fq_sponge, &com);
             }
 
             Some(joint_combiner)
@@ -131,11 +131,11 @@ where
 
         //~ 1. If using lookup, absorb the commitment to the aggregation lookup polynomial.
         self.commitments.lookup.iter().for_each(|l| {
-            fq_sponge.absorb_g(&l.aggreg.unshifted);
+            absorb_commitment(&mut fq_sponge, &l.aggreg);
         });
 
         //~ 1. Absorb the commitment to the permutation trace with the Fq-Sponge.
-        fq_sponge.absorb_g(&self.commitments.z_comm.unshifted);
+        absorb_commitment(&mut fq_sponge, &self.commitments.z_comm);
 
         //~ 1. Sample $\alpha'$ with the Fq-Sponge.
         let alpha_chal = ScalarChallenge(fq_sponge.challenge());
@@ -149,7 +149,7 @@ where
         }
 
         //~ 1. Absorb the commitment to the quotient polynomial $t$ into the argument.
-        fq_sponge.absorb_g(&self.commitments.t_comm.unshifted);
+        absorb_commitment(&mut fq_sponge, &self.commitments.t_comm);
 
         //~ 1. Sample $\zeta'$ with the Fq-Sponge.
         let zeta_chal = ScalarChallenge(fq_sponge.challenge());

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -321,6 +321,21 @@ pub fn squeeze_challenge<
     squeeze_prechallenge(sponge).to_field(endo_r)
 }
 
+pub fn absorb_commitment<
+    Fq: Field,
+    G: Clone,
+    Fr: PrimeField + SquareRootField,
+    EFqSponge: FqSponge<Fq, G, Fr>,
+>(
+    sponge: &mut EFqSponge,
+    commitment: &PolyComm<G>,
+) {
+    sponge.absorb_g(&commitment.unshifted);
+    if let Some(shifted) = commitment.shifted.as_ref() {
+        sponge.absorb_g(&[shifted.clone()]);
+    }
+}
+
 /// A useful trait extending AffineCurve for commitments.
 /// Unfortunately, we can't specify that `AffineCurve<BaseField : PrimeField>`,
 /// so usage of this traits must manually bind `G::BaseField: PrimeField`.


### PR DESCRIPTION
This PR updates the prover and verifier to absorb the shifted commitments in `PolyComm`, via a new helper function `absorb_commitment`.

This builds upon #870.