### PR TITLE
Remove unused custom blinders

### DIFF
--- a/circuit-construction/src/tests/example_proof.rs
+++ b/circuit-construction/src/tests/example_proof.rs
@@ -91,7 +91,6 @@ fn test_example_circuit() {
     let proof = prove::<Vesta, _, SpongeQ, SpongeR>(
         &prover_index,
         &group_map,
-        None,
         vec![public_key.x, public_key.y, hash],
         |sys, p| circuit::<Fp, Pallas, _>(&proof_system_constants, Some(&witness), sys, p),
     );

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -139,7 +139,6 @@ where
             runtime_tables,
             index,
             Vec::new(),
-            None,
         )
     }
 
@@ -161,7 +160,6 @@ where
         runtime_tables: &[RuntimeTable<G::ScalarField>],
         index: &ProverIndex<G>,
         prev_challenges: Vec<RecursionChallenge<G>>,
-        blinders: Option<[Option<PolyComm<G::ScalarField>>; COLUMNS]>,
     ) -> Result<Self> {
         // make sure that the SRS is not smaller than the domain size
         let d1_size = index.cs.domain.d1.size();
@@ -265,23 +263,9 @@ where
                     index.cs.domain.d1,
                 );
 
-            let com = match blinders.as_ref().and_then(|b| b[col].as_ref()) {
-                // no blinders: blind the witness
-                None => index
-                    .srs
-                    .commit_evaluations(index.cs.domain.d1, &witness_eval, rng),
-                // blinders: blind the witness with them
-                Some(blinder) => {
-                    // TODO: make this a function rather no? mask_with_custom()
-                    let witness_com = index
-                        .srs
-                        .commit_evaluations_non_hiding(index.cs.domain.d1, &witness_eval);
-                    index
-                        .srs
-                        .mask_custom(witness_com, blinder)
-                        .map_err(ProverError::WrongBlinders)?
-                }
-            };
+            let com = index
+                .srs
+                .commit_evaluations(index.cs.domain.d1, &witness_eval, rng);
 
             w_comm.push(com);
         }

--- a/kimchi/src/tests/framework.rs
+++ b/kimchi/src/tests/framework.rs
@@ -169,7 +169,6 @@ where
             &self.0.runtime_tables,
             &prover,
             self.0.recursion,
-            None,
         )
         .unwrap();
         println!("- time to create proof: {:?}s", start.elapsed().as_secs());


### PR DESCRIPTION
This PR removes the notion of 'custom blinders' when proving. These were never used, and are generally not a useful feature.