### PR TITLE
Add note about SRS directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ _build
 *.swp
 *.swo
 .vscode
+
+*.html
+# If symlink created for kimchi-visu
+tools/srs

--- a/tools/kimchi-visu/README.md
+++ b/tools/kimchi-visu/README.md
@@ -13,3 +13,8 @@ You can reuse the implementation in [src/main.rs](src/main.rs) and call it as:
 ```console
 $ cargo run --bin kimchi-visu
 ```
+
+The SRS is supposed to be in the parent directory. Create a symlink if you encounter SRS loading issue:
+```
+ln -s $(pwd)/../../srs $(pwd)/../srs
+```


### PR DESCRIPTION
It seems the SRS loading is strict in terms of path location (parent directory). Add a note if the user wants to run kimchi-visu from kimchi-visu directory.

It might be better to provide the path in a environment variable. Not in the scope of this PR.