### PR TITLE
Add support for compact limbs (2 limb mode) to multi-range-check gadget

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1089,25 +1089,25 @@ This is how the three 88-bit inputs $v_0, v_1$ and $v_2$ are layed out and const
 * `vipj` is the jth 12-bit limb of value $v_i$
 * `vicj` is the jth 2-bit crumb limb of value $v_i$
 
-| Gates | `RangeCheck0`  | `RangeCheck0`  | `RangeCheck1`  | `Zero`          |
-| ----- | -------------- | -------------- | -------------- | --------------- |
-| Rows  |          0     |          1     |          2     |          3      |
-| Cols  |                |                |                |                 |
-|     0 |         `v0`   |         `v1`   |         `v2`   |         `0`     |
-|  MS:1 | copy    `v0p0` | copy    `v1p0` | crumb   `v2c0` | crumb   `v2c10` |
-|     2 | copy    `v0p1` | copy    `v1p1` | crumb   `v2c1` | crumb   `v2c11` |
-|     3 | plookup `v0p2` | plookup `v1p2` | plookup `v2p0` | plookup `v0p0`  |
-|     4 | plookup `v0p3` | plookup `v1p3` | plookup `v2p1` | plookup `v0p1`  |
-|     5 | plookup `v0p4` | plookup `v1p4` | plookup `v2p2` | plookup `v1p0`  |
-|     6 | plookup `v0p5` | plookup `v1p5` | plookup `v2p3` | plookup `v1p1`  |
-|     7 | crumb   `v0c0` | crumb   `v1c0` | crumb   `v2c2` | crumb   `v2c12` |
-|     8 | crumb   `v0c1` | crumb   `v1c1` | crumb   `v2c3` | crumb   `v2c13` |
-|     9 | crumb   `v0c2` | crumb   `v1c2` | crumb   `v2c4` | crumb   `v2c14` |
-|    10 | crumb   `v0c3` | crumb   `v1c3` | crumb   `v2c5` | crumb   `v2c15` |
-|    11 | crumb   `v0c4` | crumb   `v1c4` | crumb   `v2c6` | crumb   `v2c16` |
-|    12 | crumb   `v0c5` | crumb   `v1c5` | crumb   `v2c7` | crumb   `v2c17` |
-|    13 | crumb   `v0c6` | crumb   `v1c6` | crumb   `v2c8` | crumb   `v2c18` |
-| LS:14 | crumb   `v0c7` | crumb   `v1c7` | crumb   `v2c9` | crumb   `v2c19` |
+| Gates | `RangeCheck0`  | `RangeCheck0`  | `RangeCheck1`   | `Zero`          |
+| ----- | -------------- | -------------- | --------------- | --------------- |
+| Rows  |          0     |          1     |          2      |          3      |
+| Cols  |                |                |                 |                 |
+|     0 |         `v0`   |         `v1`   |          `v2`   | crumb   `v2c9`  |
+|  MS:1 | copy    `v0p0` | copy    `v1p0` | optional `v12`  | crumb   `v2c10` |
+|     2 | copy    `v0p1` | copy    `v1p1` | crumb    `v2c0` | crumb   `v2c11` |
+|     3 | plookup `v0p2` | plookup `v1p2` | plookup  `v2p0` | plookup `v0p0`  |
+|     4 | plookup `v0p3` | plookup `v1p3` | plookup  `v2p1` | plookup `v0p1`  |
+|     5 | plookup `v0p4` | plookup `v1p4` | plookup  `v2p2` | plookup `v1p0`  |
+|     6 | plookup `v0p5` | plookup `v1p5` | plookup  `v2p3` | plookup `v1p1`  |
+|     7 | crumb   `v0c0` | crumb   `v1c0` | crumb    `v2c1` | crumb   `v2c12` |
+|     8 | crumb   `v0c1` | crumb   `v1c1` | crumb    `v2c2` | crumb   `v2c13` |
+|     9 | crumb   `v0c2` | crumb   `v1c2` | crumb    `v2c3` | crumb   `v2c14` |
+|    10 | crumb   `v0c3` | crumb   `v1c3` | crumb    `v2c4` | crumb   `v2c15` |
+|    11 | crumb   `v0c4` | crumb   `v1c4` | crumb    `v2c5` | crumb   `v2c16` |
+|    12 | crumb   `v0c5` | crumb   `v1c5` | crumb    `v2c6` | crumb   `v2c17` |
+|    13 | crumb   `v0c6` | crumb   `v1c6` | crumb    `v2c7` | crumb   `v2c18` |
+| LS:14 | crumb   `v0c7` | crumb   `v1c7` | crumb    `v2c8` | crumb   `v2c19` |
 
 The 12-bit chunks are constrained with plookups and the 2-bit crumbs are
 constrained with degree-4 constraints of the form $x (x - 1) (x - 2) (x - 3)$.
