### PR TITLE
Account for lookup tables when computing the domain size

### DIFF
--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -653,10 +653,39 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
         // for some reason we need more than 1 gate for the circuit to work, see TODO below
         assert!(gates.len() > 1);
 
+        let lookup_features = LookupFeatures::from_gates(&gates, runtime_tables.is_some());
+
+        let num_lookups = {
+            let mut num_lookups: usize = lookup_tables
+                .iter()
+                .map(
+                    |LookupTable { data, id: _ }| {
+                        if data.len() > 0 {
+                            data[0].len()
+                        } else {
+                            0
+                        }
+                    },
+                )
+                .sum();
+            for runtime_table in runtime_tables.iter() {
+                num_lookups += runtime_table.len();
+            }
+            let LookupFeatures { patterns, .. } = &lookup_features;
+            for pattern in patterns.into_iter() {
+                if let Some(gate_table) = pattern.table() {
+                    num_lookups += gate_table.table_size();
+                }
+            }
+            num_lookups
+        };
+
         //~ 2. Create a domain for the circuit. That is,
         //~    compute the smallest subgroup of the field that
         //~    has order greater or equal to `n + ZK_ROWS` elements.
-        let domain = EvaluationDomains::<F>::create(gates.len() + ZK_ROWS as usize)?;
+        let domain_size_lower_bound =
+            std::cmp::max(gates.len(), num_lookups + 1) + ZK_ROWS as usize;
+        let domain = EvaluationDomains::<F>::create(domain_size_lower_bound)?;
 
         assert!(domain.d1.size > ZK_ROWS);
 
@@ -671,8 +700,6 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
             })
             .collect();
         gates.append(&mut padding);
-
-        let lookup_features = LookupFeatures::from_gates(&gates, runtime_tables.is_some());
 
         let mut feature_flags = FeatureFlags {
             range_check0: false,

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -660,10 +660,10 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
                 .iter()
                 .map(
                     |LookupTable { data, id: _ }| {
-                        if data.len() > 0 {
-                            data[0].len()
-                        } else {
+                        if data.is_empty() {
                             0
+                        } else {
+                            data[0].len()
                         }
                     },
                 )

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -66,6 +66,16 @@ pub fn get_table<F: FftField>(table_name: GateLookupTable) -> LookupTable<F> {
     }
 }
 
+impl GateLookupTable {
+    /// Returns the lookup table associated to a [`GateLookupTable`].
+    pub fn table_size(&self) -> usize {
+        match self {
+            GateLookupTable::Xor => xor::TABLE_SIZE,
+            GateLookupTable::RangeCheck => range_check::TABLE_SIZE,
+        }
+    }
+}
+
 /// Let's say we want to do a lookup in a "vector-valued" table `T: Vec<[F; n]>` (here I
 /// am using `[F; n]` to model a vector of length `n`).
 ///

--- a/kimchi/src/circuits/lookup/tables/range_check.rs
+++ b/kimchi/src/circuits/lookup/tables/range_check.rs
@@ -20,3 +20,5 @@ where
         data: table,
     }
 }
+
+pub const TABLE_SIZE: usize = RANGE_CHECK_UPPERBOUND as usize;

--- a/kimchi/src/circuits/lookup/tables/xor.rs
+++ b/kimchi/src/circuits/lookup/tables/xor.rs
@@ -42,3 +42,5 @@ pub fn xor_table<F: Field>() -> LookupTable<F> {
         data,
     }
 }
+
+pub const TABLE_SIZE: usize = 256;

--- a/kimchi/src/tests/and.rs
+++ b/kimchi/src/tests/and.rs
@@ -46,13 +46,7 @@ where
     EFrSponge: FrSponge<G::ScalarField>,
 {
     let mut gates = vec![];
-    let mut next_row = CircuitGate::<G::ScalarField>::extend_and(&mut gates, bytes);
-
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
-    }
+    let _next_row = CircuitGate::<G::ScalarField>::extend_and(&mut gates, bytes);
 
     gates
 }
@@ -140,13 +134,7 @@ where
 
     // Create
     let mut gates = vec![];
-    let mut next_row = CircuitGate::<G::ScalarField>::extend_and(&mut gates, bytes);
-
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
-    }
+    let _next_row = CircuitGate::<G::ScalarField>::extend_and(&mut gates, bytes);
 
     // Create inputs
     let input1 = rng.gen(None, Some(bytes * 8));

--- a/kimchi/src/tests/foreign_field_mul.rs
+++ b/kimchi/src/tests/foreign_field_mul.rs
@@ -7,7 +7,6 @@ use crate::{
         gate::{CircuitGate, CircuitGateError, CircuitGateResult, Connect, GateType},
         polynomial::COLUMNS,
         polynomials::{foreign_field_add::witness::FFOps, foreign_field_mul, range_check},
-        wires::Wire,
     },
     curve::KimchiCurve,
     plonk_sponge::FrSponge,
