### PR TITLE
Prevent user from accidentally specifying invalid non-native modulus

### DIFF
--- a/book/src/rfcs/foreign_field_mul.md
+++ b/book/src/rfcs/foreign_field_mul.md
@@ -183,7 +183,15 @@ m_{max} &= \frac{258 + 255}{2} = 256.5,
 \end{aligned}
 $$
 
-which is not enough space to handle anything larger than 256 bit moduli.  Instead, we will use $t=264$, giving a maximum modulus $m_{max} = 259$ bits.  However, max modulus $2^{259}$ is too course, so to be more precise we actually use $max_{modulus} = \sqrt{2^t \cdot n}$.
+which is not enough space to handle anything larger than 256 bit moduli.  Instead, we will use $t=264$, giving $m_{max} = 259$ bits.
+
+The above formula is useful for checking the maximum number of bits supported of the foreign field modulus, but it is not useful for computing the maximum foreign field modulus itself (because $2^{m_{max}}$ is too coarse). For these checks, we can compute our maximum foreign field modulus more precisely with
+
+$$
+max_{mod} = \lfloor \sqrt{2^t \cdot n} \rfloor.
+$$
+
+The max prime foreign field modulus satisfying the above inequality for both Pallas and Vesta is `926336713898529563388567880069503262826888842373627227613104999999999999999607`.
 
 #### Choosing the limb configuration
 

--- a/book/src/rfcs/foreign_field_mul.md
+++ b/book/src/rfcs/foreign_field_mul.md
@@ -183,7 +183,7 @@ m_{max} &= \frac{258 + 255}{2} = 256.5,
 \end{aligned}
 $$
 
-which is not enough space to handle anything larger than 256 bit moduli.  Instead, we will use $t=264$, giving a maximum modulus $m_{max} = 259$ bits.
+which is not enough space to handle anything larger than 256 bit moduli.  Instead, we will use $t=264$, giving a maximum modulus $m_{max} = 259$ bits.  However, max modulus $2^{259}$ is too course, so to be more precise we actually use $max_{modulus} = \sqrt{2^t \cdot n}$.
 
 #### Choosing the limb configuration
 