@@ -1178,23 +1178,23 @@ It uses two different types of constraints
 
 Given value `v2` the layout looks like this
 
-| Column | `Curr`         | `Next`        |
-| ------ | -------------- | ------------- |
-|      0 |         `v2`   | (ignored)     |
-|      1 | crumb   `v2c0` | crumb `v2c10` |
-|      2 | crumb   `v2c1` | crumb `v2c11` |
-|      3 | plookup `v2p0` | (ignored)     |
-|      4 | plookup `v2p1` | (ignored)     |
-|      5 | plookup `v2p2` | (ignored)     |
-|      6 | plookup `v2p3` | (ignored)     |
-|      7 | crumb   `v2c2` | crumb `v2c12` |
-|      8 | crumb   `v2c3` | crumb `v2c13` |
-|      9 | crumb   `v2c4` | crumb `v2c14` |
-|     10 | crumb   `v2c5` | crumb `v2c15` |
-|     11 | crumb   `v2c6` | crumb `v2c16` |
-|     12 | crumb   `v2c7` | crumb `v2c17` |
-|     13 | crumb   `v2c8` | crumb `v2c18` |
-|     14 | crumb   `v2c9` | crumb `v2c19` |
+| Column | `Curr`          | `Next`        |
+| ------ | --------------- | ------------- |
+|      0 |          `v2`   | crumb `v2c9`  |
+|      1 | optional `v12`  | crumb `v2c10` |
+|      2 | crumb    `v2c0` | crumb `v2c11` |
+|      3 | plookup  `v2p0` | (ignored)     |
+|      4 | plookup  `v2p1` | (ignored)     |
+|      5 | plookup  `v2p2` | (ignored)     |
+|      6 | plookup  `v2p3` | (ignored)     |
+|      7 | crumb    `v2c1` | crumb `v2c12` |
+|      8 | crumb    `v2c2` | crumb `v2c13` |
+|      9 | crumb    `v2c3` | crumb `v2c14` |
+|     10 | crumb    `v2c4` | crumb `v2c15` |
+|     11 | crumb    `v2c5` | crumb `v2c16` |
+|     12 | crumb    `v2c6` | crumb `v2c17` |
+|     13 | crumb    `v2c7` | crumb `v2c18` |
+|     14 | crumb    `v2c8` | crumb `v2c19` |
 
 where the notation `v2ci` and `v2pi` defined in the "Layout" section above.
 

--- a/kimchi/src/circuits/polynomials/foreign_field_mul/witness.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_mul/witness.rs
@@ -285,6 +285,14 @@ impl<F: PrimeField> ExternalChecks<F> {
         }
     }
 