@@ -154,12 +153,6 @@ where
         gates.connect_cell_pair((1, 3), (22, 1));
         gates.connect_cell_pair((1, 4), (20, 0));
         external_checks.extend_witness_compact_multi_range_checks(&mut witness);
-    }
-
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
     }
 
     let runner = if full {

--- a/kimchi/src/tests/keccak.rs
+++ b/kimchi/src/tests/keccak.rs
@@ -16,12 +16,6 @@ type PallasField = <Pallas as AffineCurve>::BaseField;
 fn create_test_constraint_system() -> ConstraintSystem<Fp> {
     let (mut next_row, mut gates) = { CircuitGate::<Fp>::create_keccak(0) };
 
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
-    }
-
     ConstraintSystem::create(gates).build().unwrap()
 }
 

--- a/kimchi/src/tests/not.rs
+++ b/kimchi/src/tests/not.rs
@@ -82,22 +82,16 @@ fn create_test_constraint_system_not_xor<G: KimchiCurve, EFqSponge, EFrSponge>(
 where
     G::BaseField: PrimeField,
 {
-    let (mut next_row, mut gates) = {
+    let gates = {
         let mut gates = vec![CircuitGate::<G::ScalarField>::create_generic_gadget(
             Wire::for_row(0),
             GenericGateSpec::Pub,
             None,
         )];
-        let next_row =
+        let _next_row =
             CircuitGate::<G::ScalarField>::extend_not_gadget_checked_length(&mut gates, 0, bits);
-        (next_row, gates)
+        gates
     };
-
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
-    }
 
     ConstraintSystem::create(gates).public(1).build().unwrap()
 }
@@ -114,14 +108,8 @@ where
         GenericGateSpec::Pub,
         None,
     )];
-    let mut next_row =
+    let _next_row =
         CircuitGate::<G::ScalarField>::extend_not_gadget_unchecked_length(&mut gates, num_nots, 0);
-
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
-    }
 
     ConstraintSystem::create(gates).public(1).build().unwrap()
 }
@@ -282,21 +270,15 @@ fn test_prove_and_verify_not_xor() {
     let rng = &mut StdRng::from_seed(RNG_SEED);
 
     // Create circuit
-    let (mut next_row, mut gates) = {
+    let gates = {
         let mut gates = vec![CircuitGate::<Fp>::create_generic_gadget(
             Wire::for_row(0),
             GenericGateSpec::Pub,
             None,
         )];
-        let next_row = CircuitGate::<Fp>::extend_not_gadget_checked_length(&mut gates, 0, bits);
-        (next_row, gates)
+        let _next_row = CircuitGate::<Fp>::extend_not_gadget_checked_length(&mut gates, 0, bits);
+        gates
     };
-
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
-    }
 
     // Create witness and random inputs
 
@@ -321,21 +303,15 @@ fn test_prove_and_verify_five_not_gnrc() {
     let rng = &mut StdRng::from_seed(RNG_SEED);
 
     // Create circuit
-    let (mut next_row, mut gates) = {
+    let gates = {
         let mut gates = vec![CircuitGate::<Fp>::create_generic_gadget(
             Wire::for_row(0),
             GenericGateSpec::Pub,
             None,
         )];
-        let next_row = CircuitGate::<Fp>::extend_not_gadget_unchecked_length(&mut gates, 5, 0);
-        (next_row, gates)
+        let _next_row = CircuitGate::<Fp>::extend_not_gadget_unchecked_length(&mut gates, 5, 0);
+        gates
     };
-
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
-    }
 
     // Create witness and random inputs
     let witness: [Vec<PallasField>; 15] = create_not_witness_unchecked_length::<PallasField>(

--- a/kimchi/src/tests/range_check.rs
+++ b/kimchi/src/tests/range_check.rs
@@ -54,17 +54,11 @@ const RNG_SEED: [u8; 32] = [
 ];
 
 fn create_test_prover_index(public_size: usize, compact: bool) -> ProverIndex<Vesta> {
-    let (mut next_row, mut gates) = if compact {
+    let (_next_row, gates) = if compact {
         CircuitGate::<Fp>::create_compact_multi_range_check(0)
     } else {
         CircuitGate::<Fp>::create_multi_range_check(0)
     };
-
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
-    }
 
     new_index_for_test_with_lookups(
         gates,
@@ -1066,13 +1060,6 @@ fn verify_64_bit_range_check() {
     gates[1].wires[2] = Wire { row: 0, col: 0 };
     gates[0].wires[0] = Wire { row: 1, col: 1 };
 
-    // Temporary workaround for lookup-table/domain-size issue
-    let mut next_row = 2;
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
-    }
-
     // Create constraint system
     let cs =
         ConstraintSystem::<Fp>::create(gates /*, mina_poseidon::pasta::fp_kimchi::params()*/)
@@ -1232,13 +1219,7 @@ fn verify_compact_multi_range_check_proof() {
     // Create witness
     let witness = range_check::witness::create_multi_compact_limbs::<PallasField>(&limbs);
 
-    let (mut next_row, mut gates) = CircuitGate::<Fp>::create_compact_multi_range_check(0);
-
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
-    }
+    let (_next_row, gates) = CircuitGate::<Fp>::create_compact_multi_range_check(0);
 
     assert!(TestFramework::<Vesta>::default()
         .gates(gates)

--- a/kimchi/src/tests/rot.rs
+++ b/kimchi/src/tests/rot.rs
@@ -81,12 +81,7 @@ where
     G::BaseField: PrimeField,
 {
     // gate for the zero value
-    let mut gates = create_rot_gadget::<G>(rot, side);
-
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(gates.len())));
-    }
+    let gates = create_rot_gadget::<G>(rot, side);
 
     ConstraintSystem::create(gates).build().unwrap()
 }
@@ -101,12 +96,7 @@ where
     let rng = &mut StdRng::from_seed(RNG_SEED);
     let rot = rng.gen_range(1..64);
     // Create
-    let mut gates = create_rot_gadget::<G>(rot, RotMode::Left);
-
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(gates.len())));
-    }
+    let gates = create_rot_gadget::<G>(rot, RotMode::Left);
 
     // Create input
     let word = rng.gen_range(0..2u128.pow(64)) as u64;
