### PR TITLE
Adding GPU-accelerated MSM implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "bcs",
+ "criterion",
  "hex",
  "mina-curves",
  "num-bigint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +207,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b12e5fd123190ce1c2e559308a94c9bacad77907d4c6005d9e58fe1a0689e55e"
 dependencies = [
  "digest 0.10.5",
+]
+
+[[package]]
+name = "blake2b_simd"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -356,6 +379,12 @@ dependencies = [
  "proc-macro-hack",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "convert_case"
@@ -599,6 +628,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "bitvec",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +669,23 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -949,12 +1006,15 @@ dependencies = [
  "ark-ff",
  "ark-poly",
  "ark-serialize",
+ "ark-std",
  "bcs",
  "hex",
  "mina-curves",
  "num-bigint",
  "num-integer",
  "num-traits",
+ "pasta-msm",
+ "pasta_curves",
  "rand",
  "rand_core",
  "rayon",
@@ -1053,6 +1113,34 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "pasta-msm"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40dc8bdddb15a18fdf7c398f341a5ef2632a287419bbeeb64c61dec25091627"
+dependencies = [
+ "cc",
+ "pasta_curves",
+ "semolina",
+ "sppark",
+ "which",
+]
+
+[[package]]
+name = "pasta_curves"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc65faf8e7313b4b1fbaa9f7ca917a0eed499a9663be71477f87993604341d8"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "lazy_static",
+ "rand",
+ "static_assertions",
+ "subtle",
+]
 
 [[package]]
 name = "paste"
@@ -1386,6 +1474,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "semolina"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e90759f733a01b95d6ba70180b954d1d96e3e7e11f86c3fb0da0231300972e05"
+dependencies = [
+ "cc",
+ "glob",
+]
+
+[[package]]
 name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1573,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.5",
+]
+
+[[package]]
+name = "sppark"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb9486baeb35ca1197c4df27451d4df5bd321e15da94c1ddb89670f9e94896a"
+dependencies = [
+ "cc",
+ "which",
 ]
 
 [[package]]
@@ -1757,6 +1865,17 @@ checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/circuit-construction/src/prover.rs
+++ b/circuit-construction/src/prover.rs
@@ -13,6 +13,7 @@ use kimchi::{
     prover_index::ProverIndex,
 };
 use mina_poseidon::FqSponge;
+use o1_utils::fast_msm::msm::MultiScalarMultiplication;
 use std::array;
 
 /// Given an index, a group map, custom blinders for the witness, a public input vector, and a circuit `main`, it creates a proof.