+    /// Extend the witness with external compact multi range_checks
+    pub fn extend_witness_compact_multi_range_checks(&self, witness: &mut [Vec<F>; COLUMNS]) {
+        for [v01, v2] in self.compact_multi_ranges.clone() {
+            range_check::witness::extend_multi_compact(witness, v01, v2)
+        }
+    }
+
+    /// Extend the witness with external bound addition
     pub fn extend_witness_bound_addition(
         &self,
         witness: &mut [Vec<F>; COLUMNS],

--- a/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
@@ -58,25 +58,25 @@
 //~ * `vipj` is the jth 12-bit limb of value $v_i$
 //~ * `vicj` is the jth 2-bit crumb limb of value $v_i$
 //~
-//~ | Gates | `RangeCheck0`  | `RangeCheck0`  | `RangeCheck1`  | `Zero`          |
-//~ | ----- | -------------- | -------------- | -------------- | --------------- |
-//~ | Rows  |          0     |          1     |          2     |          3      |
-//~ | Cols  |                |                |                |                 |
-//~ |     0 |         `v0`   |         `v1`   |         `v2`   |         `0`     |
-//~ |  MS:1 | copy    `v0p0` | copy    `v1p0` | crumb   `v2c0` | crumb   `v2c10` |
-//~ |     2 | copy    `v0p1` | copy    `v1p1` | crumb   `v2c1` | crumb   `v2c11` |
-//~ |     3 | plookup `v0p2` | plookup `v1p2` | plookup `v2p0` | plookup `v0p0`  |
-//~ |     4 | plookup `v0p3` | plookup `v1p3` | plookup `v2p1` | plookup `v0p1`  |
-//~ |     5 | plookup `v0p4` | plookup `v1p4` | plookup `v2p2` | plookup `v1p0`  |
-//~ |     6 | plookup `v0p5` | plookup `v1p5` | plookup `v2p3` | plookup `v1p1`  |
-//~ |     7 | crumb   `v0c0` | crumb   `v1c0` | crumb   `v2c2` | crumb   `v2c12` |
-//~ |     8 | crumb   `v0c1` | crumb   `v1c1` | crumb   `v2c3` | crumb   `v2c13` |
-//~ |     9 | crumb   `v0c2` | crumb   `v1c2` | crumb   `v2c4` | crumb   `v2c14` |
-//~ |    10 | crumb   `v0c3` | crumb   `v1c3` | crumb   `v2c5` | crumb   `v2c15` |
-//~ |    11 | crumb   `v0c4` | crumb   `v1c4` | crumb   `v2c6` | crumb   `v2c16` |
-//~ |    12 | crumb   `v0c5` | crumb   `v1c5` | crumb   `v2c7` | crumb   `v2c17` |
-//~ |    13 | crumb   `v0c6` | crumb   `v1c6` | crumb   `v2c8` | crumb   `v2c18` |
-//~ | LS:14 | crumb   `v0c7` | crumb   `v1c7` | crumb   `v2c9` | crumb   `v2c19` |
+//~ | Gates | `RangeCheck0`  | `RangeCheck0`  | `RangeCheck1`   | `Zero`          |
+//~ | ----- | -------------- | -------------- | --------------- | --------------- |
+//~ | Rows  |          0     |          1     |          2      |          3      |
+//~ | Cols  |                |                |                 |                 |
+//~ |     0 |         `v0`   |         `v1`   |          `v2`   | crumb   `v2c9`  |
+//~ |  MS:1 | copy    `v0p0` | copy    `v1p0` | optional `v12`  | crumb   `v2c10` |
+//~ |     2 | copy    `v0p1` | copy    `v1p1` | crumb    `v2c0` | crumb   `v2c11` |
+//~ |     3 | plookup `v0p2` | plookup `v1p2` | plookup  `v2p0` | plookup `v0p0`  |
+//~ |     4 | plookup `v0p3` | plookup `v1p3` | plookup  `v2p1` | plookup `v0p1`  |
+//~ |     5 | plookup `v0p4` | plookup `v1p4` | plookup  `v2p2` | plookup `v1p0`  |
+//~ |     6 | plookup `v0p5` | plookup `v1p5` | plookup  `v2p3` | plookup `v1p1`  |
+//~ |     7 | crumb   `v0c0` | crumb   `v1c0` | crumb    `v2c1` | crumb   `v2c12` |
+//~ |     8 | crumb   `v0c1` | crumb   `v1c1` | crumb    `v2c2` | crumb   `v2c13` |
+//~ |     9 | crumb   `v0c2` | crumb   `v1c2` | crumb    `v2c3` | crumb   `v2c14` |
+//~ |    10 | crumb   `v0c3` | crumb   `v1c3` | crumb    `v2c4` | crumb   `v2c15` |
+//~ |    11 | crumb   `v0c4` | crumb   `v1c4` | crumb    `v2c5` | crumb   `v2c16` |
+//~ |    12 | crumb   `v0c5` | crumb   `v1c5` | crumb    `v2c6` | crumb   `v2c17` |
+//~ |    13 | crumb   `v0c6` | crumb   `v1c6` | crumb    `v2c7` | crumb   `v2c18` |
+//~ | LS:14 | crumb   `v0c7` | crumb   `v1c7` | crumb    `v2c8` | crumb   `v2c19` |
 //~
 //~ The 12-bit chunks are constrained with plookups and the 2-bit crumbs are
 //~ constrained with degree-4 constraints of the form $x (x - 1) (x - 2) (x - 3)$.
@@ -155,7 +155,7 @@ where
     F: PrimeField,
 {
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::RangeCheck0);
-    const CONSTRAINTS: u32 = 9;
+    const CONSTRAINTS: u32 = 10;
 
     // Constraints for RangeCheck0
     //   * Operates on Curr row
@@ -202,6 +202,15 @@ where
         // Check value v against the sum of limbs
         constraints.push(sum_of_limbs - env.witness_curr(0));
 
+        // Optional compact limbs format (enabled when coeff[0] == 1, disabled when coeff[1] = 0)
+        //   Constrain decomposition of compact limb next(1)
+        //   next(1) = curr(0) + 2^L * next(0)
+        constraints.push(
+            env.coeff(0)
+                * (env.witness_next(1)
+                    - (env.witness_curr(0) + T::two_to_limb() * env.witness_next(0))),
+        );
+
         constraints
     }
 }
