### PR TITLE
Stop re-running a whole test setup for small tweaks to the witness

### DIFF
--- a/kimchi/src/circuits/lookup/runtime_tables.rs
+++ b/kimchi/src/circuits/lookup/runtime_tables.rs
@@ -21,6 +21,7 @@ pub struct RuntimeTableSpec {
 /// Use this type at setup time, to list all the runtime tables.
 ///
 /// Note: care must be taken as table IDs can collide with IDs of other types of lookup tables.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RuntimeTableCfg<F> {
     /// An indexed runtime table has a counter (starting at zero) in its first column.
     Indexed(RuntimeTableSpec),

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 /// The index used by the prover
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 //~spec:startcode
 pub struct ProverIndex<G: KimchiCurve> {
     /// constraints system polynomials

--- a/kimchi/src/tests/framework.rs
+++ b/kimchi/src/tests/framework.rs
@@ -25,7 +25,7 @@ use std::{fmt::Write, mem, time::Instant};
 
 // aliases
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub(crate) struct TestFramework<G: KimchiCurve> {
     gates: Option<Vec<CircuitGate<G::ScalarField>>>,
     witness: Option<[Vec<G::ScalarField>; COLUMNS]>,
@@ -41,6 +41,7 @@ pub(crate) struct TestFramework<G: KimchiCurve> {
     verifier_index: Option<VerifierIndex<G>>,
 }
 
+#[derive(Clone)]
 pub(crate) struct TestRunner<G: KimchiCurve>(TestFramework<G>);
 
 impl<G: KimchiCurve> TestFramework<G>
@@ -138,6 +139,12 @@ where
     #[must_use]
     pub(crate) fn recursion(mut self, recursion: Vec<RecursionChallenge<G>>) -> Self {
         self.0.recursion = recursion;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn witness(mut self, witness: [Vec<G::ScalarField>; COLUMNS]) -> Self {
+        self.0.witness = Some(witness);
         self
     }
 

--- a/kimchi/src/tests/range_check.rs
+++ b/kimchi/src/tests/range_check.rs
@@ -574,7 +574,7 @@ fn verify_range_check0_v0_test_lookups() {
     );
 
     let test_runner = TestFramework::<Vesta>::default()
-        .gates(index.cs.gates.clone())
+        .gates(index.cs.gates)
         .setup();
 
     for i in 3..=6 {
@@ -627,7 +627,7 @@ fn verify_range_check0_v1_test_lookups() {
     );
 
     let test_runner = TestFramework::<Vesta>::default()
-        .gates(index.cs.gates.clone())
+        .gates(index.cs.gates)
         .setup();
 
     for i in 3..=6 {
@@ -981,7 +981,7 @@ fn verify_range_check1_test_curr_row_lookups() {
     );
 
     let test_runner = TestFramework::<Vesta>::default()
-        .gates(index.cs.gates.clone())
+        .gates(index.cs.gates)
         .setup();
 
     for i in 3..=6 {
@@ -1030,7 +1030,7 @@ fn verify_range_check1_test_next_row_lookups() {
     );
 
     let test_runner = TestFramework::<Vesta>::default()
-        .gates(index.cs.gates.clone())
+        .gates(index.cs.gates)
         .setup();
 
     for row in 0..=1 {

--- a/kimchi/src/tests/range_check.rs
+++ b/kimchi/src/tests/range_check.rs
@@ -555,25 +555,31 @@ fn verify_range_check0_test_copy_constraints() {
 fn verify_range_check0_v0_test_lookups() {
     let index = create_test_prover_index(0, false);
 
+    let witness = range_check::witness::create_multi::<PallasField>(
+        PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
+        PallasField::zero(),
+        PallasField::zero(),
+    );
+
+    // Positive test
+    // gates[0] is RangeCheck0 and constrains some of v0
+    assert_eq!(
+        index.cs.gates[0].verify_witness::<Vesta>(
+            0,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public]
+        ),
+        Ok(())
+    );
+
+    let test_runner = TestFramework::<Vesta>::default()
+        .gates(index.cs.gates.clone())
+        .setup();
+
     for i in 3..=6 {
         // Test ith lookup
-        let mut witness = range_check::witness::create_multi::<PallasField>(
-            PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
-            PallasField::zero(),
-            PallasField::zero(),
-        );
-
-        // Positive test
-        // gates[0] is RangeCheck0 and constrains some of v0
-        assert_eq!(
-            index.cs.gates[0].verify_witness::<Vesta>(
-                0,
-                &witness,
-                &index.cs,
-                &witness[0][0..index.cs.public]
-            ),
-            Ok(())
-        );
+        let mut witness = witness.clone();
 
         // Negative test
         // Make ith plookup limb out of range while keeping the
@@ -587,10 +593,9 @@ fn verify_range_check0_v0_test_lookups() {
 
         // Perform test that will catch invalid plookup constraints
         assert_eq!(
-            TestFramework::<Vesta>::default()
-                .gates(index.cs.gates.clone())
-                .witness(witness.clone())
-                .setup()
+            test_runner
+                .clone()
+                .witness(witness)
                 .prove_and_verify::<BaseSponge, ScalarSponge>(),
             Err(String::from(
                 "the lookup failed to find a match in the table"
@@ -603,25 +608,31 @@ fn verify_range_check0_v0_test_lookups() {
 fn verify_range_check0_v1_test_lookups() {
     let index = create_test_prover_index(0, false);
 
+    let witness = range_check::witness::create_multi::<PallasField>(
+        PallasField::zero(),
+        PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
+        PallasField::zero(),
+    );
+
+    // Positive test
+    // gates[1] is RangeCheck0 and constrains some of v1
+    assert_eq!(
+        index.cs.gates[1].verify_witness::<Vesta>(
+            1,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public]
+        ),
+        Ok(())
+    );
+
+    let test_runner = TestFramework::<Vesta>::default()
+        .gates(index.cs.gates.clone())
+        .setup();
+
     for i in 3..=6 {
         // Test ith lookup
-        let mut witness = range_check::witness::create_multi::<PallasField>(
-            PallasField::zero(),
-            PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
-            PallasField::zero(),
-        );
-
-        // Positive test
-        // gates[1] is RangeCheck0 and constrains some of v1
-        assert_eq!(
-            index.cs.gates[1].verify_witness::<Vesta>(
-                1,
-                &witness,
-                &index.cs,
-                &witness[0][0..index.cs.public]
-            ),
-            Ok(())
-        );
+        let mut witness = witness.clone();
 
         // Negative test
         // Make ith plookup limb out of range while keeping the
@@ -635,10 +646,9 @@ fn verify_range_check0_v1_test_lookups() {
 
         // Perform test that will catch invalid plookup constraints
         assert_eq!(
-            TestFramework::<Vesta>::default()
-                .gates(index.cs.gates.clone())
-                .witness(witness.clone())
-                .setup()
+            test_runner
+                .clone()
+                .witness(witness)
                 .prove_and_verify::<BaseSponge, ScalarSponge>(),
             Err(String::from(
                 "the lookup failed to find a match in the table"
@@ -952,26 +962,31 @@ fn verify_range_check1_test_copy_constraints() {
 #[test]
 fn verify_range_check1_test_curr_row_lookups() {
     let index = create_test_prover_index(0, false);
+    let witness = range_check::witness::create_multi::<PallasField>(
+        PallasField::zero(),
+        PallasField::zero(),
+        PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
+    );
+
+    // Positive test
+    // gates[2] is RangeCheck1 and constrains v2
+    assert_eq!(
+        index.cs.gates[2].verify_witness::<Vesta>(
+            2,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public]
+        ),
+        Ok(())
+    );
+
+    let test_runner = TestFramework::<Vesta>::default()
+        .gates(index.cs.gates.clone())
+        .setup();
 
     for i in 3..=6 {
         // Test ith lookup (impacts v2)
-        let mut witness = range_check::witness::create_multi::<PallasField>(
-            PallasField::zero(),
-            PallasField::zero(),
-            PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
-        );
-
-        // Positive test
-        // gates[2] is RangeCheck1 and constrains v2
-        assert_eq!(
-            index.cs.gates[2].verify_witness::<Vesta>(
-                2,
-                &witness,
-                &index.cs,
-                &witness[0][0..index.cs.public]
-            ),
-            Ok(())
-        );
+        let mut witness = witness.clone();
 
         // Negative test
         // Make ith plookup limb out of range while keeping the
@@ -981,10 +996,9 @@ fn verify_range_check1_test_curr_row_lookups() {
 
         // Perform test that will catch invalid plookup constraints
         assert_eq!(
-            TestFramework::<Vesta>::default()
-                .gates(index.cs.gates.clone())
+            test_runner
+                .clone()
                 .witness(witness.clone())
-                .setup()
                 .prove_and_verify::<BaseSponge, ScalarSponge>(),
             Err(String::from(
                 "the lookup failed to find a match in the table"
@@ -997,25 +1011,31 @@ fn verify_range_check1_test_curr_row_lookups() {
 fn verify_range_check1_test_next_row_lookups() {
     let index = create_test_prover_index(0, false);
 
+    let witness = range_check::witness::create_multi::<PallasField>(
+        PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
+        PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
+        PallasField::zero(),
+    );
+
+    // Positive test case (gates[2] is RangeCheck1 and constrains
+    // both v0's and v1's lookups that are deferred to 4th row)
+    assert_eq!(
+        index.cs.gates[2].verify_witness::<Vesta>(
+            2,
+            &witness,
+            &index.cs,
+            &witness[0][0..index.cs.public]
+        ),
+        Ok(())
+    );
+
+    let test_runner = TestFramework::<Vesta>::default()
+        .gates(index.cs.gates.clone())
+        .setup();
+
     for row in 0..=1 {
         for col in 1..=2 {
-            let mut witness = range_check::witness::create_multi::<PallasField>(
-                PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
-                PallasField::from(2u64).pow([88]) - PallasField::one(), // in range
-                PallasField::zero(),
-            );
-
-            // Positive test case (gates[2] is RangeCheck1 and constrains
-            // both v0's and v1's lookups that are deferred to 4th row)
-            assert_eq!(
-                index.cs.gates[2].verify_witness::<Vesta>(
-                    2,
-                    &witness,
-                    &index.cs,
-                    &witness[0][0..index.cs.public]
-                ),
-                Ok(())
-            );
+            let mut witness = witness.clone();
 
             // Negative test by making plookup limb out of range
             // while also assuring the rest of the witness is still valid
@@ -1030,10 +1050,9 @@ fn verify_range_check1_test_next_row_lookups() {
 
             // Perform test that will catch invalid plookup constraints
             assert_eq!(
-                TestFramework::<Vesta>::default()
-                    .gates(index.cs.gates.clone())
+                test_runner
+                    .clone()
                     .witness(witness.clone())
-                    .setup()
                     .prove_and_verify::<BaseSponge, ScalarSponge>(),
                 Err(String::from(
                     "the lookup failed to find a match in the table"


### PR DESCRIPTION
This PR restructures some tests to be less wasteful. Previously, they were taking about 3-4 mins each on CI because of poor caching.