### PR TITLE
Use batch inversion for additive lookup inverses

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,6 +75,12 @@ jobs:
           command: fmt
           args: -- --check
 
+      - name: Setup OCaml
+        run: |
+          sudo apt update
+          sudo apt install -y ocaml
+
+
       - name: Lint (clippy)
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
This PR is a follow-up tweak to #1001. This
* uses batch inversion to compute the table inverses
* restructures the aggregation code so that no extra inversions need to be done for individual lookups

This also adds the comments, and restructures the aggregation in a form that (IMO) makes it easier to follow the logic.