### PR TITLE
Don't create a shifted segment when the domain size is smaller than srs

### DIFF
--- a/poly-commitment/src/srs.rs
+++ b/poly-commitment/src/srs.rs
@@ -187,7 +187,7 @@ where
 
         // If the srs size does not exactly divide the domain size
         let shifted: Option<Vec<<G as AffineCurve>::Projective>> =
-            if num_unshifteds * self.g.len() == n {
+            if n < srs_size || num_unshifteds * srs_size == n {
                 None
             } else {
                 // Initialize the vector to zero


### PR DESCRIPTION
This PR fixes an oversight in #870, which is triggered by proofs on the Mina side with very small circuit sizes.