### PR TITLE
FFAdd sign update inside coefficients

### DIFF
--- a/book/src/rfcs/foreign_field_add.md
+++ b/book/src/rfcs/foreign_field_add.md
@@ -201,40 +201,48 @@ with $r_{top} = r_2$ and $c = c_1$.
 
 ## Gadget
 
-The foreign field gadget will be composed by 4 sets of `RangeCheck` gadgets for witnesses $a, b, r, u$ accounting for 16 rows in total; followed by one row with `ForeignFieldAdd` gate type; a final `ForeignFieldAdd` with a `Zero` row. The first four rows constrain the range of the left input. The following four constrain the range of the right input. The next range check is for the result of the addition of left and right. Next, a final range check for the upper bound therm. Then the foreign field addition gate performs the actual addition. And the final foreign field addition gate (followed by a zero gate) takes care of the final upper bound operation. A total of 19 rows with 15 columns in Kimchi.
+The full foreign field addition/subtraction gadget will be composed by: 
+- $1$ public input row containing the value $1$;
+- $n$ rows with `ForeignFieldAdd` gate type:
+  - for the actual $n$ chained additions or subtractions;  
+- $1$ `ForeignFieldAdd` row for the final bound check;
+- $1$ `Zero` row for the final upper bound check.
+- $1$ `RangeCheck` gadget for the first left input of the chain $a_1 := a$;
+- Then, $n$ of the following set of rows:
+  - $1$ `RangeCheck` gadget for the $i$-th right input $b_i$;
+  - $1$ `RangeCheck` gadget for the $i$-th result which will correspond to the $(i+1)$-th left input of the chain $r_i = a_{i+1}$.
+- $1$ final `RangeCheck` gadget for the upper bound term $u$.
 
-| Row(s) | Gate type(s)        | Witness |
-| ------ | ------------------- | ------- |
-| 0-3    | `multi-range-check` | $a$     |
-| 4-7    | `multi-range-check` | $b$     |
-| 8-11   | `multi-range-check` | $r$     |
-| 12-15  | `multi-range-check` | $u$     |
-| 16     | `ForeignFieldAdd`   |         |
-| 17     | `ForeignFieldAdd`   |         |
-| 18     | `Zero`              |         |
+A total of 20 rows with 15 columns in Kimchi for 1 addition. All ranges below are inclusive.
 
-We have a mechanism to chain foreign field additions together. In this case, an initial left input range check is performed, which is followed by a $n$ pairs of range check gates for the right input and intermediate result (which become the left input for the next iteration). After the chained inputs checks, a final range check on the upper bound takes place. Then, there are $n$ foreign field addition gates, and finally a foreign field addition gate for the upper bound (whose current row corresponds to the next row of the last foreign field addition gate), and an auxiliary `Zero` row that holds the upper bound.
+| Row(s)           | Gate type(s)        | Witness |
+| ---------------- | ------------------- | ------- |
+| 0                | `PublicInput`       | $1$     |
+| 1..n             | `ForeignFieldAdd`   | +/-     |
+| n+1              | `ForeignFieldAdd`   | bound   |
+| n+2              | `Zero`              | bound   |
+| n+3..n+6         | `multi-range-check` | left    |
+| n+7+8i..n+10+8i  | `multi-range-check` | right   |
+| n+11+8i..n+14+8i | `multi-range-check` | $r$     |
+| 9n+7..9n+10      | `multi-range-check` | $u$     |
 
-More formally, these are the rows for the chained gadget:
 
