### PR TITLE
Figure out what's broken in CI (and fix it)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,11 @@ jobs:
         run: |
           npm install -g markdownlint-cli
 
+      - name: Setup OCaml (because of ocaml-gen)
+        run: |
+          sudo apt update
+          sudo apt install -y ocaml
+
       # https://github.com/Swatinem/rust-cache
       - name: Cache Rust stuff
         uses: Swatinem/rust-cache@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,8 @@ To scan for lints:
 cargo clippy --all-features --tests --all-targets -- -D warnings
 ```
 
+Note: cargo can automatically fix some lints. To do so, add `--fix` to the above command (as the first parameter).
+
 Finally, to check formatting:
 ```bash
 cargo fmt


### PR DESCRIPTION
CI is failing with
```
error: failed to run custom build command for `ocaml-sys v0.22.3`
```
even for things like adding a line to a markdown file.

This PR is to figure out why and hopefully fix it.
