### PR TITLE
Constrain inversions in batches of 6 in additive lookups

### DIFF
--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -167,7 +167,8 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
                 LookupConfiguration::new(LookupInfo::create(feature_flags.lookup_features));
 
             {
-                let constraints = additive_lookup::constraints(&lookup_configuration, false);
+                let constraints =
+                    additive_lookup::constraints(&lookup_configuration, false, &mut cache);
                 let constraints_len = u32::try_from(constraints.len())
                     .expect("we always expect a relatively low amount of constraints");
 
@@ -194,7 +195,7 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
         let lookup_configuration = LookupConfiguration::new(LookupInfo::create(all_features));
 
         {
-            let constraints = additive_lookup::constraints(&lookup_configuration, true);
+            let constraints = additive_lookup::constraints(&lookup_configuration, true, &mut cache);
             let constraints_len = u32::try_from(constraints.len())
                 .expect("we always expect a relatively low amount of constraints");
 
@@ -286,7 +287,7 @@ pub fn linearization_columns<F: FftField + SquareRootField>(
 
     // the lookup polynomials
     if let Some(lookup_info) = lookup_info {
-        for i in 0..=lookup_info.max_per_row {
+        for i in 0..additive_lookup::num_inverses_columns(&lookup_info) {
             h.insert(AdditiveLookupInverse(i));
         }
         h.insert(LookupTable);

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -728,7 +728,8 @@ where
             // additive lookup
             {
                 if let Some(lcs) = index.cs.lookup_constraint_system.as_ref() {
-                    let constraints = additive_lookup::constraints(&lcs.configuration, false);
+                    let constraints =
+                        additive_lookup::constraints(&lcs.configuration, false, &mut cache);
                     let constraints_len = u32::try_from(constraints.len())
                         .expect("not expecting a large amount of constraints");
                     let lookup_alphas =


### PR DESCRIPTION
This PR builds on #1019, which in turn builds on #1018, #1017, #1001.

This modifies the inversion constraints, changing them from
```
inverse = 1/lookup
```
to
```
inverse = 1/lookup_0 + ... + 1/lookup_5
```

Since we can't do inversions, instead we multiply across by the common denominator, giving
```
  lookup_0 * lookup_1 * lookup_2 * lookup_3 * lookup_4 * lookup_5 * inverse
= lookup_1 * lookup_2 * lookup_3 * lookup_4 * lookup_5
+ lookup_0 * lookup_2 * lookup_3 * lookup_4 * lookup_5
+ lookup_0 * lookup_1 * lookup_3 * lookup_4 * lookup_5
+ lookup_0 * lookup_1 * lookup_2 * lookup_4 * lookup_5
+ lookup_0 * lookup_1 * lookup_2 * lookup_3 * lookup_5
+ lookup_0 * lookup_1 * lookup_2 * lookup_3 * lookup_4
```

We choose 6 to ensure that we can multiply 6 lookups, the inverse, and the lookup selector without breaking through the 8n domain size limit.