### PR TITLE
Use Two trait in the code

### DIFF
--- a/circuit-construction/src/writer.rs
+++ b/circuit-construction/src/writer.rs
@@ -1,3 +1,4 @@
+use crate::constants::Constants;
 use ark_ff::{BigInteger, FftField, PrimeField};
 use kimchi::circuits::{
     gate::{CircuitGate, GateType},
@@ -10,10 +11,9 @@ use mina_poseidon::{
     constants::{PlonkSpongeConstantsKimchi, SpongeConstants},
     permutation::full_round,
 };
+use o1_utils::Two;
 use std::array;
 use std::collections::HashMap;
-
-use crate::constants::Constants;
 
 /// A variable in our circuit.
 /// Variables are assigned with an index to differentiate from each other.
@@ -161,7 +161,7 @@ pub trait Cs<F: PrimeField> {
 
         let v = self.var(|| {
             // TODO: No need to recompute this each time.
-            let two = Fr::from(2u64);
+            let two = Fr::two();
             let shift = Fr::one() + two.pow(&[length as u64]);
 
             let x = g();
@@ -706,8 +706,8 @@ pub trait Cs<F: PrimeField> {
         // Reverse string of bits to have MSB first in the vector
         let bits_msb: Vec<_> = bits_lsb.iter().rev().collect();
 
-        let mut a = self.var(|| F::from(2u64));
-        let mut b = self.var(|| F::from(2u64));
+        let mut a = self.var(|| F::two());
+        let mut b = self.var(|| F::two());
         let mut n = zero;
 
         let one = F::one();

--- a/kimchi/src/alphas.rs
+++ b/kimchi/src/alphas.rs
@@ -244,6 +244,7 @@ mod tests {
     use super::*;
     use crate::circuits::gate::GateType;
     use mina_curves::pasta::{Fp, Vesta};
+    use o1_utils::Two;
 
     // testing [Builder]
 
@@ -301,7 +302,7 @@ mod tests {
         assert_eq!(powers.next(), Some(2));
         assert_eq!(powers.next(), Some(3));
 
-        let alpha = Fp::from(2);
+        let alpha = Fp::two();
         alphas.instantiate(alpha);
 
         let mut alphas = alphas.get_alphas(ArgumentType::Gate(GateType::Poseidon), 4);

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -2475,6 +2475,9 @@ pub mod constraints {
         /// 2^pow
         fn two_pow(pow: u64) -> Self;
 
+        /// 2
+        fn two() -> Self;
+
         /// 2^{LIMB_BITS}
         fn two_to_limb() -> Self;
 
@@ -2516,6 +2519,10 @@ pub mod constraints {
     where
         F: PrimeField,
     {
+        fn two() -> Self {
+            Expr::<ConstantExpr<F>>::literal(<F as Two<F>>::two())
+        }
+
         fn two_pow(pow: u64) -> Self {
             Expr::<ConstantExpr<F>>::literal(<F as Two<F>>::two_pow(pow))
         }
@@ -2570,6 +2577,10 @@ pub mod constraints {
     }
 
     impl<F: Field> ExprOps<F> for F {
+        fn two() -> Self {
+            <F as Two<F>>::two()
+        }
+
         fn two_pow(pow: u64) -> Self {
             <F as Two<F>>::two_pow(pow)
         }
@@ -2583,7 +2594,7 @@ pub mod constraints {
         }
 
         fn double(&self) -> Self {
-            *self * F::from(2u64)
+            *self * <F as Two<F>>::two()
         }
 
         fn square(&self) -> Self {
@@ -2845,15 +2856,12 @@ pub mod test {
             T::one() + T::one()
         }
         assert_eq!(test_2::<Fp, E<Fp>>(), E::one() + E::one());
-        assert_eq!(test_2::<Fp, Fp>(), Fp::from(2u64));
+        assert_eq!(test_2::<Fp, Fp>(), Fp::two());
 
         fn test_3<F: Field, T: ExprOps<F>>(x: T) -> T {
-            T::from(2u64) * x
+            T::two() * x
         }
-        assert_eq!(
-            test_3::<Fp, E<Fp>>(E::from(3u64)),
-            E::from(2u64) * E::from(3u64)
-        );
+        assert_eq!(test_3::<Fp, E<Fp>>(E::from(3u64)), E::two() * E::from(3u64));
         assert_eq!(test_3(Fp::from(3u64)), Fp::from(6u64));
 
         fn test_4<F: Field, T: ExprOps<F>>(x: T) -> T {

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -10,6 +10,7 @@ use crate::circuits::{
 use ark_ff::{Field, One, PrimeField, Zero};
 use ark_poly::{EvaluationDomain, Evaluations as E, Radix2EvaluationDomain as D};
 use o1_utils::field_helpers::i32_to_field;
+use o1_utils::Two;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::ops::{Mul, Neg};
@@ -345,7 +346,7 @@ impl LookupPattern {
                     .collect()
             }
             LookupPattern::ChaChaFinal => {
-                let one_half = F::from(2u64).inverse().unwrap();
+                let one_half = F::two().inverse().unwrap();
                 let neg_one_half = -one_half;
                 (0..4)
                     .map(|i| {

--- a/kimchi/src/circuits/polynomials/chacha.rs
+++ b/kimchi/src/circuits/polynomials/chacha.rs
@@ -285,7 +285,7 @@ where
         let low_bits = chunks_over_2_rows(env, 5);
         let yprime = env.witness_curr(0);
 
-        let one_half = F::from(2u64).inverse().unwrap();
+        let one_half = F::two().inverse().unwrap();
 
         // (y xor xprime) <<< 7
         // per the comment at the top of the file

--- a/kimchi/src/circuits/polynomials/endomul_scalar.rs
+++ b/kimchi/src/circuits/polynomials/endomul_scalar.rs
@@ -180,8 +180,8 @@ where
         let c_coeffs = [
             F::zero(),
             F::from(11u64) / F::from(6u64),
-            -F::from(5u64) / F::from(2u64),
-            F::from(2u64) / F::from(3u64),
+            -F::from(5u64) / F::two(),
+            F::two() / F::from(3u64),
         ];
 
         let crumb_over_x_coeffs = [-F::from(6u64), F::from(11u64), -F::from(6u64), F::one()];
@@ -232,8 +232,8 @@ pub fn gen_witness<F: PrimeField + std::fmt::Display>(
         .collect();
     let bits_msb: Vec<_> = bits_lsb.iter().rev().collect();
 
-    let mut a = F::from(2u64);
-    let mut b = F::from(2u64);
+    let mut a = F::two();
+    let mut b = F::two();
     let mut n = F::zero();
 
     let one = F::one();
@@ -283,7 +283,7 @@ pub fn gen_witness<F: PrimeField + std::fmt::Display>(
 fn c_func<F: Field>(x: F) -> F {
     let zero = F::zero();
     let one = F::one();
-    let two = F::from(2u64);
+    let two = F::two();
     let three = F::from(3u64);
 
     match x {
@@ -298,7 +298,7 @@ fn c_func<F: Field>(x: F) -> F {
 fn d_func<F: Field>(x: F) -> F {
     let zero = F::zero();
     let one = F::one();
-    let two = F::from(2u64);
+    let two = F::two();
     let three = F::from(3u64);
 
     match x {
@@ -321,7 +321,7 @@ mod tests {
     fn c_poly<F: Field>(x: F) -> F {
         let x2 = x.square();
         let x3 = x * x2;
-        (F::from(2u64) / F::from(3u64)) * x3 - (F::from(5u64) / F::from(2u64)) * x2
+        (F::two() / F::from(3u64)) * x3 - (F::from(5u64) / F::two()) * x2
             + (F::from(11u64) / F::from(6u64)) * x
     }
 

--- a/kimchi/src/circuits/polynomials/turshi.rs
+++ b/kimchi/src/circuits/polynomials/turshi.rs
@@ -493,7 +493,7 @@ pub mod testing {
 
         // well formness of instruction
         let shape = {
-            let shift = F::from(2u32.pow(15)); // 2^15;
+            let shift = F::two_pow(15); // 2^15;
             let pow16 = shift.double(); // 2^16
             let dst_sft = off_dst + shift;
             let op0_sft = off_op0 + shift;
@@ -501,7 +501,7 @@ pub mod testing {
             // recompose instruction as: flags[14..0] | op1_sft | op0_sft | dst_sft
             let mut aux = flags[14];
             for i in (0..14).rev() {
-                aux = aux * F::from(2u32) + flags[i];
+                aux = aux * F::two() + flags[i];
             }
             // complete with "flags" * 2^48 + op1_sft * 2^32 + op0_sft * 2^16 + dst_sft
             ((aux * pow16 + op1_sft) * pow16 + op0_sft) * pow16 + dst_sft
@@ -620,7 +620,7 @@ pub mod testing {
 
         let zero = F::zero();
         let one = F::one();
-        let two = F::from(2u16);
+        let two = F::two();
 
         // REGISTERS RELATED
 

--- a/kimchi/src/circuits/polynomials/xor.rs
+++ b/kimchi/src/circuits/polynomials/xor.rs
@@ -386,7 +386,7 @@ where
     //   * Constrain the decomposition of `in1`, `in2` and `out` of multiples of 16 bits
     //   * The actual XOR is performed thanks to the plookups of 4-bit XORs.
     fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
-        let two = T::from(2u64);
+        let two = T::two();
         // in1 = in1_0 + in1_1 * 2^4 + in1_2 * 2^8 + in1_3 * 2^12 + next_in1 * 2^16
         // in2 = in2_0 + in2_1 * 2^4 + in2_2 * 2^8 + in2_3 * 2^12 + next_in2 * 2^16
         // out = out_0 + out_1 * 2^4 + out_2 * 2^8 + out_3 * 2^12 + next_out * 2^16

--- a/kimchi/src/circuits/witness/copy_shift_cell.rs
+++ b/kimchi/src/circuits/witness/copy_shift_cell.rs
@@ -1,6 +1,7 @@
 use super::{variables::Variables, WitnessCell};
 use crate::circuits::polynomial::COLUMNS;
 use ark_ff::Field;
+use o1_utils::Two;
 
 /// Witness cell copied from another cell and shifted
 pub struct CopyShiftCell {
@@ -18,6 +19,6 @@ impl CopyShiftCell {
 
 impl<F: Field> WitnessCell<F> for CopyShiftCell {
     fn value(&self, witness: &mut [Vec<F>; COLUMNS], _variables: &Variables<F>) -> F {
-        F::from(2u32).pow([self.shift]) * witness[self.col][self.row]
+        F::two_pow(self.shift) * witness[self.col][self.row]
     }
 }

--- a/kimchi/src/tests/foreign_field_add.rs
+++ b/kimchi/src/tests/foreign_field_add.rs
@@ -28,8 +28,8 @@ use mina_poseidon::{
 use num_bigint::{BigUint, RandBigInt};
 use num_traits::FromPrimitive;
 use o1_utils::{
-    foreign_field::{ForeignElement, HI, LO, MI, TWO_TO_LIMB},
-    FieldHelpers,
+    foreign_field::{HI, LO, MI},
+    BigUintForeignFieldHelpers, FieldHelpers, ForeignElement, ForeignFieldHelpers,
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::sync::Arc;
@@ -377,12 +377,12 @@ fn compute_dif(modulus: BigUint, left: &[u8], right: &[u8]) -> BigUint {
 // obtains a random input of 32 bytes that fits in the foreign modulus
 fn random_input(rng: &mut StdRng, modulus: BigUint, large: bool) -> Vec<u8> {
     let mut random_str = vec![];
-    let mut random_big = BigUint::from_u128(2u128.pow(88)).unwrap().pow(3);
+    let mut random_big = BigUint::two_to_limb().pow(3);
     while random_big > modulus {
         random_big = if large {
-            rng.gen_biguint_below(&BigUint::from(2u32).pow(32))
+            rng.gen_biguint_below(&BigUint::two_pow(32))
         } else {
-            rng.gen_biguint_below(&BigUint::from(2u32).pow(20))
+            rng.gen_biguint_below(&BigUint::two_pow(20))
         };
         random_str = random_big.to_bytes_be();
     }
@@ -676,7 +676,7 @@ fn test_no_carry_limbs() {
     );
     check_carry(witness.clone(), PallasField::zero());
     // check middle limb is all ones
-    let all_one_limb = PallasField::from(2u128.pow(88) - 1);
+    let all_one_limb = PallasField::two_to_limb() - PallasField::one();
     assert_eq!(witness[1][1], all_one_limb);
 }
 
@@ -724,7 +724,7 @@ fn test_wrong_sum() {
         true,
     );
     // wrong result
-    let all_ones_limb = PallasField::from(2u128.pow(88) - 1);
+    let all_ones_limb = PallasField::two_to_limb() - PallasField::one();
     witness[0][1] = all_ones_limb;
     witness[0][11] = all_ones_limb;
 
@@ -922,7 +922,7 @@ fn test_foreign_is_native_add() {
     let result = ForeignElement::<PallasField, 3>::from_biguint(sum_big.clone());
     check_result(witness, vec![result.clone()]);
     // check result is in the native field
-    let two_to_limb = PallasField::from(TWO_TO_LIMB);
+    let two_to_limb = PallasField::two_to_limb();
     let left = ForeignElement::<PallasField, 3>::from_be(&left_input);
     let right = ForeignElement::<PallasField, 3>::from_be(&right_input);
     let left = (left[HI] * two_to_limb + left[MI]) * two_to_limb + left[LO];
@@ -955,7 +955,7 @@ fn test_foreign_is_native_sub() {
     let result = ForeignElement::<PallasField, 3>::from_biguint(dif_big.clone());
     check_result(witness, vec![result.clone()]);
     // check result is in the native field
-    let two_to_limb = PallasField::from(TWO_TO_LIMB);
+    let two_to_limb = PallasField::two_to_limb();
     let left = ForeignElement::<PallasField, 3>::from_be(&left_input);
     let right = ForeignElement::<PallasField, 3>::from_be(&right_input);
     let left = (left[HI] * two_to_limb + left[MI]) * two_to_limb + left[LO];

--- a/kimchi/src/tests/foreign_field_mul.rs
+++ b/kimchi/src/tests/foreign_field_mul.rs
@@ -12,7 +12,7 @@ use crate::{
     tests::framework::TestFramework,
 };
 use ark_ec::AffineCurve;
-use ark_ff::{Field, PrimeField, Zero};
+use ark_ff::{PrimeField, Zero};
 use mina_curves::pasta::{Fp, Fq, Pallas, PallasParameters, Vesta, VestaParameters};
 use num_bigint::BigUint;
 use num_integer::Integer;
@@ -31,6 +31,7 @@ use mina_poseidon::{
     FqSponge,
 };
 use num_bigint::RandBigInt;
+use o1_utils::Two;
 use rand::{rngs::StdRng, SeedableRng};
 
 type PallasField = <Pallas as AffineCurve>::BaseField;
@@ -490,7 +491,7 @@ where
             &left_input,
             &right_input,
             foreign_field_modulus,
-            vec![((0, 13), G::ScalarField::from(2u32))], // Make q'_carry01 non-boolean
+            vec![((0, 13), G::ScalarField::two())], // Make q'_carry01 non-boolean
         );
         assert_eq!(
             (&left_input * &right_input) % foreign_field_modulus,
@@ -528,7 +529,7 @@ where
             &left_input,
             &right_input,
             foreign_field_modulus,
-            vec![((0, 14), G::ScalarField::from(2u32))], // Make q'_carry2 non-boolean
+            vec![((0, 14), G::ScalarField::two())], // Make q'_carry2 non-boolean
         );
         assert_eq!(
             (&left_input * &right_input) % foreign_field_modulus,
@@ -889,7 +890,7 @@ fn test_nonzero_second_bit_carry11() {
         vec![],
     );
     assert_eq!(result, Ok(()));
-    assert_eq!(witness[7][0], PallasField::from(2u32)); // carry11 is not zero
+    assert_eq!(witness[7][0], PallasField::two()); // carry11 is not zero
     assert_eq!(
         &a * &b % secp256k1_modulus(),
         [witness[0][1], witness[1][1], witness[2][1]].compose()
@@ -957,7 +958,7 @@ fn test_invalid_carry11_scaling() {
         &a,
         &b,
         &secp256k1_modulus(),
-        vec![((0, 8), PallasField::from(2u32))], // Invalidate scaled_carry11
+        vec![((0, 8), PallasField::two())], // Invalidate scaled_carry11
     );
     // The 5th constraint (i.e. C8) should fail
     assert_eq!(
@@ -1009,7 +1010,7 @@ fn test_invalid_carry11_plookup() {
         &a,
         &b,
         &secp256k1_modulus(),
-        vec![((0, 7), PallasField::from(2u32).pow(&[12u64]))], // Make carry11 13 bits long
+        vec![((0, 7), PallasField::two_pow(12))], // Make carry11 13 bits long
     );
     // Above should panic
 }
@@ -1053,7 +1054,7 @@ fn test_invalid_scaled_carry11_plookup() {
         &a,
         &b,
         &secp256k1_modulus(),
-        vec![((0, 8), PallasField::from(2u32).pow(&[12u64]))], // Make scaled_carry11 13 bits long
+        vec![((0, 8), PallasField::two_pow(12))], // Make scaled_carry11 13 bits long
     );
     // Above should panic
 }
@@ -1344,7 +1345,7 @@ fn test_rand_foreign_field_element_with_bound_overflows_2() {
     for _ in 0..1000 {
         test_rand_foreign_field_element_with_bound_overflows::<PallasField>(
             rng,
-            &(BigUint::from(2u32).pow(259) - BigUint::one()),
+            &(BigUint::two_pow(259) - BigUint::one()),
         );
     }
 }
@@ -1356,7 +1357,7 @@ fn test_rand_foreign_field_element_with_bound_overflows_3() {
     for _ in 0..1000 {
         test_rand_foreign_field_element_with_bound_overflows::<PallasField>(
             rng,
-            &(BigUint::from(2u32).pow(259) / BigUint::from(382734983107u64)),
+            &(BigUint::two_pow(259) / BigUint::from(382734983107u64)),
         );
     }
 }
@@ -1401,9 +1402,6 @@ fn test_rand_foreign_field_element_with_bound_overflows_6() {
 // Cannot have overflow when f'0 is zero
 fn test_rand_foreign_field_element_with_bound_overflows_7() {
     let rng = &mut StdRng::from_seed(RNG_SEED);
-    rand_foreign_field_element_with_bound_overflows::<PallasField>(
-        rng,
-        &BigUint::from(2u32).pow(257),
-    )
-    .expect("Failed to get element with bound overflow");
+    rand_foreign_field_element_with_bound_overflows::<PallasField>(rng, &BigUint::two_pow(257))
+        .expect("Failed to get element with bound overflow");
 }

--- a/kimchi/src/tests/not.rs
+++ b/kimchi/src/tests/not.rs
@@ -319,7 +319,7 @@ fn test_prove_and_verify_five_not_gnrc() {
     assert!(TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
-        .public_inputs(vec![PallasField::two_pow(bits) - PallasField::one(),])
+        .public_inputs(vec![PallasField::two_pow(bits as u64) - PallasField::one(),])
         .setup()
         .prove_and_verify::<VestaBaseSponge, VestaScalarSponge>()
         .is_ok());

--- a/kimchi/src/tests/not.rs
+++ b/kimchi/src/tests/not.rs
@@ -1,0 +1,447 @@
+use std::cmp::max;
+
+use crate::{
+    circuits::{
+        constraints::ConstraintSystem,
+        gate::{CircuitGate, CircuitGateError, GateType},
+        polynomial::COLUMNS,
+        polynomials::{
+            generic::GenericGateSpec,
+            not::{create_not_gnrc_witness, create_not_xor_witness},
+            xor::{self},
+        },
+        wires::Wire,
+    },
+    curve::KimchiCurve,
+    plonk_sponge::FrSponge,
+    prover_index::testing::new_index_for_test_with_lookups,
+    tests::xor::{all_ones, check_xor},
+};
+
+use super::framework::TestFramework;
+use ark_ec::AffineCurve;
+use ark_ff::{Field, One, PrimeField, Zero};
+use mina_curves::pasta::{Fp, Fq, Pallas, PallasParameters, Vesta, VestaParameters};
+use mina_poseidon::{
+    constants::PlonkSpongeConstantsKimchi,
+    sponge::{DefaultFqSponge, DefaultFrSponge},
+    FqSponge,
+};
+use num_bigint::BigUint;
+use o1_utils::{BigUintHelpers, BitOps, FieldHelpers, RandomField};
+use rand::{rngs::StdRng, SeedableRng};
+
+type PallasField = <Pallas as AffineCurve>::BaseField;
+type VestaField = <Vesta as AffineCurve>::BaseField;
+type SpongeParams = PlonkSpongeConstantsKimchi;
+type VestaBaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;
+type VestaScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
+type PallasBaseSponge = DefaultFqSponge<PallasParameters, SpongeParams>;
+type PallasScalarSponge = DefaultFrSponge<Fq, SpongeParams>;
+
+const NOT: bool = false;
+
+const RNG_SEED: [u8; 32] = [
+    211, 31, 143, 75, 29, 255, 0, 126, 237, 193, 86, 160, 1, 90, 131, 221, 186, 168, 4, 95, 50, 48,
+    89, 29, 13, 250, 215, 172, 130, 24, 164, 162,
+];
+
+// Constraint system for Not gadget using Xor16
+fn create_test_constraint_system_not_xor<G: KimchiCurve, EFqSponge, EFrSponge>(
+    bits: usize,
+) -> ConstraintSystem<G::ScalarField>
+where
+    G::BaseField: PrimeField,
+{
+    let (mut next_row, mut gates) = {
+        let mut gates = vec![CircuitGate::<G::ScalarField>::create_generic_gadget(
+            Wire::for_row(0),
+            GenericGateSpec::Pub,
+            None,
+        )];
+        let next_row = CircuitGate::<G::ScalarField>::extend_not_xor_gadget(&mut gates, 0, 1, bits);
+        (next_row, gates)
+    };
+
+    // Temporary workaround for lookup-table/domain-size issue
+    for _ in 0..(1 << 13) {
+        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
+        next_row += 1;
+    }
+
+    ConstraintSystem::create(gates).public(1).build().unwrap()
+}
+
+// Constraint system for Not gadget using generic gates
+fn create_test_constraint_system_not_gnrc<G: KimchiCurve, EFqSponge, EFrSponge>(
+    nots: usize,
+) -> ConstraintSystem<G::ScalarField>
+where
+    G::BaseField: PrimeField,
+{
+    let mut gates = vec![CircuitGate::<G::ScalarField>::create_generic_gadget(
+        Wire::for_row(0),
+        GenericGateSpec::Pub,
+        None,
+    )];
+    let mut next_row =
+        CircuitGate::<G::ScalarField>::extend_not_gnrc_gadget(&mut gates, nots, 0, 1);
+
+    // Temporary workaround for lookup-table/domain-size issue
+    for _ in 0..(1 << 13) {
+        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
+        next_row += 1;
+    }
+
+    ConstraintSystem::create(gates).public(1).build().unwrap()
+}
+
+// Creates the witness and circuit for NOT gadget using XOR
+fn setup_not_xor<G: KimchiCurve, EFqSponge, EFrSponge>(
+    inp: Option<G::ScalarField>,
+    bits: Option<usize>,
+) -> (
+    [Vec<G::ScalarField>; COLUMNS],
+    ConstraintSystem<G::ScalarField>,
+)
+where
+    G::BaseField: PrimeField,
+    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
+    EFrSponge: FrSponge<G::ScalarField>,
+{
+    let rng = &mut StdRng::from_seed(RNG_SEED);
+
+    let inp = rng.gen(inp, bits);
+
+    // If user specified a concrete number of bits, use that (if they are sufficient to hold the input)
+    // Otherwise, use the length of the input
+    let bits_real = max(inp.to_biguint().bitlen(), bits.unwrap_or(0));
+
+    let cs = create_test_constraint_system_not_xor::<G, EFqSponge, EFrSponge>(bits_real);
+
+    let witness = create_not_xor_witness::<G::ScalarField>(inp, bits);
+
+    check_not_xor::<G>(&witness, inp, bits);
+
+    (witness, cs)
+}
+
+// Tester for not gate
+fn test_not_xor<G: KimchiCurve, EFqSponge, EFrSponge>(
+    inp: Option<G::ScalarField>,
+    bits: Option<usize>,
+) -> [Vec<G::ScalarField>; COLUMNS]
+where
+    G::BaseField: PrimeField,
+    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
+    EFrSponge: FrSponge<G::ScalarField>,
+{
+    let (witness, cs) = setup_not_xor::<G, EFqSponge, EFrSponge>(inp, bits);
+
+    for row in 0..witness[0].len() {
+        assert_eq!(
+            cs.gates[row].verify_witness::<G>(row, &witness, &cs, &witness[0][0..cs.public]),
+            Ok(())
+        );
+    }
+
+    witness
+}
+
+// Creates the witness and circuit for NOT gadget using generic
+fn setup_not_gnrc<G: KimchiCurve, EFqSponge, EFrSponge>(
+    inputs: Option<Vec<G::ScalarField>>,
+    bits: usize,
+    len: Option<usize>,
+) -> (
+    [Vec<G::ScalarField>; COLUMNS],
+    ConstraintSystem<G::ScalarField>,
+)
+where
+    G::BaseField: PrimeField,
+    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
+    EFrSponge: FrSponge<G::ScalarField>,
+{
+    let rng = &mut StdRng::from_seed(RNG_SEED);
+
+    let inputs = if let Some(inps) = inputs {
+        assert!(len.is_none());
+        inps
+    } else {
+        assert!(len.is_some());
+        let len = len.unwrap();
+        (0..len)
+            .map(|_| rng.gen_field_with_bits(bits))
+            .collect::<Vec<G::ScalarField>>()
+    };
+
+    let cs = create_test_constraint_system_not_gnrc::<G, EFqSponge, EFrSponge>(inputs.len());
+
+    let witness = create_not_gnrc_witness::<G::ScalarField>(&inputs, bits);
+
+    check_not_gnrc::<G>(&witness, &inputs, bits);
+
+    (witness, cs)
+}
+
+// Tester for not gate generic
+fn test_not_gnrc<G: KimchiCurve, EFqSponge, EFrSponge>(
+    inputs: Option<Vec<G::ScalarField>>,
+    bits: usize,
+    len: Option<usize>,
+) -> [Vec<G::ScalarField>; COLUMNS]
+where
+    G::BaseField: PrimeField,
+    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
+    EFrSponge: FrSponge<G::ScalarField>,
+{
+    let (witness, cs) = setup_not_gnrc::<G, EFqSponge, EFrSponge>(inputs, bits, len);
+
+    // test public input and not generic gate
+    for row in 0..witness[0].len() {
+        assert_eq!(
+            cs.gates[row].verify_witness::<G>(row, &witness, &cs, &witness[0][0..cs.public]),
+            Ok(())
+        );
+    }
+
+    witness
+}
+
+// Manually checks the NOT of each crumb in the witness
+fn check_not_xor<G: KimchiCurve>(
+    witness: &[Vec<G::ScalarField>; COLUMNS],
+    input: G::ScalarField,
+    bits: Option<usize>,
+) {
+    let input_big = input.to_biguint();
+    let bits = max(input_big.bitlen(), bits.unwrap_or(0));
+    check_xor::<G>(witness, bits, input, all_ones::<G>(bits), NOT);
+    assert_eq!(
+        witness[2][1],
+        BigUint::bitnot(&input_big, Some(bits)).into()
+    );
+}
+
+// Manually checks the NOTs of a vector of inputs in generic gates
+fn check_not_gnrc<G: KimchiCurve>(
+    witness: &[Vec<G::ScalarField>; COLUMNS],
+    inputs: &[G::ScalarField],
+    bits: usize,
+) {
+    for (i, input) in inputs.iter().enumerate() {
+        let input = input.to_biguint();
+        if i % 2 == 0 {
+            assert_eq!(
+                witness[2][1 + i / 2],
+                BigUint::bitnot(&input, Some(bits)).into()
+            );
+        } else {
+            assert_eq!(
+                witness[5][1 + (i - 1) / 2],
+                BigUint::bitnot(&input, Some(bits)).into()
+            );
+        }
+    }
+}
+
+#[test]
+// End-to-end test of NOT using XOR gadget
+fn test_prove_and_verify_not_xor() {
+    let bits = 64;
+    let rng = &mut StdRng::from_seed(RNG_SEED);
+
+    // Create circuit
+    let (mut next_row, mut gates) = {
+        let mut gates = vec![CircuitGate::<Fp>::create_generic_gadget(
+            Wire::for_row(0),
+            GenericGateSpec::Pub,
+            None,
+        )];
+        let next_row = CircuitGate::<Fp>::extend_not_xor_gadget(&mut gates, 0, 1, bits);
+        (next_row, gates)
+    };
+
+    // Temporary workaround for lookup-table/domain-size issue
+    for _ in 0..(1 << 13) {
+        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
+        next_row += 1;
+    }
+
+    // Create witness and random inputs
+
+    let witness = create_not_xor_witness::<PallasField>(rng.gen_field_with_bits(bits), Some(bits));
+
+    TestFramework::<Vesta>::default()
+        .gates(gates)
+        .witness(witness)
+        .public_inputs(vec![PallasField::two_pow(bits) - PallasField::one()])
+        .lookup_tables(vec![xor::lookup_table()])
+        .setup()
+        .prove_and_verify::<VestaBaseSponge, VestaScalarSponge>();
+}
+
+#[test]
+// End-to-end test of NOT using generic gadget
+fn test_prove_and_verify_five_not_gnrc() {
+    let bits = 64;
+    let rng = &mut StdRng::from_seed(RNG_SEED);
+
+    // Create circuit
+    let (mut next_row, mut gates) = {
+        let mut gates = vec![CircuitGate::<Fp>::create_generic_gadget(
+            Wire::for_row(0),
+            GenericGateSpec::Pub,
+            None,
+        )];
+        let next_row = CircuitGate::<Fp>::extend_not_gnrc_gadget(&mut gates, 5, 0, 1);
+        (next_row, gates)
+    };
+
+    // Temporary workaround for lookup-table/domain-size issue
+    for _ in 0..(1 << 13) {
+        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
+        next_row += 1;
+    }
+
+    // Create witness and random inputs
+    let witness: [Vec<PallasField>; 15] = create_not_gnrc_witness::<PallasField>(
+        &(0..5)
+            .map(|_| rng.gen_field_with_bits(bits))
+            .collect::<Vec<PallasField>>(),
+        bits,
+    );
+
+    TestFramework::<Vesta>::default()
+        .gates(gates)
+        .witness(witness)
+        .public_inputs(vec![PallasField::two_pow(bits) - PallasField::one()])
+        .setup()
+        .prove_and_verify::<VestaBaseSponge, VestaScalarSponge>();
+}
+
+#[test]
+// Tests all possible 16 values for a crumb, for both full 4, 8, 12, and 16 bits, and smallest
+fn test_not_xor_all_crumb() {
+    for i in 0..2u8.pow(4) {
+        let input = PallasField::from(i);
+        test_not_xor::<Vesta, VestaBaseSponge, VestaScalarSponge>(Some(input), None);
+        for c in (4..=16).step_by(4) {
+            let bits = Some(c);
+            test_not_xor::<Vesta, VestaBaseSponge, VestaScalarSponge>(Some(input), bits);
+        }
+    }
+}
+
+#[test]
+// Tests NOT for bitlengths of 4, 8, 16, 32, 64, 128, for both exact output width and varying
+fn test_not_xor_crumbs_random() {
+    for i in 2..=7 {
+        let bits = 2u32.pow(i) as usize;
+        let rng = &mut StdRng::from_seed(RNG_SEED);
+        let input = rng.gen_field_with_bits(bits);
+        test_not_xor::<Vesta, VestaBaseSponge, VestaScalarSponge>(Some(input), Some(bits));
+        test_not_xor::<Vesta, VestaBaseSponge, VestaScalarSponge>(Some(input), None);
+    }
+}
+
+#[test]
+// Tests a NOT for a random-length big input
+fn test_not_xor_big_random() {
+    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let input = rng.gen_field_with_bits(200);
+    test_not_xor::<Vesta, VestaBaseSponge, VestaScalarSponge>(Some(input), None);
+    let input = rng.gen_field_with_bits(200);
+    test_not_xor::<Pallas, PallasBaseSponge, PallasScalarSponge>(Some(input), None);
+}
+
+#[test]
+// Tests two NOTs with the generic builder
+fn test_not_gnrc_double() {
+    test_not_gnrc::<Vesta, VestaBaseSponge, VestaScalarSponge>(None, 64, Some(2));
+    test_not_gnrc::<Pallas, PallasBaseSponge, PallasScalarSponge>(None, 64, Some(2));
+}
+
+#[test]
+// Tests one NOT with the generic builder
+fn test_not_gnrc_single() {
+    test_not_gnrc::<Vesta, VestaBaseSponge, VestaScalarSponge>(None, 64, Some(1));
+    test_not_gnrc::<Pallas, PallasBaseSponge, PallasScalarSponge>(None, 64, Some(1));
+}
+
+#[test]
+// Tests a chain of 5 NOTs with different lengths but padded to 254 bits with the generic builder
+fn test_not_gnrc_vector() {
+    let rng = &mut StdRng::from_seed(RNG_SEED);
+    // up to 2^16, 2^32, 2^64, 2^128, 2^254
+    let inputs = (0..5)
+        .map(|i| rng.gen_field_with_bits(4 + i))
+        .collect::<Vec<PallasField>>();
+    test_not_gnrc::<Vesta, VestaBaseSponge, VestaScalarSponge>(Some(inputs), 254, None);
+    let inputs = (0..5)
+        .map(|i| rng.gen_field_with_bits(4 + i))
+        .collect::<Vec<VestaField>>();
+    test_not_gnrc::<Pallas, PallasBaseSponge, PallasScalarSponge>(Some(inputs), 254, None);
+}
+
+#[test]
+// Test a bad NOT with gnrc builder
+fn test_bad_not_gnrc() {
+    let (mut witness, cs) =
+        setup_not_gnrc::<Vesta, VestaBaseSponge, VestaScalarSponge>(None, 64, Some(1));
+    // modify public input row to make sure the copy constraint fails and the generic gate also fails
+    witness[0][0] += PallasField::one();
+    assert_eq!(
+        cs.gates[0].verify_witness::<Vesta>(0, &witness, &cs, &witness[0][0..cs.public]),
+        Err(CircuitGateError::CopyConstraint {
+            typ: GateType::Generic,
+            src: Wire { row: 0, col: 0 },
+            dst: Wire { row: 1, col: 0 }
+        })
+    );
+    witness[0][1] += PallasField::one();
+    let index =
+        new_index_for_test_with_lookups(cs.gates, 1, 0, vec![xor::lookup_table()], None, None);
+    assert_eq!(
+        index.cs.gates[1].verify::<Vesta>(1, &witness, &index, &[]),
+        Err(("generic: incorrect gate").to_string())
+    );
+}
+
+#[test]
+// Test a bad NOT with XOR builder
+fn test_bad_not_xor() {
+    let (mut witness, cs) =
+        setup_not_xor::<Vesta, VestaBaseSponge, VestaScalarSponge>(None, Some(16));
+    // modify public input row to make sure the copy constraint fails and the XOR gate also fails
+    witness[0][0] += PallasField::one();
+    assert_eq!(
+        cs.gates[0].verify_witness::<Vesta>(0, &witness, &cs, &witness[0][0..cs.public]),
+        Err(CircuitGateError::CopyConstraint {
+            typ: GateType::Generic,
+            src: Wire { row: 0, col: 0 },
+            dst: Wire { row: 1, col: 1 }
+        })
+    );
+    witness[1][1] += PallasField::one();
+    // decomposition of xor fails
+    assert_eq!(
+        cs.gates[1].verify_witness::<Vesta>(1, &witness, &cs, &witness[0][0..cs.public]),
+        Err(CircuitGateError::Constraint(GateType::Xor16, 2))
+    );
+    // Make the second input zero with correct decomposition to make sure XOR table fails
+    witness[0][0] = PallasField::zero();
+    witness[1][1] = PallasField::zero();
+    witness[7][1] = PallasField::zero();
+    witness[8][1] = PallasField::zero();
+    witness[9][1] = PallasField::zero();
+    witness[10][1] = PallasField::zero();
+    let index =
+        new_index_for_test_with_lookups(cs.gates, 1, 0, vec![xor::lookup_table()], None, None);
+    assert_eq!(
+        index.cs.gates[1].verify_xor::<Vesta>(1, &witness, &index),
+        Err(CircuitGateError::InvalidLookupConstraintSorted(
+            GateType::Xor16
+        ))
+    );
+}

--- a/kimchi/src/tests/range_check.rs
+++ b/kimchi/src/tests/range_check.rs
@@ -12,12 +12,11 @@ use crate::{
     proof::ProverProof,
     prover_index::testing::new_index_for_test_with_lookups,
 };
-
 use ark_ec::AffineCurve;
-use ark_ff::{Field, One, Zero};
+use ark_ff::{One, Zero};
 use ark_poly::EvaluationDomain;
 use mina_curves::pasta::{Fp, Pallas, Vesta, VestaParameters};
-use o1_utils::FieldHelpers;
+use o1_utils::{FieldHelpers, ForeignFieldHelpers, Two};
 
 use std::array;
 use std::sync::Arc;
@@ -318,7 +317,7 @@ fn verify_range_check0_valid_v0_in_range() {
     let index = create_test_prover_index(0);
 
     let witness = range_check::witness::create_multi::<PallasField>(
-        PallasField::from(2u64).pow([88]) - PallasField::one(),
+        PallasField::two_to_limb() - PallasField::one(),
         PallasField::zero(),
         PallasField::zero(),
     );
@@ -341,7 +340,7 @@ fn verify_range_check0_valid_v0_in_range() {
     );
 
     let witness = range_check::witness::create_multi::<PallasField>(
-        PallasField::from(2u64).pow([64]),
+        PallasField::two_pow(64),
         PallasField::zero(),
         PallasField::zero(),
     );
@@ -416,7 +415,7 @@ fn verify_range_check0_valid_v1_in_range() {
 
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
-        PallasField::from(2u64).pow([88]) - PallasField::one(),
+        PallasField::two_to_limb() - PallasField::one(),
         PallasField::zero(),
     );
 
@@ -439,7 +438,7 @@ fn verify_range_check0_valid_v1_in_range() {
 
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
-        PallasField::from(2u64).pow([63]),
+        PallasField::two_pow(63),
         PallasField::zero(),
     );
 
@@ -512,7 +511,7 @@ fn verify_range_check0_invalid_v0_not_in_range() {
     let index = create_test_prover_index(0);
 
     let witness = range_check::witness::create_multi::<PallasField>(
-        PallasField::from(2u64).pow([88]), // out of range
+        PallasField::two_to_limb(), // out of range
         PallasField::zero(),
         PallasField::zero(),
     );
@@ -535,7 +534,7 @@ fn verify_range_check0_invalid_v0_not_in_range() {
     );
 
     let witness = range_check::witness::create_multi::<PallasField>(
-        PallasField::from(2u64).pow([96]), // out of range
+        PallasField::two_pow(96), // out of range
         PallasField::zero(),
         PallasField::zero(),
     );
@@ -564,7 +563,7 @@ fn verify_range_check0_invalid_v1_not_in_range() {
 
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
-        PallasField::from(2u64).pow([88]), // out of range
+        PallasField::two_to_limb(), // out of range
         PallasField::zero(),
     );
 
@@ -587,7 +586,7 @@ fn verify_range_check0_invalid_v1_not_in_range() {
 
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
-        PallasField::from(2u64).pow([96]), // out of range
+        PallasField::two_pow(96), // out of range
         PallasField::zero(),
     );
 
@@ -617,8 +616,8 @@ fn verify_range_check0_test_copy_constraints() {
         for col in 1..=2 {
             // Copy constraints impact v0 and v1
             let mut witness = range_check::witness::create_multi::<PallasField>(
-                PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
-                PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
+                PallasField::two_to_limb() - PallasField::one(), // in range
+                PallasField::two_to_limb() - PallasField::one(), // in range
                 PallasField::zero(),
             );
 
@@ -677,7 +676,7 @@ fn verify_range_check0_v0_test_lookups() {
     for i in 3..=6 {
         // Test ith lookup
         let mut witness = range_check::witness::create_multi::<PallasField>(
-            PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
+            PallasField::two_to_limb() - PallasField::one(), // in range
             PallasField::zero(),
             PallasField::zero(),
         );
@@ -691,7 +690,7 @@ fn verify_range_check0_v0_test_lookups() {
 
         // Negative test
         // make ith plookup limb out of range
-        witness[i][0] = PallasField::from(2u64.pow(12));
+        witness[i][0] = PallasField::two_pow(12);
 
         // gates[0] is RangeCheck0 and constrains some of v0
         assert_eq!(
@@ -711,7 +710,7 @@ fn verify_range_check0_v1_test_lookups() {
         // Test ith lookup
         let mut witness = range_check::witness::create_multi::<PallasField>(
             PallasField::zero(),
-            PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
+            PallasField::two_to_limb() - PallasField::one(), // in range
             PallasField::zero(),
         );
 
@@ -724,7 +723,7 @@ fn verify_range_check0_v1_test_lookups() {
 
         // Negative test
         // make ith plookup limb out of range
-        witness[i][1] = PallasField::from(2u64.pow(12));
+        witness[i][1] = PallasField::two_pow(12);
 
         // gates[1] is RangeCheck0 and constrains some of v1
         assert_eq!(
@@ -909,7 +908,7 @@ fn verify_range_check1_valid_v2_in_range() {
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::zero(),
-        PallasField::from(2u64).pow([88]) - PallasField::one(),
+        PallasField::two_to_limb() - PallasField::one(),
     );
 
     // gates[2] is RangeCheck1 and constrains v2
@@ -932,7 +931,7 @@ fn verify_range_check1_valid_v2_in_range() {
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::zero(),
-        PallasField::from(2u64).pow([64]),
+        PallasField::two_pow(64),
     );
 
     // gates[2] is RangeCheck1 and constrains v2
@@ -1006,7 +1005,7 @@ fn verify_range_check1_invalid_v2_not_in_range() {
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::zero(),
-        PallasField::from(2u64).pow([88]), // out of range
+        PallasField::two_to_limb(), // out of range
     );
 
     // gates[2] is RangeCheck1 and constrains v2
@@ -1029,7 +1028,7 @@ fn verify_range_check1_invalid_v2_not_in_range() {
     let witness = range_check::witness::create_multi::<PallasField>(
         PallasField::zero(),
         PallasField::zero(),
-        PallasField::from(2u64).pow([96]), // out of range
+        PallasField::two_pow(96), // out of range
     );
 
     // gates[2] is RangeCheck1 and constrains v2
@@ -1058,8 +1057,8 @@ fn verify_range_check1_test_copy_constraints() {
         for col in 1..=2 {
             // Copy constraints impact v0 and v1
             let mut witness = range_check::witness::create_multi::<PallasField>(
-                PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
-                PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
+                PallasField::two_to_limb() - PallasField::one(), // in range
+                PallasField::two_to_limb() - PallasField::one(), // in range
                 PallasField::zero(),
             );
 
@@ -1122,7 +1121,7 @@ fn verify_range_check1_test_curr_row_lookups() {
         let mut witness = range_check::witness::create_multi::<PallasField>(
             PallasField::zero(),
             PallasField::zero(),
-            PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
+            PallasField::two_to_limb() - PallasField::one(), // in range
         );
 
         // Positive test
@@ -1154,8 +1153,8 @@ fn verify_range_check1_test_next_row_lookups() {
     for row in 0..=1 {
         for col in 1..=2 {
             let mut witness = range_check::witness::create_multi::<PallasField>(
-                PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
-                PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
+                PallasField::two_to_limb() - PallasField::one(), // in range
+                PallasField::two_to_limb() - PallasField::one(), // in range
                 PallasField::zero(),
             );
 
@@ -1168,8 +1167,8 @@ fn verify_range_check1_test_next_row_lookups() {
 
             // Negative test by making plookup limb out of range
             // and making sure copy constraint is valid
-            witness[col][row] = PallasField::from(2u64.pow(12));
-            witness[col - 1 + 2 * row + 3][3] = PallasField::from(2u64.pow(12));
+            witness[col][row] = PallasField::two_pow(12);
+            witness[col - 1 + 2 * row + 3][3] = PallasField::two_pow(12);
             assert_eq!(
                 index.cs.gates[2].verify_range_check::<Vesta>(2, &witness, &index),
                 Err(CircuitGateError::InvalidLookupConstraintSorted(
@@ -1225,7 +1224,7 @@ fn verify_64_bit_range_check() {
     //   1   0 0 X X ... X   RangeCheck0
     let mut witness: [Vec<PallasField>; COLUMNS] = array::from_fn(|_| vec![PallasField::zero()]);
     range_check::witness::create::<PallasField>(
-        PallasField::from(2u64).pow([64]) - PallasField::one(), // in range
+        PallasField::two_pow(64) - PallasField::one(), // in range
     )
     .iter_mut()
     .enumerate()
@@ -1254,7 +1253,7 @@ fn verify_64_bit_range_check() {
     //   1   0 X X X ... X   RangeCheck0
     let mut witness: [Vec<PallasField>; COLUMNS] = array::from_fn(|_| vec![PallasField::zero()]);
     range_check::witness::create::<PallasField>(
-        PallasField::from(2u64).pow([64]), // out of range
+        PallasField::two_pow(64), // out of range
     )
     .iter_mut()
     .enumerate()

--- a/kimchi/src/tests/varbasemul.rs
+++ b/kimchi/src/tests/varbasemul.rs
@@ -12,6 +12,7 @@ use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
+use o1_utils::Two;
 use rand::{rngs::StdRng, SeedableRng};
 use std::array;
 use std::time::Instant;
@@ -75,7 +76,7 @@ fn varbase_mul_test() {
             acc,
         );
 
-        let shift = <Other as AffineCurve>::ScalarField::from(2).pow(&[(bits_msb.len()) as u64]);
+        let shift = <Other as AffineCurve>::ScalarField::two_pow(bits_msb.len() as u64);
         let expected = g
             .mul((<Other as AffineCurve>::ScalarField::one() + shift + x_.double()).into_repr())
             .into_affine();

--- a/kimchi/src/tests/xor.rs
+++ b/kimchi/src/tests/xor.rs
@@ -13,7 +13,7 @@ use crate::{
     prover_index::testing::new_index_for_test_with_lookups,
 };
 use ark_ec::AffineCurve;
-use ark_ff::{Field, One, PrimeField, Zero};
+use ark_ff::{One, PrimeField, Zero};
 use mina_curves::pasta::{Fp, Fq, Pallas, PallasParameters, Vesta, VestaParameters};
 use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi,
@@ -21,6 +21,7 @@ use mina_poseidon::{
     FqSponge,
 };
 use num_bigint::BigUint;
+use o1_utils::Two;
 use o1_utils::{BigUintHelpers, BitOps, FieldHelpers, RandomField};
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -59,7 +60,7 @@ where
 
 // Returns the all ones BigUint of bits length
 pub(crate) fn all_ones<G: KimchiCurve>(bits: usize) -> G::ScalarField {
-    G::ScalarField::from(2u128).pow(&[bits as u64]) - G::ScalarField::one()
+    G::ScalarField::two_pow(bits as u64) - G::ScalarField::one()
 }
 
 // Returns a given nybble of 4 bits
@@ -191,11 +192,11 @@ fn test_xor64_alternating() {
     let input2 = PallasField::from(11936128518282651045u64);
     let witness =
         test_xor::<Vesta, VestaBaseSponge, VestaScalarSponge>(Some(input1), Some(input2), Some(64));
-    assert_eq!(witness[2][0], PallasField::from(2u128.pow(64) - 1));
-    assert_eq!(witness[2][1], PallasField::from(2u64.pow(48) - 1));
-    assert_eq!(witness[2][2], PallasField::from(2u64.pow(32) - 1));
-    assert_eq!(witness[2][3], PallasField::from(2u32.pow(16) - 1));
-    assert_eq!(witness[2][4], PallasField::from(0));
+    assert_eq!(witness[2][0], PallasField::two_pow(64) - PallasField::one());
+    assert_eq!(witness[2][1], PallasField::two_pow(48) - PallasField::one());
+    assert_eq!(witness[2][2], PallasField::two_pow(32) - PallasField::one());
+    assert_eq!(witness[2][3], PallasField::two_pow(16) - PallasField::one());
+    assert_eq!(witness[2][4], PallasField::zero());
 }
 
 #[test]

--- a/turshi/src/runner.rs
+++ b/turshi/src/runner.rs
@@ -5,6 +5,7 @@ use crate::flags::*;
 use crate::memory::CairoMemory;
 use crate::word::{CairoWord, FlagBits, FlagSets, Offsets};
 use ark_ff::Field;
+use o1_utils::Two;
 
 /// A structure to store program counter, allocation pointer and frame pointer
 #[derive(Clone, Copy)]
@@ -308,7 +309,7 @@ impl<'a, F: Field> CairoStep<'a, F> {
             /*0*/
             OP1_DBL => (self.vars.op0.expect("None op0 for OP1_DBL"), F::one()), // double indexing, op0 should be positive for address
             /*1*/
-            OP1_VAL => (self.curr.pc, F::from(2u32)), // off_op1 will be 1 and then op1 contains an immediate value
+            OP1_VAL => (self.curr.pc, F::two()), // off_op1 will be 1 and then op1 contains an immediate value
             /*2*/ OP1_FP => (self.curr.fp, F::one()),
             /*4*/ OP1_AP => (self.curr.ap, F::one()),
             _ => panic!("Invalid op1_src flagset"),
@@ -417,11 +418,11 @@ impl<'a, F: Field> CairoStep<'a, F> {
             self.vars.op0 = self.mem.read(self.curr.ap + F::one()); //update op0 content
 
             // Update fp
-            next_fp = Some(self.curr.ap + F::from(2u32)); // pointer for next frame is after current fp and instruction after call
-                                                          // Update ap
+            next_fp = Some(self.curr.ap + F::two()); // pointer for next frame is after current fp and instruction after call
+                                                     // Update ap
             match self.instr().ap_up() {
                 /*0*/
-                AP_Z2 => next_ap = Some(self.curr.ap + F::from(2u32)), // two words were written so advance 2 positions
+                AP_Z2 => next_ap = Some(self.curr.ap + F::two()), // two words were written so advance 2 positions
                 _ => panic!("ap increment in call instruction"), // ap increments not allowed in call instructions
             };
         } else if self.instr().opcode() == OPC_JMP_INC /*0*/

--- a/turshi/src/word.rs
+++ b/turshi/src/word.rs
@@ -7,7 +7,7 @@
 use crate::flags::*;
 use crate::helper::CairoFieldHelpers;
 use ark_ff::Field;
-use o1_utils::field_helpers::FieldHelpers;
+use o1_utils::{FieldHelpers, Two};
 
 /// A Cairo word for the runner. Some words are instructions (which fit inside a `u64`). Others are immediate values (any `F` element).
 #[derive(Clone, Copy)]
@@ -15,7 +15,7 @@ pub struct CairoWord<F>(F);
 
 /// Returns an offset of 16 bits to its biased representation in the interval `[-2^15,2^15)` as a field element
 fn bias<F: Field>(offset: F) -> F {
-    offset - F::from(2u16.pow(15u32)) // -2^15 + sum_(i=0..15) b_i * 2^i
+    offset - F::two_pow(15) // -2^15 + sum_(i=0..15) b_i * 2^i
 }
 
 impl<F: Field> CairoWord<F> {

--- a/utils/src/foreign_field.rs
+++ b/utils/src/foreign_field.rs
@@ -1,6 +1,7 @@
 //! Describes helpers for foreign field arithmetics
 
 use crate::field_helpers::FieldHelpers;
+use crate::Two;
 use ark_ff::{Field, PrimeField};
 use num_bigint::BigUint;
 use num_traits::Zero;
@@ -18,19 +19,11 @@ pub const HI: usize = 2;
 /// Limb length for foreign field elements
 pub const LIMB_BITS: usize = 88;
 
-/// Two to the power of the limb length
-pub const TWO_TO_LIMB: u128 = 2u128.pow(LIMB_BITS as u32);
-
 /// Number of desired limbs for foreign field elements
 pub const LIMB_COUNT: usize = 3;
 
 /// Exponent of binary modulus (i.e. t)
 pub const BINARY_MODULUS_EXP: usize = LIMB_BITS * LIMB_COUNT;
-
-/// Two to the power of the limb length
-pub fn two_to_limb() -> BigUint {
-    BigUint::from(TWO_TO_LIMB)
-}
 
 /// Represents a foreign field element
 #[derive(Clone, PartialEq, Eq)]
@@ -162,11 +155,11 @@ pub trait ForeignFieldHelpers<T> {
 
 impl<F: Field> ForeignFieldHelpers<F> for F {
     fn two_to_limb() -> Self {
-        F::from(2u64).pow(&[LIMB_BITS as u64])
+        F::two_pow(LIMB_BITS as u64)
     }
 
     fn two_to_2limb() -> Self {
-        F::from(2u64).pow(&[2 * LIMB_BITS as u64])
+        F::two_to_limb().square()
     }
 }
 
@@ -174,6 +167,9 @@ impl<F: Field> ForeignFieldHelpers<F> for F {
 pub trait BigUintForeignFieldHelpers {
     /// 2
     fn two() -> Self;
+
+    /// 2^pow
+    fn two_pow(pow: u32) -> Self;
 
     /// 2^{LIMB_SIZE}
     fn two_to_limb() -> Self;
@@ -203,6 +199,10 @@ pub trait BigUintForeignFieldHelpers {
 impl BigUintForeignFieldHelpers for BigUint {
     fn two() -> Self {
         Self::from(2u32)
+    }
+
+    fn two_pow(pow: u32) -> Self {
+        Self::two().pow(pow)
     }
 
     fn two_to_limb() -> Self {

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -21,4 +21,6 @@ pub use chunked_evaluations::ChunkedEvaluations;
 pub use dense_polynomial::ExtendedDensePolynomial;
 pub use evaluations::ExtendedEvaluations;
 pub use field_helpers::{BigUintFieldHelpers, FieldHelpers, RandomField, Two};
-pub use foreign_field::{ForeignElement, LIMB_COUNT};
+pub use foreign_field::{
+    BigUintForeignFieldHelpers, ForeignElement, ForeignFieldHelpers, LIMB_COUNT,
+};


### PR DESCRIPTION
This PR updates the codebase (specially tests) to use the Two trait for field elements.