### PR TITLE
Remove dense polynomial forms

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1712,9 +1712,6 @@ pub struct ProverIndex<G: KimchiCurve> {
     /// maximal size of polynomial section
     pub max_poly_size: usize,
 
-    #[serde(bound = "EvaluatedColumnCoefficients<G::ScalarField>: Serialize + DeserializeOwned")]
-    pub evaluated_column_coefficients: EvaluatedColumnCoefficients<G::ScalarField>,
-
     #[serde(bound = "ColumnEvaluations<G::ScalarField>: Serialize + DeserializeOwned")]
     pub column_evaluations: ColumnEvaluations<G::ScalarField>,
 
@@ -2103,7 +2100,9 @@ The prover then follows the following steps to create the proof:
    we can use the `commit_evaluation` optimization.
 1. Absorb the witness commitments with the Fq-Sponge.
 1. Compute the witness polynomials by interpolating each `COLUMNS` of the witness.
-   TODO: why not do this first, and then commit? Why commit from evaluation directly?
+   As mentioned above, we commit using the evaluations form rather than the coefficients
+   form so we can take advantage of the sparsity of the evaluations (i.e., there are many
+   0 entries and entries that have less-than-full-size field elemnts.)
 1. If using lookup:
 	- if using runtime table:
 		- check that all the provided runtime tables have length and IDs that match the runtime table configuration of the index

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1658,7 +1658,7 @@ impl<F: FftField> Linearization<Vec<PolishToken<F>>> {
         env: &Environment<F>,
         pt: F,
         evals: &ProofEvaluations<PointEvaluations<F>>,
-    ) -> (F, DensePolynomial<F>) {
+    ) -> (F, Evaluations<F, D<F>>) {
         let cs = &env.constants;
         let n = env.domain.d1.size();
         let mut res = vec![F::zero(); n];
@@ -1672,7 +1672,7 @@ impl<F: FftField> Linearization<Vec<PolishToken<F>>> {
                 .enumerate()
                 .for_each(|(i, r)| *r += c * e.evals[scale * i]);
         });
-        let p = Evaluations::<F, D<F>>::from_vec_and_domain(res, env.domain.d1).interpolate();
+        let p = Evaluations::<F, D<F>>::from_vec_and_domain(res, env.domain.d1);
         (
             PolishToken::evaluate(&self.constant_term, env.domain.d1, pt, evals, cs).unwrap(),
             p,

--- a/kimchi/src/circuits/polynomials/generic.rs
+++ b/kimchi/src/circuits/polynomials/generic.rs
@@ -314,7 +314,13 @@ pub mod testing {
             res += public;
 
             // selector poly
-            res = &res * &self.evaluated_column_coefficients.generic_selector;
+            res = &res
+                * &self
+                    .column_evaluations
+                    .generic_selector4
+                    .interpolate_by_ref();
+            // Interpolation above is inefficient, as is the rest of the function,
+            // would be better just to check the equation on all the rows.
 
             // verify that it is divisible by Z_H
             match res.divide_by_vanishing_poly(self.cs.domain.d1) {

--- a/kimchi/src/lagrange_basis_evaluations.rs
+++ b/kimchi/src/lagrange_basis_evaluations.rs
@@ -120,24 +120,17 @@ mod tests {
         let x = Fp::rand(rng);
         let evaluator = LagrangeBasisEvaluations::new(domain, x);
 
-        let expected = (0..n)
-            .map(|i| {
-                let mut lagrange_i = vec![Fp::zero(); n];
-                lagrange_i[i] = Fp::one();
-                Evaluations::from_vec_and_domain(lagrange_i, domain)
-                    .interpolate()
-                    .evaluate(&x)
-            });
+        let expected = (0..n).map(|i| {
+            let mut lagrange_i = vec![Fp::zero(); n];
+            lagrange_i[i] = Fp::one();
+            Evaluations::from_vec_and_domain(lagrange_i, domain)
+                .interpolate()
+                .evaluate(&x)
+        });
 
         for (i, expected) in expected.enumerate() {
             if evaluator.evals[i] != expected {
-                panic!(
-                    "{}, {}: {} != {}",
-                    line!(),
-                    i,
-                    evaluator.evals[i],
-                    expected
-                );
+                panic!("{}, {}: {} != {}", line!(), i, evaluator.evals[i], expected);
             }
         }
     }

--- a/kimchi/src/lagrange_basis_evaluations.rs
+++ b/kimchi/src/lagrange_basis_evaluations.rs
@@ -167,7 +167,7 @@ mod tests {
     }
 
     #[test]
-    fn test_evaluation_zero_one() {
+    fn test_evaluation_boolean() {
         let rng = &mut StdRng::from_seed([0u8; 32]);
         let n = 1 << 1;
         let domain = Radix2EvaluationDomain::new(n).unwrap();

--- a/kimchi/src/lagrange_basis_evaluations.rs
+++ b/kimchi/src/lagrange_basis_evaluations.rs
@@ -120,17 +120,16 @@ mod tests {
         let x = Fp::rand(rng);
         let evaluator = LagrangeBasisEvaluations::new(domain, x);
 
-        let expected: Vec<_> = (0..n)
+        let expected = (0..n)
             .map(|i| {
                 let mut lagrange_i = vec![Fp::zero(); n];
                 lagrange_i[i] = Fp::one();
                 Evaluations::from_vec_and_domain(lagrange_i, domain)
                     .interpolate()
                     .evaluate(&x)
-            })
-            .collect();
+            });
 
-        for (i, expected) in expected.into_iter().enumerate() {
+        for (i, expected) in expected.enumerate() {
             if evaluator.evals[i] != expected {
                 panic!(
                     "{}, {}: {} != {}",

--- a/kimchi/src/lagrange_basis_evaluations.rs
+++ b/kimchi/src/lagrange_basis_evaluations.rs
@@ -1,0 +1,196 @@
+use ark_ff::{batch_inversion_and_mul, FftField};
+use ark_poly::{EvaluationDomain, Evaluations, Radix2EvaluationDomain as D};
+use rayon::prelude::*;
+
+/// The evaluations of all normalized lagrange basis polynomials at a given
+/// point. Can be used to evaluate an `Evaluations` form polynomial at that point.
+pub struct LagrangeBasisEvaluations<F> {
+    pub evals: Vec<F>,
+}
+
+impl<F: FftField> LagrangeBasisEvaluations<F> {
+    /// Given the evaluations form of a polynomial, directly evaluate that polynomial at a point.
+    pub fn evaluate<D: EvaluationDomain<F>>(&self, p: &Evaluations<F, D>) -> F {
+        assert_eq!(p.evals.len() % self.evals.len(), 0);
+        let stride = p.evals.len() / self.evals.len();
+        let p_evals = &p.evals;
+        (&self.evals)
+            .into_par_iter()
+            .enumerate()
+            .map(|(i, e)| p_evals[stride * i] * e)
+            .sum()
+    }
+
+    /// Given the evaluations form of a polynomial, directly evaluate that polynomial at a point,
+    /// assuming that the given evaluations are either 0 or 1 at every point of the domain.
+    pub fn evaluate_zero_one<D: EvaluationDomain<F>>(&self, p: &Evaluations<F, D>) -> F {
+        assert_eq!(p.evals.len() % self.evals.len(), 0);
+        let stride = p.evals.len() / self.evals.len();
+        let mut result = F::zero();
+        for (i, e) in self.evals.iter().enumerate() {
+            if !p.evals[stride * i].is_zero() {
+                result += e;
+            }
+        }
+        result
+    }
+
+    /// Compute all evaluations of the normalized lagrange basis polynomials of the
+    /// given domain at the given point. Runs in time O(domain size).
+    pub fn new(domain: D<F>, x: F) -> LagrangeBasisEvaluations<F> {
+        let n = domain.size();
+        // We want to compute for all i
+        // s_i = 1 / t_i
+        // where
+        // t_i = prod_{j != i} (omega^i - omega^j)
+        //
+        // Suppose we have t_0 = prod_{j = 1}^{n-1} (1 - omega^j).
+        // This is a product with n-1 terms. We want to shift each term over by omega
+        // so we multiply by omega^{n-1}:
+        //
+        // omega^{n-1} * t_0
+        // = prod_{j = 1}^{n-1} omega (1 - omega^j).
+        // = prod_{j = 1}^{n-1} (omega - omega^{j+1)).
+        // = (omega - omega^2) (omega - omega^3) ... (omega - omega^{n-1+1})
+        // = (omega - omega^2) (omega - omega^3) ... (omega - omega^0)
+        // = t_1
+        //
+        // And generally
+        // omega^{n-1} * t_i
+        // = prod_{j != i} omega (omega^i - omega^j)
+        // = prod_{j != i} (omega^{i + 1} - omega^{j + 1})
+        // = prod_{j + 1 != i + 1} (omega^{i + 1} - omega^{j + 1})
+        // = prod_{j' != i + 1} (omega^{i + 1} - omega^{j'})
+        // = t_{i + 1}
+        //
+        // Since omega^{n-1} = omega^{-1}, we write this as
+        // omega{-1} t_i = t_{i + 1}
+        // and then by induction,
+        // omega^{-i} t_0 = t_i
+
+        // Now, the ith lagrange evaluation at x is
+        // (1 / prod_{j != i} (omega^i - omega^j)) (x^n - 1) / (x - omega^i)
+        // = (x^n - 1) / [t_i (x - omega^i)]
+        // = (x^n - 1) / [omega^{-i} * t_0 * (x - omega^i)]
+        //
+        // We compute this using the [batch_inversion_and_mul] function.
+
+        let t_0: F = domain
+            .elements()
+            .skip(1)
+            .map(|omega_i| F::one() - omega_i)
+            .product();
+
+        let mut denominators: Vec<F> = {
+            let omegas: Vec<F> = domain.elements().collect();
+            let omega_invs: Vec<F> = (0..n).map(|i| omegas[(n - i) % n]).collect();
+
+            omegas
+                .into_par_iter()
+                .zip(omega_invs)
+                .map(|(omega_i, omega_i_inv)| omega_i_inv * t_0 * (x - omega_i))
+                .collect()
+        };
+
+        let numerator = x.pow([n as u64]) - F::one();
+
+        batch_inversion_and_mul(&mut denominators[..], &numerator);
+
+        // Denominators now contains the desired result.
+        LagrangeBasisEvaluations {
+            evals: denominators,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ark_ff::{One, UniformRand, Zero};
+    use ark_poly::{Polynomial, Radix2EvaluationDomain};
+    use mina_curves::pasta::Fp;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn test_lagrange_evaluations() {
+        let n = 1 << 4;
+        let domain = Radix2EvaluationDomain::new(n).unwrap();
+        let rng = &mut StdRng::from_seed([0u8; 32]);
+        let x = Fp::rand(rng);
+        let evaluator = LagrangeBasisEvaluations::new(domain, x);
+
+        let expected: Vec<_> = (0..n)
+            .map(|i| {
+                let mut lagrange_i = vec![Fp::zero(); n];
+                lagrange_i[i] = Fp::one();
+                Evaluations::from_vec_and_domain(lagrange_i, domain)
+                    .interpolate()
+                    .evaluate(&x)
+            })
+            .collect();
+
+        for i in 0..n {
+            if evaluator.evals[i] != expected[i] {
+                panic!(
+                    "{}, {}: {} != {}",
+                    line!(),
+                    i,
+                    evaluator.evals[i],
+                    expected[i]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_evaluation() {
+        let rng = &mut StdRng::from_seed([0u8; 32]);
+        let n = 1 << 10;
+        let domain = Radix2EvaluationDomain::new(n).unwrap();
+
+        let evals = {
+            let mut e = vec![];
+            for _ in 0..n {
+                e.push(Fp::rand(rng));
+            }
+            Evaluations::from_vec_and_domain(e, domain)
+        };
+
+        let x = Fp::rand(rng);
+
+        let evaluator = LagrangeBasisEvaluations::new(domain, x);
+
+        let y = evaluator.evaluate(&evals);
+        let expected = evals.interpolate().evaluate(&x);
+        assert_eq!(y, expected)
+    }
+
+    #[test]
+    fn test_evaluation_zero_one() {
+        let rng = &mut StdRng::from_seed([0u8; 32]);
+        let n = 1 << 1;
+        let domain = Radix2EvaluationDomain::new(n).unwrap();
+
+        let evals = {
+            let mut e = vec![];
+            for _ in 0..n {
+                e.push(if bool::rand(rng) {
+                    Fp::one()
+                } else {
+                    Fp::zero()
+                });
+            }
+            e = vec![Fp::zero(), Fp::one()];
+            Evaluations::from_vec_and_domain(e, domain)
+        };
+
+        let x = Fp::rand(rng);
+
+        let evaluator = LagrangeBasisEvaluations::new(domain, x);
+
+        let y = evaluator.evaluate_zero_one(&evals);
+        let expected = evals.interpolate().evaluate(&x);
+        assert_eq!(y, expected)
+    }
+}

--- a/kimchi/src/lagrange_basis_evaluations.rs
+++ b/kimchi/src/lagrange_basis_evaluations.rs
@@ -23,7 +23,7 @@ impl<F: FftField> LagrangeBasisEvaluations<F> {
 
     /// Given the evaluations form of a polynomial, directly evaluate that polynomial at a point,
     /// assuming that the given evaluations are either 0 or 1 at every point of the domain.
-    pub fn evaluate_zero_one<D: EvaluationDomain<F>>(&self, p: &Evaluations<F, D>) -> F {
+    pub fn evaluate_boolean<D: EvaluationDomain<F>>(&self, p: &Evaluations<F, D>) -> F {
         assert_eq!(p.evals.len() % self.evals.len(), 0);
         let stride = p.evals.len() / self.evals.len();
         let mut result = F::zero();
@@ -189,7 +189,7 @@ mod tests {
 
         let evaluator = LagrangeBasisEvaluations::new(domain, x);
 
-        let y = evaluator.evaluate_zero_one(&evals);
+        let y = evaluator.evaluate_boolean(&evals);
         let expected = evals.interpolate().evaluate(&x);
         assert_eq!(y, expected)
     }

--- a/kimchi/src/lagrange_basis_evaluations.rs
+++ b/kimchi/src/lagrange_basis_evaluations.rs
@@ -130,14 +130,14 @@ mod tests {
             })
             .collect();
 
-        for i in 0..n {
-            if evaluator.evals[i] != expected[i] {
+        for (i, expected) in expected.into_iter().enumerate() {
+            if evaluator.evals[i] != expected {
                 panic!(
                     "{}, {}: {} != {}",
                     line!(),
                     i,
                     evaluator.evals[i],
-                    expected[i]
+                    expected
                 );
             }
         }

--- a/kimchi/src/lib.rs
+++ b/kimchi/src/lib.rs
@@ -15,6 +15,7 @@ pub mod bench;
 pub mod circuits;
 pub mod curve;
 pub mod error;
+pub mod lagrange_basis_evaluations;
 pub mod linearization;
 pub mod oracles;
 pub mod plonk_sponge;

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1112,7 +1112,7 @@ where
             shifted: None,
         };
 
-        let coefficients_form = |p| DensePolynomialOrEvaluations::DensePolynomial(p);
+        let coefficients_form = DensePolynomialOrEvaluations::DensePolynomial;
         let evaluations_form = |e| DensePolynomialOrEvaluations::Evaluations(e, index.cs.domain.d1);
 
         let mut polynomials = polys

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -927,8 +927,8 @@ where
 
         let chunked_evals_for_selector =
             |p: &Evaluations<G::ScalarField, D<G::ScalarField>>| PointEvaluations {
-                zeta: vec![zeta_evals.evaluate_zero_one(p)],
-                zeta_omega: vec![zeta_omega_evals.evaluate_zero_one(p)],
+                zeta: vec![zeta_evals.evaluate_boolean(p)],
+                zeta_omega: vec![zeta_omega_evals.evaluate_boolean(p)],
             };
 
         let chunked_evals_for_evaluations =

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -3,7 +3,7 @@
 use crate::{
     alphas::Alphas,
     circuits::{
-        constraints::{ColumnEvaluations, ConstraintSystem, EvaluatedColumnCoefficients},
+        constraints::{ColumnEvaluations, ConstraintSystem},
         expr::{Linearization, PolishToken},
     },
     curve::KimchiCurve,
@@ -40,9 +40,6 @@ pub struct ProverIndex<G: KimchiCurve> {
 
     /// maximal size of polynomial section
     pub max_poly_size: usize,
-
-    #[serde(bound = "EvaluatedColumnCoefficients<G::ScalarField>: Serialize + DeserializeOwned")]
-    pub evaluated_column_coefficients: EvaluatedColumnCoefficients<G::ScalarField>,
 
     #[serde(bound = "ColumnEvaluations<G::ScalarField>: Serialize + DeserializeOwned")]
     pub column_evaluations: ColumnEvaluations<G::ScalarField>,
@@ -90,7 +87,6 @@ impl<G: KimchiCurve> ProverIndex<G> {
             powers_of_alpha,
             srs,
             max_poly_size,
-            evaluated_column_coefficients,
             column_evaluations,
             verifier_index: None,
             verifier_index_digest: None,

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -216,9 +216,9 @@ impl<G: KimchiCurve> ProverIndex<G> {
             },
 
             sigma_comm: array::from_fn(|i| {
-                self.srs.commit_non_hiding(
-                    &self.evaluated_column_coefficients.permutation_coefficients[i],
-                    None,
+                self.srs.commit_evaluations_non_hiding(
+                    domain,
+                    &self.column_evaluations.permutation_coefficients8[i],
                 )
             }),
             coefficients_comm: array::from_fn(|i| {
@@ -228,14 +228,16 @@ impl<G: KimchiCurve> ProverIndex<G> {
                 )
             }),
             generic_comm: mask_fixed(
-                self.srs
-                    .commit_non_hiding(&self.evaluated_column_coefficients.generic_selector, None),
+                self.srs.commit_evaluations_non_hiding(
+                    domain,
+                    &self.column_evaluations.generic_selector4,
+                ),
             ),
 
-            psm_comm: mask_fixed(
-                self.srs
-                    .commit_non_hiding(&self.evaluated_column_coefficients.poseidon_selector, None),
-            ),
+            psm_comm: mask_fixed(self.srs.commit_evaluations_non_hiding(
+                domain,
+                &self.column_evaluations.poseidon_selector8,
+            )),
 
             complete_add_comm: self.srs.commit_evaluations_non_hiding(
                 domain,

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -888,7 +888,7 @@ mod tests {
     use super::*;
 
     use crate::srs::SRS;
-    use ark_poly::{Polynomial, UVPolynomial};
+    use ark_poly::{Polynomial, Radix2EvaluationDomain, UVPolynomial};
     use mina_curves::pasta::{Fp, Vesta as VestaG};
     use mina_poseidon::constants::PlonkSpongeConstantsKimchi as SC;
     use mina_poseidon::sponge::DefaultFqSponge;
@@ -995,9 +995,21 @@ mod tests {
         let sponge =
             DefaultFqSponge::<_, SC>::new(mina_poseidon::pasta::fq_kimchi::static_params());
 
-        let polys = vec![
-            (&poly1, None, commitment.blinders),
-            (&poly2, Some(upperbound), bounded_commitment.blinders),
+        let polys: Vec<(
+            DensePolynomialOrEvaluations<_, Radix2EvaluationDomain<_>>,
+            Option<usize>,
+            PolyComm<_>,
+        )> = vec![
+            (
+                DensePolynomialOrEvaluations::DensePolynomial(&poly1),
+                None,
+                commitment.blinders,
+            ),
+            (
+                DensePolynomialOrEvaluations::DensePolynomial(&poly2),
+                Some(upperbound),
+                bounded_commitment.blinders,
+            ),
         ];
         let elm = vec![Fp::rand(rng), Fp::rand(rng)];
 

--- a/poly-commitment/src/tests/batch_15_wires.rs
+++ b/poly-commitment/src/tests/batch_15_wires.rs
@@ -3,10 +3,11 @@
 
 use crate::{
     commitment::{BatchEvaluationProof, CommitmentCurve, Evaluation},
+    evaluation_proof::DensePolynomialOrEvaluations,
     srs::SRS,
 };
 use ark_ff::{UniformRand, Zero};
-use ark_poly::{univariate::DensePolynomial, UVPolynomial};
+use ark_poly::{univariate::DensePolynomial, Radix2EvaluationDomain, UVPolynomial};
 use colored::Colorize;
 use groupmap::GroupMap;
 use mina_curves::pasta::{Fp, Vesta, VestaParameters};
@@ -89,10 +90,20 @@ where
             commit += start.elapsed();
 
             start = Instant::now();
-            let polys: Vec<_> = (0..a.len())
-                .map(|i| (&a[i], bounds[i], (comm[i].0).blinders.clone()))
+            let polys: Vec<(
+                DensePolynomialOrEvaluations<_, Radix2EvaluationDomain<_>>,
+                _,
+                _,
+            )> = (0..a.len())
+                .map(|i| {
+                    (
+                        DensePolynomialOrEvaluations::DensePolynomial(&a[i]),
+                        bounds[i],
+                        (comm[i].0).blinders.clone(),
+                    )
+                })
                 .collect();
-            let proof = srs.open::<DefaultFqSponge<VestaParameters, SC>, _>(
+            let proof = srs.open::<DefaultFqSponge<VestaParameters, SC>, _, _>(
                 &group_map,
                 &polys,
                 &x,

--- a/poly-commitment/src/tests/commitment.rs
+++ b/poly-commitment/src/tests/commitment.rs
@@ -164,6 +164,7 @@ fn test_randomised<RNG: Rng + CryptoRng>(mut rng: &mut RNG) {
         }
 
         // create aggregated evaluation proof
+        #[allow(clippy::type_complexity)]
         let mut polynomials: Vec<(
             DensePolynomialOrEvaluations<Fp, Radix2EvaluationDomain<Fp>>,
             Option<usize>,

--- a/poly-commitment/src/tests/commitment.rs
+++ b/poly-commitment/src/tests/commitment.rs
@@ -1,10 +1,10 @@
 use crate::{
     commitment::{BatchEvaluationProof, BlindedCommitment, CommitmentCurve, Evaluation, PolyComm},
-    evaluation_proof::OpeningProof,
+    evaluation_proof::{DensePolynomialOrEvaluations, OpeningProof},
     srs::SRS,
 };
 use ark_ff::{UniformRand, Zero};
-use ark_poly::{univariate::DensePolynomial, UVPolynomial};
+use ark_poly::{univariate::DensePolynomial, Radix2EvaluationDomain, UVPolynomial};
 use colored::Colorize;
 use groupmap::GroupMap;
 use mina_curves::pasta::{Fp, Vesta, VestaParameters};
@@ -164,10 +164,14 @@ fn test_randomised<RNG: Rng + CryptoRng>(mut rng: &mut RNG) {
         }
 
         // create aggregated evaluation proof
-        let mut polynomials = vec![];
+        let mut polynomials: Vec<(
+            DensePolynomialOrEvaluations<Fp, Radix2EvaluationDomain<Fp>>,
+            Option<usize>,
+            PolyComm<_>,
+        )> = vec![];
         for c in &commitments {
             polynomials.push((
-                &c.poly,
+                DensePolynomialOrEvaluations::DensePolynomial(&c.poly),
                 c.eval_commit.commit.bound,
                 c.chunked_blinding.clone(),
             ));
@@ -177,7 +181,7 @@ fn test_randomised<RNG: Rng + CryptoRng>(mut rng: &mut RNG) {
         let evalmask = Fp::rand(&mut rng);
 
         let timer = Instant::now();
-        let proof = srs.open::<DefaultFqSponge<VestaParameters, SC>, _>(
+        let proof = srs.open::<DefaultFqSponge<VestaParameters, SC>, _, _>(
             &group_map,
             &polynomials,
             &eval_points.clone(),


### PR DESCRIPTION
This PR removes dense polynomial forms of evaluated columns from the prover index, instead using evaluations forms directly to evaluate and open those polynomials. The result is (currently) one more size n FFT in the opening proof and reduced prover memory. It also paves the way for opening all the polynomials (in order to remove the linearization technique) without any increase in prover memory usage.

It does not currently allow the evaluations form polynomials to have size greater than n. This would require changing chunking to happen post-accumulation (rather than on a per-polynomial basis) which can be done in a follow up PR.