### PR TITLE
Non-native field multiplication optimization 1

### DIFF
--- a/book/src/rfcs/foreign_field_mul.md
+++ b/book/src/rfcs/foreign_field_mul.md
@@ -1211,7 +1211,7 @@ Next we have check (8)
 
 **C5:** $2^{2\ell} \cdot v_0 = p_0 + 2^{\ell} \cdot p_{10} - r_0 - 2^{\ell} \cdot r_1$
 
-Up next, checks (9) is a 3-bit range check
+Up next, check (9) is a 3-bit range check
 
 **C6:** Plookup $v_{11}$ (12-bit plookup scaled by $2^9$)
 

--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1405,13 +1405,13 @@ The foreign field multiplication gate's rows are laid out like this
 |   5 | `right_input2`        (copy) | `product1_lo`      (copy) |
 |   6 | `carry1_lo`           (copy) | `product1_hi_0`    (copy) |
 |   7 | `carry1_hi`        (plookup) | `product1_hi_1`           |
-|   8 | `scaled_carry1_hi` (plookup) |                           |
-|   9 | `carry0`                     |                           |
-|  10 | `quotient0`                  |                           |
-|  11 | `quotient1`                  |                           |
-|  12 | `quotient2`                  |                           |
-|  13 | `quotient_bound_carry01`     |                           |
-|  14 | `quotient_bound_carry2`      |                           |
+|   8 | `carry0`                     |                           |
+|   9 | `quotient0`                  |                           |
+|  10 | `quotient1`                  |                           |
+|  11 | `quotient2`                  |                           |
+|  12 | `quotient_bound_carry01`     |                           |
+|  13 | `quotient_bound_carry2`      |                           |
+|  14 |                              |                           |
 
 
 #### Xor

--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1343,11 +1343,9 @@ left_input0 => a0  right_input0 => b0  quotient0 => q0  remainder0 => r0
 left_input1 => a1  right_input1 => b1  quotient1 => q1  remainder1 => r1
 left_input2 => a2  right_input2 => b2  quotient2 => q2  remainder2 => r2
 
-   product1_lo => p10   product1_hi_0 => p110   product1_hi_1 => p111
-     carry0 => v0        carry1_lo => v10          carry1_hi => v11
-
-                    scaled_carry1_hi => scaled_v11
-         quotient_bound0 => q'0       quotient_bound12 => q'12
+   product1_lo => p10      product1_hi_0 => p110     product1_hi_1 => p111
+   carry0 => v0            carry1_lo => v10          carry1_hi => v11
+   quotient_bound0 => q'0  quotient_bound12 => q'12
 
   quotient_bound_carry0 => q'_carry0 quotient_bound_carry12 = q'_carry12
 ````
@@ -1383,7 +1381,6 @@ would be split into `x1_lo_0` and `x1_lo_1`.
 * `carry0` := 2 bit carry
 * `carry1_lo` := low 88 bits of `carry1`
 * `carry1_hi` := high 3 bits of `carry1`
-* `scaled_carry1_hi` : = `carry1_hi` scaled by 2^9
 * `product1_lo` := lowest 88 bits of middle intermediate product
 * `product1_hi_0` := lowest 88 bits of middle intermediate product's highest 88 + 2 bits
 * `product1_hi_1` := highest 2 bits of middle intermediate product