-| Row(s)      | Gate type(s)                     | Witness |
-| ----------- | -------------------------------- | ------- |
-| 0..3        | `multi-range-check` for `left`   | $a$     |
-|             |                                  |         |
-| 8i+4..8i+7  | `multi-range-check` for `right`  | $b$     |
-| 8i+8..8i+11 | `multi-range-check` for `result` | $r$     |
-|             |                                  |         |
-| 8n+4..8n+7  | `multi-range-check` for `bound`  | $u$     |
-|             |                                  |         |
-| 8n+i+8      | `ForeignFieldAdd`                |         |
-|             |                                  |         |
-| 9n+8        | `ForeignFieldAdd`                |         |
-| 9n+9        | `Zero`                           |         |
+This mechanism can chain foreign field additions together. Initially, there are $n$ foreign field addition gates, followed by a foreign field addition gate for the upper bound (whose current row corresponds to the next row of the last foreign field addition gate), and an auxiliary `Zero` row that holds the upper bound. At the end, an initial left input range check is performed, which is followed by a $n$ pairs of range check gates for the right input and intermediate result (which become the left input for the next iteration). After the chained inputs checks, a final range check on the upper bound takes place. 
+
+Nonetheless, such an exhaustive set of checks are not necessary for completeness nor soundness. In particular, only the very final range check for the bound is required. Thus, a shorter gadget that is equally valid and takes $(8*n+4)$ less rows is possible, and it follows the next layout (with inclusive ranges):
+
+| Row(s)   | Gate type(s)                                          | Witness |
+| -------- | ----------------------------------------------------- | ------- |
+| 0        | public input row for soundness of bound overflow flag | $1$     |
+| 1..n     | `ForeignFieldAdd`                                     |         |
+| n+1      | `ForeignFieldAdd`                                     |         |
+| n+2      | `Zero`                                                |         |
+| n+3..n+6 | `multi-range-check` for `bound`                       | $u$     |
 
 
 ### Layout
 
-For this gate, we need to perform 4 range checks to assert that the limbs of $a, b, r, u$ have a correct size, meaning they fit in $2^{88}$ (and thus, range-checking $a, b, r, u$ for $2^{264}$). Because each of these elements is split into 3 limbs, we will have to use 3 copy constraints between the `RangeCheck` gates and the `ForeignFieldAdd` rows (per element). That amounts to 12 copy constraints. Recalling that Kimchi only allows for the first 7 columns of each row to host a copy constraint, we necessarily have to use 2 rows for the actual addition gate. The layout of these two rows is the following:
+For the full mode of tests of this gate, we need to perform 4 range checks to assert that the limbs of $a, b, r, u$ have a correct size, meaning they fit in $2^{88}$ (and thus, range-checking $a, b, r, u$ for $2^{264}$). Because each of these elements is split into 3 limbs, we will have to use 3 copy constraints between the `RangeCheck` gates and the `ForeignFieldAdd` rows (per element). That amounts to 12 copy constraints. Recalling that Kimchi only allows for the first 7 columns of each row to host a copy constraint, we necessarily have to use 2 rows for the actual addition gate. The layout of these two rows is the following:
 
 |            | Curr              | Next              | ... Final    |
 | ---------- | ----------------- | ----------------- | ------------ |
@@ -248,7 +256,7 @@ For this gate, we need to perform 4 range checks to assert that the limbs of $a,
 | 6          | $q$               |
 | 7          | $c_0$             |
 | 8          | $c_1$             |
-| 9          | $s$               |
+| 9          |                   |
 | 10         |                   |
 | 11         |                   |
 | 12         |                   |
@@ -272,6 +280,7 @@ So far, we have pointed out the following sets of constraints:
 - $0 = c_1 \cdot (c_0 + 1) \cdot (c_1 - 1)$
 
 #### Sign checks
+TODO: decide if we really want to keep this check or leave it implicit as it is a coefficient value
 - $0 = (s + 1) \cdot (s - 1)$
 
 #### Overflow checks
@@ -281,3 +290,5 @@ So far, we have pointed out the following sets of constraints:
 
 When we use this gate as part of a larger chained gadget, we should optimize the number of range check rows
 to avoid redundant checks. In particular, if the result of an addition becomes one input of another addition, there is no need to check twice that the limbs of that term have the right length.
+
+The sign is now part of the coefficients of the gate. This will allow us to remove the sign check constraint and release one witness cell element. But more importantly, it brings soundness to the gate as it is now possible to wire the $1$ public input to the overflow witness of the final bound check of every addition chain.  

--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1282,40 +1282,39 @@ With this idea in mind, the sole carry flag we need is the one located between t
 
 ##### Layout
 
