### PR TITLE
Allow feature-flagged gates to be exposed to OCaml

### DIFF
--- a/kimchi/src/alphas.rs
+++ b/kimchi/src/alphas.rs
@@ -323,7 +323,8 @@ mod tests {
     fn get_alphas_for_spec() {
         let gates = vec![CircuitGate::<Fp>::zero(Wire::for_row(0)); 2];
         let index = new_index_for_test(gates, 0);
-        let (_linearization, powers_of_alpha) = expr_linearization(&index.cs.feature_flags, true);
+        let (_linearization, powers_of_alpha) =
+            expr_linearization(Some(&index.cs.feature_flags), true);
         // make sure this is present in the specification
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let spec_path = Path::new(&manifest_dir)

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -447,7 +447,7 @@ pub enum FeatureFlag {
 }
 
 impl FeatureFlag {
-    pub fn is_enabled(&self) -> bool {
+    fn is_enabled(&self) -> bool {
         todo!("Handle features")
     }
 }

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -2257,7 +2257,7 @@ where
                 id.var_name()
             }
             EnabledIf(feature, e) => {
-                format!("enabled_if({:?}, (fun () -> {})", feature, e.ocaml(cache))
+                format!("enabled_if({:?}, (fun () -> {}))", feature, e.ocaml(cache))
             }
         }
     }

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1837,11 +1837,13 @@ impl<F: Neg<Output = F> + Clone + One + Zero + PartialEq> Expr<F> {
                 mul_monomials(&x, &x)
             }
             EnabledIf(feature, x) => {
-                let e = x.monomials(ev);
-                HashMap::from_iter(
-                    e.into_iter()
-                        .map(|(m, c)| (m, Expr::EnabledIf(*feature, Box::new(c)))),
-                )
+                let mut monomials = x.monomials(ev);
+                for expr in monomials.values_mut() {
+                    let mut unflagged = Expr::zero();
+                    std::mem::swap(expr, &mut unflagged);
+                    *expr = Expr::EnabledIf(*feature, Box::new(unflagged))
+                }
+                monomials
             }
         }
     }

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1836,11 +1836,11 @@ impl<F: Neg<Output = F> + Clone + One + Zero + PartialEq> Expr<F> {
                 mul_monomials(&x, &x)
             }
             EnabledIf(feature, x) => {
-                if feature.is_enabled() {
-                    x.monomials(ev)
-                } else {
-                    HashMap::default()
-                }
+                let e = x.monomials(ev);
+                HashMap::from_iter(
+                    e.into_iter()
+                        .map(|(m, c)| (m, Expr::EnabledIf(*feature, Box::new(c)))),
+                )
             }
         }
     }

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -506,7 +506,7 @@ pub enum PolishToken<F> {
     Store,
     Load(usize),
     /// Skip the given number of tokens if the feature is disabled, and emit a zero instead.
-    SkipIf(FeatureFlag, usize),
+    SkipIfNot(FeatureFlag, usize),
 }
 
 impl Variable {
@@ -602,7 +602,7 @@ impl<F: FftField> PolishToken<F> {
                     cache.push(x);
                 }
                 Load(i) => stack.push(cache[*i]),
-                SkipIf(feature, count) => {
+                SkipIfNot(feature, count) => {
                     if !feature.is_enabled() {
                         skip_count = *count;
                         stack.push(F::zero());
@@ -1297,7 +1297,7 @@ impl<F: FftField> Expr<ConstantExpr<F>> {
                 }
             }
             Expr::EnabledIf(feature, e) => {
-                let tok = PolishToken::SkipIf(*feature, 0);
+                let tok = PolishToken::SkipIfNot(*feature, 0);
                 res.push(tok);
                 let len_before = res.len();
                 /* Clone the cache, to make sure we don't try to access cached statements later
@@ -1305,7 +1305,7 @@ impl<F: FftField> Expr<ConstantExpr<F>> {
                 let mut cache = cache.clone();
                 e.to_polish_(&mut cache, res);
                 let len_after = res.len();
-                res[len_before - 1] = PolishToken::SkipIf(*feature, len_after - len_before);
+                res[len_before - 1] = PolishToken::SkipIfNot(*feature, len_after - len_before);
             }
         }
     }

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1378,13 +1378,8 @@ impl<F: FftField> Expr<ConstantExpr<F>> {
             UnnormalizedLagrangeBasis(i) => Ok(unnormalized_lagrange_basis(&d, *i, &pt)),
             Cell(v) => v.evaluate(evals),
             Cache(_, e) => e.evaluate_(d, pt, evals, c),
-            EnabledIf(feature, e) => {
-                if feature.is_enabled() {
-                    e.evaluate_(d, pt, evals, c)
-                } else {
-                    Ok(F::zero())
-                }
-            }
+            EnabledIf(feature, e) if feature.is_enabled() => e.evaluate_(d, pt, evals, c),
+            EnabledIf(feature, e) => Ok(F::zero()),
         }
     }
 

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1379,7 +1379,7 @@ impl<F: FftField> Expr<ConstantExpr<F>> {
             Cell(v) => v.evaluate(evals),
             Cache(_, e) => e.evaluate_(d, pt, evals, c),
             EnabledIf(feature, e) if feature.is_enabled() => e.evaluate_(d, pt, evals, c),
-            EnabledIf(feature, e) => Ok(F::zero()),
+            EnabledIf(_, _) => Ok(F::zero()),
         }
     }
 

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -475,6 +475,7 @@ pub enum Expr<C> {
     UnnormalizedLagrangeBasis(i32),
     Pow(Box<Expr<C>>, u64),
     Cache(CacheId, Box<Expr<C>>),
+    /// Expression is conditional on the given feature flag, returns 0 if disabled.
     EnabledIf(FeatureFlag, Box<Expr<C>>),
 }
 

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -435,6 +435,10 @@ impl Op2 {
 
 /// The feature flags that can be used to enable or disable parts of constraints.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "ocaml_types",
+    derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Enum)
+)]
 pub enum FeatureFlag {
     ChaCha,
     RangeCheck,

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -182,6 +182,9 @@ pub fn linearization_columns<F: FftField + SquareRootField>(
 
 /// Linearize the `expr`.
 ///
+/// If the `feature_flags` argument is `None`, this will generate an expression using the
+/// `Expr::EnabledIf` variant for each of the flags.
+///
 /// # Panics
 ///
 /// Will panic if the `linearization` process fails.

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -15,7 +15,7 @@ use crate::circuits::polynomials::varbasemul::VarbaseMul;
 use crate::circuits::polynomials::{generic, permutation, xor};
 use crate::circuits::{
     constraints::FeatureFlags,
-    expr::{Column, ConstantExpr, Expr, Linearization, PolishToken},
+    expr::{Column, ConstantExpr, Expr, FeatureFlag, Linearization, PolishToken},
     gate::GateType,
     wires::COLUMNS,
 };
@@ -27,7 +27,7 @@ use ark_ff::{FftField, PrimeField, SquareRootField};
 ///
 /// Will panic if `generic_gate` is not associate with `alpha^0`.
 pub fn constraints_expr<F: PrimeField + SquareRootField>(
-    feature_flags: &FeatureFlags<F>,
+    feature_flags: Option<&FeatureFlags<F>>,
     generic: bool,
 ) -> (Expr<ConstantExpr<F>>, Alphas<F>) {
     // register powers of alpha so that we don't reuse them across mutually inclusive constraints
@@ -46,23 +46,58 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
     expr += EndosclMul::combined_constraints(&powers_of_alpha);
     expr += EndomulScalar::combined_constraints(&powers_of_alpha);
 
-    if feature_flags.chacha {
-        expr += ChaCha0::combined_constraints(&powers_of_alpha);
-        expr += ChaCha1::combined_constraints(&powers_of_alpha);
-        expr += ChaCha2::combined_constraints(&powers_of_alpha);
-        expr += ChaChaFinal::combined_constraints(&powers_of_alpha);
+    {
+        let chacha_expr = || {
+            let mut expr = ChaCha0::combined_constraints(&powers_of_alpha);
+            expr += ChaCha1::combined_constraints(&powers_of_alpha);
+            expr += ChaCha2::combined_constraints(&powers_of_alpha);
+            expr += ChaChaFinal::combined_constraints(&powers_of_alpha);
+            expr
+        };
+        if let Some(feature_flags) = feature_flags {
+            if feature_flags.chacha {
+                expr += chacha_expr();
+            }
+        } else {
+            expr += Expr::EnabledIf(FeatureFlag::ChaCha, Box::new(chacha_expr()));
+        }
     }
 
-    if feature_flags.range_check {
-        expr += range_check::gadget::combined_constraints(&powers_of_alpha);
+    {
+        let range_check_expr = || range_check::gadget::combined_constraints(&powers_of_alpha);
+
+        if let Some(feature_flags) = feature_flags {
+            if feature_flags.range_check {
+                expr += range_check_expr();
+            }
+        } else {
+            expr += Expr::EnabledIf(FeatureFlag::RangeCheck, Box::new(range_check_expr()));
+        }
     }
 
-    if feature_flags.foreign_field_add {
-        expr += ForeignFieldAdd::combined_constraints(&powers_of_alpha);
+    {
+        let foreign_field_add_expr = || ForeignFieldAdd::combined_constraints(&powers_of_alpha);
+        if let Some(feature_flags) = feature_flags {
+            if feature_flags.foreign_field_add {
+                expr += foreign_field_add_expr();
+            }
+        } else {
+            expr += Expr::EnabledIf(
+                FeatureFlag::ForeignFieldAdd,
+                Box::new(foreign_field_add_expr()),
+            );
+        }
     }
 
-    if feature_flags.xor {
-        expr += xor::Xor16::combined_constraints(&powers_of_alpha);
+    {
+        let xor_expr = || xor::Xor16::combined_constraints(&powers_of_alpha);
+        if let Some(feature_flags) = feature_flags {
+            if feature_flags.xor {
+                expr += xor_expr();
+            }
+        } else {
+            expr += Expr::EnabledIf(FeatureFlag::Xor, Box::new(xor_expr()));
+        }
     }
 
     if generic {
@@ -73,7 +108,7 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
     powers_of_alpha.register(ArgumentType::Permutation, permutation::CONSTRAINTS);
 
     // lookup
-    if let Some(lcs) = feature_flags.lookup_configuration.as_ref() {
+    if let Some(lcs) = feature_flags.and_then(|x| x.lookup_configuration.as_ref()) {
         let constraints = lookup::constraints::constraints(lcs);
 
         // note: the number of constraints depends on the lookup configuration,
@@ -146,10 +181,11 @@ pub fn linearization_columns<F: FftField + SquareRootField>(
 ///
 /// Will panic if the `linearization` process fails.
 pub fn expr_linearization<F: PrimeField + SquareRootField>(
-    feature_flags: &FeatureFlags<F>,
+    feature_flags: Option<&FeatureFlags<F>>,
     generic: bool,
 ) -> (Linearization<Vec<PolishToken<F>>>, Alphas<F>) {
-    let evaluated_cols = linearization_columns::<F>(feature_flags.lookup_configuration.as_ref());
+    let evaluated_cols =
+        linearization_columns::<F>(feature_flags.and_then(|x| x.lookup_configuration.as_ref()));
 
     let (expr, powers_of_alpha) = constraints_expr(feature_flags, generic);
 

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -82,7 +82,7 @@ impl<G: KimchiCurve> ProverIndex<G> {
         cs.endo = endo_q;
 
         // pre-compute the linearization
-        let (linearization, powers_of_alpha) = expr_linearization(&cs.feature_flags, true);
+        let (linearization, powers_of_alpha) = expr_linearization(Some(&cs.feature_flags), true);
 
         // set `max_quot_size` to the degree of the quotient polynomial,
         // which is obtained by looking at the highest monomial in the sum


### PR DESCRIPTION
This PR
* adds an `EnabledIf` constructor for `Expr` (and a `SkipIf` counterpart for the `PolishToken` variant)
  - the implementation for these is still to-do; they're not used by anything here, so everything still works
* tweaks the `linearization` functions to accept an `Option<FeatureFlags>`, which uses the `EnabledIf` form if no feature flags are given

This then generates code on the OCaml side that can be used to (optionally) enable the logic for these gates, making it easier to update pickles for new gate kinds.