### PR TITLE
Fix the mdbook build issue coming from CI(`gh-page.yml`)

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -30,3 +30,6 @@ command = "mdbook-mermaid"
 [preprocessor.toc]
 command = "mdbook-toc"
 renderer = ["html"]
+
+# for mdbook-katex compatibility
+[output.katex]


### PR DESCRIPTION
Add the `[output.katex]` line to `book/book.toml` file for the compatibility of using the `mdbook-katex` crate(**v0.2.17**)