### PR TITLE
Tweak tests to emit useful errors

### DIFF
--- a/kimchi/src/snarky/constraint_system.rs
+++ b/kimchi/src/snarky/constraint_system.rs
@@ -944,7 +944,7 @@ impl<Field: PrimeField> SnarkyConstraintSystem<Field> {
                             if !s1.is_zero() {
                                 self.union_find(x1);
                                 self.union_find(x2);
-                                assert!(self.union_finds.union(x1, x2).is_ok());
+                                self.union_finds.union(x1, x2).unwrap();
                             };
                         } else if
                         /* s1 x1 - s2 x2 = 0 */
@@ -974,7 +974,7 @@ impl<Field: PrimeField> SnarkyConstraintSystem<Field> {
                                 let x2 = x2.clone();
                                 self.union_find(x1);
                                 self.union_find(x2);
-                                assert!(self.union_finds.union(x1, x2).is_ok());
+                                self.union_finds.union(x1, x2).unwrap();
                             }
                             None => {
                                 self.add_generic_constraint(
@@ -997,7 +997,7 @@ impl<Field: PrimeField> SnarkyConstraintSystem<Field> {
                                 let x1 = x1.clone();
                                 self.union_find(x1);
                                 self.union_find(x2);
-                                assert!(self.union_finds.union(x1, x2).is_ok());
+                                self.union_finds.union(x1, x2).unwrap();
                             }
                             None => {
                                 self.add_generic_constraint(

--- a/kimchi/src/tests/and.rs
+++ b/kimchi/src/tests/and.rs
@@ -143,12 +143,12 @@ where
     // Create witness
     let witness = and::create_and_witness(input1, input2, bytes);
 
-    assert!(TestFramework::<G>::default()
+    TestFramework::<G>::default()
         .gates(gates)
         .witness(witness)
         .setup()
         .prove_and_verify::<EFqSponge, EFrSponge>()
-        .is_ok());
+        .unwrap();
 }
 
 #[test]

--- a/kimchi/src/tests/ec.rs
+++ b/kimchi/src/tests/ec.rs
@@ -145,10 +145,10 @@ fn ec_test() {
         witness[14].push(F::zero());
     }
 
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }

--- a/kimchi/src/tests/endomul.rs
+++ b/kimchi/src/tests/endomul.rs
@@ -110,10 +110,10 @@ fn endomul_test() {
         assert_eq!(x.into_repr(), res.n.into_repr());
     }
 
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }

--- a/kimchi/src/tests/endomul_scalar.rs
+++ b/kimchi/src/tests/endomul_scalar.rs
@@ -64,10 +64,10 @@ fn endomul_scalar_test() {
         );
     }
 
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }

--- a/kimchi/src/tests/foreign_field_add.rs
+++ b/kimchi/src/tests/foreign_field_add.rs
@@ -1277,13 +1277,13 @@ fn prove_and_verify(operation_count: usize) {
     // Create witness
     let witness = short_witness(&inputs, &operations, foreign_field_modulus);
 
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .public_inputs(vec![PallasField::one()])
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }
 
 // Prove and verify a randomly generated operation (only ffadd)
@@ -1529,11 +1529,11 @@ fn test_ffadd_finalization() {
         );
     }
 
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness.clone())
         .public_inputs(vec![witness[0][0]])
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }

--- a/kimchi/src/tests/generic.rs
+++ b/kimchi/src/tests/generic.rs
@@ -22,12 +22,12 @@ fn test_generic_gate() {
     fill_in_witness(0, &mut witness, &[]);
 
     // create and verify proof based on the witness
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }
 
 #[test]
@@ -40,13 +40,13 @@ fn test_generic_gate_pub() {
     fill_in_witness(0, &mut witness, &public);
 
     // create and verify proof based on the witness
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .public_inputs(public)
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }
 
 #[test]
@@ -59,13 +59,13 @@ fn test_generic_gate_pub_all_zeros() {
     fill_in_witness(0, &mut witness, &public);
 
     // create and verify proof based on the witness
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .public_inputs(public)
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }
 
 #[test]
@@ -78,11 +78,11 @@ fn test_generic_gate_pub_empty() {
     fill_in_witness(0, &mut witness, &public);
 
     // create and verify proof based on the witness
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .public_inputs(public)
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }

--- a/kimchi/src/tests/lookup.rs
+++ b/kimchi/src/tests/lookup.rs
@@ -94,13 +94,13 @@ fn setup_lookup_proof(use_values_from_table: bool, num_lookups: usize, table_siz
         ]
     };
 
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .lookup_tables(lookup_tables)
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }
 
 #[test]
