### PR TITLE
add default-members to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ members = [
     "internal-tracing",
 ]
 
+default-members = [
+    "kimchi",
+]
 [profile.release]
 lto = true
 panic = 'abort'


### PR DESCRIPTION
This may require updating some cases of `cargo subcommad` to `cargo subcommand --workspace`. In exchange `cargo subcommand --p kimchi` will become just `cargo subcommand`.