@@ -30,7 +31,7 @@ pub fn prove<G, H, EFqSponge, EFrSponge>(
 where
     H: FnMut(&mut WitnessGenerator<G::ScalarField>, Vec<Var<G::ScalarField>>),
     G::BaseField: PrimeField,
-    G: KimchiCurve,
+    G: KimchiCurve + MultiScalarMultiplication,
     EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
     EFrSponge: FrSponge<G::ScalarField>,
 {

--- a/kimchi/Cargo.toml
+++ b/kimchi/Cargo.toml
@@ -43,7 +43,7 @@ turshi = { path = "../turshi", version = "0.1.0" }
 commitment_dlog = { path = "../poly-commitment", version = "0.1.0" }
 groupmap = { path = "../groupmap", version = "0.1.0" }
 mina-curves = { path = "../curves", version = "0.1.0" }
-o1-utils = { path = "../utils", version = "0.1.0" }
+o1-utils = { path = "../utils", version = "0.1.0", features = ["gpu"] }
 mina-poseidon = { path = "../poseidon", version = "0.1.0" }
 
 ocaml = { version = "0.22.2", optional = true }

--- a/kimchi/Cargo.toml
+++ b/kimchi/Cargo.toml
@@ -43,7 +43,7 @@ turshi = { path = "../turshi", version = "0.1.0" }
 commitment_dlog = { path = "../poly-commitment", version = "0.1.0" }
 groupmap = { path = "../groupmap", version = "0.1.0" }
 mina-curves = { path = "../curves", version = "0.1.0" }
-o1-utils = { path = "../utils", version = "0.1.0", features = ["gpu"] }
+o1-utils = { path = "../utils", version = "0.1.0" }
 mina-poseidon = { path = "../poseidon", version = "0.1.0" }
 
 ocaml = { version = "0.22.2", optional = true }
@@ -76,3 +76,4 @@ default = []
 ocaml_types = [ "ocaml", "ocaml-gen", "commitment_dlog/ocaml_types", "mina-poseidon/ocaml_types" ]
 wasm_types = [ "wasm-bindgen" ]
 check_feature_flags = []
+gpu = [ "o1-utils/gpu" ]

--- a/kimchi/README.md
+++ b/kimchi/README.md
@@ -9,7 +9,7 @@ To bench kimchi, we have two types of benchmark engines.
 [Criterion](https://bheisler.github.io/criterion.rs/) is used to benchmark time:
 
 ```console
-$ cargo criterion -p kimchi --bench proof_criterion
+$ cargo criterion -p kimchi --bench proof_criterion --features gpu
 ```
 
 The result will appear in `target/criterion/single\ proof/report/index.html` and look like this:
@@ -21,7 +21,7 @@ Note that it only does 10 passes. To have more accurate statistics, remove the `
 The other benchmark uses [iai](https://github.com/bheisler/iai) to perform precise one-shot benchmarking. This is useful in CI, for example, where typical benchmarks are affected by the load of the host running CI.
 
 ```console
-$ cargo bench -p kimchi --bench proof_iai
+$ cargo bench -p kimchi --bench proof_iai --features gpu
 ```
 
 It will look like this:

--- a/kimchi/benches/proof_criterion.rs
+++ b/kimchi/benches/proof_criterion.rs
@@ -17,6 +17,18 @@ pub fn bench_proof_creation(c: &mut Criterion) {
         |b| b.iter(|| black_box(ctx.create_proof())),
     );
 
+    let ctx = BenchmarkCtx::new(1 << 16);
+    group.bench_function(
+        format!("proof creation (SRS size 2^{})", ctx.srs_size()),
+        |b| b.iter(|| black_box(ctx.create_proof())),
+    );
+
+    let ctx = BenchmarkCtx::new(1 << 18);
+    group.bench_function(
+        format!("proof creation (SRS size 2^{})", ctx.srs_size()),
+        |b| b.iter(|| black_box(ctx.create_proof())),
+    );
+
     let proof = ctx.create_proof();
 
     group.sample_size(100).sampling_mode(SamplingMode::Auto);

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -1,5 +1,6 @@
 use ark_ff::{FftField, One, Zero};
 use commitment_dlog::PolyComm;
+use o1_utils::fast_msm::msm::MultiScalarMultiplication;
 use serde::{Deserialize, Serialize};
 
 pub mod range_check;
@@ -111,6 +112,7 @@ pub fn combine_table<G>(
     runtime_vector: Option<&PolyComm<G>>,
 ) -> PolyComm<G>
 where
+    G: MultiScalarMultiplication,
     G: commitment_dlog::commitment::CommitmentCurve,
 {
     assert!(!columns.is_empty());

--- a/kimchi/src/curve.rs
+++ b/kimchi/src/curve.rs
@@ -1,14 +1,18 @@
 use ark_ec::{short_weierstrass_jacobian::GroupAffine, ModelParameters};
 use commitment_dlog::{commitment::CommitmentCurve, srs::endos};
-use mina_curves::pasta::curves::{
-    pallas::{LegacyPallasParameters, PallasParameters},
-    vesta::{LegacyVestaParameters, VestaParameters},
+use mina_curves::pasta::{
+    curves::{
+        pallas::{LegacyPallas, PallasParameters},
+        vesta::{LegacyVesta, VestaParameters},
+    },
+    Pallas, Vesta,
 };
 use mina_poseidon::poseidon::ArithmeticSpongeParams;
+use o1_utils::fast_msm::msm::MultiScalarMultiplication;
 use once_cell::sync::Lazy;
 
 ///Represents additional information that a curve needs in order to be used with Kimchi
-pub trait KimchiCurve: CommitmentCurve {
+pub trait KimchiCurve: CommitmentCurve + MultiScalarMultiplication {
     /// The other curve that forms the cycle used for recursion
     type OtherCurve: KimchiCurve<
         ScalarField = Self::BaseField,
@@ -25,8 +29,8 @@ pub trait KimchiCurve: CommitmentCurve {
     fn endos() -> &'static (Self::BaseField, Self::ScalarField);
 }
 
-impl KimchiCurve for GroupAffine<VestaParameters> {
-    type OtherCurve = GroupAffine<PallasParameters>;
+impl KimchiCurve for Vesta {
+    type OtherCurve = Pallas;
 
     fn sponge_params() -> &'static ArithmeticSpongeParams<Self::ScalarField> {
         mina_poseidon::pasta::fp_kimchi::static_params()
@@ -36,13 +40,13 @@ impl KimchiCurve for GroupAffine<VestaParameters> {
         static VESTA_ENDOS: Lazy<(
             <VestaParameters as ModelParameters>::BaseField,
             <VestaParameters as ModelParameters>::ScalarField,
-        )> = Lazy::new(endos::<GroupAffine<VestaParameters>>);
+        )> = Lazy::new(endos::<Vesta>);
         &VESTA_ENDOS
     }
 }
 
-impl KimchiCurve for GroupAffine<PallasParameters> {
-    type OtherCurve = GroupAffine<VestaParameters>;
+impl KimchiCurve for Pallas {
+    type OtherCurve = Vesta;
 
     fn sponge_params() -> &'static ArithmeticSpongeParams<Self::ScalarField> {
         mina_poseidon::pasta::fq_kimchi::static_params()
@@ -52,7 +56,7 @@ impl KimchiCurve for GroupAffine<PallasParameters> {
         static PALLAS_ENDOS: Lazy<(
             <PallasParameters as ModelParameters>::BaseField,
             <PallasParameters as ModelParameters>::ScalarField,
-        )> = Lazy::new(endos::<GroupAffine<PallasParameters>>);
+        )> = Lazy::new(endos::<Pallas>);
         &PALLAS_ENDOS
     }
 }
@@ -61,8 +65,8 @@ impl KimchiCurve for GroupAffine<PallasParameters> {
 // legacy curves
 //
 
-impl KimchiCurve for GroupAffine<LegacyVestaParameters> {
-    type OtherCurve = GroupAffine<LegacyPallasParameters>;
+impl KimchiCurve for LegacyVesta {
+    type OtherCurve = LegacyPallas;
 
     fn sponge_params() -> &'static ArithmeticSpongeParams<Self::ScalarField> {
         mina_poseidon::pasta::fp_legacy::static_params()
@@ -72,8 +76,9 @@ impl KimchiCurve for GroupAffine<LegacyVestaParameters> {
         GroupAffine::<VestaParameters>::endos()
     }
 }
-impl KimchiCurve for GroupAffine<LegacyPallasParameters> {
-    type OtherCurve = GroupAffine<LegacyVestaParameters>;
+
+impl KimchiCurve for LegacyPallas {
+    type OtherCurve = LegacyVesta;
 
     fn sponge_params() -> &'static ArithmeticSpongeParams<Self::ScalarField> {
         mina_poseidon::pasta::fq_legacy::static_params()

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -47,7 +47,7 @@ use commitment_dlog::{
 };
 use itertools::Itertools;
 use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
-use o1_utils::ExtendedDensePolynomial as _;
+use o1_utils::{fast_msm::msm::MultiScalarMultiplication, ExtendedDensePolynomial as _};
 use rayon::prelude::*;
 use std::array;
 use std::collections::HashMap;
@@ -115,7 +115,7 @@ where
     runtime_second_col_d8: Option<Evaluations<F, D<F>>>,
 }
 
-impl<G: KimchiCurve> ProverProof<G>
+impl<G: KimchiCurve + MultiScalarMultiplication> ProverProof<G>
 where
     G::BaseField: PrimeField,
 {

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -24,6 +24,7 @@ use commitment_dlog::commitment::{
     absorb_commitment, combined_inner_product, BatchEvaluationProof, Evaluation, PolyComm,
 };
 use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
+use o1_utils::fast_msm::msm::MultiScalarMultiplication;
 use rand::thread_rng;
 
 /// The result of a proof verification.
@@ -786,7 +787,7 @@ pub fn batch_verify<G, EFqSponge, EFrSponge>(
     proofs: &[(&VerifierIndex<G>, &ProverProof<G>)],
 ) -> Result<()>
 where
-    G: KimchiCurve,
+    G: KimchiCurve + MultiScalarMultiplication,
     G::BaseField: PrimeField,
     EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
     EFrSponge: FrSponge<G::ScalarField>,

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -20,6 +20,7 @@ use commitment_dlog::{
     srs::SRS,
 };
 use mina_poseidon::FqSponge;
+use o1_utils::fast_msm::msm::MultiScalarMultiplication;
 use once_cell::sync::OnceCell;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
@@ -153,7 +154,7 @@ pub struct VerifierIndex<G: KimchiCurve> {
 }
 //~spec:endcode
 
-impl<G: KimchiCurve> ProverIndex<G> {
+impl<G: KimchiCurve + MultiScalarMultiplication> ProverIndex<G> {
     /// Produces the [`VerifierIndex`] from the prover's [`ProverIndex`].
     ///
     /// # Panics

--- a/poly-commitment/Cargo.toml
+++ b/poly-commitment/Cargo.toml
@@ -27,7 +27,7 @@ once_cell = "1.10.0"
 
 groupmap = { path = "../groupmap", version = "0.1.0" }
 mina-curves = { path = "../curves", version = "0.1.0" }
-o1-utils = { path = "../utils", version = "0.1.0", features = [ "gpu" ] }
+o1-utils = { path = "../utils", version = "0.1.0" }
 mina-poseidon = { path = "../poseidon", version = "0.1.0" }
 
 ocaml = { version = "0.22.2", optional = true }
@@ -38,4 +38,6 @@ colored = "2.0.0"
 rand_chacha = { version = "0.3.0" }
 
 [features]
+default = []
 ocaml_types = [ "ocaml", "ocaml-gen" ]
+gpu = [ "o1-utils/gpu" ]

--- a/poly-commitment/Cargo.toml
+++ b/poly-commitment/Cargo.toml
@@ -27,7 +27,7 @@ once_cell = "1.10.0"
 
 groupmap = { path = "../groupmap", version = "0.1.0" }
 mina-curves = { path = "../curves", version = "0.1.0" }
-o1-utils = { path = "../utils", version = "0.1.0" }
+o1-utils = { path = "../utils", version = "0.1.0", features = [ "gpu" ] }
 mina-poseidon = { path = "../poseidon", version = "0.1.0" }
 
 ocaml = { version = "0.22.2", optional = true }

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -579,7 +579,7 @@ impl<G: CommitmentCurve + MultiScalarMultiplication> SRS<G> {
             unshifted.push(G::zero());
         } else {
             plnm.chunks(self.g.len()).for_each(|coeffs_chunk| {
-                let chunk = G::msm(&self.g, coeffs_chunk);
+                let chunk = G::msm(&self.g[..coeffs_chunk.len()], coeffs_chunk);
                 unshifted.push(chunk);
             });
         }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -19,6 +19,7 @@ rayon = "1.3.0"
 serde = "1.0.130"
 serde_with = "1.10.0"
 hex = "0.4"
+mina-curves = { path = "../curves", version = "0.1.0" }
 num-bigint = { version = "0.4.3", features = ["rand"]}
 num-integer = "0.1.45"
 num-traits = "0.2"
@@ -27,8 +28,14 @@ thiserror = "1.0.30"
 rand = "0.8.0"
 rand_core = "0.6.3"
 
+# for faster MSM
+# todo: make this a feature
+#[target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
+pasta-msm = "0.1.3"
+pasta_curves = { version = ">=0.3.1, <=0.4", features = ["repr-c"] }
+
 [dev-dependencies]
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
-mina-curves = { path = "../curves", version = "0.1.0" }
+ark-std = "0.3.0"
 num-bigint = { version = "0.4.3", features = ["rand"] }
 secp256k1 = "0.24.2"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -37,5 +37,10 @@ pasta_curves = { version = ">=0.3.1, <=0.4", features = ["repr-c"] }
 [dev-dependencies]
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 ark-std = "0.3.0"
+criterion = "0.3"
 num-bigint = { version = "0.4.3", features = ["rand"] }
 secp256k1 = "0.24.2"
+
+[[bench]]
+name = "msm"
+harness = false

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -14,6 +14,7 @@ ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-poly = { version = "0.3.0", features = [ "parallel" ] }
 ark-serialize = "0.3.0"
+ark-std = "0.3.0"
 bcs = "0.1.3"
 rayon = "1.3.0"
 serde = "1.0.130"
@@ -36,7 +37,6 @@ pasta_curves = { version = ">=0.3.1, <=0.4", features = ["repr-c"], optional = t
 
 [dev-dependencies]
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
-ark-std = "0.3.0"
 criterion = "0.3"
 num-bigint = { version = "0.4.3", features = ["rand"] }
 secp256k1 = "0.24.2"
@@ -48,3 +48,9 @@ gpu = [ "dep:pasta-msm", "dep:pasta_curves" ]
 [[bench]]
 name = "msm"
 harness = false
+required-features = ["gpu"]
+
+[[bin]]
+name = "msm"
+path = "src/bin/msm.rs"
+required-features = ["gpu"]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -31,8 +31,8 @@ rand_core = "0.6.3"
 # for faster MSM
 # todo: make this a feature
 #[target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
-pasta-msm = "0.1.3"
-pasta_curves = { version = ">=0.3.1, <=0.4", features = ["repr-c"] }
+pasta-msm = { version = "0.1.3", optional = true }
+pasta_curves = { version = ">=0.3.1, <=0.4", features = ["repr-c"], optional = true }
 
 [dev-dependencies]
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
@@ -40,6 +40,10 @@ ark-std = "0.3.0"
 criterion = "0.3"
 num-bigint = { version = "0.4.3", features = ["rand"] }
 secp256k1 = "0.24.2"
+
+[features]
+default = [ ]
+gpu = [ "dep:pasta-msm", "dep:pasta_curves" ]
 
 [[bench]]
 name = "msm"

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,3 +1,23 @@
 # O1-Utils
 
 A collection of utility functions and trait extensions.
+
+## MSM
+
+You can run the MSM benchmark like so:
+
+```console
+$ cargo criterion -p o1-utils --bench msm --features gpu
+```
+
+You can also run a flamegraph with [cargo flamegraph]() by doing:
+
+```console
+$ sudo RUSTFLAGS=-g CARGO_PROFILE_RELEASE_DEBUG=true cargo +nightly flamegraph --bin msm --features gpu
+```
+
+on Mac you'll need the `--root` flag:
+
+```console
+$ sudo RUSTFLAGS=-g CARGO_PROFILE_RELEASE_DEBUG=true cargo +nightly flamegraph --root --bin msm --features gpu
+```

--- a/utils/benches/msm.rs
+++ b/utils/benches/msm.rs
@@ -1,0 +1,58 @@
+use ark_ec::{msm::VariableBaseMSM, ProjectiveCurve};
+use ark_ff::PrimeField;
+use ark_std::{test_rng, UniformRand};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use mina_curves::pasta::Vesta;
+use o1_utils::fast_msm::msm::MultiScalarMultiplication;
+
+fn create_scalars_and_points<G: MultiScalarMultiplication>(
+    len: usize,
+) -> (Vec<G::ScalarField>, Vec<G>) {
+    let mut scalars = Vec::with_capacity(len);
+    let mut points = Vec::with_capacity(len);
+    for _ in 0..len {
+        scalars.push(G::ScalarField::rand(&mut test_rng()));
+        points.push(G::Projective::rand(&mut test_rng()).into_affine());
+    }
+    (scalars, points)
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let (scalars, points) = create_scalars_and_points::<Vesta>(20);
+    let scalars_repr: Vec<_> = scalars.iter().map(|x| x.into_repr()).collect();
+
+    c.bench_function("arkworks msm of length 20", |b| {
+        b.iter(|| {
+            let _ = black_box(VariableBaseMSM::multi_scalar_mul(
+                black_box(&points),
+                black_box(&scalars_repr),
+            ));
+        })
+    });
+
+    c.bench_function("supra msm of length 20", |b| {
+        b.iter(|| {
+            let _ = black_box(Vesta::msm(black_box(&points), black_box(&scalars)));
+        })
+    });
+
+    let (scalars, points) = create_scalars_and_points::<Vesta>(100);
+
+    c.bench_function("arkworks msm of length 100", |b| {
+        b.iter(|| {
+            let _ = black_box(VariableBaseMSM::multi_scalar_mul(
+                black_box(&points),
+                black_box(&scalars_repr),
+            ));
+        })
+    });
+
+    c.bench_function("supra msm of length 100", |b| {
+        b.iter(|| {
+            let _ = black_box(Vesta::msm(black_box(&points), black_box(&scalars)));
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/utils/benches/msm.rs
+++ b/utils/benches/msm.rs
@@ -2,7 +2,7 @@
 //! You can run this benchmark like so:
 //!
 //! ```ignore
-//! cargo criterion -p o1-utils --bench msm
+//! cargo criterion -p o1-utils --bench msm --features gpu
 //! ```
 //!
 //! It will show you the performance of the arkworks (CPU) and supra (GPU) MSM impls,

--- a/utils/benches/msm.rs
+++ b/utils/benches/msm.rs
@@ -1,3 +1,14 @@
+//!
+//! You can run this benchmark like so:
+//!
+//! ```ignore
+//! cargo criterion -p o1-utils --bench msm
+//! ```
+//!
+//! It will show you the performance of the arkworks (CPU) and supra (GPU) MSM impls,
+//! using different vector lengths.
+//!
+
 use ark_ec::{msm::VariableBaseMSM, ProjectiveCurve};
 use ark_ff::PrimeField;
 use ark_std::{test_rng, UniformRand};
@@ -32,7 +43,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("supra msm of length 20", |b| {
         b.iter(|| {
-            let _ = black_box(Vesta::msm(black_box(&points), black_box(&scalars)));
+            let _ = black_box(Vesta::gpu_msm(black_box(&points), black_box(&scalars)));
         })
     });
 
@@ -50,7 +61,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("supra msm of length 128", |b| {
         b.iter(|| {
-            let _ = black_box(Vesta::msm(black_box(&points), black_box(&scalars)));
+            let _ = black_box(Vesta::gpu_msm(black_box(&points), black_box(&scalars)));
         })
     });
 
@@ -68,7 +79,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("supra msm of length 200", |b| {
         b.iter(|| {
-            let _ = black_box(Vesta::msm(black_box(&points), black_box(&scalars)));
+            let _ = black_box(Vesta::gpu_msm(black_box(&points), black_box(&scalars)));
         })
     });
 
@@ -86,7 +97,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("supra msm of length 400", |b| {
         b.iter(|| {
-            let _ = black_box(Vesta::msm(black_box(&points), black_box(&scalars)));
+            let _ = black_box(Vesta::gpu_msm(black_box(&points), black_box(&scalars)));
         })
     });
 }

--- a/utils/benches/msm.rs
+++ b/utils/benches/msm.rs
@@ -36,9 +36,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
-    let (scalars, points) = create_scalars_and_points::<Vesta>(100);
+    let (scalars, points) = create_scalars_and_points::<Vesta>(128);
+    let scalars_repr: Vec<_> = scalars.iter().map(|x| x.into_repr()).collect();
 
-    c.bench_function("arkworks msm of length 100", |b| {
+    c.bench_function("arkworks msm of length 128", |b| {
         b.iter(|| {
             let _ = black_box(VariableBaseMSM::multi_scalar_mul(
                 black_box(&points),
@@ -47,7 +48,43 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
-    c.bench_function("supra msm of length 100", |b| {
+    c.bench_function("supra msm of length 128", |b| {
+        b.iter(|| {
+            let _ = black_box(Vesta::msm(black_box(&points), black_box(&scalars)));
+        })
+    });
+
+    let (scalars, points) = create_scalars_and_points::<Vesta>(200);
+    let scalars_repr: Vec<_> = scalars.iter().map(|x| x.into_repr()).collect();
+
+    c.bench_function("arkworks msm of length 200", |b| {
+        b.iter(|| {
+            let _ = black_box(VariableBaseMSM::multi_scalar_mul(
+                black_box(&points),
+                black_box(&scalars_repr),
+            ));
+        })
+    });
+
+    c.bench_function("supra msm of length 200", |b| {
+        b.iter(|| {
+            let _ = black_box(Vesta::msm(black_box(&points), black_box(&scalars)));
+        })
+    });
+
+    let (scalars, points) = create_scalars_and_points::<Vesta>(400);
+    let scalars_repr: Vec<_> = scalars.iter().map(|x| x.into_repr()).collect();
+
+    c.bench_function("arkworks msm of length 400", |b| {
+        b.iter(|| {
+            let _ = black_box(VariableBaseMSM::multi_scalar_mul(
+                black_box(&points),
+                black_box(&scalars_repr),
+            ));
+        })
+    });
+
+    c.bench_function("supra msm of length 400", |b| {
         b.iter(|| {
             let _ = black_box(Vesta::msm(black_box(&points), black_box(&scalars)));
         })

--- a/utils/src/bin/msm.rs
+++ b/utils/src/bin/msm.rs
@@ -1,0 +1,24 @@
+use ark_ec::ProjectiveCurve;
+use ark_std::{test_rng, UniformRand};
+use mina_curves::pasta::Vesta;
+use o1_utils::fast_msm::msm::MultiScalarMultiplication;
+
+fn create_scalars_and_points<G: MultiScalarMultiplication>(
+    len: usize,
+) -> (Vec<G::ScalarField>, Vec<G>) {
+    let mut scalars = Vec::with_capacity(len);
+    let mut points = Vec::with_capacity(len);
+    for _ in 0..len {
+        scalars.push(G::ScalarField::rand(&mut test_rng()));
+        points.push(G::Projective::rand(&mut test_rng()).into_affine());
+    }
+    (scalars, points)
+}
+
+fn main() {
+    let (scalars, points) = create_scalars_and_points::<Vesta>(1 << 18);
+
+    for _ in 0..100 {
+        let _ = Vesta::msm(&points, &scalars);
+    }
+}

--- a/utils/src/fast_msm.rs
+++ b/utils/src/fast_msm.rs
@@ -1,0 +1,406 @@
+//! Routes to the best available MSM implementation.
+
+use mina_curves::pasta::{Fp, Fq, Pallas, Vesta};
+
+/// Fast MSM implementations using GPU-acceleration.
+//#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub mod msm {
+    use ark_ec::AffineCurve;
+    use ark_ff::ToBytes as _;
+    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+    use mina_curves::pasta::curves::pallas::LegacyPallas;
+    use mina_curves::pasta::curves::vesta::LegacyVesta;
+    use pasta_curves::arithmetic::FieldExt;
+    use pasta_curves::group::Curve;
+    use pasta_curves::group::{ff::PrimeField as _, GroupEncoding};
+
+    use super::*;
+
+    //
+    // Traits for scalars
+    //
+
+    /// TKTK
+    // TODO: bonus point if you can have default implementations hold the logic here
+    pub trait ToOtherScalar {
+        /// The other curve's type
+        type Other: FieldExt + pasta_curves::group::ff::Field;
+
+        /// The conversion to that type
+        fn to_other(&self) -> Self::Other;
+
+        /// The conversion back from that type
+        fn from_other(other: &Self::Other) -> Self;
+    }
+
+    impl ToOtherScalar for Fp {
+        type Other = pasta_curves::vesta::Scalar;
+
+        fn to_other(&self) -> Self::Other {
+            let mut bytes = [0u8; 64];
+            // arkwork points to bytes
+            self.write(&mut bytes[..]).unwrap();
+
+            // TODO: use our own helper
+            Self::Other::from_bytes_wide(&bytes)
+        }
+
+        fn from_other(other: &Self::Other) -> Self {
+            let repr = other.to_repr();
+            Self::deserialize(&repr[..]).unwrap()
+        }
+    }
+
+    impl ToOtherScalar for Fq {
+        type Other = pasta_curves::pallas::Scalar;
+
+        fn to_other(&self) -> Self::Other {
+            let mut bytes = [0u8; 64];
+            // arkwork points to bytes
+            self.write(&mut bytes[..]).unwrap();
+
+            // TODO: use our own helper
+            Self::Other::from_bytes_wide(&bytes)
+        }
+
+        fn from_other(other: &Self::Other) -> Self {
+            let repr = other.to_repr();
+            Self::deserialize(&repr[..]).unwrap()
+        }
+    }
+
+    //
+    // Traits for elliptic curve affine points
+    //
+
+    /// TKTK
+    // TODO: bonus point if you can have default implementations hold the logic here
+    pub trait ToOtherAffine: AffineCurve {
+        /// The other curve's type.
+        type Other;
+
+        /// The conversion to that type.
+        fn to_other(&self) -> Self::Other;
+
+        /// The conversion back from that type.
+        fn from_other(other: &Self::Other) -> Self;
+    }
+
+    impl ToOtherAffine for Pallas {
+        type Other = pasta_curves::pallas::Affine;
+
+        fn to_other(&self) -> Self::Other {
+            // we base this code on the assumption that the odd bit is in the last byte
+            assert_eq!(self.serialized_size(), 33);
+
+            // the other library encodes it in the MSB of the last byte instead:
+            //
+            // ```
+            // fn to_bytes(&self) -> [u8; 32] {
+            //     if bool::from(self.is_identity()) {
+            //         [0; 32]
+            //     } else {
+            //         let (x, y) = (self.x, self.y);
+            //         let sign = y.is_odd().unwrap_u8() << 7;
+            //         let mut xbytes = x.to_repr();
+            //         xbytes[31] |= sign;
+            //         xbytes
+            //     }
+            // }
+            // ```
+
+            let mut bytes = vec![];
+            self.serialize(&mut bytes).unwrap();
+
+            let is_odd = if bytes[32] == 1 { 1 << 7 } else { 0 };
+            bytes[32] |= is_odd;
+
+            let bytes: [u8; 32] = bytes[..32].try_into().unwrap();
+
+            if cfg!(debug_assertions) {
+                let res = pasta_curves::pallas::Affine::from_bytes(&bytes).unwrap();
+                let res2 = pasta_curves::pallas::Affine::from_bytes_unchecked(&bytes).unwrap();
+                assert_eq!(res, res2);
+                res2
+            } else {
+                pasta_curves::pallas::Affine::from_bytes_unchecked(&bytes).unwrap()
+            }
+        }
+
+        fn from_other(other: &Self::Other) -> Self {
+            let mut bytes = other.to_bytes().to_vec();
+
+            // as commented in the other function, the last byte's MSB contains the odd bit.
+            // arkworks expects it to be in an extra byte.
+            if bytes[31] >> 7 == 1 {
+                bytes[31] &= 0b0111_1111;
+                bytes.push(1);
+            } else {
+                bytes.push(0);
+            }
+
+            Pallas::deserialize(&*bytes).unwrap()
+        }
+    }
+
+    impl ToOtherAffine for Vesta {
+        type Other = pasta_curves::vesta::Affine;
+
+        fn to_other(&self) -> Self::Other {
+            // we base this code on the assumption that the odd bit is in the last byte
+            assert_eq!(self.serialized_size(), 33);
+
+            // the other library encodes it in the MSB of the last byte instead:
+            //
+            // ```
+            // fn to_bytes(&self) -> [u8; 32] {
+            //     if bool::from(self.is_identity()) {
+            //         [0; 32]
+            //     } else {
+            //         let (x, y) = (self.x, self.y);
+            //         let sign = y.is_odd().unwrap_u8() << 7;
+            //         let mut xbytes = x.to_repr();
+            //         xbytes[31] |= sign;
+            //         xbytes
+            //     }
+            // }
+            // ```
+
+            let mut bytes = vec![];
+            self.serialize(&mut bytes).unwrap();
+
+            let is_odd = if bytes[32] == 1 { 1 << 7 } else { 0 };
+            bytes[32] |= is_odd;
+
+            let bytes: [u8; 32] = bytes[..32].try_into().unwrap();
+
+            if cfg!(debug_assertions) {
+                let res = pasta_curves::vesta::Affine::from_bytes(&bytes).unwrap();
+                let res2 = pasta_curves::vesta::Affine::from_bytes_unchecked(&bytes).unwrap();
+                assert_eq!(res, res2);
+                res2
+            } else {
+                pasta_curves::vesta::Affine::from_bytes_unchecked(&bytes).unwrap()
+            }
+        }
+
+        fn from_other(other: &Self::Other) -> Self {
+            let mut bytes = other.to_bytes().to_vec();
+
+            // as commented in the other function, the last byte's MSB contains the odd bit.
+            // arkworks expects it to be in an extra byte.
+            if bytes[31] >> 7 == 1 {
+                bytes[31] &= 0b0111_1111;
+                bytes.push(1);
+            } else {
+                bytes.push(0);
+            }
+
+            Vesta::deserialize(&*bytes).unwrap()
+        }
+    }
+
+    //
+    // MSM
+    //
+
+    /// TKTK
+    // TODO: bonus point if you can move the logic to a default impl
+    pub trait MultiScalarMultiplication: ToOtherAffine {
+        /// MSM implementation
+        fn msm(bases: &[Self], scalars: &[Self::ScalarField]) -> Self;
+    }
+
+    impl MultiScalarMultiplication for Pallas {
+        fn msm(bases: &[Self], scalars: &[Self::ScalarField]) -> Self {
+            // convert arkworks points/scalars to pasta_curves types
+            let points: Vec<_> = bases.iter().map(ToOtherAffine::to_other).collect();
+            let scalars: Vec<_> = scalars.iter().map(ToOtherScalar::to_other).collect();
+
+            let res = pasta_msm::pallas(&points, &scalars);
+
+            Pallas::from_other(&res.to_affine())
+        }
+    }
+
+    impl MultiScalarMultiplication for Vesta {
+        fn msm(bases: &[Self], scalars: &[Self::ScalarField]) -> Self {
+            // convert arkworks points/scalars to pasta_curves types
+            let points: Vec<_> = bases.iter().map(ToOtherAffine::to_other).collect();
+            let scalars: Vec<_> = scalars.iter().map(ToOtherScalar::to_other).collect();
+
+            let res = pasta_msm::vesta(&points, &scalars);
+
+            Vesta::from_other(&res.to_affine())
+        }
+    }
+
+    //
+    // Due to the trait KimchiCurve (see in kimchi) we need to implement this for the legacy curves
+    //
+
+    impl ToOtherAffine for LegacyVesta {
+        type Other = pasta_curves::vesta::Affine;
+
+        fn to_other(&self) -> Self::Other {
+            unreachable!()
+        }
+
+        fn from_other(_other: &Self::Other) -> Self {
+            unreachable!()
+        }
+    }
+
+    impl ToOtherAffine for LegacyPallas {
+        type Other = pasta_curves::pallas::Affine;
+
+        fn to_other(&self) -> Self::Other {
+            unreachable!()
+        }
+
+        fn from_other(_other: &Self::Other) -> Self {
+            unreachable!()
+        }
+    }
+
+    impl MultiScalarMultiplication for LegacyVesta {
+        fn msm(_bases: &[Self], _scalars: &[Self::ScalarField]) -> Self {
+            unreachable!()
+        }
+    }
+
+    impl MultiScalarMultiplication for LegacyPallas {
+        fn msm(_bases: &[Self], _scalars: &[Self::ScalarField]) -> Self {
+            unreachable!()
+        }
+    }
+
+    // /// Do we need this function now?
+    // pub fn fast_msm<G: MultiScalarMultiplication>(bases: &[G], scalars: &[G::ScalarField]) -> G {
+    //     G::msm(&bases, &scalars)
+    // }
+
+    //
+    // Sanity checks
+    //
+
+    // TODO: bonus point for using proptests
+    #[cfg(test)]
+    mod tests {
+        use std::ops::Mul;
+
+        use super::*;
+        use ark_ec::ProjectiveCurve as _;
+        use ark_ec::{msm::VariableBaseMSM, AffineCurve};
+        use ark_ff::{FftField, PrimeField};
+        use ark_std::{test_rng, UniformRand};
+        use pasta_curves::arithmetic::FieldExt;
+
+        //
+        // Test that scalar conversion works
+        //
+
+        fn test_scalars_conv_generic<F: FftField + ToOtherScalar>() {
+            {
+                // check a root of unity
+                let arkworks_root = F::get_root_of_unity(2).unwrap();
+                println!("{arkworks_root}");
+                let other_fq = arkworks_root.to_other();
+                println!("{:?}", other_fq);
+
+                // multiply by order
+                let one = arkworks_root.pow(&[4u64]);
+                assert!(one.is_one());
+                println!("one: {one}");
+
+                // same with other
+                let one2 = other_fq.pow(&[0u64, 0, 0, 4]);
+                println!("one: {:?}", one2);
+                // TODO: not sure how to check that the other is one too
+            }
+
+            // do the same with a random value
+            let x: F = UniformRand::rand(&mut test_rng());
+            let y: F = UniformRand::rand(&mut test_rng());
+            let res = x * y;
+
+            let other_x = x.to_other();
+            let other_y = y.to_other();
+            let other_res = other_x * other_y;
+
+            let res_back = F::from_other(&other_res);
+            assert_eq!(res, res_back);
+        }
+
+        // TODO: this only tests Fq, not Fp
+        #[test]
+        fn test_arkworks_pasta_scalar_conversion() {
+            test_scalars_conv_generic::<Fq>();
+            test_scalars_conv_generic::<Fp>();
+        }
+        //
+        // Test that point conversion works
+        //
+
+        // TODO: make a generic test like the tests around
+        #[test]
+        fn test_arkworks_pasta_point_conversion() {
+            // generate random arkworks pallas point
+            let x = Pallas::prime_subgroup_generator();
+            let y = x.mul(Fq::from(2u64));
+
+            let other_x = x.to_other();
+            let other_y = other_x.mul(&Fq::from(2u64).to_other());
+            let other_y_bis = other_x.mul(&pasta_curves::Fq::from(2u64));
+
+            assert_eq!(other_y, other_y_bis);
+
+            let y_back = Pallas::from_other(&other_y.to_affine());
+            assert_eq!(y, y_back);
+        }
+
+        //
+        // Test that MSM works
+        //
+
+        fn test_msm_generic<G: MultiScalarMultiplication>() {
+            let scalars = vec![G::ScalarField::from(2u64), G::ScalarField::from(3u8)];
+            let points = vec![G::prime_subgroup_generator(), G::prime_subgroup_generator()];
+
+            let res = VariableBaseMSM::multi_scalar_mul(
+                &points,
+                &scalars.iter().map(|x| x.into_repr()).collect::<Vec<_>>(),
+            );
+
+            let other_res = G::msm(&points, &scalars);
+
+            assert_eq!(res.into_affine(), other_res);
+        }
+
+        #[test]
+        fn test_msm() {
+            test_msm_generic::<Pallas>();
+            test_msm_generic::<Vesta>();
+        }
+    }
+}
+
+// #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+// pub mod msm {
+//     use super::*;
+
+//     pub fn pallas_msm(bases: &[G], scalars: &[<G::ScalarField as PrimeField>::BigInt]) -> Self {
+
+// VariableBaseMSM::multi_scalar_mul(
+//     &[&g[0..n], &[self.h, u]].concat(),
+//     &[&a[n..], &[rand_l, inner_prod(a_hi, b_lo)]]
+//         .concat()
+//         .iter()
+//         .map(|x| x.into_repr())
+//         .collect::<Vec<_>>(),
+// )
+// .into_affine();
+
+//         VariableBaseMSM::multi_scalar_mul();
+//     }
+// }

--- a/utils/src/fast_msm.rs
+++ b/utils/src/fast_msm.rs
@@ -475,6 +475,29 @@ pub mod msm {
             test_msm_generic::<Pallas>();
             test_msm_generic::<Vesta>();
         }
+
+        //
+        // Sketchy bench for large MSMs
+        //
+
+        // you can run this with `cargo test --release --package o1-utils --features gpu -- --ignored large_msm --nocapture`
+        #[test]
+        #[ignore]
+        fn large_msm() {
+            // simulates a 2^18 URS for commitments
+            let (scalars, points) = create_scalars_and_points::<Vesta>(1 << 18);
+            println!("running MSM of size {}", scalars.len());
+
+            let start = std::time::Instant::now();
+            let _ = cpu_msm(&points, &scalars);
+            let end = std::time::Instant::now();
+            println!("cpu msm took: {:?}", end - start);
+
+            let start = std::time::Instant::now();
+            let _ = Vesta::msm(&points, &scalars);
+            let end = std::time::Instant::now();
+            println!("gpu msm took: {:?}", end - start);
+        }
     }
 }
 

--- a/utils/src/fast_msm.rs
+++ b/utils/src/fast_msm.rs
@@ -4,6 +4,9 @@ use ark_ec::msm::VariableBaseMSM;
 use ark_ec::AffineCurve;
 use ark_ec::ProjectiveCurve;
 use ark_ff::PrimeField;
+use mina_curves::pasta::curves::pallas::LegacyPallas;
+use mina_curves::pasta::curves::vesta::LegacyVesta;
+use mina_curves::pasta::{Pallas, Vesta};
 
 /// The arkworks implementation of the MSM algorithm (not GPU-accelerated).
 fn cpu_msm<G: AffineCurve>(points: &[G], scalars: &[G::ScalarField]) -> G {
@@ -19,9 +22,7 @@ fn cpu_msm<G: AffineCurve>(points: &[G], scalars: &[G::ScalarField]) -> G {
 pub mod msm {
     use ark_ff::ToBytes as _;
     use ark_serialize::CanonicalDeserialize;
-    use mina_curves::pasta::curves::pallas::LegacyPallas;
-    use mina_curves::pasta::curves::vesta::LegacyVesta;
-    use mina_curves::pasta::{Fp, Fq, Pallas, Vesta};
+    use mina_curves::pasta::{Fp, Fq};
     use pasta_curves::arithmetic::CurveAffine;
     use pasta_curves::group::ff::PrimeField as _;
     use pasta_curves::group::prime::PrimeCurveAffine;
@@ -496,4 +497,9 @@ pub mod msm {
             cpu_msm(points, scalars)
         }
     }
+
+    impl MultiScalarMultiplication for Vesta {}
+    impl MultiScalarMultiplication for Pallas {}
+    impl MultiScalarMultiplication for LegacyVesta {}
+    impl MultiScalarMultiplication for LegacyPallas {}
 }

--- a/utils/src/fast_msm.rs
+++ b/utils/src/fast_msm.rs
@@ -489,14 +489,18 @@ pub mod msm {
             println!("running MSM of size {}", scalars.len());
 
             let start = std::time::Instant::now();
-            let _ = cpu_msm(&points, &scalars);
+            for _ in 0..100 {
+                let _ = cpu_msm(&points, &scalars);
+            }
             let end = std::time::Instant::now();
-            println!("cpu msm took: {:?}", end - start);
+            println!("100 cpu msm took: {:?}", end - start);
 
             let start = std::time::Instant::now();
-            let _ = Vesta::msm(&points, &scalars);
+            for _ in 0..100 {
+                let _ = Vesta::msm(&points, &scalars);
+            }
             let end = std::time::Instant::now();
-            println!("gpu msm took: {:?}", end - start);
+            println!("100 gpu msm took: {:?}", end - start);
         }
     }
 }

--- a/utils/src/fast_msm.rs
+++ b/utils/src/fast_msm.rs
@@ -6,14 +6,14 @@ use mina_curves::pasta::{Fp, Fq, Pallas, Vesta};
 //#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub mod msm {
     use ark_ec::AffineCurve;
-    use ark_ff::{BigInteger, PrimeField, ToBytes as _};
+    use ark_ff::ToBytes as _;
     use ark_serialize::CanonicalDeserialize;
     use mina_curves::pasta::curves::pallas::LegacyPallas;
     use mina_curves::pasta::curves::vesta::LegacyVesta;
     use pasta_curves::arithmetic::CurveAffine;
+    use pasta_curves::group::ff::PrimeField as _;
     use pasta_curves::group::prime::PrimeCurveAffine;
     use pasta_curves::group::Curve;
-    use pasta_curves::group::{ff::PrimeField as _, GroupEncoding};
 
     use super::*;
 
@@ -75,18 +75,7 @@ pub mod msm {
     //
 
     /// This is a trait to convert points from the arkwork's [AffineCurve] library to points on the [pasta_curves] library.
-    /// Unfortunately, the serializations are different, with the arkworks one being non-standard.
-    ///
-    /// The arkworks one uses a 33-byte representation, with the last byte only used for a set of flags:
-    /// - the MSB (1 << 7) is set if the y coordinate is greater than -y (as bigints)
-    /// - the second MSB (1 << 6) is set if the point is at infinity
-    ///
-    /// On the other hand, the pasta_curves library uses a 32-byte representation,
-    /// with the MSB of the last byte set if the y coordinate is odd.
-    ///
-    /// Because the two libraries don't expose the functions we need to perform the conversion efficiently,
-    /// we resort to deserializing twice, once with the flag set to 0 and once with the flag set to 1.
-    /// Ideally, we should fix the serialization of arkworks.
+    /// It is designed a certain way due to the two libraries not exposing convenient functions from their traits.
     pub trait ToOtherAffine: AffineCurve {
         /// The other curve's type.
         type Other: CurveAffine<Repr = [u8; 32]>;
@@ -236,8 +225,8 @@ pub mod msm {
         }
 
         fn new_xy(
-            x: &<Self::Other as CurveAffine>::Base,
-            y: &<Self::Other as CurveAffine>::Base,
+            _x: &<Self::Other as CurveAffine>::Base,
+            _y: &<Self::Other as CurveAffine>::Base,
         ) -> Self {
             unreachable!()
         }
@@ -256,8 +245,8 @@ pub mod msm {
         }
 
         fn new_xy(
-            x: &<Self::Other as CurveAffine>::Base,
-            y: &<Self::Other as CurveAffine>::Base,
+            _x: &<Self::Other as CurveAffine>::Base,
+            _y: &<Self::Other as CurveAffine>::Base,
         ) -> Self {
             unreachable!()
         }

--- a/utils/src/fast_msm.rs
+++ b/utils/src/fast_msm.rs
@@ -10,7 +10,6 @@ pub mod msm {
     use ark_serialize::CanonicalDeserialize;
     use mina_curves::pasta::curves::pallas::LegacyPallas;
     use mina_curves::pasta::curves::vesta::LegacyVesta;
-    use pasta_curves::arithmetic::CurveAffine;
     use pasta_curves::group::prime::PrimeCurveAffine;
     use pasta_curves::group::Curve;
     use pasta_curves::group::{ff::PrimeField as _, GroupEncoding};
@@ -179,6 +178,12 @@ pub mod msm {
 
     impl MultiScalarMultiplication for Pallas {
         fn msm(bases: &[Self], scalars: &[Self::ScalarField]) -> Self {
+            assert_eq!(
+                bases.len(),
+                scalars.len(),
+                "bases and scalars must have the same length"
+            );
+
             // convert arkworks points/scalars to pasta_curves types
             let points: Vec<_> = bases.iter().map(ToOtherAffine::to_other).collect();
             let scalars: Vec<_> = scalars.iter().map(ToOtherScalar::to_other).collect();
@@ -232,11 +237,6 @@ pub mod msm {
             unreachable!()
         }
     }
-
-    // /// Do we need this function now?
-    // pub fn fast_msm<G: MultiScalarMultiplication>(bases: &[G], scalars: &[G::ScalarField]) -> G {
-    //     G::msm(&bases, &scalars)
-    // }
 
     //
     // Sanity checks

--- a/utils/src/fast_msm.rs
+++ b/utils/src/fast_msm.rs
@@ -307,51 +307,75 @@ pub mod msm {
                 Output = <G::Other as pasta_curves::arithmetic::CurveAffine>::CurveExt,
             >,
         {
-            // x
-            let x = G::prime_subgroup_generator();
-            let other_x = x.to_other();
-            assert_eq!(x, G::from_other(&other_x));
+            // test with our pasta generator
+            {
+                let x = G::prime_subgroup_generator();
+                let other_x = x.to_other();
+                assert_eq!(x, G::from_other(&other_x));
 
-            println!("x: {x}");
+                println!("x: {x}");
 
-            // for vesta: (1, 0x1943666ea922ae6b13b64e3aae89754cacce3a7f298ba20c4e4389b9b0276a62)
-            // for pallas: (1, 0x1b74b5a30a12937c53dfa9f06378ee548f655bd4333d477119cf7a23caed2abb)
-            dbg!(other_x);
+                // for vesta: (1, 0x1943666ea922ae6b13b64e3aae89754cacce3a7f298ba20c4e4389b9b0276a62)
+                // for pallas: (1, 0x1b74b5a30a12937c53dfa9f06378ee548f655bd4333d477119cf7a23caed2abb)
+                dbg!(other_x);
 
-            // y = x * 2
-            let y = x.mul(G::ScalarField::from(2u64));
-            let temp = F::from(2u64).to_other();
-            let other_y = other_x.mul(&temp);
+                // y = x * 2
+                let y = x.mul(G::ScalarField::from(2u64));
+                let temp = F::from(2u64).to_other();
+                let other_y = other_x.mul(&temp);
 
-            let other_y_bis = other_x.mul(&F::Other::from(2u64));
-            let other_y_from_conv = y.into_affine().to_other();
+                let other_y_bis = other_x.mul(&F::Other::from(2u64));
+                let other_y_from_conv = y.into_affine().to_other();
 
-            println!("debug: {}", y.into_affine()); // correct
-            dbg!(other_y.to_affine()); // correct
-            dbg!(other_y_from_conv);
+                println!("debug: {}", y.into_affine());
+                dbg!(other_y.to_affine());
+                dbg!(other_y_from_conv);
 
-            assert_eq!(other_y, other_y_bis);
-            assert_eq!(other_y_from_conv, other_y.to_affine()); // TODO: why is this not equal?
+                assert_eq!(other_y, other_y_bis);
+                assert_eq!(other_y_from_conv, other_y.to_affine());
 
-            let y_back = G::from_other(&other_y.to_affine());
-            dbg!(y_back);
-            assert_eq!(y.into_affine(), y_back);
+                let y_back = G::from_other(&other_y.to_affine());
+                dbg!(y_back);
+                assert_eq!(y.into_affine(), y_back);
+            }
 
-            // the zero point
-            let zero = G::zero();
-            let other_zero = zero.to_other();
+            // test the zero point
+            {
+                let zero = G::zero();
+                let other_zero = zero.to_other();
 
-            // check that it is indeed zero
-            let should_be_x = zero + x;
-            assert_eq!(should_be_x, x);
+                let x = G::prime_subgroup_generator();
+                let other_x = x.to_other();
 
-            let should_be_x_as_well = other_zero + other_x;
-            assert_eq!(should_be_x_as_well.to_affine(), other_x);
+                // check that it is indeed zero
+                let should_be_x = zero + x;
+                assert_eq!(should_be_x, x);
 
-            dbg!(other_zero);
-            let zero_back = G::from_other(&other_zero);
-            assert!(zero_back.is_zero());
-            assert_eq!(zero, zero_back);
+                let should_be_x_as_well = other_zero + other_x;
+                assert_eq!(should_be_x_as_well.to_affine(), other_x);
+
+                // check the conversion back
+                dbg!(other_zero);
+                let zero_back = G::from_other(&other_zero);
+                assert!(zero_back.is_zero());
+                assert_eq!(zero, zero_back);
+            }
+
+            // test with a random value
+            {
+                let x = G::Projective::rand(&mut test_rng()).into_affine();
+                let y = G::Projective::rand(&mut test_rng()).into_affine();
+                let res = x + y;
+
+                let other_x = x.to_other();
+                let other_y = y.to_other();
+                let other_res = res.to_other();
+                let r = other_x + other_y;
+                assert_eq!(r.to_affine(), other_res);
+
+                let res_back = G::from_other(&other_res);
+                assert_eq!(res, res_back);
+            }
         }
 
         #[test]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -14,6 +14,7 @@ pub mod foreign_field;
 pub mod hasher;
 pub mod math;
 pub mod serialization;
+pub mod fast_msm;
 
 pub use biguint_helpers::BigUintHelpers;
 pub use bitwise_operations::BitwiseOps;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -9,12 +9,12 @@ pub mod chunked_evaluations;
 pub mod chunked_polynomial;
 pub mod dense_polynomial;
 pub mod evaluations;
+pub mod fast_msm;
 pub mod field_helpers;
 pub mod foreign_field;
 pub mod hasher;
 pub mod math;
 pub mod serialization;
-pub mod fast_msm;
 
 pub use biguint_helpers::BigUintHelpers;
 pub use bitwise_operations::BitwiseOps;


### PR DESCRIPTION
This PR adds a GPU-accelerated implementation for MSM: https://github.com/supranational/pasta-msm/blob/main/Cargo.toml

Mina side: https://github.com/MinaProtocol/mina/pull/12602)

## Stability?

I did run into some weird mutex bug that I can't reproduce anymore (https://github.com/supranational/pasta-msm/issues/2) so I'm putting this behind a `gpu` feature.

## Setup

You need a [CUDA-compatible GPU](https://developer.nvidia.com/cuda-gpus) for this to work. If you don't, it'll try to fall back on an AVX CPU implementation which seems to be somewhat faster than arkworks in my case.

You also need to have `nvcc` in your path. On Ubuntu I had to downgrade to g++-10 and c++-10 to make it work (make sure that `cc`, `c++`, also point to `gcc-10` and `g++-10` using `update-alternatives`)

## Run the bench

The bench can be ran with:

```
$ cargo criterion -p o1-utils --bench msm --features gpu
```

it only runs on small URS size. It's expected that the GPU implementation only starts getting interesting around MSM of size 128.

There's a simple test that measures a larger URS (2^18) can be run by doing:

```
$ cargo test --release --package o1-utils --features gpu -- --ignored large_msm --nocapture
```

## ADX implementation

The test running without the GPU impl but the ADX impl shows a 10ms difference for me:

```
$ cargo test --release --package o1-utils --features gpu -- --ignored large_msm --nocapture
running MSM of size 262144
cpu msm took: 281.071544ms
gpu msm took: 271.999473ms
```

if I do 100 of them the gap increases, so perhaps this is good

```
running MSM of size 262144
100 cpu msm took: 43.320211253s
100 gpu msm took: 35.781777069s
```

## Sanity of integration

Here's a flamegraph, from my reading our usage is not spending much time doing non-useful things (like converting types).

![flamegraph](https://user-images.githubusercontent.com/1316043/216749422-99e9c92d-e037-4616-9e3d-3748fc475842.svg)

## GPU numbers

I'm getting really bad numbers for the GPU implementation. It's basically almost 5x slower than the non-GPU implementation. My guess is that it's because I'm running things in WSL and I misconfigured something.

It'd be good to have someone running linux with a CUDA-compatible GPU to perform some bench here : o