@@ -186,14 +186,14 @@ fn runtime_table(num: usize, indexed: bool) {
     print_witness(&witness, 0, 20);
 
     // run test
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .runtime_tables_setup(runtime_tables_setup)
         .setup()
         .runtime_tables(runtime_tables)
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }
 
 #[test]

--- a/kimchi/src/tests/not.rs
+++ b/kimchi/src/tests/not.rs
@@ -285,7 +285,7 @@ fn test_prove_and_verify_not_xor() {
     let witness =
         create_not_witness_checked_length::<PallasField>(rng.gen_field_with_bits(bits), Some(bits));
 
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .public_inputs(vec![
@@ -293,7 +293,7 @@ fn test_prove_and_verify_not_xor() {
         ])
         .setup()
         .prove_and_verify::<VestaBaseSponge, VestaScalarSponge>()
-        .is_ok());
+        .unwrap();
 }
 
 #[test]
@@ -321,7 +321,7 @@ fn test_prove_and_verify_five_not_gnrc() {
         bits,
     );
 
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .public_inputs(vec![
@@ -329,7 +329,7 @@ fn test_prove_and_verify_five_not_gnrc() {
         ])
         .setup()
         .prove_and_verify::<VestaBaseSponge, VestaScalarSponge>()
-        .is_ok());
+        .unwrap();
 }
 
 #[test]

--- a/kimchi/src/tests/poseidon.rs
+++ b/kimchi/src/tests/poseidon.rs
@@ -81,10 +81,10 @@ fn test_poseidon() {
         );
     }
 
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }

--- a/kimchi/src/tests/range_check.rs
+++ b/kimchi/src/tests/range_check.rs
@@ -1224,7 +1224,7 @@ fn verify_range_check_valid_proof1() {
         &public_input,
     );
 
-    assert!(res.is_ok());
+    res.unwrap();
 }
 
 #[test]
@@ -1240,10 +1240,10 @@ fn verify_compact_multi_range_check_proof() {
 
     let (_next_row, gates) = CircuitGate::<Fp>::create_compact_multi_range_check(0);
 
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }

--- a/kimchi/src/tests/recursion.rs
+++ b/kimchi/src/tests/recursion.rs
@@ -48,8 +48,8 @@ fn test_recursion() {
         RecursionChallenge::new(chals, comm)
     };
 
-    assert!(test_runner
+    test_runner
         .recursion(vec![prev_challenges])
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }

--- a/kimchi/src/tests/rot.rs
+++ b/kimchi/src/tests/rot.rs
@@ -104,12 +104,12 @@ where
     // Create witness
     let witness = create_rot_witness::<G>(word, rot, RotMode::Left);
 
-    assert!(TestFramework::<G>::default()
+    TestFramework::<G>::default()
         .gates(gates)
         .witness(witness)
         .setup()
         .prove_and_verify::<EFqSponge, EFrSponge>()
-        .is_ok());
+        .unwrap();
 }
 
 #[test]
@@ -353,11 +353,11 @@ fn test_rot_finalization() {
         );
     }
 
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness.clone())
         .public_inputs(vec![witness[0][0], witness[0][1]])
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }

--- a/kimchi/src/tests/varbasemul.rs
+++ b/kimchi/src/tests/varbasemul.rs
@@ -89,10 +89,10 @@ fn varbase_mul_test() {
         start.elapsed()
     );
 
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }

--- a/kimchi/src/tests/xor.rs
+++ b/kimchi/src/tests/xor.rs
@@ -174,12 +174,12 @@ fn test_prove_and_verify_xor() {
     // Create witness and random inputs
     let witness = xor::create_xor_witness(input1, input2, bits);
 
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness)
         .setup()
         .prove_and_verify::<VestaBaseSponge, VestaScalarSponge>()
-        .is_ok());
+        .unwrap();
 }
 
 #[test]
@@ -430,11 +430,11 @@ fn test_xor_finalization() {
         );
     }
 
-    assert!(TestFramework::<Vesta>::default()
+    TestFramework::<Vesta>::default()
         .gates(gates)
         .witness(witness.clone())
         .public_inputs(vec![witness[0][0], witness[0][1]])
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
-        .is_ok());
+        .unwrap();
 }


### PR DESCRIPTION
This replaces the `assert!(foo.is_ok())` in tests with `foo.unwrap()`, emitting the underlying error message instead of a non-descriptive assertion.