--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -123,9 +123,6 @@ pub enum GateType {
 #[derive(Error, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CircuitGateError {
     /// Invalid constraint
-    #[error("Invalid circuit gate type {0:?}")]
-    InvalidCircuitGateType(GateType),
-    /// Invalid constraint
     #[error("Invalid {0:?} constraint")]
     InvalidConstraint(GateType),
     /// Invalid constraint with number
@@ -137,18 +134,9 @@ pub enum CircuitGateError {
     /// Disconnected wires
     #[error("Invalid {typ:?} copy constraint: {},{} -> {},{}", .src.row, .src.col, .dst.row, .dst.col)]
     CopyConstraint { typ: GateType, src: Wire, dst: Wire },
-    /// Invalid copy constraint
-    #[error("Invalid {0:?} copy constraint")]
-    InvalidCopyConstraint(GateType),
-    /// Invalid lookup constraint - sorted evaluations
-    #[error("Invalid {0:?} lookup constraint - sorted evaluations")]
-    InvalidLookupConstraintSorted(GateType),
-    /// Invalid lookup constraint - sorted evaluations
-    #[error("Invalid {0:?} lookup constraint - aggregation polynomial")]
-    InvalidLookupConstraintAggregation(GateType),
-    /// Missing lookup constraint system
-    #[error("Failed to get lookup constraint system for {0:?}")]
-    MissingLookupConstraintSystem(GateType),
+    /// Invalid lookup
+    #[error("Invalid {0:?} lookup constraint")]
+    InvalidLookupConstraint(GateType),
     /// Failed to get witness for row
     #[error("Failed to get {0:?} witness for row {1}")]
     FailedToGetWitnessForRow(GateType, usize),

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -296,7 +296,7 @@ impl LookupPattern {
         match self {
             LookupPattern::Xor | LookupPattern::ChaChaFinal | LookupPattern::RangeCheck => 4,
             LookupPattern::Lookup => 3,
-            LookupPattern::ForeignFieldMul => 2,
+            LookupPattern::ForeignFieldMul => 1,
         }
     }
 

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -397,18 +397,17 @@ impl LookupPattern {
                     .collect()
             }
             LookupPattern::ForeignFieldMul => {
-                (7..=8)
-                    .map(|column| {
-                        //   0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
-                        //   - - - - - - - L L - -  -  -  -  -
-                        JointLookup {
-                            table_id: LookupTableID::Constant(RANGE_CHECK_TABLE_ID),
-                            entry: vec![SingleLookup {
-                                value: vec![(F::one(), curr_row(column))],
-                            }],
-                        }
-                    })
-                    .collect()
+                vec![
+                    //   0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
+                    //   - - - - - - - L - - -  -  -  -  -
+                    // Constrain w(7) to 3 bits.
+                    JointLookup {
+                        table_id: LookupTableID::Constant(RANGE_CHECK_TABLE_ID),
+                        entry: vec![SingleLookup {
+                            value: vec![(F::from(2u64).pow(&[9u64]), curr_row(7))],
+                        }],
+                    },
+                ]
             }
         }
     }

--- a/kimchi/src/tests/foreign_field_mul.rs
+++ b/kimchi/src/tests/foreign_field_mul.rs
@@ -232,7 +232,7 @@ where
                 .prove_and_verify::<EFqSponge, EFrSponge>()
             {
                 Err(err_msg) => {
-                    if err_msg == String::from("the lookup failed to find a match in the table") {
+                    if err_msg == *"the lookup failed to find a match in the table" {
                         return (
                             Err(CircuitGateError::InvalidLookupConstraint(
                                 GateType::ForeignFieldMul,


### PR DESCRIPTION
    * Halve the number of plookups
    * Eliminate custom constraint for scaling carry1_hi
    * Remove unused CircuitGateErrors (n.b. clippy doesn't detect these)
    * Add native modulus constraint test case
    
Speedup:
- time to create prover index: 62.8/62s ~ 1.3%
- time to create proof: 36/27s ~ 33%
- time to verify: 870/837ms ~ 3.9% 

```text
OPT1

- time to create prover index: 62s
- time to create proof: 27s
- time to verify: 844ms

- time to create prover index: 62s
- time to create proof: 27s
- time to verify: 838ms

- time to create prover index: 62s
- time to create proof: 27s
- time to verify: 834ms

- time to create prover index: 62s
- time to create proof: 27s
- time to verify: 837ms

- time to create prover index: 62s
- time to create proof: 27s
- time to verify: 832ms

=== averaged over 5 runs ===

- time to create prover index: 62s
- time to create proof: 27s
- time to verify: 837ms
```

```text
VANILLA

- time to create prover index: 63s
- time to create proof: 36s
- time to verify: 831ms

- time to create prover index: 63s
- time to create proof: 36s
- time to verify: 866ms

- time to create prover index: 63s
- time to create proof: 36s
- time to verify: 837ms

- time to create prover index: 62s
- time to create proof: 36s
- time to verify: 977ms

- time to create prover index: 63s
- time to create proof: 36s
- time to verify: 839ms

=== averaged over 5 runs ===

- time to create prover index: 62.8s
- time to create proof: 36s
- time to verify: 870ms
```

Closes #923 