### PR TITLE
[easy] Add a connect function for the range checks in FFAdd

### DIFF
--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -387,6 +387,8 @@ pub trait Connect {
     /// - `left_rc`: the first row of the range check for the left input
     /// - `right_rc`: the first row of the range check for the right input
     /// - `out_rc`: the first row of the range check for the output of the addition
+    /// Note:
+    /// If run with `left_rc = None` and `right_rc = None` then it can be used for the bound check range check
     fn connect_ffadd_range_checks(
         &mut self,
         ffadd_row: usize,

--- a/kimchi/src/tests/foreign_field_mul.rs
+++ b/kimchi/src/tests/foreign_field_mul.rs
@@ -143,9 +143,7 @@ where
 
         // Result/remainder bound multi-range-check
         CircuitGate::extend_multi_range_check(&mut gates, &mut next_row);
-        gates.connect_cell_pair((3, 0), (16, 0));
-        gates.connect_cell_pair((3, 1), (17, 0));
-        gates.connect_cell_pair((3, 2), (18, 0));
+        gates.connect_ffadd_range_checks(2, None, None, 16);
         // Witness updated below
 
         // Add witness for external multi-range checks (product1_lo, product1_hi_0, carry1_lo and result)


### PR DESCRIPTION
This PR adds a function `connect_ffadd_range_checks` inside the `Connect` trait to more easily configure the wiring of foreign field additions, given the row of the actual addition, and (optionally) any number of rows of the range checks of the left input, right input, and result. It can be reused by setting Left and Right to None for the bound check range check. 