-You could lay this out as a double-width gate for chained foreign additions and a final row, e.g.:
+The sign of the operation (whether it is an addition or a subtraction) is stored in the fourth coefficient as
+a value +1 (for addition) or -1 (for subtraction). The first 3 coefficients are the 3 limbs of the foreign modulus.
+One could lay this out as a double-width gate for chained foreign additions and a final row, e.g.:
 
-| col | `ForeignFieldAdd`       | chain `ForeignFieldAdd` | final `ForeignFieldAdd` | final `Zero`      |
-| --- | ----------------------- | ----------------------- | ----------------------- | ----------------- |
-|   0 | `left_input_lo`  (copy) | `result_lo` (copy)      | `min_result_lo` (copy)  | `bound_lo` (copy) |
-|   1 | `left_input_mi`  (copy) | `result_mi` (copy)      | `min_result_mi` (copy)  | `bound_mi` (copy) |
-|   2 | `left_input_hi`  (copy) | `result_hi` (copy)      | `min_result_hi` (copy)  | `bound_hi` (copy) |
-|   3 | `right_input_lo` (copy) |                         |  0              (check) |                   |
-|   4 | `right_input_mi` (copy) |                         |  0              (check) |                   |
-|   5 | `right_input_hi` (copy) |                         |  2^88           (check) |                   |
-|   6 | `sign`           (copy) |                         |  1              (check) |                   |
-|   7 | `field_overflow`        |                         |  1              (check) |                   |
-|   8 | `carry`                 |                         | `bound_carry`           |                   |
-|   9 |                         |                         |                         |                   |
-|  10 |                         |                         |                         |                   |
-|  11 |                         |                         |                         |                   |
-|  12 |                         |                         |                         |                   |
-|  13 |                         |                         |                         |                   |
-|  14 |                         |                         |                         |                   |
+| col | `ForeignFieldAdd`        | chain `ForeignFieldAdd` | final `ForeignFieldAdd` | final `Zero`      |
+| --- | ------------------------ | ----------------------- | ----------------------- | ----------------- |
+|   0 | `left_input_lo`  (copy)  | `result_lo` (copy)      | `min_result_lo` (copy)  | `bound_lo` (copy) |
+|   1 | `left_input_mi`  (copy)  | `result_mi` (copy)      | `min_result_mi` (copy)  | `bound_mi` (copy) |
+|   2 | `left_input_hi`  (copy)  | `result_hi` (copy)      | `min_result_hi` (copy)  | `bound_hi` (copy) |
+|   3 | `right_input_lo` (copy)  |                         |  0              (check) |                   |
+|   4 | `right_input_mi` (copy)  |                         |  0              (check) |                   |
+|   5 | `right_input_hi` (copy)  |                         |  2^88           (check) |                   |
+|   6 | `field_overflow` (copy?) |                         |  1              (check) |                   |
+|   7 | `carry`                  |                         | `bound_carry`           |                   |
+|   8 |                          |                         |                         |                   |
+|   9 |                          |                         |                         |                   |
+|  10 |                          |                         |                         |                   |
+|  11 |                          |                         |                         |                   |
+|  12 |                          |                         |                         |                   |
+|  13 |                          |                         |                         |                   |
+|  14 |                          |                         |                         |                   |
 
 We reuse the foreign field addition gate for the final bound check since this is an addition with a
-specific parameter structure. Checking that the correct right input, overflow, and sign are used shall
+specific parameter structure. Checking that the correct right input, overflow, and overflow are used shall
 be done by copy constraining these values with a public input value. One could have a specific gate
 for just this check requiring less constrains, but the cost of adding one more selector gate outweights
 the savings of one row and a few constraints of difference.
 
 ##### Integration
 
-- Copy signs from public input
+- Copy final overflow bit from public input containing value 1
  - Range check the final bound
 
-```admonish info
-TODO: move sign to the coefficient so that the bound check can also check that ovf is one.
-```
 
 
 #### Foreign Field Multiplication