@@ -218,23 +227,23 @@ where
 //~
 //~ Given value `v2` the layout looks like this
 //~
-//~ | Column | `Curr`         | `Next`        |
-//~ | ------ | -------------- | ------------- |
-//~ |      0 |         `v2`   | (ignored)     |
-//~ |      1 | crumb   `v2c0` | crumb `v2c10` |
-//~ |      2 | crumb   `v2c1` | crumb `v2c11` |
-//~ |      3 | plookup `v2p0` | (ignored)     |
-//~ |      4 | plookup `v2p1` | (ignored)     |
-//~ |      5 | plookup `v2p2` | (ignored)     |
-//~ |      6 | plookup `v2p3` | (ignored)     |
-//~ |      7 | crumb   `v2c2` | crumb `v2c12` |
-//~ |      8 | crumb   `v2c3` | crumb `v2c13` |
-//~ |      9 | crumb   `v2c4` | crumb `v2c14` |
-//~ |     10 | crumb   `v2c5` | crumb `v2c15` |
-//~ |     11 | crumb   `v2c6` | crumb `v2c16` |
-//~ |     12 | crumb   `v2c7` | crumb `v2c17` |
-//~ |     13 | crumb   `v2c8` | crumb `v2c18` |
-//~ |     14 | crumb   `v2c9` | crumb `v2c19` |
+//~ | Column | `Curr`          | `Next`        |
+//~ | ------ | --------------- | ------------- |
+//~ |      0 |          `v2`   | crumb `v2c9`  |
+//~ |      1 | optional `v12`  | crumb `v2c10` |
+//~ |      2 | crumb    `v2c0` | crumb `v2c11` |
+//~ |      3 | plookup  `v2p0` | (ignored)     |
+//~ |      4 | plookup  `v2p1` | (ignored)     |
+//~ |      5 | plookup  `v2p2` | (ignored)     |
+//~ |      6 | plookup  `v2p3` | (ignored)     |
+//~ |      7 | crumb    `v2c1` | crumb `v2c12` |
+//~ |      8 | crumb    `v2c2` | crumb `v2c13` |
+//~ |      9 | crumb    `v2c3` | crumb `v2c14` |
+//~ |     10 | crumb    `v2c4` | crumb `v2c15` |
+//~ |     11 | crumb    `v2c5` | crumb `v2c16` |
+//~ |     12 | crumb    `v2c6` | crumb `v2c17` |
+//~ |     13 | crumb    `v2c7` | crumb `v2c18` |
+//~ |     14 | crumb    `v2c8` | crumb `v2c19` |
 //~
 //~ where the notation `v2ci` and `v2pi` defined in the "Layout" section above.
 
@@ -254,10 +263,9 @@ where
     //   * Constrain that combining all limbs equals the value v2 stored in row Curr, column 0
     fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
         // 1) Apply range constraints on limbs for Curr row
-        //    * Columns 1-2 are 2-bit crumbs
-        let mut constraints = (1..=2)
-            .map(|i| crumb(&env.witness_curr(i)))
-            .collect::<Vec<T>>();
+        //    * Column 2 is a 2-bit crumb
+        let mut constraints = vec![crumb(&env.witness_curr(2))];
+
         //    * Columns 3-6 are 12-bit plookup range constraints (these are specified
         //      in the lookup gate)
         //    * Columns 7-14 are 2-bit crumb range constraints
@@ -268,9 +276,9 @@ where
         );
 
         // 2) Apply range constraints on limbs for Next row
-        //    * Columns 1-2 are 2-bit crumbs
+        //    * Columns 0-2 are 2-bit crumbs
         constraints.append(
-            &mut (1..=2)
+            &mut (0..=2)
                 .map(|i| crumb(&env.witness_next(i)))
                 .collect::<Vec<T>>(),
         );
