### PR TITLE
Evaluate varbasemul selector

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1969,6 +1969,8 @@ pub struct ProofEvaluations<Evals> {
     pub generic_selector: Evals,
     /// evaluation of the poseidon selector polynomial
     pub poseidon_selector: Evals,
+    /// evaluation of the varbasemul selector polynomial
+    pub varbasemul_selector: Evals,
 }
 
 /// Commitments linked to the lookup feature

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -675,6 +675,7 @@ impl Variable {
                 LookupRuntimeTable => l.and_then(|l| l.runtime.ok_or(ExprError::MissingRuntime)),
                 Index(GateType::Poseidon) => Ok(evals.poseidon_selector),
                 Index(GateType::Generic) => Ok(evals.generic_selector),
+                Index(GateType::VarBaseMul) => Ok(evals.varbasemul_selector),
                 Permutation(i) => Ok(evals.s[i]),
                 Coefficient(i) => Ok(evals.coefficients[i]),
                 LookupKindIndex(_) | LookupRuntimeSelector | Index(_) => {

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -305,6 +305,8 @@ pub fn linearization_columns<F: FftField + SquareRootField>(
     // the generic selector polynomial
     h.insert(Index(GateType::Generic));
 
+    h.insert(Index(GateType::VarBaseMul));
+
     h
 }
 

--- a/kimchi/src/plonk_sponge.rs
+++ b/kimchi/src/plonk_sponge.rs
@@ -67,9 +67,10 @@ impl<Fr: PrimeField> FrSponge<Fr> for DefaultFrSponge<Fr, SC> {
             lookup,
             generic_selector,
             poseidon_selector,
+            varbasemul_selector,
         } = e;
 
-        let mut points = vec![z, generic_selector, poseidon_selector];
+        let mut points = vec![z, generic_selector, poseidon_selector, varbasemul_selector];
         w.iter().for_each(|w_i| points.push(w_i));
         coefficients.iter().for_each(|c_i| points.push(c_i));
         s.iter().for_each(|s_i| points.push(s_i));

--- a/kimchi/src/proof.rs
+++ b/kimchi/src/proof.rs
@@ -76,6 +76,8 @@ pub struct ProofEvaluations<Evals> {
     pub generic_selector: Evals,
     /// evaluation of the poseidon selector polynomial
     pub poseidon_selector: Evals,
+    /// evaluation of the varbasemul selector polynomial
+    pub varbasemul_selector: Evals,
 }
 
 /// Commitments linked to the lookup feature
@@ -205,6 +207,7 @@ impl<Eval> ProofEvaluations<Eval> {
             lookup,
             generic_selector,
             poseidon_selector,
+            varbasemul_selector,
         } = self;
         ProofEvaluations {
             w: w.map(f),
@@ -214,6 +217,7 @@ impl<Eval> ProofEvaluations<Eval> {
             lookup: lookup.map(|x| LookupEvaluations::map(x, f)),
             generic_selector: f(generic_selector),
             poseidon_selector: f(poseidon_selector),
+            varbasemul_selector: f(varbasemul_selector),
         }
     }
 
@@ -226,6 +230,7 @@ impl<Eval> ProofEvaluations<Eval> {
             lookup,
             generic_selector,
             poseidon_selector,
+            varbasemul_selector,
         } = self;
         ProofEvaluations {
             w: [
@@ -267,6 +272,7 @@ impl<Eval> ProofEvaluations<Eval> {
             lookup: lookup.as_ref().map(|l| l.map_ref(f)),
             generic_selector: f(generic_selector),
             poseidon_selector: f(poseidon_selector),
+            varbasemul_selector: f(varbasemul_selector),
         }
     }
 }
@@ -289,6 +295,7 @@ impl<F> ProofEvaluations<F> {
         ProofEvaluations {
             generic_selector: array::from_fn(|i| &evals[i].generic_selector),
             poseidon_selector: array::from_fn(|i| &evals[i].poseidon_selector),
+            varbasemul_selector: array::from_fn(|i| &evals[i].varbasemul_selector),
             z: array::from_fn(|i| &evals[i].z),
             w: array::from_fn(|j| array::from_fn(|i| &evals[i].w[j])),
             s: array::from_fn(|j| array::from_fn(|i| &evals[i].s[j])),
@@ -380,6 +387,7 @@ impl<F: Zero + Copy> ProofEvaluations<PointEvaluations<F>> {
             lookup: None,
             generic_selector: pt(F::zero(), F::zero()),
             poseidon_selector: pt(F::zero(), F::zero()),
+            varbasemul_selector: pt(F::zero(), F::zero()),
         }
     }
 }
@@ -406,6 +414,7 @@ impl<F> ProofEvaluations<F> {
             Column::LookupRuntimeTable => Some(self.lookup.as_ref()?.runtime.as_ref()?),
             Column::Index(GateType::Generic) => Some(&self.generic_selector),
             Column::Index(GateType::Poseidon) => Some(&self.poseidon_selector),
+            Column::Index(GateType::VarBaseMul) => Some(&self.varbasemul_selector),
             Column::Index(_) => None,
             Column::Coefficient(i) => Some(&self.coefficients[i]),
             Column::Permutation(i) => Some(&self.s[i]),
@@ -570,6 +579,7 @@ pub mod caml {
 
         pub generic_selector: PointEvaluations<Vec<CamlF>>,
         pub poseidon_selector: PointEvaluations<Vec<CamlF>>,
+        pub varbasemul_selector: PointEvaluations<Vec<CamlF>>,
     }
 
     //
@@ -708,6 +718,9 @@ pub mod caml {
                 poseidon_selector: pe
                     .poseidon_selector
                     .map(&|x| x.into_iter().map(Into::into).collect()),
+                varbasemul_selector: pe
+                    .varbasemul_selector
+                    .map(&|x| x.into_iter().map(Into::into).collect()),
                 lookup: pe.lookup.map(Into::into),
             }
         }
@@ -802,6 +815,9 @@ pub mod caml {
                     .map(&|x| x.into_iter().map(Into::into).collect()),
                 poseidon_selector: cpe
                     .poseidon_selector
+                    .map(&|x| x.into_iter().map(Into::into).collect()),
+                varbasemul_selector: cpe
+                    .varbasemul_selector
                     .map(&|x| x.into_iter().map(Into::into).collect()),
                 lookup: cpe.lookup.map(Into::into),
             }

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1138,6 +1138,11 @@ where
             None,
             fixed_hiding(1),
         ));