--- a/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
@@ -39,11 +39,11 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
         opcodes: &[FFOps],
         foreign_field_modulus: &BigUint,
     ) -> (usize, Vec<Self>) {
-        if *foreign_field_modulus > BigUint::max_foreign_field_modulus() {
+        if *foreign_field_modulus > BigUint::max_foreign_field_modulus::<F>() {
             panic!(
                 "foreign_field_modulus exceeds maximum: {} > {}",
                 *foreign_field_modulus,
-                BigUint::max_foreign_field_modulus()
+                BigUint::max_foreign_field_modulus::<F>()
             );
         }
 
@@ -95,11 +95,11 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
         operation: FFOps,
         foreign_field_modulus: &BigUint,
     ) -> (usize, Vec<Self>) {
-        if *foreign_field_modulus > BigUint::max_foreign_field_modulus() {
+        if *foreign_field_modulus > BigUint::max_foreign_field_modulus::<F>() {
             panic!(
                 "foreign_field_modulus exceeds maximum: {} > {}",
                 *foreign_field_modulus,
-                BigUint::max_foreign_field_modulus()
+                BigUint::max_foreign_field_modulus::<F>()
             );
         }
 

--- a/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/gadget.rs
@@ -39,6 +39,14 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
         opcodes: &[FFOps],
         foreign_field_modulus: &BigUint,
     ) -> (usize, Vec<Self>) {
+        if *foreign_field_modulus > BigUint::max_foreign_field_modulus() {
+            panic!(
+                "foreign_field_modulus exceeds maximum: {} > {}",
+                *foreign_field_modulus,
+                BigUint::max_foreign_field_modulus()
+            );
+        }
+
         let next_row = start_row;
         let foreign_field_modulus = foreign_field_modulus.to_field_limbs::<F>();
         let mut circuit_gates = vec![];
@@ -87,6 +95,14 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
         operation: FFOps,
         foreign_field_modulus: &BigUint,
     ) -> (usize, Vec<Self>) {
+        if *foreign_field_modulus > BigUint::max_foreign_field_modulus() {
+            panic!(
+                "foreign_field_modulus exceeds maximum: {} > {}",
+                *foreign_field_modulus,
+                BigUint::max_foreign_field_modulus()
+            );
+        }
+
         let foreign_field_modulus = foreign_field_modulus.to_field_limbs::<F>();
         let mut coeffs = foreign_field_modulus.to_vec();
         coeffs.push(operation.sign::<F>());

--- a/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
@@ -131,11 +131,11 @@ pub fn create_chain<F: PrimeField>(
     opcodes: &[FFOps],
     modulus: BigUint,
 ) -> [Vec<F>; COLUMNS] {
-    if modulus > BigUint::max_foreign_field_modulus() {
+    if modulus > BigUint::max_foreign_field_modulus::<F>() {
         panic!(
             "foreign_field_modulus exceeds maximum: {} > {}",
             modulus,
-            BigUint::max_foreign_field_modulus()
+            BigUint::max_foreign_field_modulus::<F>()
         );
     }
 
@@ -277,11 +277,11 @@ pub fn extend_witness_bound_addition<F: PrimeField>(
     // Convert to types used by this module
     let fe = ForeignElement::<F, 3>::new(*limbs);
     let foreign_field_modulus = ForeignElement::<F, 3>::new(*foreign_field_modulus);
-    if foreign_field_modulus.to_biguint() > BigUint::max_foreign_field_modulus() {
+    if foreign_field_modulus.to_biguint() > BigUint::max_foreign_field_modulus::<F>() {
         panic!(
             "foreign_field_modulus exceeds maximum: {} > {}",
             foreign_field_modulus.to_biguint(),
-            BigUint::max_foreign_field_modulus()
+            BigUint::max_foreign_field_modulus::<F>()
         );
     }
 

--- a/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
@@ -131,6 +131,14 @@ pub fn create_chain<F: PrimeField>(
     opcodes: &[FFOps],
     modulus: BigUint,
 ) -> [Vec<F>; COLUMNS] {
+    if modulus > BigUint::max_foreign_field_modulus() {
+        panic!(
+            "foreign_field_modulus exceeds maximum: {} > {}",
+            modulus,
+            BigUint::max_foreign_field_modulus()
+        );
+    }
+
     let num = inputs.len() - 1; // number of chained additions
 
     // make sure there are as many operands as operations
@@ -269,6 +277,13 @@ pub fn extend_witness_bound_addition<F: PrimeField>(
     // Convert to types used by this module
     let fe = ForeignElement::<F, 3>::new(*limbs);
     let foreign_field_modulus = ForeignElement::<F, 3>::new(*foreign_field_modulus);
+    if foreign_field_modulus.to_biguint() > BigUint::max_foreign_field_modulus() {
+        panic!(
+            "foreign_field_modulus exceeds maximum: {} > {}",
+            foreign_field_modulus.to_biguint(),
+            BigUint::max_foreign_field_modulus()
+        );
+    }
 
     // Compute values for final bound check, needs a 4 limb right input
     let right_input = ForeignElement::<F, 4>::from_biguint(BigUint::binary_modulus());

--- a/kimchi/src/circuits/polynomials/foreign_field_mul/gadget.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_mul/gadget.rs
@@ -33,6 +33,14 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
         start_row: usize,
         foreign_field_modulus: &BigUint,
     ) -> (usize, Vec<Self>) {
+        if *foreign_field_modulus > BigUint::max_foreign_field_modulus() {
+            panic!(
+                "foreign_field_modulus exceeds maximum: {} > {}",
+                *foreign_field_modulus,
+                BigUint::max_foreign_field_modulus()
+            );
+        }
+
         let neg_foreign_field_modulus = foreign_field_modulus.negate().to_field_limbs::<F>();
         let foreign_field_modulus = foreign_field_modulus.to_field_limbs::<F>();
         let circuit_gates = vec![

--- a/kimchi/src/circuits/polynomials/foreign_field_mul/gadget.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_mul/gadget.rs
@@ -33,11 +33,11 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
         start_row: usize,
         foreign_field_modulus: &BigUint,
     ) -> (usize, Vec<Self>) {
-        if *foreign_field_modulus > BigUint::max_foreign_field_modulus() {
+        if *foreign_field_modulus > BigUint::max_foreign_field_modulus::<F>() {
             panic!(
                 "foreign_field_modulus exceeds maximum: {} > {}",
                 *foreign_field_modulus,
-                BigUint::max_foreign_field_modulus()
+                BigUint::max_foreign_field_modulus::<F>()
             );
         }
 

--- a/kimchi/src/circuits/polynomials/foreign_field_mul/witness.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_mul/witness.rs
@@ -164,11 +164,11 @@ pub fn create<F: PrimeField>(
     right_input: &BigUint,
     foreign_field_modulus: &BigUint,
 ) -> ([Vec<F>; COLUMNS], ExternalChecks<F>) {
-    if *foreign_field_modulus > BigUint::max_foreign_field_modulus() {
+    if *foreign_field_modulus > BigUint::max_foreign_field_modulus::<F>() {
         panic!(
             "foreign_field_modulus exceeds maximum: {} > {}",
             *foreign_field_modulus,
-            BigUint::max_foreign_field_modulus()
+            BigUint::max_foreign_field_modulus::<F>()
         );
     }
 

--- a/kimchi/src/circuits/polynomials/foreign_field_mul/witness.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_mul/witness.rs
@@ -164,6 +164,14 @@ pub fn create<F: PrimeField>(
     right_input: &BigUint,
     foreign_field_modulus: &BigUint,
 ) -> ([Vec<F>; COLUMNS], ExternalChecks<F>) {
+    if *foreign_field_modulus > BigUint::max_foreign_field_modulus() {
+        panic!(
+            "foreign_field_modulus exceeds maximum: {} > {}",
+            *foreign_field_modulus,
+            BigUint::max_foreign_field_modulus()
+        );
+    }
+
     let mut witness = array::from_fn(|_| vec![F::zero(); 0]);
     let mut external_checks = ExternalChecks::<F>::default();
 

--- a/kimchi/src/tests/foreign_field_add.rs
+++ b/kimchi/src/tests/foreign_field_add.rs
@@ -1543,7 +1543,7 @@ fn test_gate_max_foreign_field_modulus() {
     CircuitGate::<PallasField>::create_single_ffadd(
         0,
         FFOps::Add,
-        &BigUint::max_foreign_field_modulus(),
+        &BigUint::max_foreign_field_modulus::<PallasField>(),
     );
 }
 
@@ -1553,7 +1553,7 @@ fn test_gate_invalid_foreign_field_modulus() {
     CircuitGate::<PallasField>::create_single_ffadd(
         0,
         FFOps::Add,
-        &(BigUint::max_foreign_field_modulus() + BigUint::one()),
+        &(BigUint::max_foreign_field_modulus::<PallasField>() + BigUint::one()),
     );
 }
 
@@ -1562,7 +1562,7 @@ fn test_witness_max_foreign_field_modulus() {
     short_witness::<PallasField>(
         &vec![BigUint::zero(), BigUint::zero()],
         &[FFOps::Add],
-        BigUint::max_foreign_field_modulus(),
+        BigUint::max_foreign_field_modulus::<PallasField>(),
     );
 }
 
@@ -1572,6 +1572,6 @@ fn test_witness_invalid_foreign_field_modulus() {
     short_witness::<PallasField>(
         &vec![BigUint::zero(), BigUint::zero()],
         &[FFOps::Add],
-        BigUint::max_foreign_field_modulus() + BigUint::one(),
+        BigUint::max_foreign_field_modulus::<PallasField>() + BigUint::one(),
     );
 }

--- a/kimchi/src/tests/foreign_field_add.rs
+++ b/kimchi/src/tests/foreign_field_add.rs
@@ -28,7 +28,7 @@ use mina_poseidon::{
 use num_bigint::{BigUint, RandBigInt};
 use num_traits::FromPrimitive;
 use o1_utils::{
-    foreign_field::{ForeignElement, HI, LO, MI, TWO_TO_LIMB},
+    foreign_field::{BigUintForeignFieldHelpers, ForeignElement, HI, LO, MI, TWO_TO_LIMB},
     FieldHelpers, Two,
 };
 use poly_commitment::srs::{endos, SRS};
@@ -1536,4 +1536,42 @@ fn test_ffadd_finalization() {
         .setup()
         .prove_and_verify::<BaseSponge, ScalarSponge>()
         .unwrap();
+}
+
+#[test]
+fn test_gate_max_foreign_field_modulus() {
+    CircuitGate::<PallasField>::create_single_ffadd(
+        0,
+        FFOps::Add,
+        &BigUint::max_foreign_field_modulus(),
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_gate_invalid_foreign_field_modulus() {
+    CircuitGate::<PallasField>::create_single_ffadd(
+        0,
+        FFOps::Add,
+        &(BigUint::max_foreign_field_modulus() + BigUint::one()),
+    );
+}
+
+#[test]
+fn test_witness_max_foreign_field_modulus() {
+    short_witness::<PallasField>(
+        &vec![BigUint::zero(), BigUint::zero()],
+        &[FFOps::Add],
+        BigUint::max_foreign_field_modulus(),
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_witness_invalid_foreign_field_modulus() {
+    short_witness::<PallasField>(
+        &vec![BigUint::zero(), BigUint::zero()],
+        &[FFOps::Add],
+        BigUint::max_foreign_field_modulus() + BigUint::one(),
+    );
 }

--- a/kimchi/src/tests/foreign_field_mul.rs
+++ b/kimchi/src/tests/foreign_field_mul.rs
@@ -1390,3 +1390,36 @@ fn test_constraint_c12() {
         Err(CircuitGateError::Constraint(GateType::ForeignFieldMul, 9)),
     );
 }
+
+#[test]
+fn test_gates_max_foreign_field_modulus() {
+    CircuitGate::<PallasField>::create_foreign_field_mul(0, &BigUint::max_foreign_field_modulus());
+}
+
+#[test]
+#[should_panic]
+fn test_gates_invalid_foreign_field_modulus() {
+    CircuitGate::<PallasField>::create_foreign_field_mul(
+        0,
+        &(BigUint::max_foreign_field_modulus() + BigUint::one()),
+    );
+}
+
+#[test]
+fn test_witness_max_foreign_field_modulus() {
+    foreign_field_mul::witness::create::<PallasField>(
+        &BigUint::zero(),
+        &BigUint::zero(),
+        &BigUint::max_foreign_field_modulus(),
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_witness_invalid_foreign_field_modulus() {
+    foreign_field_mul::witness::create::<PallasField>(
+        &BigUint::zero(),
+        &BigUint::zero(),
+        &(BigUint::max_foreign_field_modulus() + BigUint::one()),
+    );
+}

--- a/kimchi/src/tests/foreign_field_mul.rs
+++ b/kimchi/src/tests/foreign_field_mul.rs
@@ -1393,7 +1393,10 @@ fn test_constraint_c12() {
 
 #[test]
 fn test_gates_max_foreign_field_modulus() {
-    CircuitGate::<PallasField>::create_foreign_field_mul(0, &BigUint::max_foreign_field_modulus());
+    CircuitGate::<PallasField>::create_foreign_field_mul(
+        0,
+        &BigUint::max_foreign_field_modulus::<PallasField>(),
+    );
 }
 
 #[test]
@@ -1401,7 +1404,7 @@ fn test_gates_max_foreign_field_modulus() {
 fn test_gates_invalid_foreign_field_modulus() {
     CircuitGate::<PallasField>::create_foreign_field_mul(
         0,
-        &(BigUint::max_foreign_field_modulus() + BigUint::one()),
+        &(BigUint::max_foreign_field_modulus::<PallasField>() + BigUint::one()),
     );
 }
 
@@ -1410,7 +1413,7 @@ fn test_witness_max_foreign_field_modulus() {
     foreign_field_mul::witness::create::<PallasField>(
         &BigUint::zero(),
         &BigUint::zero(),
-        &BigUint::max_foreign_field_modulus(),
+        &BigUint::max_foreign_field_modulus::<PallasField>(),
     );
 }
 
@@ -1420,6 +1423,6 @@ fn test_witness_invalid_foreign_field_modulus() {
     foreign_field_mul::witness::create::<PallasField>(
         &BigUint::zero(),
         &BigUint::zero(),
-        &(BigUint::max_foreign_field_modulus() + BigUint::one()),
+        &(BigUint::max_foreign_field_modulus::<PallasField>() + BigUint::one()),
     );
 }

--- a/utils/src/foreign_field.rs
+++ b/utils/src/foreign_field.rs
@@ -1,7 +1,7 @@
 //! Describes helpers for foreign field arithmetics
 
 use crate::field_helpers::FieldHelpers;
-use ark_ff::{Field, PrimeField};
+use ark_ff::{Field, One, PrimeField};
 use num_bigint::BigUint;
 use num_traits::Zero;
 use std::array;
@@ -184,6 +184,9 @@ pub trait BigUintForeignFieldHelpers {
     /// 2^t
     fn binary_modulus() -> Self;
 
+    /// 2^259 (see foreign field multiplication RFC)
+    fn max_foreign_field_modulus() -> Self;
+
     /// Convert to 3 limbs of LIMB_BITS each
     fn to_limbs(&self) -> [BigUint; 3];
 
@@ -215,6 +218,10 @@ impl BigUintForeignFieldHelpers for BigUint {
 
     fn binary_modulus() -> Self {
         BigUint::two().pow(3 * LIMB_BITS as u32)
+    }
+
+    fn max_foreign_field_modulus() -> Self {
+        BigUint::two().pow(259u32) - BigUint::one()
     }
 
     fn to_limbs(&self) -> [Self; 3] {

--- a/utils/src/foreign_field.rs
+++ b/utils/src/foreign_field.rs
@@ -222,7 +222,8 @@ impl BigUintForeignFieldHelpers for BigUint {
 
     fn max_foreign_field_modulus<F: PrimeField>() -> Self {
         // For simplicity and efficiency we use the approximation m = floor(sqrt(2^t * n))
-        //     * Our maximum prime foreign field modulus for both Pallas and Vesta is
+        //     * Distinct from this approximation is the maximum prime foreign field modulus
+        //       for both Pallas and Vesta given our CRT scheme:
         //       926336713898529563388567880069503262826888842373627227613104999999999999999607
         //     * BigUint::sqrt return truncated principle square root (rounds down to int) ~ floor
         (BigUint::binary_modulus() * F::modulus_biguint()).sqrt()

--- a/utils/src/foreign_field.rs
+++ b/utils/src/foreign_field.rs
@@ -222,8 +222,7 @@ impl BigUintForeignFieldHelpers for BigUint {
 
     fn max_foreign_field_modulus<F: PrimeField>() -> Self {
         // For simplicity and efficiency we use the approximation m = floor(sqrt(2^t * n))
-        //     * The maximum prime foreign field modulus satisfying the above inequality
-        //       for  both Pallas and Vesta is
+        //     * Our maximum prime foreign field modulus for both Pallas and Vesta is
         //       926336713898529563388567880069503262826888842373627227613104999999999999999607
         //     * BigUint::sqrt return truncated principle square root (rounds down to int) ~ floor
         (BigUint::binary_modulus() * F::modulus_biguint()).sqrt()

--- a/utils/src/foreign_field.rs
+++ b/utils/src/foreign_field.rs
@@ -221,7 +221,10 @@ impl BigUintForeignFieldHelpers for BigUint {
     }
 
     fn max_foreign_field_modulus<F: PrimeField>() -> Self {
-        // m = sqrt(2^t * n)
+        // For simplicity and efficiency we use the approximation m = floor(sqrt(2^t * n))
+        //     * The maximum prime foreign field modulus satisfying the above inequality
+        //       for  both Pallas and Vesta is
+        //       926336713898529563388567880069503262826888842373627227613104999999999999999607
         (BigUint::binary_modulus() * F::modulus_biguint()).sqrt()
     }
 

--- a/utils/src/foreign_field.rs
+++ b/utils/src/foreign_field.rs
@@ -225,6 +225,7 @@ impl BigUintForeignFieldHelpers for BigUint {
         //     * The maximum prime foreign field modulus satisfying the above inequality
         //       for  both Pallas and Vesta is
         //       926336713898529563388567880069503262826888842373627227613104999999999999999607
+        //     * BigUint::sqrt return truncated principle square root (rounds down to int) ~ floor
         (BigUint::binary_modulus() * F::modulus_biguint()).sqrt()
     }
 

--- a/utils/src/foreign_field.rs
+++ b/utils/src/foreign_field.rs
@@ -1,7 +1,7 @@
 //! Describes helpers for foreign field arithmetics
 
 use crate::field_helpers::FieldHelpers;
-use ark_ff::{Field, One, PrimeField};
+use ark_ff::{Field, PrimeField};
 use num_bigint::BigUint;
 use num_traits::Zero;
 use std::array;
@@ -185,7 +185,7 @@ pub trait BigUintForeignFieldHelpers {
     fn binary_modulus() -> Self;
 
     /// 2^259 (see foreign field multiplication RFC)
-    fn max_foreign_field_modulus() -> Self;
+    fn max_foreign_field_modulus<F: PrimeField>() -> Self;
 
     /// Convert to 3 limbs of LIMB_BITS each
     fn to_limbs(&self) -> [BigUint; 3];
@@ -220,8 +220,9 @@ impl BigUintForeignFieldHelpers for BigUint {
         BigUint::two().pow(3 * LIMB_BITS as u32)
     }
 
-    fn max_foreign_field_modulus() -> Self {
-        BigUint::two().pow(259u32) - BigUint::one()
+    fn max_foreign_field_modulus<F: PrimeField>() -> Self {
+        // m = sqrt(2^t * n)
+        (BigUint::binary_modulus() * F::modulus_biguint()).sqrt()
     }
 
     fn to_limbs(&self) -> [Self; 3] {


### PR DESCRIPTION
    * Fail fast at circuit or witness creation time
    * Since non-native modulus is public (coeff) parameter
      we don't need constraints for this
    * However, this is helpful for the circuit designer