@@ -305,7 +313,7 @@ where
         }
 
         // Next row:  Sum remaining 2-bit limbs vc10 and vc11
-        for i in (1..=2).rev() {
+        for i in (0..=2).rev() {
             sum_of_limbs += power_of_2.clone() * env.witness_next(i);
             power_of_2 *= 4u64.into(); // 2 bits
         }
@@ -322,11 +330,8 @@ where
             power_of_2 *= 4096u64.into(); // 12 bits
         }
 
-        // Curr row:  Sum remaining 2-bit limbs: vc0 and vc1
-        for i in (1..=2).rev() {
-            sum_of_limbs += power_of_2.clone() * env.witness_curr(i);
-            power_of_2 *= 4u64.into(); // 2 bits
-        }
+        // Curr row:  Add remaining 2-bit limb v2c0 to sum
+        sum_of_limbs += power_of_2.clone() * env.witness_curr(2);
 
         // Check value v2 against the sum of limbs
         constraints.push(sum_of_limbs - env.witness_curr(0));

--- a/kimchi/src/circuits/polynomials/range_check/gadget.rs
+++ b/kimchi/src/circuits/polynomials/range_check/gadget.rs
@@ -38,9 +38,72 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     ///       `next_row`      - next row after this gate
     ///       `circuit_gates` - vector of circuit gates comprising this gate
     pub fn create_multi_range_check(start_row: usize) -> (usize, Vec<Self>) {
+        Self::create_multi_range_check_gadget(start_row, false)
+    }
+
+    /// Create range check gate for constraining compact limbs.
+    ///     Inputs the starting row
+    ///     Outputs tuple (`next_row`, `circuit_gates`) where
+    ///       `next_row`      - next row after this gate
+    ///       `circuit_gates` - vector of circuit gates comprising this gate
+    pub fn create_compact_multi_range_check(start_row: usize) -> (usize, Vec<Self>) {
+        Self::create_multi_range_check_gadget(start_row, true)
+    }
+
+    /// Create foreign field muti-range-check gadget by extending the existing gates
+    pub fn extend_multi_range_check(gates: &mut Vec<Self>, curr_row: &mut usize) {
+        let (next_row, circuit_gates) = Self::create_multi_range_check(*curr_row);
+        *curr_row = next_row;
+        gates.extend_from_slice(&circuit_gates);
+    }
+
+    /// Create foreign field muti-range-check gadget by extending the existing gates
+    pub fn extend_compact_multi_range_check(gates: &mut Vec<Self>, curr_row: &mut usize) {
+        let (next_row, circuit_gates) = Self::create_compact_multi_range_check(*curr_row);
+        *curr_row = next_row;
+        gates.extend_from_slice(&circuit_gates);
+    }
+
+    /// Create single range check gate
+    ///     Inputs the starting row
+    ///     Outputs tuple (`next_row`, `circuit_gates`) where
+    ///       `next_row`      - next row after this gate
+    ///       `circuit_gates` - vector of circuit gates comprising this gate
+    pub fn create_range_check(start_row: usize) -> (usize, Vec<Self>) {
+        let gate = CircuitGate::new(
+            GateType::RangeCheck0,
+            Wire::for_row(start_row),
+            vec![F::zero()],
+        );
+        (start_row + 1, vec![gate])
+    }
+
+    /// Create foreign field range-check gate by extending the existing gates
+    pub fn extend_range_check(gates: &mut Vec<Self>, curr_row: &mut usize) {
+        let (next_row, circuit_gates) = Self::create_range_check(*curr_row);
+        *curr_row = next_row;
+        gates.extend_from_slice(&circuit_gates);
+    }
+
+    // Create range check gate for constraining three 88-bit values.
+    //     Inputs the starting row and whether the limbs are in compact format
+    //     Outputs tuple (`next_row`, `circuit_gates`) where
+    //       `next_row`      - next row after this gate
+    //       `circuit_gates` - vector of circuit gates comprising this gate
+    fn create_multi_range_check_gadget(start_row: usize, compact: bool) -> (usize, Vec<Self>) {
+        let coeff = if compact { F::one() } else { F::zero() };
+
         let mut circuit_gates = vec![
-            CircuitGate::new(GateType::RangeCheck0, Wire::for_row(start_row), vec![]),
-            CircuitGate::new(GateType::RangeCheck0, Wire::for_row(start_row + 1), vec![]),
+            CircuitGate::new(
+                GateType::RangeCheck0,
+                Wire::for_row(start_row),
+                vec![F::zero()],
+            ),
+            CircuitGate::new(
+                GateType::RangeCheck0,
+                Wire::for_row(start_row + 1),
+                vec![coeff],
+            ),
             CircuitGate::new(GateType::RangeCheck1, Wire::for_row(start_row + 2), vec![]),
             CircuitGate::new(GateType::Zero, Wire::for_row(start_row + 3), vec![]),
         ];
@@ -58,30 +121,6 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
         circuit_gates.connect_cell_pair((1, 2), (3, 6));
 
         (start_row + circuit_gates.len(), circuit_gates)
-    }
-
-    /// Create foreign field muti-range-check gadget by extending the existing gates
-    pub fn extend_multi_range_check(gates: &mut Vec<Self>, curr_row: &mut usize) {
-        let (next_row, circuit_gates) = Self::create_multi_range_check(*curr_row);
-        *curr_row = next_row;
-        gates.extend_from_slice(&circuit_gates);
-    }
-
-    /// Create single range check gate
-    ///     Inputs the starting row
-    ///     Outputs tuple (`next_row`, `circuit_gates`) where
-    ///       `next_row`      - next row after this gate
-    ///       `circuit_gates` - vector of circuit gates comprising this gate
-    pub fn create_range_check(start_row: usize) -> (usize, Vec<Self>) {
-        let gate = CircuitGate::new(GateType::RangeCheck0, Wire::for_row(start_row), vec![]);
-        (start_row + 1, vec![gate])
-    }
-
-    /// Create foreign field range-check gate by extending the existing gates
-    pub fn extend_range_check(gates: &mut Vec<Self>, curr_row: &mut usize) {
-        let (next_row, circuit_gates) = Self::create_range_check(*curr_row);
-        *curr_row = next_row;
-        gates.extend_from_slice(&circuit_gates);
     }
 
     /// Verify the witness against a range check (related) circuit gate

