### PR TITLE
Replace the horner method with arkworks(ark_poly) method

### DIFF
--- a/utils/src/dense_polynomial.rs
+++ b/utils/src/dense_polynomial.rs
@@ -1,7 +1,7 @@
 //! This adds a few utility functions for the [DensePolynomial] arkworks type.
 
 use ark_ff::Field;
-use ark_poly::{univariate::DensePolynomial, UVPolynomial};
+use ark_poly::{univariate::DensePolynomial, Polynomial, UVPolynomial};
 use rayon::prelude::*;
 
 use crate::chunked_polynomial::ChunkedPolynomial;
@@ -43,13 +43,7 @@ impl<F: Field> ExtendedDensePolynomial<F> for DensePolynomial<F> {
     }
 
     fn eval_polynomial(coeffs: &[F], x: F) -> F {
-        // this uses https://en.wikipedia.org/wiki/Horner%27s_method
-        let mut res = F::zero();
-        for c in coeffs.iter().rev() {
-            res *= &x;
-            res += c;
-        }
-        res
+        DensePolynomial::from_coefficients_slice(coeffs).evaluate(&x)
     }
 
     fn to_chunked_polynomial(&self, chunk_size: usize) -> ChunkedPolynomial<F> {


### PR DESCRIPTION
**What's been done here:**
Replace the horner method of [here](https://github.com/o1-labs/proof-systems/blob/master/utils/src/dense_polynomial.rs#L45-L53) with the standard method(`DensePolynomial::from_coefficients_slice(coeffs).evaluate(&point)`) of `arkworks` crate.


Reference: #437 