--- a/kimchi/src/circuits/polynomials/foreign_field_add/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/circuitgates.rs
@@ -7,7 +7,7 @@ use crate::circuits::{
 };
 use ark_ff::PrimeField;
 use o1_utils::LIMB_COUNT;
-use std::{array, marker::PhantomData};
+use std::marker::PhantomData;
 
 //~ These circuit gates are used to constrain that
 //~
@@ -90,40 +90,39 @@ use std::{array, marker::PhantomData};
 //~
 //~ ##### Layout
 //~
-//~ You could lay this out as a double-width gate for chained foreign additions and a final row, e.g.:
+//~ The sign of the operation (whether it is an addition or a subtraction) is stored in the fourth coefficient as
+//~ a value +1 (for addition) or -1 (for subtraction). The first 3 coefficients are the 3 limbs of the foreign modulus.
+//~ One could lay this out as a double-width gate for chained foreign additions and a final row, e.g.:
 //~
-//~ | col | `ForeignFieldAdd`       | chain `ForeignFieldAdd` | final `ForeignFieldAdd` | final `Zero`      |
-//~ | --- | ----------------------- | ----------------------- | ----------------------- | ----------------- |
-//~ |   0 | `left_input_lo`  (copy) | `result_lo` (copy)      | `min_result_lo` (copy)  | `bound_lo` (copy) |
-//~ |   1 | `left_input_mi`  (copy) | `result_mi` (copy)      | `min_result_mi` (copy)  | `bound_mi` (copy) |
-//~ |   2 | `left_input_hi`  (copy) | `result_hi` (copy)      | `min_result_hi` (copy)  | `bound_hi` (copy) |
-//~ |   3 | `right_input_lo` (copy) |                         |  0              (check) |                   |
-//~ |   4 | `right_input_mi` (copy) |                         |  0              (check) |                   |
-//~ |   5 | `right_input_hi` (copy) |                         |  2^88           (check) |                   |
-//~ |   6 | `sign`           (copy) |                         |  1              (check) |                   |
-//~ |   7 | `field_overflow`        |                         |  1              (check) |                   |
-//~ |   8 | `carry`                 |                         | `bound_carry`           |                   |
-//~ |   9 |                         |                         |                         |                   |
-//~ |  10 |                         |                         |                         |                   |
-//~ |  11 |                         |                         |                         |                   |
-//~ |  12 |                         |                         |                         |                   |
-//~ |  13 |                         |                         |                         |                   |
-//~ |  14 |                         |                         |                         |                   |
+//~ | col | `ForeignFieldAdd`        | chain `ForeignFieldAdd` | final `ForeignFieldAdd` | final `Zero`      |
+//~ | --- | ------------------------ | ----------------------- | ----------------------- | ----------------- |
+//~ |   0 | `left_input_lo`  (copy)  | `result_lo` (copy)      | `min_result_lo` (copy)  | `bound_lo` (copy) |
+//~ |   1 | `left_input_mi`  (copy)  | `result_mi` (copy)      | `min_result_mi` (copy)  | `bound_mi` (copy) |
+//~ |   2 | `left_input_hi`  (copy)  | `result_hi` (copy)      | `min_result_hi` (copy)  | `bound_hi` (copy) |
+//~ |   3 | `right_input_lo` (copy)  |                         |  0              (check) |                   |
+//~ |   4 | `right_input_mi` (copy)  |                         |  0              (check) |                   |
+//~ |   5 | `right_input_hi` (copy)  |                         |  2^88           (check) |                   |
+//~ |   6 | `field_overflow` (copy?) |                         |  1              (check) |                   |
+//~ |   7 | `carry`                  |                         | `bound_carry`           |                   |
+//~ |   8 |                          |                         |                         |                   |
+//~ |   9 |                          |                         |                         |                   |
+//~ |  10 |                          |                         |                         |                   |
+//~ |  11 |                          |                         |                         |                   |
+//~ |  12 |                          |                         |                         |                   |
+//~ |  13 |                          |                         |                         |                   |
+//~ |  14 |                          |                         |                         |                   |
 //~
 //~ We reuse the foreign field addition gate for the final bound check since this is an addition with a
