### PR TITLE
[commitment] rewrite MSM function over polycomm to make it clearer

### DIFF
--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -34,10 +34,8 @@ use super::evaluation_proof::*;
 /// A polynomial commitment.
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PolyComm<C>
-where
-    C: CanonicalDeserialize + CanonicalSerialize,
-{
+#[serde(bound = "C: CanonicalDeserialize + CanonicalSerialize")]
+pub struct PolyComm<C> {
     #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
     pub unshifted: Vec<C>,
     #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]
@@ -51,6 +49,12 @@ where
 {
     pub commitment: PolyComm<G>,
     pub blinders: PolyComm<G::ScalarField>,
+}
+
+impl<T> PolyComm<T> {
+    pub fn new(unshifted: Vec<T>, shifted: Option<T>) -> Self {
+        Self { unshifted, shifted }
+    }
 }
 
 impl<A: Copy> PolyComm<A>
@@ -213,44 +217,51 @@ impl<C: AffineCurve> PolyComm<C> {
         }
     }
 
+    /// Performs a multi-scalar multiplication between scalars `elm` and commitments `com`.
+    /// If both are empty, returns a commitment of length 1 containing the point at infinity.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if `com` and `elm` are not of the same size.
     pub fn multi_scalar_mul(com: &[&PolyComm<C>], elm: &[C::ScalarField]) -> Self {
         assert_eq!(com.len(), elm.len());
-        PolyComm::<C> {
-            shifted: {
-                let pairs = com
-                    .iter()
-                    .zip(elm.iter())
-                    .filter_map(|(c, s)| c.shifted.map(|c| (c, s)))
-                    .collect::<Vec<_>>();
-                if pairs.is_empty() {
-                    None
-                } else {
-                    let points = pairs.iter().map(|(c, _)| *c).collect::<Vec<_>>();
-                    let scalars = pairs.iter().map(|(_, s)| s.into_repr()).collect::<Vec<_>>();
-                    Some(VariableBaseMSM::multi_scalar_mul(&points, &scalars).into_affine())
-                }
-            },
-            unshifted: {
-                if com.is_empty() || elm.is_empty() {
-                    vec![C::zero()]
-                } else {
-                    let n = Iterator::max(com.iter().map(|c| c.unshifted.len())).unwrap();
-                    (0..n)
-                        .map(|i| {
-                            let mut points = Vec::new();
-                            let mut scalars = Vec::new();
-                            com.iter().zip(elm.iter()).for_each(|(p, s)| {
-                                if i < p.unshifted.len() {
-                                    points.push(p.unshifted[i]);
-                                    scalars.push(s.into_repr())
-                                }
-                            });
-                            VariableBaseMSM::multi_scalar_mul(&points, &scalars).into_affine()
-                        })
-                        .collect::<Vec<_>>()
-                }
-            },
+
+        if com.is_empty() || elm.is_empty() {
+            return Self::new(vec![C::zero()], None);
         }
+
+        let all_scalars: Vec<_> = elm.into_iter().map(|s| s.into_repr()).collect();
+
+        let unshifted_size = Iterator::max(com.iter().map(|c| c.unshifted.len())).unwrap();
+        let mut unshifted = Vec::with_capacity(unshifted_size);
+
+        for chunk in 0..unshifted_size {
+            let (points, scalars): (Vec<_>, Vec<_>) = com
+                .iter()
+                .zip(&all_scalars)
+                // get rid of scalars that don't have an associated chunk
+                .filter_map(|(com, scalar)| com.unshifted.get(chunk).map(|c| (c, scalar)))
+                .unzip();
+
+            let chunk_msm = VariableBaseMSM::multi_scalar_mul::<C>(&points, &scalars);
+            unshifted.push(chunk_msm.into_affine());
+        }
+
+        let shifted_pairs: Vec<_> = com
+            .iter()
+            .zip(all_scalars)
+            // get rid of commitments without a `shifted` part
+            .filter_map(|(c, s)| c.shifted.map(|c| (c, s)))
+            .collect();
+
+        let shifted = if shifted_pairs.is_empty() {
+            None
+        } else {
+            let (points, scalars): (Vec<_>, Vec<_>) = shifted_pairs.into_iter().unzip();
+            Some(VariableBaseMSM::multi_scalar_mul(&points, &scalars).into_affine())
+        };
+
+        Self::new(unshifted, shifted)
     }
 }
 

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -230,7 +230,7 @@ impl<C: AffineCurve> PolyComm<C> {
             return Self::new(vec![C::zero()], None);
         }
 
-        let all_scalars: Vec<_> = elm.into_iter().map(|s| s.into_repr()).collect();
+        let all_scalars: Vec<_> = elm.iter().map(|s| s.into_repr()).collect();
 
         let unshifted_size = Iterator::max(com.iter().map(|c| c.unshifted.len())).unwrap();
         let mut unshifted = Vec::with_capacity(unshifted_size);

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -247,17 +247,17 @@ impl<C: AffineCurve> PolyComm<C> {
             unshifted.push(chunk_msm.into_affine());
         }
 
-        let shifted_pairs: Vec<_> = com
+        let mut shifted_pairs = com
             .iter()
             .zip(all_scalars)
             // get rid of commitments without a `shifted` part
             .filter_map(|(c, s)| c.shifted.map(|c| (c, s)))
-            .collect();
+            .peekable();
 
-        let shifted = if shifted_pairs.is_empty() {
+        let shifted = if shifted_pairs.peek().is_none() {
             None
         } else {
-            let (points, scalars): (Vec<_>, Vec<_>) = shifted_pairs.into_iter().unzip();
+            let (points, scalars): (Vec<_>, Vec<_>) = shifted_pairs.unzip();
             Some(VariableBaseMSM::multi_scalar_mul(&points, &scalars).into_affine())
         };
 


### PR DESCRIPTION
clearer, but also it returns early when it can, and it only computes the `into_repr()` of the scalars once