### PR TITLE
[easy] Extend function for custom gates

### DIFF
--- a/kimchi/src/circuits/polynomials/and.rs
+++ b/kimchi/src/circuits/polynomials/and.rs
@@ -65,8 +65,8 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     /// - bytes    : number of bytes of the AND operation
     /// Output:
     /// - next_row  : next row after this gate
-    /// INTEGRATION:
-    /// - IF THERE'S ANY PUBLIC INPUT FOR THE AND, DON'T FORGET TO WIRE IT
+    /// Warning:
+    /// - if there's any public input for the and, don't forget to wire it
     pub fn extend_and(gates: &mut Vec<Self>, bytes: usize) -> usize {
         assert!(bytes > 0, "Bytes must be a positive number");
         let xor_row = gates.len();
@@ -97,8 +97,8 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     // Outputs tuple (next_row, circuit_gates) where
     // - next_row  : next row after this gate
     // - gates     : vector of circuit gates comprising the AND double generic gate
-    // INTEGRATION:
-    // - DON'T FORGET TO CONNECT THE WIRING FROM THE AND
+    // Warning:
+    // - don't forget to connect the wiring from the and
     fn create_and(new_row: usize, bytes: usize) -> (usize, Vec<Self>) {
         assert!(bytes > 0, "Bytes must be a positive number");
 

--- a/kimchi/src/circuits/polynomials/and.rs
+++ b/kimchi/src/circuits/polynomials/and.rs
@@ -53,20 +53,55 @@ use o1_utils::{BigUintFieldHelpers, BigUintHelpers, BitwiseOps, FieldHelpers, Tw
 //~ * the `sum` in `a + b = sum` is connected to the `sum` in `2 \cdot and = sum - xor`
 
 impl<F: PrimeField + SquareRootField> CircuitGate<F> {
-    /// Creates an AND gadget for `bytes` length.
+    /// Extends an AND gadget for `bytes` length.
     /// The full operation being performed is the following:
     /// `a AND b = 1/2 * (a + b - (a XOR b))`
     /// Includes:
     /// - num_xors Xor16 gates to perform `xor = a XOR b`
     /// - 1 Generic gate to constrain the final row to be zero with itself
     /// - 1 double Generic gate to perform the AND operation as `a + b = sum` and `2 * and = sum - xor`
+    /// Input:
+    /// - gates    : vector of circuit gates comprising the full circuit
+    /// - bytes    : number of bytes of the AND operation
+    /// Output:
+    /// - next_row  : next row after this gate
+    /// INTEGRATION:
+    /// - If there's any public input for the AND, wire it
+    pub fn extend_and(gates: &mut Vec<Self>, bytes: usize) -> usize {
+        assert!(bytes > 0, "Bytes must be a positive number");
+        let xor_row = gates.len();
+        let and_row = Self::extend_xor_gadget(gates, bytes * 8);
+        let (_, mut and_gates) = Self::create_and(and_row, bytes);
+        // extend the whole circuit with the AND gadget
+        gates.append(&mut and_gates);
+
+        // connect the XOR inputs to the inputs of the first generic gate
+        gates.connect_cell_pair((xor_row, 0), (and_row, 0));
+        gates.connect_cell_pair((xor_row, 1), (and_row, 1));
+        // connect the sum output of the first generic gate to the left input of the second generic gate
+        gates.connect_cell_pair((and_row, 2), (and_row, 3));
+        // connect the XOR output to the right input of the second generic gate
+        gates.connect_cell_pair((xor_row, 2), (and_row, 4));
+
+        gates.len()
+    }
+
+    /// Creates an AND gadget for `bytes` length.
+    /// The full operation being performed is the following:
+    /// `a AND b = 1/2 * (a + b - (a XOR b))`
+    /// Includes:
+    /// - 1 double Generic gate to perform the AND operation as `a + b = sum` and `2 * and = sum - xor`
+    /// Input:
+    /// - new_row  : row where the AND generic gate starts
+    /// - bytes    : number of bytes of the AND operation
     /// Outputs tuple (next_row, circuit_gates) where
     /// - next_row  : next row after this gate
-    /// - gates     : vector of circuit gates comprising this gate
+    /// - gates     : vector of circuit gates comprising the AND double generic gate
+    /// INTEGRATION:
+    /// - connect the wiring from the AND
     pub fn create_and(new_row: usize, bytes: usize) -> (usize, Vec<Self>) {
         assert!(bytes > 0, "Bytes must be a positive number");
-        let xor_row = new_row;
-        let (and_row, mut gates) = Self::create_xor_gadget(xor_row, bytes * 8);
+
         // a + b = sum
         let sum = GenericGateSpec::Add {
             left_coeff: None,
@@ -79,20 +114,9 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
             right_coeff: Some(-F::one()),
             output_coeff: Some(-F::two()),
         };
-        gates.push(Self::create_generic_gadget(
-            Wire::for_row(and_row),
-            sum,
-            Some(and),
-        ));
-        // connect the XOR inputs to the inputs of the first generic gate
-        gates.connect_cell_pair((xor_row, 0), (and_row, 0));
-        gates.connect_cell_pair((xor_row, 1), (and_row, 1));
-        // connect the sum output of the first generic gate to the left input of the second generic gate
-        gates.connect_cell_pair((and_row, 2), (and_row, 3));
-        // connect the XOR output to the right input of the second generic gate
-        gates.connect_cell_pair((xor_row, 2), (and_row, 4));
+        let gates = vec![(Self::create_generic_gadget(Wire::for_row(new_row), sum, Some(and)))];
 
-        (gates.len(), gates)
+        (new_row + gates.len(), gates)
     }
 }
 
@@ -132,4 +156,19 @@ pub fn create_and_witness<F: PrimeField>(input1: F, input2: F, bytes: usize) -> 
     and_witness[5][and_row] = and;
 
     and_witness
+}
+
+/// Extends an AND witness to the whole witness
+/// Input: first input, second input, and desired byte length
+/// Panics if the input is too large for the chosen number of bytes
+pub fn extend_and_witness<F: PrimeField>(
+    witness: &mut [Vec<F>; COLUMNS],
+    input1: F,
+    input2: F,
+    bytes: usize,
+) {
+    let and_witness = create_and_witness(input1, input2, bytes);
+    for col in 0..COLUMNS {
+        witness[col].extend(and_witness[col].iter());
+    }
 }

--- a/kimchi/src/circuits/polynomials/and.rs
+++ b/kimchi/src/circuits/polynomials/and.rs
@@ -66,7 +66,7 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     /// Output:
     /// - next_row  : next row after this gate
     /// INTEGRATION:
-    /// - If there's any public input for the AND, wire it
+    /// - IF THERE'S ANY PUBLIC INPUT FOR THE AND, DON'T FORGET TO WIRE IT
     pub fn extend_and(gates: &mut Vec<Self>, bytes: usize) -> usize {
         assert!(bytes > 0, "Bytes must be a positive number");
         let xor_row = gates.len();
@@ -86,20 +86,20 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
         gates.len()
     }
 
-    /// Creates an AND gadget for `bytes` length.
-    /// The full operation being performed is the following:
-    /// `a AND b = 1/2 * (a + b - (a XOR b))`
-    /// Includes:
-    /// - 1 double Generic gate to perform the AND operation as `a + b = sum` and `2 * and = sum - xor`
-    /// Input:
-    /// - new_row  : row where the AND generic gate starts
-    /// - bytes    : number of bytes of the AND operation
-    /// Outputs tuple (next_row, circuit_gates) where
-    /// - next_row  : next row after this gate
-    /// - gates     : vector of circuit gates comprising the AND double generic gate
-    /// INTEGRATION:
-    /// - connect the wiring from the AND
-    pub fn create_and(new_row: usize, bytes: usize) -> (usize, Vec<Self>) {
+    // Creates an AND gadget for `bytes` length.
+    // The full operation being performed is the following:
+    // `a AND b = 1/2 * (a + b - (a XOR b))`
+    // Includes:
+    // - 1 double Generic gate to perform the AND operation as `a + b = sum` and `2 * and = sum - xor`
+    // Input:
+    // - new_row  : row where the AND generic gate starts
+    // - bytes    : number of bytes of the AND operation
+    // Outputs tuple (next_row, circuit_gates) where
+    // - next_row  : next row after this gate
+    // - gates     : vector of circuit gates comprising the AND double generic gate
+    // INTEGRATION:
+    // - DON'T FORGET TO CONNECT THE WIRING FROM THE AND
+    fn create_and(new_row: usize, bytes: usize) -> (usize, Vec<Self>) {
         assert!(bytes > 0, "Bytes must be a positive number");
 
         // a + b = sum

--- a/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
@@ -33,6 +33,7 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     /// INTEGRATION:
     /// - Wire the range check for result bound manually
     /// - Connect to public input containing the 1 value for the overflow in the final bound check
+    /// - If the inputs of the addition come from public input, wire it as well
     pub fn create_chain_ffadd(
         start_row: usize,
         opcodes: &[FFOps],
@@ -105,7 +106,7 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
         (start_row + circuit_gates.len(), circuit_gates)
     }
 
-    /// Extend a chain of foreign field addition gates. It already wires the public input to the overflow cell.
+    /// Extend a chain of foreign field addition gates. It already wires 1 value to the overflow cell.
     /// - Inputs
     ///   - gates: vector of gates to extend
     ///   - pub_row: row of the public input

--- a/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
@@ -30,7 +30,7 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     ///      [n+1]         -> 1 Zero row for bound result
     /// ]
     ///
-    /// INTEGRATION:
+    /// Warning:
     /// - Wire the range check for result bound manually
     /// - Connect to public input containing the 1 value for the overflow in the final bound check
     /// - If the inputs of the addition come from public input, wire it as well

--- a/kimchi/src/circuits/polynomials/not.rs
+++ b/kimchi/src/circuits/polynomials/not.rs
@@ -70,7 +70,7 @@ impl<F: PrimeField> CircuitGate<F> {
     /// - If the bit length of the input is not fixed, then it must be constrained somewhere else.
     /// - Otherwise, use the `extend_neg_checked_length` instead (but this one requires about 8 times more rows).
     /// INTEGRATION:
-    /// - Needs a leading public input generic gate in `pub_row` to constrain the left input of each generic gate for negation to be `2^bits-1`.
+    /// - DON'T FORGET TO INCLUDE A PUBLIC INPUT IN `pub_row` TO CONSTRAIN THE LEFT INPUT OF EACH GENERIC GATE FOR NEGATION TO BE `2^bits - 1`
     pub fn extend_not_gadget_unchecked_length(
         gates: &mut Vec<Self>,
         n: usize,
@@ -142,12 +142,12 @@ impl<F: PrimeField> CircuitGate<F> {
     /// - pub_row : row containing the public input with the all-one word of the given length
     /// - bits    : number of bits of the input
     /// Requires:
-    /// - 1 initial public input generic gate in `pub_row` to constrain the input to be `2^bits-1`.
+    /// - 1 initial public input generic gate in `allone_row` to constrain the input to be `2^bits-1`.
     /// INTEGRATION:
-    /// - Connect the left input to a public input row containing the 2^bits-1 value
+    /// - DON'T FORGET TO CONNECT THE LEFT INPUT TO A PUBLIC INPUT ROW CONTAINING THE `2^bits - 1` VALUE
     pub fn extend_not_gadget_checked_length(
         gates: &mut Vec<Self>,
-        pub_row: usize,
+        allone_row: usize,
         bits: usize,
     ) -> usize {
         let n = num_xors(bits);
@@ -170,7 +170,7 @@ impl<F: PrimeField> CircuitGate<F> {
         gates.connect_cell_pair((zero_row, 0), (zero_row, 1));
         gates.connect_cell_pair((zero_row, 0), (zero_row, 2));
         // Integration
-        gates.connect_cell_pair((pub_row, 0), (new_row, 1)); // input2 of xor is all ones
+        gates.connect_cell_pair((allone_row, 0), (new_row, 1)); // input2 of xor is all ones
 
         gates.len()
     }
@@ -180,7 +180,8 @@ impl<F: PrimeField> CircuitGate<F> {
 /// Input: full witness, first input and optional bit length
 /// If `bits` is not provided, the negation is performed using the length of the `input` in bits.
 /// If `bits` is provided, the negation takes the maximum length between `bits` and that of `input`.
-/// INTEGRATION: set a row of the witness with public input `2^bits - 1` and wire to the second input of the first Xor gate.
+/// INTEGRATION:
+/// - DON'T FORGET TO SET A ROW OF THE WITNESS WITH PUBLIC INPUT `2^bits -1` AND WIRE IT TO THE SECOND INPUT OF THE FIRST Xor16 GATE
 pub fn extend_not_witness_checked_length<F: PrimeField>(
     witness: &mut [Vec<F>; COLUMNS],
     input: F,
@@ -205,22 +206,6 @@ pub fn extend_not_witness_checked_length<F: PrimeField>(
     for col in 0..COLUMNS {
         witness[col].extend(not_witness[col].iter());
     }
-}
-
-/// Create a Not witness for less than 255 bits (native field) starting at row 0
-/// Input: first input and optional bit length
-/// If `bits` is not provided, the negation is performed using the length of the `input` in bits.
-/// If `bits` is provided, the negation takes the maximum length between `bits` and that of `input`.
-pub fn create_not_witness_checked_length<F: PrimeField>(
-    input: F,
-    bits: Option<usize>,
-) -> [Vec<F>; COLUMNS] {
-    let mut witness: [Vec<F>; COLUMNS] = array::from_fn(|_| vec![F::zero(); 1]);
-    let input_big = input.to_biguint();
-    let real_bits = max(input_big.bitlen(), bits.unwrap_or(0));
-    witness[0][0] = F::from(2u8).pow(&[real_bits as u64]) - F::one();
-    extend_not_witness_checked_length(&mut witness, input, bits);
-    witness
 }
 
 /// Extends negation witnesses from generic gate, assuming the input witness already contains
@@ -267,18 +252,4 @@ pub fn extend_not_witness_unchecked_length<F: PrimeField>(
     for col in 0..COLUMNS {
         witness[col].extend(not_witness[col].iter());
     }
-}
-
-/// Creates as many negations as the number of inputs. The inputs must fit in the native field.
-/// We start at the row 0 using generic gates to perform the negations.
-/// Input: a vector of words to be negated, and the number of bits (all the same)
-/// Panics if the bits length is too small for the inputs
-pub fn create_not_witness_unchecked_length<F: PrimeField>(
-    inputs: &[F],
-    bits: usize,
-) -> [Vec<F>; COLUMNS] {
-    let mut witness: [Vec<F>; COLUMNS] = array::from_fn(|_| vec![F::zero(); 1]);
-    witness[0][0] = F::from(2u8).pow(&[bits as u64]) - F::one();
-    extend_not_witness_unchecked_length(&mut witness, inputs, bits);
-    witness
 }

--- a/kimchi/src/circuits/polynomials/rot.rs
+++ b/kimchi/src/circuits/polynomials/rot.rs
@@ -56,8 +56,8 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     /// - rot : the rotation offset
     /// - side : the rotation side
     /// - zero_row : the row of the Generic gate to constrain the 64-bit check of shifted word
-    /// INTEGRATION:
-    /// - Word should come from the copy of another cell so it is intrinsic that it is 64-bits length,
+    /// Warning:
+    /// - witness word should come from the copy of another cell so it is intrinsic that it is 64-bits length,
     /// - same with rotated word
     pub fn extend_rot(gates: &mut Vec<Self>, rot: u32, side: RotMode, zero_row: usize) -> usize {
         let (new_row, mut rot_gates) = Self::create_rot(gates.len(), rot, side);
@@ -73,7 +73,7 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     /// Input:
     /// - rot : the rotation offset
     /// - side : the rotation side
-    /// INTEGRATION:
+    /// Warning:
     /// - Word should come from the copy of another cell so it is intrinsic that it is 64-bits length,
     /// - same with rotated word
     /// - need to check that the 2 most significant limbs of shifted are zero
@@ -298,8 +298,8 @@ fn init_rot64<F: PrimeField>(
 /// - word: 64-bit word to be rotated
 /// - rot:  rotation offset
 /// - side: side of the rotation, either left or right
-/// INTEGRATION:
-/// - DON'T FORGET TO INCLUDE A PUBLIC INPUT ROW WITH ZERO VALUE
+/// Warning:
+/// - don't forget to include a public input row with zero value
 pub fn extend_rot<F: PrimeField>(
     witness: &mut [Vec<F>; COLUMNS],
     word: u64,

--- a/kimchi/src/circuits/polynomials/xor.rs
+++ b/kimchi/src/circuits/polynomials/xor.rs
@@ -57,8 +57,8 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     /// Outputs tuple (next_row, circuit_gates) where
     /// - next_row  : next row after this gate
     /// - gates     : vector of circuit gates comprising this gate
-    /// INTEGRATION:
-    /// - DON'T FORGET TO CHECK THAT THE FINAL ROW IS ALL ZEROS AS IN `extend_xor_gadget`
+    /// Warning:
+    /// - don't forget to check that the final row is all zeros as in `extend_xor_gadget`
     pub fn create_xor_gadget(new_row: usize, bits: usize) -> (usize, Vec<Self>) {
         let num_xors = num_xors(bits);
         let mut xor_gates = (0..num_xors)

--- a/kimchi/src/circuits/polynomials/xor.rs
+++ b/kimchi/src/circuits/polynomials/xor.rs
@@ -57,8 +57,8 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     /// Outputs tuple (next_row, circuit_gates) where
     /// - next_row  : next row after this gate
     /// - gates     : vector of circuit gates comprising this gate
-    /// Integration:
-    /// - Check that fin_in1, fin_in2, fin_out are zero
+    /// INTEGRATION:
+    /// - DON'T FORGET TO CHECK THAT THE FINAL ROW IS ALL ZEROS AS IN `extend_xor_gadget`
     pub fn create_xor_gadget(new_row: usize, bits: usize) -> (usize, Vec<Self>) {
         let num_xors = num_xors(bits);
         let mut xor_gates = (0..num_xors)

--- a/kimchi/src/circuits/polynomials/xor.rs
+++ b/kimchi/src/circuits/polynomials/xor.rs
@@ -35,9 +35,9 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
     /// - new row index
     pub fn extend_xor_gadget(gates: &mut Vec<Self>, bits: usize) -> usize {
         let new_row = gates.len();
-        let (_, xor_gates) = Self::create_xor_gadget(new_row, bits);
+        let (_, mut xor_gates) = Self::create_xor_gadget(new_row, bits);
         // extend the whole circuit with the xor gadget
-        gates.extend_from_slice(&xor_gates);
+        gates.append(&mut xor_gates);
 
         // check fin_in1, fin_in2, fin_out are zero
         let zero_row = gates.len() - 1;

--- a/kimchi/src/circuits/polynomials/xor.rs
+++ b/kimchi/src/circuits/polynomials/xor.rs
@@ -24,16 +24,44 @@ use std::{array, marker::PhantomData};
 use super::generic::GenericGateSpec;
 
 impl<F: PrimeField + SquareRootField> CircuitGate<F> {
+    /// Extends a XOR gadget for `bits` length to a circuit
+    /// Includes:
+    /// - num_xors Xor16 gates
+    /// - 1 Generic gate to constrain the final row to be zero with itself
+    /// Input:
+    /// - gates     : vector of circuit gates
+    /// - bits      : length of the XOR gadget
+    /// Output:
+    /// - new row index
+    pub fn extend_xor_gadget(gates: &mut Vec<Self>, bits: usize) -> usize {
+        let new_row = gates.len();
+        let (_, xor_gates) = Self::create_xor_gadget(new_row, bits);
+        // extend the whole circuit with the xor gadget
+        gates.extend_from_slice(&xor_gates);
+
+        // check fin_in1, fin_in2, fin_out are zero
+        let zero_row = gates.len() - 1;
+        gates.connect_cell_pair((zero_row, 0), (zero_row, 1));
+        gates.connect_cell_pair((zero_row, 0), (zero_row, 2));
+
+        gates.len()
+    }
+
     /// Creates a XOR gadget for `bits` length
     /// Includes:
     /// - num_xors Xor16 gates
     /// - 1 Generic gate to constrain the final row to be zero with itself
+    /// Input:
+    /// - new_row   : row to start the XOR gadget
+    /// - bits      : number of bits in the XOR
     /// Outputs tuple (next_row, circuit_gates) where
     /// - next_row  : next row after this gate
     /// - gates     : vector of circuit gates comprising this gate
+    /// Integration:
+    /// - Check that fin_in1, fin_in2, fin_out are zero
     pub fn create_xor_gadget(new_row: usize, bits: usize) -> (usize, Vec<Self>) {
         let num_xors = num_xors(bits);
-        let mut gates = (0..num_xors)
+        let mut xor_gates = (0..num_xors)
             .map(|i| CircuitGate {
                 typ: GateType::Xor16,
                 wires: Wire::for_row(new_row + i),
@@ -41,16 +69,13 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
             })
             .collect::<Vec<_>>();
         let zero_row = new_row + num_xors;
-        gates.push(CircuitGate::create_generic_gadget(
+        xor_gates.push(CircuitGate::create_generic_gadget(
             Wire::for_row(zero_row),
             GenericGateSpec::Const(F::zero()),
             None,
         ));
-        // check fin_in1, fin_in2, fin_out are zero
-        gates.connect_cell_pair((zero_row, 0), (zero_row, 1));
-        gates.connect_cell_pair((zero_row, 0), (zero_row, 2));
 
-        (zero_row + 1, gates)
+        (new_row + xor_gates.len(), xor_gates)
     }
 }
 
@@ -211,14 +236,10 @@ pub(crate) fn init_xor<F: PrimeField>(
 
 /// Extends the Xor rows to the full witness
 /// Panics if the words are larger than the desired bits
-pub fn extend_xor_rows<F: PrimeField>(
-    witness: &mut [Vec<F>; COLUMNS],
-    bits: usize,
-    words: (F, F, F),
-) {
+pub fn extend_xor_rows<F: PrimeField>(witness: &mut [Vec<F>; COLUMNS], bits: usize, words: (F, F)) {
     let input1_big = words.0.to_biguint();
     let input2_big = words.1.to_biguint();
-    let output_big = words.2.to_biguint();
+    let output_big = BigUint::bitwise_xor(&input1_big, &input2_big);
     if bits < input1_big.bitlen() || bits < input2_big.bitlen() || bits < output_big.bitlen() {
         panic!("Bits must be greater or equal than the inputs length");
     }
@@ -228,7 +249,12 @@ pub fn extend_xor_rows<F: PrimeField>(
     for col in 0..COLUMNS {
         witness[col].extend(xor_witness[col].iter());
     }
-    init_xor(witness, xor_row, bits, words);
+    init_xor(
+        witness,
+        xor_row,
+        bits,
+        (words.0, words.1, output_big.into()),
+    );
 }
 
 /// Create a Xor for up to the native length starting at row 0

--- a/kimchi/src/circuits/polynomials/xor.rs
+++ b/kimchi/src/circuits/polynomials/xor.rs
@@ -236,25 +236,16 @@ pub(crate) fn init_xor<F: PrimeField>(
 
 /// Extends the Xor rows to the full witness
 /// Panics if the words are larger than the desired bits
-pub fn extend_xor_rows<F: PrimeField>(witness: &mut [Vec<F>; COLUMNS], bits: usize, words: (F, F)) {
-    let input1_big = words.0.to_biguint();
-    let input2_big = words.1.to_biguint();
-    let output_big = BigUint::bitwise_xor(&input1_big, &input2_big);
-    if bits < input1_big.bitlen() || bits < input2_big.bitlen() || bits < output_big.bitlen() {
-        panic!("Bits must be greater or equal than the inputs length");
-    }
-    let xor_witness: [Vec<F>; COLUMNS] =
-        array::from_fn(|_| vec![F::zero(); 1 + num_xors(bits) as usize]);
-    let xor_row = witness[0].len();
+pub fn extend_xor_witness<F: PrimeField>(
+    witness: &mut [Vec<F>; COLUMNS],
+    input1: F,
+    input2: F,
+    bits: usize,
+) {
+    let xor_witness = create_xor_witness(input1, input2, bits);
     for col in 0..COLUMNS {
         witness[col].extend(xor_witness[col].iter());
     }
-    init_xor(
-        witness,
-        xor_row,
-        bits,
-        (words.0, words.1, output_big.into()),
-    );
 }
 
 /// Create a Xor for up to the native length starting at row 0

--- a/kimchi/src/tests/and.rs
+++ b/kimchi/src/tests/and.rs
@@ -45,7 +45,8 @@ where
     EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
     EFrSponge: FrSponge<G::ScalarField>,
 {
-    let (mut next_row, mut gates) = CircuitGate::<G::ScalarField>::create_and(0, bytes);
+    let mut gates = vec![];
+    let mut next_row = CircuitGate::<G::ScalarField>::extend_and(&mut gates, bytes);
 
     // Temporary workaround for lookup-table/domain-size issue
     for _ in 0..(1 << 13) {
@@ -138,7 +139,8 @@ where
     let rng = &mut StdRng::from_seed(RNG_SEED);
 
     // Create
-    let (mut next_row, mut gates) = CircuitGate::<G::ScalarField>::create_and(0, bytes);
+    let mut gates = vec![];
+    let mut next_row = CircuitGate::<G::ScalarField>::extend_and(&mut gates, bytes);
 
     // Temporary workaround for lookup-table/domain-size issue
     for _ in 0..(1 << 13) {

--- a/kimchi/src/tests/foreign_field_add.rs
+++ b/kimchi/src/tests/foreign_field_add.rs
@@ -1527,6 +1527,7 @@ fn test_ffadd_finalization() {
 
     let index = {
         let cs = ConstraintSystem::create(gates.clone())
+            .lookup(vec![range_check::gadget::lookup_table()])
             .public(num_inputs)
             .build()
             .unwrap();

--- a/kimchi/src/tests/foreign_field_add.rs
+++ b/kimchi/src/tests/foreign_field_add.rs
@@ -1480,13 +1480,7 @@ fn test_ffadd_finalization() {
 
         let mut curr_row = num_inputs;
         // Foreign field addition and bound check
-        CircuitGate::<Fp>::extend_chain_ffadd(
-            &mut gates,
-            0,
-            &mut curr_row,
-            operation,
-            &modulus.clone(),
-        );
+        CircuitGate::<Fp>::extend_chain_ffadd(&mut gates, 0, &mut curr_row, operation, &modulus);
 
         // Extend rangechecks of left input, right input, result, and bound
         for _ in 0..4 {

--- a/kimchi/src/tests/not.rs
+++ b/kimchi/src/tests/not.rs
@@ -52,14 +52,17 @@ fn create_not_witness_unchecked_length<F: PrimeField>(
 ) -> [Vec<F>; COLUMNS] {
     let mut witness: [Vec<F>; COLUMNS] = array::from_fn(|_| vec![F::zero(); 1]);
     witness[0][0] = F::from(2u8).pow(&[bits as u64]) - F::one();
-    not::extend_not_witness_unchecked_length(&mut witness, inputs, bits);
+    let result = not::extend_not_witness_unchecked_length(&mut witness, inputs, bits);
+    if let Err(e) = result {
+        panic!("{}", e);
+    }
     witness
 }
 
 // Create a Not witness for less than 255 bits (native field) starting at row 0
 // Input: first input and optional bit length
 // If `bits` is not provided, the negation is performed using the length of the `input` in bits.
-// If `bits` is provided, the negation takes the maximum length between `bits` and that of `input`.
+// If `bits` is provided, the negation takes the maximum length of `bits` and `input`.
 fn create_not_witness_checked_length<F: PrimeField>(
     input: F,
     bits: Option<usize>,

--- a/kimchi/src/tests/not.rs
+++ b/kimchi/src/tests/not.rs
@@ -60,7 +60,7 @@ where
             None,
         )];
         let next_row =
-            CircuitGate::<G::ScalarField>::extend_not_gadget_checked_length(&mut gates, 0, 1, bits);
+            CircuitGate::<G::ScalarField>::extend_not_gadget_checked_length(&mut gates, 0, bits);
         (next_row, gates)
     };
 
@@ -85,9 +85,8 @@ where
         GenericGateSpec::Pub,
         None,
     )];
-    let mut next_row = CircuitGate::<G::ScalarField>::extend_not_gadget_unchecked_length(
-        &mut gates, num_nots, 0, 1,
-    );
+    let mut next_row =
+        CircuitGate::<G::ScalarField>::extend_not_gadget_unchecked_length(&mut gates, num_nots, 0);
 
     // Temporary workaround for lookup-table/domain-size issue
     for _ in 0..(1 << 13) {
@@ -260,7 +259,7 @@ fn test_prove_and_verify_not_xor() {
             GenericGateSpec::Pub,
             None,
         )];
-        let next_row = CircuitGate::<Fp>::extend_not_gadget_checked_length(&mut gates, 0, 1, bits);
+        let next_row = CircuitGate::<Fp>::extend_not_gadget_checked_length(&mut gates, 0, bits);
         (next_row, gates)
     };
 
@@ -300,7 +299,7 @@ fn test_prove_and_verify_five_not_gnrc() {
             GenericGateSpec::Pub,
             None,
         )];
-        let next_row = CircuitGate::<Fp>::extend_not_gadget_unchecked_length(&mut gates, 5, 0, 1);
+        let next_row = CircuitGate::<Fp>::extend_not_gadget_unchecked_length(&mut gates, 5, 0);
         (next_row, gates)
     };
 

--- a/kimchi/src/tests/rot.rs
+++ b/kimchi/src/tests/rot.rs
@@ -68,7 +68,7 @@ where
 {
     // Include the zero row
     let mut witness: [Vec<G::ScalarField>; COLUMNS] =
-        array::from_fn(|_| vec![G::ScalarField::from(0u32)]);
+        array::from_fn(|_| vec![G::ScalarField::zero()]);
     rot::extend_rot(&mut witness, word, rot, side);
     witness
 }
@@ -302,7 +302,7 @@ fn test_bad_constraints() {
 // Finalization test
 fn test_rot_finalization() {
     // Includes the actual input of the rotation and a row with the zero value
-    let num_inputs = 2;
+    let num_public_inputs = 2;
     // 1 ROT of 32 to the left
     let rot = 32;
     let mode = RotMode::Left;
@@ -311,7 +311,7 @@ fn test_rot_finalization() {
     let gates = {
         let mut gates = vec![];
         // public inputs
-        for row in 0..num_inputs {
+        for row in 0..num_public_inputs {
             gates.push(CircuitGate::<Fp>::create_generic_gadget(
                 Wire::for_row(row),
                 GenericGateSpec::Pub,
@@ -345,7 +345,7 @@ fn test_rot_finalization() {
 
     let index = {
         let cs = ConstraintSystem::create(gates.clone())
-            .public(num_inputs)
+            .public(num_public_inputs)
             .lookup(vec![rot::lookup_table()])
             .build()
             .unwrap();

--- a/kimchi/src/tests/rot.rs
+++ b/kimchi/src/tests/rot.rs
@@ -346,6 +346,7 @@ fn test_rot_finalization() {
     let index = {
         let cs = ConstraintSystem::create(gates.clone())
             .public(num_inputs)
+            .lookup(vec![rot::lookup_table()])
             .build()
             .unwrap();
         let mut srs = SRS::<Vesta>::create(cs.domain.d1.size());

--- a/kimchi/src/tests/xor.rs
+++ b/kimchi/src/tests/xor.rs
@@ -322,7 +322,7 @@ fn test_extend_xor() {
         next_row += 1;
     }
 
-    let cs = ConstraintSystem::create(gates).build().unwrap();
+    let cs = ConstraintSystem::create(gates).public(2).build().unwrap();
 
     let mut witness: [_; COLUMNS] = array::from_fn(|_col| vec![Fp::zero(); 2]);
     witness[0][0] = input1;

--- a/kimchi/src/tests/xor.rs
+++ b/kimchi/src/tests/xor.rs
@@ -3,7 +3,7 @@ use std::{array, cmp::max};
 use crate::{
     circuits::{
         constraints::ConstraintSystem,
-        gate::{CircuitGate, CircuitGateError, GateType},
+        gate::{CircuitGate, CircuitGateError, Connect, GateType},
         polynomial::COLUMNS,
         polynomials::{
             generic::GenericGateSpec,
@@ -317,6 +317,9 @@ fn test_extend_xor() {
         ));
     }
     let mut next_row = CircuitGate::<PallasField>::extend_xor_gadget(&mut gates, bits);
+    // connect public input
+    gates.connect_cell_pair((0, 0), (2, 0));
+    gates.connect_cell_pair((1, 0), (2, 1));
 
     // Temporary workaround for lookup-table/domain-size issue
     for _ in 0..(1 << 13) {
@@ -329,7 +332,7 @@ fn test_extend_xor() {
     let mut witness: [_; COLUMNS] = array::from_fn(|_col| vec![Fp::zero(); 2]);
     witness[0][0] = input1;
     witness[0][1] = input2;
-    xor::extend_xor_rows::<Fp>(&mut witness, bits, (input1, input2));
+    xor::extend_xor_witness::<Fp>(&mut witness, input1, input2, bits);
 
     for row in 0..witness[0].len() {
         assert_eq!(

--- a/kimchi/src/tests/xor.rs
+++ b/kimchi/src/tests/xor.rs
@@ -307,7 +307,7 @@ fn test_extend_xor() {
     let input1: PallasField = rng.gen(None, bits);
     let input2: PallasField = rng.gen(None, bits);
 
-    // If user specified a concrete number of bits, use that (if they are sufficient to hold both inputs)
+    // If one specifies a concrete number of bits, use that (if they are sufficient to hold both inputs)
     // Otherwise, use the max number of bits required to hold both inputs (if only one, the other is zero)
     let bits1 = input1.to_biguint().bitlen();
     let bits2 = input2.to_biguint().bitlen();
@@ -425,12 +425,12 @@ fn test_xor_finalization() {
         let mut cols: [_; COLUMNS] = array::from_fn(|_col| vec![Fp::zero(); num_inputs]);
 
         // initialize the 2 inputs
-        let input1 = 0xDC811727DAF22EC15927D6AA275F406Bu128;
-        let input2 = 0xA4F4417AF072DF9016A1EAB458DA80D1u128;
-        cols[0][0] = input1.into();
-        cols[0][1] = input2.into();
+        let input1 = 0xDC811727DAF22EC15927D6AA275F406Bu128.into();
+        let input2 = 0xA4F4417AF072DF9016A1EAB458DA80D1u128.into();
+        cols[0][0] = input1;
+        cols[0][1] = input2;
 
-        xor::extend_xor_witness::<Fp>(&mut cols, input1.into(), input2.into(), 128);
+        xor::extend_xor_witness::<Fp>(&mut cols, input1, input2, 128);
         cols
     };
 

--- a/kimchi/src/tests/xor.rs
+++ b/kimchi/src/tests/xor.rs
@@ -436,6 +436,7 @@ fn test_xor_finalization() {
 
     let index = {
         let cs = ConstraintSystem::create(gates.clone())
+            .lookup(vec![xor::lookup_table()])
             .public(num_inputs)
             .build()
             .unwrap();

--- a/kimchi/src/tests/xor.rs
+++ b/kimchi/src/tests/xor.rs
@@ -48,7 +48,8 @@ fn create_test_constraint_system_xor<G: KimchiCurve, EFqSponge, EFrSponge>(
 where
     G::BaseField: PrimeField,
 {
-    let (mut next_row, mut gates) = CircuitGate::<G::ScalarField>::create_xor_gadget(0, bits);
+    let mut gates = vec![];
+    let mut next_row = CircuitGate::<G::ScalarField>::extend_xor_gadget(&mut gates, bits);
 
     // Temporary workaround for lookup-table/domain-size issue
     for _ in 0..(1 << 13) {
@@ -164,7 +165,8 @@ fn test_prove_and_verify_xor() {
 
     let bits = 64;
     // Create
-    let (mut next_row, mut gates) = CircuitGate::<Fp>::create_xor_gadget(0, bits);
+    let mut gates = vec![];
+    let mut next_row = CircuitGate::<Fp>::extend_xor_gadget(&mut gates, bits);
 
     // Temporary workaround for lookup-table/domain-size issue
     for _ in 0..(1 << 13) {
@@ -351,7 +353,8 @@ fn test_bad_xor() {
     let bits = bits.map_or(0, |b| b); // 0 or bits
     let bits = max(bits, max(bits1, bits2));
 
-    let (mut next_row, mut gates) = CircuitGate::<PallasField>::create_xor_gadget(0, bits);
+    let mut gates = vec![];
+    let mut next_row = CircuitGate::<PallasField>::extend_xor_gadget(&mut gates, bits);
     // Temporary workaround for lookup-table/domain-size issue
     for _ in 0..(1 << 13) {
         gates.push(CircuitGate::zero(Wire::for_row(next_row)));


### PR DESCRIPTION
This PR provides extend functions to all of Xor, And, Not, Rot.  This function allows the gadgets to appear anywhere in the circuit (not only assuming the row 0).