+        polynomials.push((
+            evaluations_form(&index.column_evaluations.mul_selector8),
+            None,
+            fixed_hiding(1),
+        ));
         polynomials.extend(
             witness_poly
                 .iter()

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -957,6 +957,9 @@ where
             poseidon_selector: chunked_evals_for_selector(
                 &index.column_evaluations.poseidon_selector8,
             ),
+            varbasemul_selector: chunked_evals_for_selector(
+                &index.column_evaluations.mul_selector8,
+            ),
         };
 
         let zeta_to_srs_len = zeta.pow([index.max_poly_size as u64]);

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -512,6 +512,7 @@ where
         lookup,
         generic_selector,
         poseidon_selector,
+        varbasemul_selector,
     } = &proof.evals;
 
     let check_eval_len = |eval: &PointEvaluations<Vec<_>>| -> Result<()> {
@@ -550,6 +551,7 @@ where
     }
     check_eval_len(generic_selector)?;
     check_eval_len(poseidon_selector)?;
+    check_eval_len(varbasemul_selector)?;
 
     Ok(())
 }

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -428,6 +428,7 @@ where
                 Column::Z,
                 Column::Index(GateType::Generic),
                 Column::Index(GateType::Poseidon),
+                Column::Index(GateType::VarBaseMul),
             ]
             .into_iter()
             .chain((0..COLUMNS).map(Column::Witness))
@@ -742,6 +743,7 @@ where
         //~~ * index commitments that use the coefficients
         Column::Index(GateType::Generic),
         Column::Index(GateType::Poseidon),
+        Column::Index(GateType::VarBaseMul),
     ]
     .into_iter()
     //~~ * witness commitments

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -237,9 +237,10 @@ impl<G: KimchiCurve> ProverIndex<G> {
                 domain,
                 &self.column_evaluations.complete_add_selector4,
             ),
-            mul_comm: self
-                .srs
-                .commit_evaluations_non_hiding(domain, &self.column_evaluations.mul_selector8),
+            mul_comm: mask_fixed(
+                self.srs
+                    .commit_evaluations_non_hiding(domain, &self.column_evaluations.mul_selector8),
+            ),
             emul_comm: self
                 .srs
                 .commit_evaluations_non_hiding(domain, &self.column_evaluations.emul_selector8),


### PR DESCRIPTION
This PR builds on #1048, proving that it allows us to finally evaluate all of the selectors by adding the varbasemul gate selector to the list of evaluated columns.