-//~ specific parameter structure. Checking that the correct right input, overflow, and sign are used shall
+//~ specific parameter structure. Checking that the correct right input, overflow, and overflow are used shall
 //~ be done by copy constraining these values with a public input value. One could have a specific gate
 //~ for just this check requiring less constrains, but the cost of adding one more selector gate outweights
 //~ the savings of one row and a few constraints of difference.
 //~
 //~ ##### Integration
 //~
-//~ - Copy signs from public input
+//~ - Copy final overflow bit from public input containing value 1
 //~ - Range check the final bound
 //~
-//~ ```admonish info
-//~ TODO: move sign to the coefficient so that the bound check can also check that ovf is one.
-//~ ```
 
 /// Implementation of the foreign field addition gate
 /// - Operates on Curr and Next rows.
@@ -138,7 +137,13 @@ where
     const CONSTRAINTS: u32 = 5;
 
     fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
-        let foreign_modulus: [T; LIMB_COUNT] = array::from_fn(|i| env.coeff(i));
+        let foreign_modulus: [T; LIMB_COUNT] = [env.coeff(0), env.coeff(1), env.coeff(2)];
+
+        // stored as coefficient for better correspondance with the relation being proved
+        // this reduces the number of copy constraints needed to check the operation
+        // it also allows the final bound check to copy the overflow bit to be 1
+        // because otherwise it did not fit in the first 7 columns of the row
+        let sign = env.coeff(3);
 
         let left_input_lo = env.witness_curr(0);
         let left_input_mi = env.witness_curr(1);
@@ -149,12 +154,10 @@ where
         let right_input_hi = env.witness_curr(5);
 
         // sign in <7 to be able to check against public input of opcodes
-        let sign = env.witness_curr(6);
-
-        let field_overflow = env.witness_curr(7);
+        let field_overflow = env.witness_curr(6);
 
         // Result carry bits for limb overflows / underflows.
-        let carry = env.witness_curr(8);
+        let carry = env.witness_curr(7);
 
         let result_lo = env.witness_next(0);
         let result_mi = env.witness_next(1);
@@ -162,10 +165,11 @@ where
 
         // Field overflow and sign constraints
         let mut checks = vec![
+            // Sign flag is 1 or -1
+            // NOTE: not sure if we really need to check this, as it is part of the relation
+            (sign.clone() + T::one()) * (sign.clone() - T::one()),
             // Field overflow bit is 0 or s.
             field_overflow.clone() * (field_overflow.clone() - sign.clone()),
-            // Sign flag is 1 or -1
-            (sign.clone() + T::one()) * (sign.clone() - T::one()),
         ];
 
         // Constraints to check the carry flag is -1, 0, or 1.

--- a/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
@@ -5,15 +5,18 @@ use num_bigint::BigUint;
 use o1_utils::foreign_field::BigUintForeignFieldHelpers;
 
 use crate::circuits::{
-    gate::{CircuitGate, GateType},
+    gate::{CircuitGate, Connect, GateType},
     wires::Wire,
 };
+
+use super::witness::FFOps;
 
 impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     /// Create foreign field addition gate chain without range checks (needs to wire the range check for result bound manually)
     ///     Inputs
     ///         starting row
-    ///         number of addition gates
+    ///         operations to perform
+    ///         modulus of the foreign field
     ///     Outputs tuple (next_row, circuit_gates) where
     ///       next_row      - next row after this gate
     ///       circuit_gates - vector of circuit gates comprising this gate
@@ -27,31 +30,40 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     ///      [n+1]         -> 1 Zero row for bound result
     /// ]
     ///
