### PR TITLE
Capture zk_rows as a variable in the expression framework

### DIFF
--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -165,8 +165,7 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
         if feature_flags.lookup_features.patterns != LookupPatterns::default() {
             let lookup_configuration =
                 LookupConfiguration::new(LookupInfo::create(feature_flags.lookup_features));
-            let constraints =
-                lookup::constraints::constraints(&lookup_configuration, false);
+            let constraints = lookup::constraints::constraints(&lookup_configuration, false);
 
             // note: the number of constraints depends on the lookup configuration,
             // specifically the presence of runtime tables.

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -38,7 +38,6 @@ use ark_ff::{FftField, PrimeField, SquareRootField, Zero};
 pub fn constraints_expr<F: PrimeField + SquareRootField>(
     feature_flags: Option<&FeatureFlags>,
     generic: bool,
-    zk_rows: usize,
 ) -> (Expr<ConstantExpr<F>>, Alphas<F>) {
     // register powers of alpha so that we don't reuse them across mutually inclusive constraints
     let mut powers_of_alpha = Alphas::<F>::default();
@@ -167,7 +166,7 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
             let lookup_configuration =
                 LookupConfiguration::new(LookupInfo::create(feature_flags.lookup_features));
             let constraints =
-                lookup::constraints::constraints(&lookup_configuration, false, zk_rows);
+                lookup::constraints::constraints(&lookup_configuration, false);
 
             // note: the number of constraints depends on the lookup configuration,
             // specifically the presence of runtime tables.
@@ -193,7 +192,7 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
             joint_lookup_used: true,
         };
         let lookup_configuration = LookupConfiguration::new(LookupInfo::create(all_features));
-        let constraints = lookup::constraints::constraints(&lookup_configuration, true, zk_rows);
+        let constraints = lookup::constraints::constraints(&lookup_configuration, true);
 
         // note: the number of constraints depends on the lookup configuration,
         // specifically the presence of runtime tables.
@@ -224,7 +223,7 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
     // flags.
     if cfg!(feature = "check_feature_flags") {
         if let Some(feature_flags) = feature_flags {
-            let (feature_flagged_expr, _) = constraints_expr(None, generic, zk_rows);
+            let (feature_flagged_expr, _) = constraints_expr(None, generic);
             let feature_flagged_expr = feature_flagged_expr.apply_feature_flags(feature_flags);
             assert_eq!(expr, feature_flagged_expr);
         }
@@ -321,11 +320,10 @@ pub fn linearization_columns<F: FftField + SquareRootField>(
 pub fn expr_linearization<F: PrimeField + SquareRootField>(
     feature_flags: Option<&FeatureFlags>,
     generic: bool,
-    zk_rows: usize,
 ) -> (Linearization<Vec<PolishToken<F>>>, Alphas<F>) {
     let evaluated_cols = linearization_columns::<F>(feature_flags);
 
-    let (expr, powers_of_alpha) = constraints_expr(feature_flags, generic, zk_rows);
+    let (expr, powers_of_alpha) = constraints_expr(feature_flags, generic);
 
     let linearization = expr
         .linearize(evaluated_cols)

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -803,10 +803,7 @@ where
             // lookup
             {
                 if let Some(lcs) = index.cs.lookup_constraint_system.as_ref() {
-                    let constraints = lookup::constraints::constraints(
-                        &lcs.configuration,
-                        false,
-                    );
+                    let constraints = lookup::constraints::constraints(&lcs.configuration, false);
                     let constraints_len = u32::try_from(constraints.len())
                         .expect("not expecting a large amount of constraints");
                     let lookup_alphas =

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -806,7 +806,6 @@ where
                     let constraints = lookup::constraints::constraints(
                         &lcs.configuration,
                         false,
-                        index.cs.zk_rows as usize,
                     );
                     let constraints_len = u32::try_from(constraints.len())
                         .expect("not expecting a large amount of constraints");

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -65,8 +65,7 @@ impl<G: KimchiCurve> ProverIndex<G> {
         cs.endo = endo_q;
 
         // pre-compute the linearization
-        let (linearization, powers_of_alpha) =
-            expr_linearization(Some(&cs.feature_flags), true);
+        let (linearization, powers_of_alpha) = expr_linearization(Some(&cs.feature_flags), true);
 
         let evaluated_column_coefficients = cs.evaluated_column_coefficients();
 

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -66,7 +66,7 @@ impl<G: KimchiCurve> ProverIndex<G> {
 
         // pre-compute the linearization
         let (linearization, powers_of_alpha) =
-            expr_linearization(Some(&cs.feature_flags), true, cs.zk_rows as usize);
+            expr_linearization(Some(&cs.feature_flags), true);
 
         let evaluated_column_coefficients = cs.evaluated_column_coefficients();
 


### PR DESCRIPTION
This PR builds upon https://github.com/o1-labs/proof-systems/pull/1045, exposing a variable `zk_rows` from the expression framework for consumption by OCaml.