### PR TITLE
Fix doc-tests, add them to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,13 +54,19 @@ jobs:
 
       #
       # Tests
-      # 
+      #
 
       - name: Test with latest nextest release (faster than cargo test)
         uses: actions-rs/cargo@v1
-        with:            
+        with:
           command: nextest
           args: run --all-features --release
+
+      - name: Doc tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: cargo
+          args: test --all-features --release --doc
 
       #
       # Coding guidelines

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Doc tests
         uses: actions-rs/cargo@v1
         with:
-          command: cargo
-          args: test --all-features --release --doc
+          command: test
+          args: --all-features --release --doc
 
       #
       # Coding guidelines

--- a/kimchi/src/circuits/witness/variables.rs
+++ b/kimchi/src/circuits/witness/variables.rs
@@ -4,8 +4,8 @@ use ark_ff::Field;
 ///   First, you use "anchor" names for the variables when specifying
 ///   the witness layout.
 ///
-///     Ex.
-///
+///   Ex.
+///```ignore
 ///     let layout = [
 ///         [
 ///             &CopyShiftCell::create(0, 2, 8),
@@ -14,20 +14,23 @@ use ark_ff::Field;
 ///             &VariableCell::create("final_value"),
 ///         ]
 ///      ;
+///```
 ///
 ///   Second, you use variables with the same names when performing the
 ///   witness computation.
 ///
-///     Ex.
+///   Ex.
+///```ignore
 ///
 ///     let sum_of_products = carry1 * limb1 + pow1 * limb2;
 ///     ...
 ///     let final_value = middle_bits.pow(&[2u8]) * carry_flag
+///```
 ///
 ///   Third, when you're ready to generate the witness, you pass those
 ///   variables to the witness creation functions using variables!(foo, bar)
 ///   or variable_map!("foo" => 12, "bar" => blah).
-///
+///```ignore
 ///     Ex.
 ///
 ///     init_witness(
@@ -35,6 +38,7 @@ use ark_ff::Field;
 ///         &layout,
 ///         &variables!(sum_of_products, something_else, final_value),
 ///     );
+///```
 ///
 use std::{
     collections::HashMap,


### PR DESCRIPTION
`cargo test` runs doc tests by default. This PR fixes them so that they pass, and adds a command to CI to ensure that they don't break again.