@@ -320,11 +310,6 @@ fn test_rot_finalization() {
         CircuitGate::<Fp>::extend_rot(&mut gates, rot, mode, 1);
         // connect first public input to the word of the ROT
         gates.connect_cell_pair((0, 0), (2, 0));
-
-        // Temporary workaround for lookup-table/domain-size issue
-        for _ in 0..(1 << 13) {
-            gates.push(CircuitGate::zero(Wire::for_row(gates.len())));
-        }
 
         gates
     };

--- a/kimchi/src/tests/xor.rs
+++ b/kimchi/src/tests/xor.rs
@@ -55,13 +55,7 @@ where
     G::BaseField: PrimeField,
 {
     let mut gates = vec![];
-    let mut next_row = CircuitGate::<G::ScalarField>::extend_xor_gadget(&mut gates, bits);
-
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
-    }
+    let _next_row = CircuitGate::<G::ScalarField>::extend_xor_gadget(&mut gates, bits);
 
     ConstraintSystem::create(gates).build().unwrap()
 }
@@ -172,13 +166,7 @@ fn test_prove_and_verify_xor() {
     let bits = 64;
     // Create
     let mut gates = vec![];
-    let mut next_row = CircuitGate::<Fp>::extend_xor_gadget(&mut gates, bits);
-
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
-    }
+    let _next_row = CircuitGate::<Fp>::extend_xor_gadget(&mut gates, bits);
 
     let input1 = rng.gen_field_with_bits(bits);
     let input2 = rng.gen_field_with_bits(bits);
@@ -321,16 +309,10 @@ fn test_extend_xor() {
             None,
         ));
     }
-    let mut next_row = CircuitGate::<PallasField>::extend_xor_gadget(&mut gates, bits);
+    let _next_row = CircuitGate::<PallasField>::extend_xor_gadget(&mut gates, bits);
     // connect public input
     gates.connect_cell_pair((0, 0), (2, 0));
     gates.connect_cell_pair((1, 0), (2, 1));
-
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
-    }
 
     let cs = ConstraintSystem::create(gates).public(2).build().unwrap();
 
@@ -362,12 +344,7 @@ fn test_bad_xor() {
     let bits = max(bits, max(bits1, bits2));
 
     let mut gates = vec![];
-    let mut next_row = CircuitGate::<PallasField>::extend_xor_gadget(&mut gates, bits);
-    // Temporary workaround for lookup-table/domain-size issue
-    for _ in 0..(1 << 13) {
-        gates.push(CircuitGate::zero(Wire::for_row(next_row)));
-        next_row += 1;
-    }
+    let _next_row = CircuitGate::<PallasField>::extend_xor_gadget(&mut gates, bits);
 
     let mut witness = xor::create_xor_witness(input1, input2, bits);
 
@@ -410,11 +387,6 @@ fn test_xor_finalization() {
         // connect public inputs to the inputs of the XOR
         gates.connect_cell_pair((0, 0), (2, 0));
         gates.connect_cell_pair((1, 0), (2, 1));
-
-        // Temporary workaround for lookup-table/domain-size issue
-        for _ in 0..(1 << 13) {
-            gates.push(CircuitGate::zero(Wire::for_row(gates.len())));
-        }
         gates
     };
 


### PR DESCRIPTION
This PR builds upon #1014, using the size of the lookup tables to calculate the domain size required for a proof. The domain size is now at least `max(num_gates, num_lookups+1)+ZK_ROWS`.

This PR also removes the copy-pasted `1 << 13` padding from a large number of tests. Despite mostly using smaller lookup tables, it seems that this was blindly pasted everywhere, which contributed at least in part to the slow tests in CI.