--- a/kimchi/src/circuits/polynomials/range_check/witness.rs
+++ b/kimchi/src/circuits/polynomials/range_check/witness.rs
@@ -1,17 +1,22 @@
 //! Range check witness computation
 
 use ark_ff::PrimeField;
-use o1_utils::ForeignElement;
+use num_bigint::BigUint;
+use num_integer::Integer;
+use o1_utils::field_helpers::BigUintFieldHelpers;
+use o1_utils::{FieldHelpers, ForeignElement};
 use std::array;
 
 use crate::circuits::witness::Variables;
+use crate::variable_map;
 use crate::{
     circuits::{
         polynomial::COLUMNS,
-        witness::{init_row, ConstantCell, CopyBitsCell, CopyCell, VariableCell, WitnessCell},
+        witness::{init_row, CopyBitsCell, CopyCell, VariableCell, WitnessCell},
     },
     variables,
 };
+use o1_utils::foreign_field::BigUintForeignFieldHelpers;
 
 /// Witness layout
 ///   * The values and cell contents are in little-endian order.
@@ -33,16 +38,17 @@ fn layout<F: PrimeField>() -> Vec<[Box<dyn WitnessCell<F>>; COLUMNS]> {
         /* row 3, RangeCheck1 row */
         [
             VariableCell::create("v2"),
+            VariableCell::create("v12"), // optional
             /* 2-bit crumbs (placed here to keep lookup pattern */
             /*               the same as RangeCheck0) */
             CopyBitsCell::create(2, 0, 86, 88),
-            CopyBitsCell::create(2, 0, 84, 86),
             /* 12-bit plookups */
-            CopyBitsCell::create(2, 0, 72, 84),
-            CopyBitsCell::create(2, 0, 60, 72),
-            CopyBitsCell::create(2, 0, 48, 60),
-            CopyBitsCell::create(2, 0, 36, 48),
+            CopyBitsCell::create(2, 0, 74, 86),
+            CopyBitsCell::create(2, 0, 62, 74),
+            CopyBitsCell::create(2, 0, 50, 62),
+            CopyBitsCell::create(2, 0, 38, 50),
             /* 2-bit crumbs */
+            CopyBitsCell::create(2, 0, 36, 38),
             CopyBitsCell::create(2, 0, 34, 36),
             CopyBitsCell::create(2, 0, 32, 34),
             CopyBitsCell::create(2, 0, 30, 32),
@@ -50,11 +56,10 @@ fn layout<F: PrimeField>() -> Vec<[Box<dyn WitnessCell<F>>; COLUMNS]> {
             CopyBitsCell::create(2, 0, 26, 28),
             CopyBitsCell::create(2, 0, 24, 26),
             CopyBitsCell::create(2, 0, 22, 24),
-            CopyBitsCell::create(2, 0, 20, 22),
         ],
         /* row 4, Zero row */
         [
-            ConstantCell::create(F::zero()),
+            CopyBitsCell::create(2, 0, 20, 22),
             /* 2-bit crumbs (placed here to keep lookup pattern */
             /*               the same as RangeCheck0) */
             CopyBitsCell::create(2, 0, 18, 20),
@@ -115,7 +120,38 @@ pub fn create_multi<F: PrimeField>(v0: F, v1: F, v2: F) -> [Vec<F>; COLUMNS] {
 
     init_row(&mut witness, 0, 0, &layout, &variables!(v0));
     init_row(&mut witness, 0, 1, &layout, &variables!(v1));
-    init_row(&mut witness, 0, 2, &layout, &variables!(v2));
+    init_row(
+        &mut witness,
+        0,
+        2,
+        &layout,
+        &variable_map!("v2" => v2, "v12" => F::zero()),
+    );
+    init_row(&mut witness, 0, 3, &layout, &variables!());
+
+    witness
+}
+
+/// Create a multi range check witness from two limbs: v01 (176 bits), v2 (88 bits),
+/// where v2 is the most significant limb and v01 is the least significant limb
+pub fn create_multi_compact<F: PrimeField>(v01: F, v2: F) -> [Vec<F>; COLUMNS] {
+    let layout = layout();
+    let mut witness: [Vec<F>; COLUMNS] = array::from_fn(|_| vec![F::zero(); 4]);
+
+    let (v1, v0) = v01.to_biguint().div_rem(&BigUint::two_to_limb());
+    let v0: F = v0.to_field().expect("failed to convert to field element");
+    let v1: F = v1.to_field().expect("failed to convert to field element");
+
+    init_row(&mut witness, 0, 0, &layout, &variable_map!("v0" => v2));
+    init_row(&mut witness, 0, 1, &layout, &variable_map!("v1" => v0));
+
+    init_row(
+        &mut witness,
+        0,
+        2,
+        &layout,
+        &variable_map!("v2" => v1, "v12" => v01),
+    );
     init_row(&mut witness, 0, 3, &layout, &variables!());
 
     witness
@@ -124,6 +160,11 @@ pub fn create_multi<F: PrimeField>(v0: F, v1: F, v2: F) -> [Vec<F>; COLUMNS] {
 /// Create a multi range check witness from limbs
 pub fn create_multi_limbs<F: PrimeField>(limbs: &[F; 3]) -> [Vec<F>; COLUMNS] {
     create_multi(limbs[0], limbs[1], limbs[2])
+}
+
+/// Create a multi range check witness from compact limbs
+pub fn create_multi_compact_limbs<F: PrimeField>(limbs: &[F; 2]) -> [Vec<F>; COLUMNS] {
+    create_multi_compact(limbs[0], limbs[1])
 }
 
 /// Create a single range check witness
@@ -137,7 +178,7 @@ pub fn create<F: PrimeField>(v0: F) -> [Vec<F>; COLUMNS] {
     witness
 }
 
-/// Extend an existing witness with a multi-range-check gadget for foreign field element
+/// Extend an existing witness with a multi-range-check gadget for three 88-bit values: v0, v1 and v2
 pub fn extend_multi<F: PrimeField>(witness: &mut [Vec<F>; COLUMNS], v0: F, v1: F, v2: F) {
     let limbs_witness = create_multi(v0, v1, v2);
     for col in 0..COLUMNS {
@@ -145,9 +186,26 @@ pub fn extend_multi<F: PrimeField>(witness: &mut [Vec<F>; COLUMNS], v0: F, v1: F
     }
 }
 
-/// Extend an existing witness with a multi-range-check gadget for foreign field element
+/// Extend and existing witness with a multi range check witness for two limbs: v01 (176 bits), v2 (88 bits),
+/// where v2 is the most significant limb and v01 is the least significant limb
+pub fn extend_multi_compact<F: PrimeField>(witness: &mut [Vec<F>; COLUMNS], v01: F, v2: F) {
+    let limbs_witness = create_multi_compact(v01, v2);
+    for col in 0..COLUMNS {
+        witness[col].extend(limbs_witness[col].iter())
+    }
+}
+
+/// Extend an existing witness with a multi-range-check gadget for limbs
 pub fn extend_multi_limbs<F: PrimeField>(witness: &mut [Vec<F>; COLUMNS], limbs: &[F; 3]) {
     let limbs_witness = create_multi_limbs(limbs);
+    for col in 0..COLUMNS {
+        witness[col].extend(limbs_witness[col].iter())
+    }
+}
+
+/// Extend an existing witness with a multi-range-check gadget for compact limbs
+pub fn extend_multi_compact_limbs<F: PrimeField>(witness: &mut [Vec<F>; COLUMNS], limbs: &[F; 2]) {
+    let limbs_witness = create_multi_compact_limbs(limbs);
     for col in 0..COLUMNS {
         witness[col].extend(limbs_witness[col].iter())
     }

--- a/kimchi/src/tests/foreign_field_mul.rs
+++ b/kimchi/src/tests/foreign_field_mul.rs
@@ -144,12 +144,11 @@ where
         // Add witness for external multi-range checks (product1_lo, product1_hi_0, carry1_lo and result)
         external_checks.extend_witness_multi_range_checks(&mut witness);
 
-        // TODO: (required for soundness) Wire this up once range-check gate is updated to support compact limbs
-        // // Quotient bound multi-range-check
-        // CircuitGate::extend_compact_multi_range_check(next_row);
-        // gates.connect_cell_pair((1, 3), (TODO1, 0));
-        // gates.connect_cell_pair((1, 4), (TODO2, 0));
-        // external_checks.extend_witness_compact_multi_range_checks(&mut witness);
+        // Quotient bound multi-range-check
+        CircuitGate::extend_compact_multi_range_check(&mut gates, &mut next_row);
+        gates.connect_cell_pair((1, 3), (22, 1));
+        gates.connect_cell_pair((1, 4), (20, 0));
+        external_checks.extend_witness_compact_multi_range_checks(&mut witness);
     }
 
     // Temporary workaround for lookup-table/domain-size issue

--- a/utils/src/foreign_field.rs
+++ b/utils/src/foreign_field.rs
@@ -284,6 +284,18 @@ impl<F: PrimeField> FieldArrayCompose<F, 3> for [F; 3] {
     }
 }
 
+/// PrimeField array compact limbs
+pub trait FieldArrayCompact<F: PrimeField> {
+    /// Compose field limbs into BigUint
+    fn to_compact_limbs(&self) -> [F; 2];
+}
+
+impl<F: PrimeField> FieldArrayCompact<F> for [F; 3] {
+    fn to_compact_limbs(&self) -> [F; 2] {
+        [self[0] + F::two_to_limb() * self[1], self[2]]
+    }
+}
+
 /// BigUint array PrimeField helpers
 pub trait BigUintArrayFieldHelpers<const N: usize> {
     /// Convert limbs from BigUint to field element


### PR DESCRIPTION
This PR adds the ability to constrain 2-limbs format (i.e. compact limbs) values with the multi-range-check gadget.

Normally the gadget can only constrain 3 limbs (`v0, v1, v2`) that are copied to column 0 of the first 3 gates of the gadget, like this

| 0  `RangeCheck0` | 1   `RangeCheck0`  | 2    `RangeCheck1` | 4 `Zero`  |
| -- | -- | -- | -- | 
| `v0` (copy) | `v1` (copy) | `v2` (copy) | ... |
| ... | ... | ... | ... |

This change allows one to copy the limbs in compact form: `v01`, `v2` to the gadget in order like this

| 0   `RangeCheck0`  | 1   `RangeCheck0`  |  2    `RangeCheck1` | 4 `Zero`  |
| -- | -- | -- | -- | 
| `v2` (copy) | `v0` | `v1` | ... |
| ... | ... | `v01` (copy) | ... |
| ... | ... | ... | ... |

where $v_{01} = v_0 + 2^{88} \cdot v_1$.

The change is comprised of two changes

* Move a couple witness elements around in `RangeCheck1`
* Add support for compact limbs to `RangeCheck0` gate (new optional mode of operation based on `coeff[0]`)

Closes #900

**Performance** 

```
Before
- time to create prover index: 56s
- time to create proof: 45s
- time to verify: 763ms
```

```
After
- time to create prover index: 56s
- time to create proof: 46s
- time to verify: 787ms
```