-    pub fn create(
+    /// INTEGRATION:
+    /// - Wire the range check for result bound manually
+    /// - Connect to public input containing the 1 value for the overflow in the final bound check
+    pub fn create_chain_ffadd(
         start_row: usize,
-        num: usize,
+        opcodes: &[FFOps],
         foreign_field_modulus: &BigUint,
     ) -> (usize, Vec<Self>) {
         let next_row = start_row;
         let foreign_field_modulus = foreign_field_modulus.to_field_limbs::<F>();
         let mut circuit_gates = vec![];
-
+        let num = opcodes.len();
+        // ---------------------------
         // Foreign field addition gates
         // ---------------------------
         // First the single-addition gates
         for i in 0..num {
+            assert_ne!(opcodes[i], FFOps::Mul);
+            let mut coeffs = foreign_field_modulus.to_vec();
+            coeffs.push(opcodes[i].sign::<F>());
             circuit_gates.append(&mut vec![CircuitGate {
                 typ: GateType::ForeignFieldAdd,
                 wires: Wire::for_row(next_row + i),
-                coeffs: foreign_field_modulus.to_vec(),
+                coeffs,
             }]);
         }
+        let mut final_coeffs = foreign_field_modulus.to_vec();
+        final_coeffs.push(FFOps::Add.sign::<F>());
         // Then the final bound gate and the zero gate
         circuit_gates.append(&mut vec![
             CircuitGate {
                 typ: GateType::ForeignFieldAdd,
                 wires: Wire::for_row(next_row + num),
-                coeffs: foreign_field_modulus.to_vec(),
+                coeffs: final_coeffs,
             },
             CircuitGate {
                 typ: GateType::Zero,
@@ -62,7 +74,7 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
         (start_row + circuit_gates.len(), circuit_gates)
     }
 
-    /// Create a single foreign field addition gate
+    /// Create a single foreign field addition gate. This is used for example in the final bound check.
     ///     Inputs
     ///         starting row
     ///     Outputs tuple (next_row, circuit_gates) where
@@ -70,14 +82,18 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     ///       circuit_gates - vector of circuit gates comprising this gate
     pub fn create_single_ffadd(
         start_row: usize,
+        operation: FFOps,
         foreign_field_modulus: &BigUint,
     ) -> (usize, Vec<Self>) {
+        assert_ne!(operation, FFOps::Mul);
         let foreign_field_modulus = foreign_field_modulus.to_field_limbs::<F>();
+        let mut coeffs = foreign_field_modulus.to_vec();
+        coeffs.push(operation.sign::<F>());
         let circuit_gates = vec![
             CircuitGate {
                 typ: GateType::ForeignFieldAdd,
                 wires: Wire::for_row(start_row),
-                coeffs: foreign_field_modulus.to_vec(),
+                coeffs,
             },
             CircuitGate {
                 typ: GateType::Zero,
@@ -89,14 +105,32 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
         (start_row + circuit_gates.len(), circuit_gates)
     }
 
-    /// Create foreign field addition gate by extending the existing gates
-    pub fn extend_single_foreign_field_add(
+    /// Extend a chain of foreign field addition gates. It already wires the public input to the overflow cell.
+    pub fn extend_chain_ffadd(
         gates: &mut Vec<Self>,
+        pub_row: usize,
         curr_row: &mut usize,
+        opcodes: &[FFOps],
         foreign_field_modulus: &BigUint,
     ) {
-        let (next_row, circuit_gates) = Self::create_single_ffadd(*curr_row, foreign_field_modulus);
+        let (next_row, add_gates) =
+            Self::create_chain_ffadd(*curr_row, opcodes, foreign_field_modulus);
+        gates.extend_from_slice(&add_gates);
         *curr_row = next_row;
-        gates.extend_from_slice(&circuit_gates);
+        // check overflow flag is one
+        gates.connect_cell_pair((pub_row, 0), (*curr_row - 2, 6));
+    }
+
+    /// Extend a single foreign field addition gate followed by a zero row containing the result
+    pub fn extend_single_ffadd(
+        gates: &mut Vec<Self>,
+        curr_row: &mut usize,
+        operation: FFOps,
+        foreign_field_modulus: &BigUint,
+    ) {
+        let (next_row, add_gates) =
+            Self::create_single_ffadd(*curr_row, operation, foreign_field_modulus);
+        *curr_row = next_row;
+        gates.extend_from_slice(&add_gates);
     }
 }

--- a/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
@@ -23,18 +23,15 @@ pub enum FFOps {
     Add,
     /// Subtraction
     Sub,
-    /// Multiplication
-    Mul,
 }
 
 /// Implementation of the FFOps enum
 impl FFOps {
-    /// Returns the sign of the operation as a field element, or zero if it is a multiplication
+    /// Returns the sign of the operation as a field element
     pub fn sign<F: PrimeField>(&self) -> F {
         match self {
             FFOps::Add => F::one(),
             FFOps::Sub => -F::one(),
-            FFOps::Mul => F::zero(),
         }
     }
 }
@@ -51,8 +48,6 @@ fn compute_ffadd_values<F: PrimeField>(
     opcode: FFOps,
     foreign_modulus: &ForeignElement<F, 3>,
 ) -> (ForeignElement<F, 3>, F, F, F) {
-    assert_ne!(opcode, FFOps::Mul);
-
     // Compute bigint version of the inputs
     let left = left_input.to_biguint();
     let right = right_input.to_biguint();

--- a/kimchi/src/tests/foreign_field_add.rs
+++ b/kimchi/src/tests/foreign_field_add.rs
@@ -159,17 +159,17 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     /// Check if a given circuit gate is a given foreign field operation
     pub fn check_ffadd_sign(&self, sign: FFOps) -> Result<(), String> {
         if self.typ != GateType::ForeignFieldAdd {
-            return Err(format!("Gate is not a foreign field add gate"));
+            return Err("Gate is not a foreign field add gate".to_string());
         }
         match sign {
             FFOps::Add => {
                 if self.coeffs[3] != F::one() {
-                    return Err(format!("Gate is not performing addition"));
+                    return Err("Gate is not performing addition".to_string());
                 }
             }
             FFOps::Sub => {
                 if self.coeffs[3] != -F::one() {
-                    return Err(format!("Gate is not performing subtraction"));
+                    return Err("Gate is not performing subtraction".to_string());
                 }
             }
         }
@@ -1097,7 +1097,7 @@ fn test_bad_bound() {
     index.cs.gates[2].coeffs[3] = -PallasField::two();
     assert_eq!(
         index.cs.gates[2].check_ffadd_sign(FFOps::Add),
-        Err(format!("Gate is not performing addition")),
+        Err("Gate is not performing addition".to_string()),
     );
     index.cs.gates[2].coeffs[3] = PallasField::one();
     // Modify overflow to check first the copy constraint and then the ovf constraint

--- a/kimchi/src/tests/foreign_field_mul.rs
+++ b/kimchi/src/tests/foreign_field_mul.rs
@@ -4,7 +4,7 @@ use crate::{
         constraints::ConstraintSystem,
         gate::{CircuitGate, CircuitGateError, CircuitGateResult, Connect, GateType},
         polynomial::COLUMNS,
-        polynomials::{foreign_field_mul, range_check},
+        polynomials::{foreign_field_add::witness::FFOps, foreign_field_mul, range_check},
         wires::Wire,
     },
     curve::KimchiCurve,
@@ -107,9 +107,10 @@ where
         //     20-23 multi-range-check (quotient range check)
 
         // Bound addition for multiplication result
-        CircuitGate::extend_single_foreign_field_add(
+        CircuitGate::extend_single_ffadd(
             &mut gates,
             &mut next_row,
+            FFOps::Add,
             foreign_field_modulus,
         );
         gates.connect_cell_pair((1, 0), (2, 0));


### PR DESCRIPTION
This PR addresses the final pending TODO inside the FFAdd gate that consists on moving the sign value to the coefficients of the gate. This is not only an aesthetic change, as it indeed makes sense that the operation being performed is known and part of the relation itself, but it also brings soundness to the final bound check of any FFAdd chain. In other words, we did not have enough space in copyable cells to both constrain that the sign of the final check is a "+" and that the final overflow flag is 1. By removing the sign from the layout, we can now constrain the overflow flag, and the sign can be publicly checked to be the right value. 

It is not clear to me though if we want to keep the `(sign - 1) * (sign + 1) = 0` constrain, as it is just a coefficients check and thus reducing further the number of constraints to 1, or if for some reason we may want to leave it as some sort of sanity check. 