### PR TITLE
Abstract Expr over columns

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1688,7 +1688,7 @@ pub struct ProverIndex<G: KimchiCurve> {
 
     /// The symbolic linearization of our circuit, which can compile to concrete types once certain values are learned in the protocol.
     #[serde(skip)]
-    pub linearization: Linearization<Vec<PolishToken<G::ScalarField, Column>>>,
+    pub linearization: Linearization<Vec<PolishToken<G::ScalarField, Column>>, Column>,
 
     /// The mapping between powers of alpha and constraints
     #[serde(skip)]
@@ -1830,7 +1830,7 @@ pub struct VerifierIndex<G: KimchiCurve> {
     pub lookup_index: Option<LookupVerifierIndex<G>>,
 
     #[serde(skip)]
-    pub linearization: Linearization<Vec<PolishToken<G::ScalarField, Column>>>,
+    pub linearization: Linearization<Vec<PolishToken<G::ScalarField, Column>>, Column>,
     /// The mapping between powers of alpha and constraints
     #[serde(skip)]
     pub powers_of_alpha: Alphas<G::ScalarField>,

--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1688,7 +1688,7 @@ pub struct ProverIndex<G: KimchiCurve> {
 
     /// The symbolic linearization of our circuit, which can compile to concrete types once certain values are learned in the protocol.
     #[serde(skip)]
-    pub linearization: Linearization<Vec<PolishToken<G::ScalarField>>>,
+    pub linearization: Linearization<Vec<PolishToken<G::ScalarField, Column>>>,
 
     /// The mapping between powers of alpha and constraints
     #[serde(skip)]
@@ -1830,7 +1830,7 @@ pub struct VerifierIndex<G: KimchiCurve> {
     pub lookup_index: Option<LookupVerifierIndex<G>>,
 
     #[serde(skip)]
-    pub linearization: Linearization<Vec<PolishToken<G::ScalarField>>>,
+    pub linearization: Linearization<Vec<PolishToken<G::ScalarField, Column>>>,
     /// The mapping between powers of alpha and constraints
     #[serde(skip)]
     pub powers_of_alpha: Alphas<G::ScalarField>,

--- a/kimchi/src/circuits/berkeley_columns.rs
+++ b/kimchi/src/circuits/berkeley_columns.rs
@@ -1,0 +1,93 @@
+use crate::circuits::{
+    expr::{self, Domain, GenericColumn},
+    gate::{CurrOrNext, GateType},
+    lookup::lookups::LookupPattern,
+};
+use serde::{Deserialize, Serialize};
+use CurrOrNext::{Curr, Next};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+/// A type representing one of the polynomials involved in the PLONK IOP.
+pub enum Column {
+    Witness(usize),
+    Z,
+    LookupSorted(usize),
+    LookupAggreg,
+    LookupTable,
+    LookupKindIndex(LookupPattern),
+    LookupRuntimeSelector,
+    LookupRuntimeTable,
+    Index(GateType),
+    Coefficient(usize),
+    Permutation(usize),
+}
+
+impl GenericColumn for Column {
+    fn domain(&self) -> Domain {
+        match self {
+            Column::Index(GateType::Generic) => Domain::D4,
+            Column::Index(GateType::CompleteAdd) => Domain::D4,
+            _ => Domain::D8,
+        }
+    }
+}
+
+impl Column {
+    pub fn latex(&self) -> String {
+        match self {
+            Column::Witness(i) => format!("w_{{{i}}}"),
+            Column::Z => "Z".to_string(),
+            Column::LookupSorted(i) => format!("s_{{{i}}}"),
+            Column::LookupAggreg => "a".to_string(),
+            Column::LookupTable => "t".to_string(),
+            Column::LookupKindIndex(i) => format!("k_{{{i:?}}}"),
+            Column::LookupRuntimeSelector => "rts".to_string(),
+            Column::LookupRuntimeTable => "rt".to_string(),
+            Column::Index(gate) => {
+                format!("{gate:?}")
+            }
+            Column::Coefficient(i) => format!("c_{{{i}}}"),
+            Column::Permutation(i) => format!("sigma_{{{i}}}"),
+        }
+    }
+
+    pub fn text(&self) -> String {
+        match self {
+            Column::Witness(i) => format!("w[{i}]"),
+            Column::Z => "Z".to_string(),
+            Column::LookupSorted(i) => format!("s[{i}]"),
+            Column::LookupAggreg => "a".to_string(),
+            Column::LookupTable => "t".to_string(),
+            Column::LookupKindIndex(i) => format!("k[{i:?}]"),
+            Column::LookupRuntimeSelector => "rts".to_string(),
+            Column::LookupRuntimeTable => "rt".to_string(),
+            Column::Index(gate) => {
+                format!("{gate:?}")
+            }
+            Column::Coefficient(i) => format!("c[{i}]"),
+            Column::Permutation(i) => format!("sigma_[{i}]"),
+        }
+    }
+}
+
+impl expr::Variable<Column> {
+    pub fn ocaml(&self) -> String {
+        format!("var({:?}, {:?})", self.col, self.row)
+    }
+
+    pub fn latex(&self) -> String {
+        let col = self.col.latex();
+        match self.row {
+            Curr => col,
+            Next => format!("\\tilde{{{col}}}"),
+        }
+    }
+
+    pub fn text(&self) -> String {
+        let col = self.col.text();
+        match self.row {
+            Curr => format!("Curr({col})"),
+            Next => format!("Next({col})"),
+        }
+    }
+}

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1524,11 +1524,11 @@ impl<F: FftField> Expr<ConstantExpr<F>, Column> {
     }
 
     /// Evaluate an expression as a field element against an environment.
-    pub fn evaluate(
+    pub fn evaluate<Evaluations: ColumnEvaluations<F, Column = Column>>(
         &self,
         d: D<F>,
         pt: F,
-        evals: &ProofEvaluations<PointEvaluations<F>>,
+        evals: &Evaluations,
         env: &Environment<F>,
     ) -> Result<F, ExprError<Column>> {
         self.evaluate_(d, pt, evals, &env.constants)
@@ -1595,11 +1595,11 @@ enum Either<A, B> {
 
 impl<F: FftField> Expr<F, Column> {
     /// Evaluate an expression into a field element.
-    pub fn evaluate(
+    pub fn evaluate<Evaluations: ColumnEvaluations<F, Column = Column>>(
         &self,
         d: D<F>,
         pt: F,
-        evals: &ProofEvaluations<PointEvaluations<F>>,
+        evals: &Evaluations,
     ) -> Result<F, ExprError<Column>> {
         use Expr::*;
         match self {
@@ -1880,11 +1880,11 @@ impl<F: FftField, Column: Copy + Debug> Linearization<Vec<PolishToken<F, Column>
 impl<F: FftField> Linearization<Expr<ConstantExpr<F>, Column>> {
     /// Given a linearization and an environment, compute the polynomial corresponding to the
     /// linearization, in evaluation form.
-    pub fn to_polynomial(
+    pub fn to_polynomial<ColEvaluations: ColumnEvaluations<F, Column = Column>>(
         &self,
         env: &Environment<F>,
         pt: F,
-        evals: &ProofEvaluations<PointEvaluations<F>>,
+        evals: &ColEvaluations,
     ) -> (F, DensePolynomial<F>) {
         let cs = &env.constants;
         let n = env.domain.d1.size();

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -923,11 +923,11 @@ pub fn pows<F: Field>(x: F, n: usize) -> Vec<F> {
 /// = (omega^{q n} omega_8^{r n} - 1) / (omega_8^k - omega^i)
 /// = ((omega_8^n)^r - 1) / (omega_8^k - omega^i)
 /// = ((omega_8^n)^r - 1) / (omega^q omega_8^r - omega^i)
-fn unnormalized_lagrange_evals<F: FftField>(
+fn unnormalized_lagrange_evals<'a, F: FftField, Environment: ColumnEnvironment<'a, F>>(
     l0_1: F,
     i: i32,
     res_domain: Domain,
-    env: &Environment<F>,
+    env: &Environment,
 ) -> Evaluations<F, D<F>> {
     let k = match res_domain {
         Domain::D1 => 1,
@@ -937,7 +937,7 @@ fn unnormalized_lagrange_evals<F: FftField>(
     };
     let res_domain = env.get_domain(res_domain);
 
-    let d1 = env.domain.d1;
+    let d1 = env.get_domain(Domain::D1);
     let n = d1.size;
     // Renormalize negative values to wrap around at domain size
     let i = if i < 0 {

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -287,7 +287,7 @@ pub enum ConstantExpr<F> {
 }
 
 impl<F: Copy> ConstantExpr<F> {
-    fn to_polish_(&self, res: &mut Vec<PolishToken<F>>) {
+    fn to_polish_<Column>(&self, res: &mut Vec<PolishToken<F, Column>>) {
         match self {
             ConstantExpr::Alpha => res.push(PolishToken::Alpha),
             ConstantExpr::Beta => res.push(PolishToken::Beta),
@@ -422,7 +422,7 @@ pub enum Op2 {
 }
 
 impl Op2 {
-    fn to_polish<A>(&self) -> PolishToken<A> {
+    fn to_polish<A, Column>(&self) -> PolishToken<A, Column> {
         use Op2::*;
         match self {
             Add => PolishToken::Add,
@@ -633,7 +633,7 @@ impl<C: Zero + One + Neg<Output = C> + PartialEq + Clone, Column: Clone + Partia
 /// [reverse Polish notation](https://en.wikipedia.org/wiki/Reverse_Polish_notation)
 /// expressions, which are vectors of the below tokens.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum PolishToken<F> {
+pub enum PolishToken<F, Column> {
     Alpha,
     Beta,
     Gamma,
@@ -694,10 +694,10 @@ impl Variable<Column> {
     }
 }
 
-impl<F: FftField> PolishToken<F> {
+impl<F: FftField> PolishToken<F, Column> {
     /// Evaluate an RPN expression to a field element.
     pub fn evaluate(
-        toks: &[PolishToken<F>],
+        toks: &[PolishToken<F, Column>],
         d: D<F>,
         pt: F,
         evals: &ProofEvaluations<PointEvaluations<F>>,
@@ -1392,16 +1392,20 @@ impl<F: Field> Expr<ConstantExpr<F>, Column> {
     }
 }
 
-impl<F: FftField> Expr<ConstantExpr<F>, Column> {
+impl<F: FftField, Column: Copy> Expr<ConstantExpr<F>, Column> {
     /// Compile an expression to an RPN expression.
-    pub fn to_polish(&self) -> Vec<PolishToken<F>> {
+    pub fn to_polish(&self) -> Vec<PolishToken<F, Column>> {
         let mut res = vec![];
         let mut cache = HashMap::new();
         self.to_polish_(&mut cache, &mut res);
         res
     }
 
-    fn to_polish_(&self, cache: &mut HashMap<CacheId, usize>, res: &mut Vec<PolishToken<F>>) {
+    fn to_polish_(
+        &self,
+        cache: &mut HashMap<CacheId, usize>,
+        res: &mut Vec<PolishToken<F, Column>>,
+    ) {
         match self {
             Expr::Double(x) => {
                 x.to_polish_(cache, res);
@@ -1481,7 +1485,9 @@ impl<F: FftField> Expr<ConstantExpr<F>, Column> {
     pub fn beta() -> Self {
         Expr::Constant(ConstantExpr::Beta)
     }
+}
 
+impl<F: FftField> Expr<ConstantExpr<F>, Column> {
     fn evaluate_constants_(&self, c: &Constants<F>) -> Expr<F, Column> {
         use Expr::*;
         // TODO: Use cache
@@ -1829,7 +1835,7 @@ impl<F: FftField> Linearization<Expr<ConstantExpr<F>, Column>> {
     }
 }
 
-impl<F: FftField> Linearization<Vec<PolishToken<F>>> {
+impl<F: FftField> Linearization<Vec<PolishToken<F, Column>>> {
     /// Given a linearization and an environment, compute the polynomial corresponding to the
     /// linearization, in evaluation form.
     pub fn to_polynomial(

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1847,14 +1847,14 @@ impl<F: FftField> Linearization<Expr<ConstantExpr<F>, Column>> {
     }
 }
 
-impl<F: FftField> Linearization<Vec<PolishToken<F, Column>>> {
+impl<F: FftField, Column: Copy + Debug> Linearization<Vec<PolishToken<F, Column>>> {
     /// Given a linearization and an environment, compute the polynomial corresponding to the
     /// linearization, in evaluation form.
-    pub fn to_polynomial(
+    pub fn to_polynomial<ColEvaluations: ColumnEvaluations<F, Column = Column>>(
         &self,
         env: &Environment<F>,
         pt: F,
-        evals: &ProofEvaluations<PointEvaluations<F>>,
+        evals: &ColEvaluations,
     ) -> (F, Evaluations<F, D<F>>) {
         let cs = &env.constants;
         let n = env.domain.d1.size();

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -667,7 +667,7 @@ pub enum PolishToken<F, Column> {
     SkipIfNot(FeatureFlag, usize),
 }
 
-trait ColumnEvaluations<F> {
+pub trait ColumnEvaluations<F> {
     type Column;
     fn evaluate(&self, col: Self::Column) -> Result<PointEvaluations<F>, ExprError<Self::Column>>;
 }
@@ -695,10 +695,10 @@ impl<F: Copy> ColumnEvaluations<F> for ProofEvaluations<PointEvaluations<F>> {
     }
 }
 
-impl Variable<Column> {
-    fn evaluate<F: Field>(
+impl<Column: Copy> Variable<Column> {
+    fn evaluate<F: Field, Evaluations: ColumnEvaluations<F, Column = Column>>(
         &self,
-        evals: &ProofEvaluations<PointEvaluations<F>>,
+        evals: &Evaluations,
     ) -> Result<F, ExprError<Column>> {
         let point_evaluations = evals.evaluate(self.col)?;
         match self.row {
@@ -708,13 +708,13 @@ impl Variable<Column> {
     }
 }
 
-impl<F: FftField> PolishToken<F, Column> {
+impl<F: FftField, Column: Copy> PolishToken<F, Column> {
     /// Evaluate an RPN expression to a field element.
-    pub fn evaluate(
+    pub fn evaluate<Evaluations: ColumnEvaluations<F, Column = Column>>(
         toks: &[PolishToken<F, Column>],
         d: D<F>,
         pt: F,
-        evals: &ProofEvaluations<PointEvaluations<F>>,
+        evals: &Evaluations,
         c: &Constants<F>,
     ) -> Result<F, ExprError<Column>> {
         let mut stack = vec![];

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1530,14 +1530,18 @@ impl<F: FftField> Expr<ConstantExpr<F>, Column> {
     }
 
     /// Evaluate an expression as a field element against an environment.
-    pub fn evaluate<Evaluations: ColumnEvaluations<F, Column = Column>>(
+    pub fn evaluate<
+        'a,
+        Evaluations: ColumnEvaluations<F, Column = Column>,
+        Environment: ColumnEnvironment<'a, F, Column = Column>,
+    >(
         &self,
         d: D<F>,
         pt: F,
         evals: &Evaluations,
-        env: &Environment<F>,
+        env: &Environment,
     ) -> Result<F, ExprError<Column>> {
-        self.evaluate_(d, pt, evals, &env.constants)
+        self.evaluate_(d, pt, evals, &env.get_constants())
     }
 
     /// Evaluate an expression as a field element against the constants.
@@ -1584,8 +1588,11 @@ impl<F: FftField> Expr<ConstantExpr<F>, Column> {
     }
 
     /// Evaluate the constant expressions in this expression down into field elements.
-    pub fn evaluate_constants(&self, env: &Environment<F>) -> Expr<F, Column> {
-        self.evaluate_constants_(&env.constants)
+    pub fn evaluate_constants<'a, Environment: ColumnEnvironment<'a, F, Column = Column>>(
+        &self,
+        env: &Environment,
+    ) -> Expr<F, Column> {
+        self.evaluate_constants_(env.get_constants())
     }
 
     /// Compute the polynomial corresponding to this expression, in evaluation form.

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -119,6 +119,7 @@ pub struct Environment<'a, F: FftField> {
 trait ColumnEnvironment<'a, F: FftField> {
     type Column;
     fn get_column(&self, col: &Column) -> Option<&'a Evaluations<F, D<F>>>;
+    fn get_domain(&self, d: Domain) -> D<F>;
 }
 
 impl<'a, F: FftField> ColumnEnvironment<'a, F> for Environment<'a, F> {
@@ -142,6 +143,15 @@ impl<'a, F: FftField> ColumnEnvironment<'a, F> for Environment<'a, F> {
                 Some(e) => Some(e),
             },
             Permutation(_) => None,
+        }
+    }
+
+    fn get_domain(&self, d: Domain) -> D<F> {
+        match d {
+            Domain::D1 => self.domain.d1,
+            Domain::D2 => self.domain.d2,
+            Domain::D4 => self.domain.d4,
+            Domain::D8 => self.domain.d8,
         }
     }
 }
@@ -925,7 +935,7 @@ fn unnormalized_lagrange_evals<F: FftField>(
         Domain::D4 => 4,
         Domain::D8 => 8,
     };
-    let res_domain = get_domain(res_domain, env);
+    let res_domain = env.get_domain(res_domain);
 
     let d1 = env.domain.d1;
     let n = d1.size;
@@ -1377,15 +1387,6 @@ impl<'a, F: FftField> EvalResult<'a, F> {
     }
 }
 
-fn get_domain<F: FftField>(d: Domain, env: &Environment<F>) -> D<F> {
-    match d {
-        Domain::D1 => env.domain.d1,
-        Domain::D2 => env.domain.d2,
-        Domain::D4 => env.domain.d4,
-        Domain::D8 => env.domain.d8,
-    }
-}
-
 impl<F: Field, Column: PartialEq> Expr<ConstantExpr<F>, Column> {
     /// Convenience function for constructing expressions from literal
     /// field elements.
@@ -1662,13 +1663,13 @@ impl<F: FftField> Expr<F, Column> {
                 assert_eq!(domain, d);
                 evals
             }
-            EvalResult::Constant(x) => EvalResult::init_((d, get_domain(d, env)), |_| x),
+            EvalResult::Constant(x) => EvalResult::init_((d, env.get_domain(d)), |_| x),
             EvalResult::SubEvals {
                 evals,
                 domain: d_sub,
                 shift: s,
             } => {
-                let res_domain = get_domain(d, env);
+                let res_domain = env.get_domain(d);
                 let scale = (d_sub as usize) / (d as usize);
                 assert!(scale != 0);
                 EvalResult::init_((d, res_domain), |i| {
@@ -1687,7 +1688,7 @@ impl<F: FftField> Expr<F, Column> {
     where
         'a: 'b,
     {
-        let dom = (d, get_domain(d, env));
+        let dom = (d, env.get_domain(d));
 
         let res: EvalResult<'a, F> = match self {
             Expr::Square(x) => match x.evaluations_helper(cache, d, env) {
@@ -1749,9 +1750,9 @@ impl<F: FftField> Expr<F, Column> {
             Expr::Pow(x, p) => {
                 let x = x.evaluations_helper(cache, d, env);
                 match x {
-                    Either::Left(x) => x.pow(*p, (d, get_domain(d, env))),
+                    Either::Left(x) => x.pow(*p, (d, env.get_domain(d))),
                     Either::Right(id) => {
-                        id.get_from(cache).unwrap().pow(*p, (d, get_domain(d, env)))
+                        id.get_from(cache).unwrap().pow(*p, (d, env.get_domain(d)))
                     }
                 }
             }
@@ -1779,7 +1780,7 @@ impl<F: FftField> Expr<F, Column> {
                 }
             }
             Expr::BinOp(op, e1, e2) => {
-                let dom = (d, get_domain(d, env));
+                let dom = (d, env.get_domain(d));
                 let f = |x: EvalResult<F>, y: EvalResult<F>| match op {
                     Op2::Mul => x.mul(y, dom),
                     Op2::Add => x.add(y, dom),

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1386,7 +1386,7 @@ fn get_domain<F: FftField>(d: Domain, env: &Environment<F>) -> D<F> {
     }
 }
 
-impl<F: Field> Expr<ConstantExpr<F>, Column> {
+impl<F: Field, Column: PartialEq> Expr<ConstantExpr<F>, Column> {
     /// Convenience function for constructing expressions from literal
     /// field elements.
     pub fn literal(x: F) -> Self {
@@ -1535,11 +1535,11 @@ impl<F: FftField> Expr<ConstantExpr<F>, Column> {
     }
 
     /// Evaluate an expression as a field element against the constants.
-    pub fn evaluate_(
+    pub fn evaluate_<Evaluations: ColumnEvaluations<F, Column = Column>>(
         &self,
         d: D<F>,
         pt: F,
-        evals: &ProofEvaluations<PointEvaluations<F>>,
+        evals: &Evaluations,
         c: &Constants<F>,
     ) -> Result<F, ExprError<Column>> {
         use Expr::*;

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -791,14 +791,12 @@ impl<F: FftField, Column: Copy> PolishToken<F, Column> {
     }
 }
 
-impl<C> Expr<C, Column> {
+impl<C, Column> Expr<C, Column> {
     /// Convenience function for constructing cell variables.
     pub fn cell(col: Column, row: CurrOrNext) -> Expr<C, Column> {
         Expr::Cell(Variable { col, row })
     }
-}
 
-impl<C, Column> Expr<C, Column> {
     pub fn double(self) -> Self {
         Expr::Double(Box::new(self))
     }

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -49,7 +49,7 @@ pub enum ExprError<Column> {
     MissingIndexEvaluation(Column),
 
     #[error("Linearization failed (too many unevaluated columns: {0:?}")]
-    FailedLinearization(Vec<Variable>),
+    FailedLinearization(Vec<Variable<Column>>),
 
     #[error("runtime table not available")]
     MissingRuntime,
@@ -232,14 +232,14 @@ impl Column {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 /// A type representing a variable which can appear in a constraint. It specifies a column
 /// and a relative position (Curr or Next)
-pub struct Variable {
+pub struct Variable<Column> {
     /// The column of this variable
     pub col: Column,
     /// The row (Curr of Next) of this variable
     pub row: CurrOrNext,
 }
 
-impl Variable {
+impl Variable<Column> {
     fn ocaml(&self) -> String {
         format!("var({:?}, {:?})", self.col, self.row)
     }
@@ -473,7 +473,7 @@ impl FeatureFlag {
 #[derive(Clone, Debug, PartialEq)]
 pub enum Expr<C> {
     Constant(C),
-    Cell(Variable),
+    Cell(Variable<Column>),
     Double(Box<Expr<C>>),
     Square(Box<Expr<C>>),
     BinOp(Op2, Box<Expr<C>>, Box<Expr<C>>),
@@ -642,7 +642,7 @@ pub enum PolishToken<F> {
         col: usize,
     },
     Literal(F),
-    Cell(Variable),
+    Cell(Variable<Column>),
     Dup,
     Pow(u64),
     Add,
@@ -658,7 +658,7 @@ pub enum PolishToken<F> {
     SkipIfNot(FeatureFlag, usize),
 }
 
-impl Variable {
+impl Variable<Column> {
     fn evaluate<F: Field>(
         &self,
         evals: &ProofEvaluations<PointEvaluations<F>>,
@@ -1899,7 +1899,7 @@ impl<F: One> Expr<F> {
     }
 }
 
-type Monomials<F> = HashMap<Vec<Variable>, Expr<F>>;
+type Monomials<F> = HashMap<Vec<Variable<Column>>, Expr<F>>;
 
 fn mul_monomials<F: Neg<Output = F> + Clone + One + Zero + PartialEq>(
     e1: &Monomials<F>,
@@ -1940,8 +1940,8 @@ impl<F: Neg<Output = F> + Clone + One + Zero + PartialEq> Expr<F> {
         }
     }
 
-    fn monomials(&self, ev: &HashSet<Column>) -> HashMap<Vec<Variable>, Expr<F>> {
-        let sing = |v: Vec<Variable>, c: Expr<F>| {
+    fn monomials(&self, ev: &HashSet<Column>) -> HashMap<Vec<Variable<Column>>, Expr<F>> {
+        let sing = |v: Vec<Variable<Column>>, c: Expr<F>| {
             let mut h = HashMap::new();
             h.insert(v, c);
             h

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -116,10 +116,11 @@ pub struct Environment<'a, F: FftField> {
     pub lookup: Option<LookupEnvironment<'a, F>>,
 }
 
-trait ColumnEnvironment<'a, F: FftField> {
+pub trait ColumnEnvironment<'a, F: FftField> {
     type Column;
     fn get_column(&self, col: &Column) -> Option<&'a Evaluations<F, D<F>>>;
     fn get_domain(&self, d: Domain) -> D<F>;
+    fn get_constants(&self) -> &Constants<F>;
 }
 
 impl<'a, F: FftField> ColumnEnvironment<'a, F> for Environment<'a, F> {
@@ -153,6 +154,10 @@ impl<'a, F: FftField> ColumnEnvironment<'a, F> for Environment<'a, F> {
             Domain::D4 => self.domain.d4,
             Domain::D8 => self.domain.d8,
         }
+    }
+
+    fn get_constants(&self) -> &Constants<F> {
+        &self.constants
     }
 }
 
@@ -850,7 +855,7 @@ where
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, FromPrimitive, ToPrimitive)]
-enum Domain {
+pub enum Domain {
     D1 = 1,
     D2 = 2,
     D4 = 4,
@@ -1851,17 +1856,22 @@ impl<F: FftField> Linearization<Expr<ConstantExpr<F>, Column>> {
 impl<F: FftField, Column: Copy + Debug> Linearization<Vec<PolishToken<F, Column>>> {
     /// Given a linearization and an environment, compute the polynomial corresponding to the
     /// linearization, in evaluation form.
-    pub fn to_polynomial<ColEvaluations: ColumnEvaluations<F, Column = Column>>(
+    pub fn to_polynomial<
+        'a,
+        ColEvaluations: ColumnEvaluations<F, Column = Column>,
+        Environment: ColumnEnvironment<'a, F, Column = Column>,
+    >(
         &self,
-        env: &Environment<F>,
+        env: &Environment,
         pt: F,
         evals: &ColEvaluations,
     ) -> (F, Evaluations<F, D<F>>) {
-        let cs = &env.constants;
-        let n = env.domain.d1.size();
+        let cs = env.get_constants();
+        let d1 = env.get_domain(Domain::D1);
+        let n = d1.size();
         let mut res = vec![F::zero(); n];
         self.index_terms.iter().for_each(|(idx, c)| {
-            let c = PolishToken::evaluate(c, env.domain.d1, pt, evals, cs).unwrap();
+            let c = PolishToken::evaluate(c, d1, pt, evals, cs).unwrap();
             let e = env
                 .get_column(idx)
                 .unwrap_or_else(|| panic!("Index polynomial {idx:?} not found"));
@@ -1870,9 +1880,9 @@ impl<F: FftField, Column: Copy + Debug> Linearization<Vec<PolishToken<F, Column>
                 .enumerate()
                 .for_each(|(i, r)| *r += c * e.evals[scale * i]);
         });
-        let p = Evaluations::<F, D<F>>::from_vec_and_domain(res, env.domain.d1);
+        let p = Evaluations::<F, D<F>>::from_vec_and_domain(res, d1);
         (
-            PolishToken::evaluate(&self.constant_term, env.domain.d1, pt, evals, cs).unwrap(),
+            PolishToken::evaluate(&self.constant_term, d1, pt, evals, cs).unwrap(),
             p,
         )
     }

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -121,6 +121,8 @@ pub trait ColumnEnvironment<'a, F: FftField> {
     fn get_column(&self, col: &Column) -> Option<&'a Evaluations<F, D<F>>>;
     fn get_domain(&self, d: Domain) -> D<F>;
     fn get_constants(&self) -> &Constants<F>;
+    fn vanishes_on_last_4_rows(&self) -> &'a Evaluations<F, D<F>>;
+    fn l0_1(&self) -> F;
 }
 
 impl<'a, F: FftField> ColumnEnvironment<'a, F> for Environment<'a, F> {
@@ -158,6 +160,14 @@ impl<'a, F: FftField> ColumnEnvironment<'a, F> for Environment<'a, F> {
 
     fn get_constants(&self) -> &Constants<F> {
         &self.constants
+    }
+
+    fn vanishes_on_last_4_rows(&self) -> &'a Evaluations<F, D<F>> {
+        &self.vanishes_on_last_4_rows
+    }
+
+    fn l0_1(&self) -> F {
+        self.l0_1
     }
 }
 
@@ -1691,11 +1701,11 @@ impl<F: FftField> Expr<F, Column> {
         }
     }
 
-    fn evaluations_helper<'a, 'b>(
+    fn evaluations_helper<'a, 'b, Environment: ColumnEnvironment<'a, F, Column = Column>>(
         &self,
         cache: &'b mut HashMap<CacheId, EvalResult<'a, F>>,
         d: Domain,
-        env: &Environment<'a, F>,
+        env: &Environment,
     ) -> Either<EvalResult<'a, F>, CacheId>
     where
         'a: 'b,
@@ -1771,12 +1781,12 @@ impl<F: FftField> Expr<F, Column> {
             Expr::VanishesOnLast4Rows => EvalResult::SubEvals {
                 domain: Domain::D8,
                 shift: 0,
-                evals: env.vanishes_on_last_4_rows,
+                evals: env.vanishes_on_last_4_rows(),
             },
             Expr::Constant(x) => EvalResult::Constant(*x),
             Expr::UnnormalizedLagrangeBasis(i) => EvalResult::Evals {
                 domain: d,
-                evals: unnormalized_lagrange_evals(env.l0_1, *i, d, env),
+                evals: unnormalized_lagrange_evals(env.l0_1(), *i, d, env),
             },
             Expr::Cell(Variable { col, row }) => {
                 let evals: &'a Evaluations<F, D<F>> = {

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1898,17 +1898,22 @@ impl<F: FftField, Column: Copy + Debug> Linearization<Vec<PolishToken<F, Column>
 impl<F: FftField> Linearization<Expr<ConstantExpr<F>, Column>> {
     /// Given a linearization and an environment, compute the polynomial corresponding to the
     /// linearization, in evaluation form.
-    pub fn to_polynomial<ColEvaluations: ColumnEvaluations<F, Column = Column>>(
+    pub fn to_polynomial<
+        'a,
+        ColEvaluations: ColumnEvaluations<F, Column = Column>,
+        Environment: ColumnEnvironment<'a, F, Column = Column>,
+    >(
         &self,
-        env: &Environment<F>,
+        env: &Environment,
         pt: F,
         evals: &ColEvaluations,
     ) -> (F, DensePolynomial<F>) {
-        let cs = &env.constants;
-        let n = env.domain.d1.size();
+        let cs = env.get_constants();
+        let d1 = env.get_domain(Domain::D1);
+        let n = d1.size();
         let mut res = vec![F::zero(); n];
         self.index_terms.iter().for_each(|(idx, c)| {
-            let c = c.evaluate_(env.domain.d1, pt, evals, cs).unwrap();
+            let c = c.evaluate_(d1, pt, evals, cs).unwrap();
             let e = env
                 .get_column(idx)
                 .unwrap_or_else(|| panic!("Index polynomial {idx:?} not found"));
@@ -1917,13 +1922,8 @@ impl<F: FftField> Linearization<Expr<ConstantExpr<F>, Column>> {
                 .enumerate()
                 .for_each(|(i, r)| *r += c * e.evals[scale * i])
         });
-        let p = Evaluations::<F, D<F>>::from_vec_and_domain(res, env.domain.d1).interpolate();
-        (
-            self.constant_term
-                .evaluate_(env.domain.d1, pt, evals, cs)
-                .unwrap(),
-            p,
-        )
+        let p = Evaluations::<F, D<F>>::from_vec_and_domain(res, d1).interpolate();
+        (self.constant_term.evaluate_(d1, pt, evals, cs).unwrap(), p)
     }
 }
 

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1,5 +1,6 @@
 use crate::{
     circuits::{
+        berkeley_columns,
         constraints::FeatureFlags,
         domains::EvaluationDomains,
         gate::{CurrOrNext, GateType},
@@ -126,10 +127,10 @@ pub trait ColumnEnvironment<'a, F: FftField> {
 }
 
 impl<'a, F: FftField> ColumnEnvironment<'a, F> for Environment<'a, F> {
-    type Column = Column;
+    type Column = berkeley_columns::Column;
 
     fn get_column(&self, col: &Self::Column) -> Option<&'a Evaluations<F, D<F>>> {
-        use Column::*;
+        use berkeley_columns::Column::*;
         let lookup = self.lookup.as_ref();
         match col {
             Witness(i) => Some(&self.witness[*i]),
@@ -199,72 +200,8 @@ fn unnormalized_lagrange_basis<F: FftField>(domain: &D<F>, i: i32, pt: &F) -> F 
     domain.evaluate_vanishing_polynomial(*pt) / (*pt - omega_i)
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-/// A type representing one of the polynomials involved in the PLONK IOP.
-pub enum Column {
-    Witness(usize),
-    Z,
-    LookupSorted(usize),
-    LookupAggreg,
-    LookupTable,
-    LookupKindIndex(LookupPattern),
-    LookupRuntimeSelector,
-    LookupRuntimeTable,
-    Index(GateType),
-    Coefficient(usize),
-    Permutation(usize),
-}
-
 pub trait GenericColumn {
     fn domain(&self) -> Domain;
-}
-
-impl GenericColumn for Column {
-    fn domain(&self) -> Domain {
-        match self {
-            Column::Index(GateType::Generic) => Domain::D4,
-            Column::Index(GateType::CompleteAdd) => Domain::D4,
-            _ => Domain::D8,
-        }
-    }
-}
-
-impl Column {
-    fn latex(&self) -> String {
-        match self {
-            Column::Witness(i) => format!("w_{{{i}}}"),
-            Column::Z => "Z".to_string(),
-            Column::LookupSorted(i) => format!("s_{{{i}}}"),
-            Column::LookupAggreg => "a".to_string(),
-            Column::LookupTable => "t".to_string(),
-            Column::LookupKindIndex(i) => format!("k_{{{i:?}}}"),
-            Column::LookupRuntimeSelector => "rts".to_string(),
-            Column::LookupRuntimeTable => "rt".to_string(),
-            Column::Index(gate) => {
-                format!("{gate:?}")
-            }
-            Column::Coefficient(i) => format!("c_{{{i}}}"),
-            Column::Permutation(i) => format!("sigma_{{{i}}}"),
-        }
-    }
-
-    fn text(&self) -> String {
-        match self {
-            Column::Witness(i) => format!("w[{i}]"),
-            Column::Z => "Z".to_string(),
-            Column::LookupSorted(i) => format!("s[{i}]"),
-            Column::LookupAggreg => "a".to_string(),
-            Column::LookupTable => "t".to_string(),
-            Column::LookupKindIndex(i) => format!("k[{i:?}]"),
-            Column::LookupRuntimeSelector => "rts".to_string(),
-            Column::LookupRuntimeTable => "rt".to_string(),
-            Column::Index(gate) => {
-                format!("{gate:?}")
-            }
-            Column::Coefficient(i) => format!("c[{i}]"),
-            Column::Permutation(i) => format!("sigma_[{i}]"),
-        }
-    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
@@ -275,28 +212,6 @@ pub struct Variable<Column> {
     pub col: Column,
     /// The row (Curr of Next) of this variable
     pub row: CurrOrNext,
-}
-
-impl Variable<Column> {
-    fn ocaml(&self) -> String {
-        format!("var({:?}, {:?})", self.col, self.row)
-    }
-
-    fn latex(&self) -> String {
-        let col = self.col.latex();
-        match self.row {
-            Curr => col,
-            Next => format!("\\tilde{{{col}}}"),
-        }
-    }
-
-    fn text(&self) -> String {
-        let col = self.col.text();
-        match self.row {
-            Curr => format!("Curr({col})"),
-            Next => format!("Next({col})"),
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -704,9 +619,9 @@ pub trait ColumnEvaluations<F> {
 }
 
 impl<F: Copy> ColumnEvaluations<F> for ProofEvaluations<PointEvaluations<F>> {
-    type Column = Column;
+    type Column = berkeley_columns::Column;
     fn evaluate(&self, col: Self::Column) -> Result<PointEvaluations<F>, ExprError<Self::Column>> {
-        use Column::*;
+        use berkeley_columns::Column::*;
         let l = self.lookup.as_ref().ok_or(ExprError::LookupShouldNotBeUsed);
         match col {
             Witness(i) => Ok(self.w[i]),
@@ -861,7 +776,7 @@ impl<C, Column> Expr<C, Column> {
     }
 }
 
-impl<F> fmt::Display for Expr<ConstantExpr<F>, Column>
+impl<F> fmt::Display for Expr<ConstantExpr<F>, berkeley_columns::Column>
 where
     F: PrimeField,
 {
@@ -2473,7 +2388,7 @@ where
     }
 }
 
-impl<F> Expr<ConstantExpr<F>, Column>
+impl<F> Expr<ConstantExpr<F>, berkeley_columns::Column>
 where
     F: PrimeField,
 {
@@ -2500,7 +2415,10 @@ where
 
     /// Recursively print the expression,
     /// except for the cached expression that are stored in the `cache`.
-    fn ocaml(&self, cache: &mut HashMap<CacheId, Expr<ConstantExpr<F>, Column>>) -> String {
+    fn ocaml(
+        &self,
+        cache: &mut HashMap<CacheId, Expr<ConstantExpr<F>, berkeley_columns::Column>>,
+    ) -> String {
         use Expr::*;
         match self {
             Double(x) => format!("double({})", x.ocaml(cache)),
@@ -2549,7 +2467,10 @@ where
         res
     }
 
-    fn latex(&self, cache: &mut HashMap<CacheId, Expr<ConstantExpr<F>, Column>>) -> String {
+    fn latex(
+        &self,
+        cache: &mut HashMap<CacheId, Expr<ConstantExpr<F>, berkeley_columns::Column>>,
+    ) -> String {
         use Expr::*;
         match self {
             Double(x) => format!("2 ({})", x.latex(cache)),
@@ -2572,7 +2493,10 @@ where
 
     /// Recursively print the expression,
     /// except for the cached expression that are stored in the `cache`.
-    fn text(&self, cache: &mut HashMap<CacheId, Expr<ConstantExpr<F>, Column>>) -> String {
+    fn text(
+        &self,
+        cache: &mut HashMap<CacheId, Expr<ConstantExpr<F>, berkeley_columns::Column>>,
+    ) -> String {
         use Expr::*;
         match self {
             Double(x) => format!("double({})", x.text(cache)),
@@ -2687,21 +2611,27 @@ pub mod constraints {
         fn cache(&self, cache: &mut Cache) -> Self;
     }
 
-    impl<F> ExprOps<F> for Expr<ConstantExpr<F>, Column>
+    impl<F> ExprOps<F> for Expr<ConstantExpr<F>, berkeley_columns::Column>
     where
         F: PrimeField,
-        Expr<ConstantExpr<F>, Column>: std::fmt::Display,
+        Expr<ConstantExpr<F>, berkeley_columns::Column>: std::fmt::Display,
     {
         fn two_pow(pow: u64) -> Self {
-            Expr::<ConstantExpr<F>, Column>::literal(<F as Two<F>>::two_pow(pow))
+            Expr::<ConstantExpr<F>, berkeley_columns::Column>::literal(<F as Two<F>>::two_pow(pow))
         }
 
         fn two_to_limb() -> Self {
-            Expr::<ConstantExpr<F>, Column>::literal(<F as ForeignFieldHelpers<F>>::two_to_limb())
+            Expr::<ConstantExpr<F>, berkeley_columns::Column>::literal(<F as ForeignFieldHelpers<
+                F,
+            >>::two_to_limb(
+            ))
         }
 
         fn two_to_2limb() -> Self {
-            Expr::<ConstantExpr<F>, Column>::literal(<F as ForeignFieldHelpers<F>>::two_to_2limb())
+            Expr::<ConstantExpr<F>, berkeley_columns::Column>::literal(<F as ForeignFieldHelpers<
+                F,
+            >>::two_to_2limb(
+            ))
         }
 
         fn double(&self) -> Self {
@@ -2833,7 +2763,7 @@ pub mod constraints {
 //
 
 /// An alias for the intended usage of the expression type in constructing constraints.
-pub type E<F> = Expr<ConstantExpr<F>, Column>;
+pub type E<F> = Expr<ConstantExpr<F>, berkeley_columns::Column>;
 
 /// Convenience function to create a constant as [Expr].
 pub fn constant<F>(x: F) -> E<F> {
@@ -2842,7 +2772,7 @@ pub fn constant<F>(x: F) -> E<F> {
 
 /// Helper function to quickly create an expression for a witness.
 pub fn witness<F>(i: usize, row: CurrOrNext) -> E<F> {
-    E::<F>::cell(Column::Witness(i), row)
+    E::<F>::cell(berkeley_columns::Column::Witness(i), row)
 }
 
 /// Same as [witness] but for the current row.
@@ -2857,11 +2787,11 @@ pub fn witness_next<F>(i: usize) -> E<F> {
 
 /// Handy function to quickly create an expression for a gate.
 pub fn index<F>(g: GateType) -> E<F> {
-    E::<F>::cell(Column::Index(g), CurrOrNext::Curr)
+    E::<F>::cell(berkeley_columns::Column::Index(g), CurrOrNext::Curr)
 }
 
 pub fn coeff<F>(i: usize) -> E<F> {
-    E::<F>::cell(Column::Coefficient(i), CurrOrNext::Curr)
+    E::<F>::cell(berkeley_columns::Column::Coefficient(i), CurrOrNext::Curr)
 }
 
 /// Auto clone macro - Helps make constraints more readable

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -116,7 +116,14 @@ pub struct Environment<'a, F: FftField> {
     pub lookup: Option<LookupEnvironment<'a, F>>,
 }
 
-impl<'a, F: FftField> Environment<'a, F> {
+trait ColumnEnvironment<'a, F: FftField> {
+    type Column;
+    fn get_column(&self, col: &Column) -> Option<&'a Evaluations<F, D<F>>>;
+}
+
+impl<'a, F: FftField> ColumnEnvironment<'a, F> for Environment<'a, F> {
+    type Column = Column;
+
     fn get_column(&self, col: &Column) -> Option<&'a Evaluations<F, D<F>>> {
         use Column::*;
         let lookup = self.lookup.as_ref();

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -11,7 +11,7 @@ use crate::{
         polynomials::permutation::eval_vanishes_on_last_4_rows,
         wires::COLUMNS,
     },
-    proof::{PointEvaluations, ProofEvaluations},
+    proof::PointEvaluations,
 };
 use ark_ff::{FftField, Field, One, PrimeField, Zero};
 use ark_poly::{
@@ -616,29 +616,6 @@ pub enum PolishToken<F, Column> {
 pub trait ColumnEvaluations<F> {
     type Column;
     fn evaluate(&self, col: Self::Column) -> Result<PointEvaluations<F>, ExprError<Self::Column>>;
-}
-
-impl<F: Copy> ColumnEvaluations<F> for ProofEvaluations<PointEvaluations<F>> {
-    type Column = berkeley_columns::Column;
-    fn evaluate(&self, col: Self::Column) -> Result<PointEvaluations<F>, ExprError<Self::Column>> {
-        use berkeley_columns::Column::*;
-        let l = self.lookup.as_ref().ok_or(ExprError::LookupShouldNotBeUsed);
-        match col {
-            Witness(i) => Ok(self.w[i]),
-            Z => Ok(self.z),
-            LookupSorted(i) => l.map(|l| l.sorted[i]),
-            LookupAggreg => l.map(|l| l.aggreg),
-            LookupTable => l.map(|l| l.table),
-            LookupRuntimeTable => l.and_then(|l| l.runtime.ok_or(ExprError::MissingRuntime)),
-            Index(GateType::Poseidon) => Ok(self.poseidon_selector),
-            Index(GateType::Generic) => Ok(self.generic_selector),
-            Permutation(i) => Ok(self.s[i]),
-            Coefficient(i) => Ok(self.coefficients[i]),
-            LookupKindIndex(_) | LookupRuntimeSelector | Index(_) => {
-                Err(ExprError::MissingIndexEvaluation(col))
-            }
-        }
-    }
 }
 
 impl<Column: Copy> Variable<Column> {

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1968,12 +1968,15 @@ impl<F: One, Column> Expr<F, Column> {
     }
 }
 
-type Monomials<F> = HashMap<Vec<Variable<Column>>, Expr<F, Column>>;
+type Monomials<F, Column> = HashMap<Vec<Variable<Column>>, Expr<F, Column>>;
 
-fn mul_monomials<F: Neg<Output = F> + Clone + One + Zero + PartialEq>(
-    e1: &Monomials<F>,
-    e2: &Monomials<F>,
-) -> Monomials<F> {
+fn mul_monomials<
+    F: Neg<Output = F> + Clone + One + Zero + PartialEq,
+    Column: Ord + Copy + std::hash::Hash,
+>(
+    e1: &Monomials<F, Column>,
+    e2: &Monomials<F, Column>,
+) -> Monomials<F, Column> {
     let mut res: HashMap<_, Expr<F, Column>> = HashMap::new();
     for (m1, c1) in e1.iter() {
         for (m2, c2) in e2.iter() {
@@ -1988,7 +1991,9 @@ fn mul_monomials<F: Neg<Output = F> + Clone + One + Zero + PartialEq>(
     res
 }
 
-impl<F: Neg<Output = F> + Clone + One + Zero + PartialEq> Expr<F, Column> {
+impl<F: Neg<Output = F> + Clone + One + Zero + PartialEq, Column: Ord + Copy + std::hash::Hash>
+    Expr<F, Column>
+{
     // TODO: This function (which takes linear time)
     // is called repeatedly in monomials, yielding quadratic behavior for
     // that function. It's ok for now as we only call that function once on

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1922,7 +1922,9 @@ impl<F: FftField, Column: Copy + Debug> Linearization<Vec<PolishToken<F, Column>
     }
 }
 
-impl<F: FftField> Linearization<Expr<ConstantExpr<F>, Column>, Column> {
+impl<F: FftField, Column: Debug + PartialEq + Copy + GenericColumn>
+    Linearization<Expr<ConstantExpr<F>, Column>, Column>
+{
     /// Given a linearization and an environment, compute the polynomial corresponding to the
     /// linearization, in evaluation form.
     pub fn to_polynomial<

--- a/kimchi/src/circuits/lookup/constraints.rs
+++ b/kimchi/src/circuits/lookup/constraints.rs
@@ -1,6 +1,7 @@
 use crate::{
     circuits::{
-        expr::{prologue::*, Column, ConstantExpr},
+        berkeley_columns::Column,
+        expr::{prologue::*, ConstantExpr},
         gate::{CircuitGate, CurrOrNext},
         lookup::lookups::{
             JointLookup, JointLookupSpec, JointLookupValue, LocalPosition, LookupInfo,

--- a/kimchi/src/circuits/lookup/runtime_tables.rs
+++ b/kimchi/src/circuits/lookup/runtime_tables.rs
@@ -2,10 +2,7 @@
 //! The setup has to prepare for their presence using [`RuntimeTableCfg`].
 //! At proving time, the prover can use [`RuntimeTable`] to specify the actual tables.
 
-use crate::circuits::{
-    expr::{prologue::*, Column},
-    gate::CurrOrNext,
-};
+use crate::circuits::{berkeley_columns::Column, expr::prologue::*, gate::CurrOrNext};
 use ark_ff::Field;
 use serde::{Deserialize, Serialize};
 

--- a/kimchi/src/circuits/mod.rs
+++ b/kimchi/src/circuits/mod.rs
@@ -2,6 +2,7 @@
 pub mod macros;
 
 pub mod argument;
+pub mod berkeley_columns;
 pub mod constraints;
 pub mod domain_constant_evaluation;
 pub mod domains;

--- a/kimchi/src/circuits/polynomials/turshi.rs
+++ b/kimchi/src/circuits/polynomials/turshi.rs
@@ -82,8 +82,9 @@ use crate::{
     alphas::Alphas,
     circuits::{
         argument::{Argument, ArgumentEnv, ArgumentType},
+        berkeley_columns::Column,
         constraints::ConstraintSystem,
-        expr::{self, constraints::ExprOps, Cache, Column, E},
+        expr::{self, constraints::ExprOps, Cache, E},
         gate::{CircuitGate, GateType},
         wires::{GateWires, Wire, COLUMNS},
     },

--- a/kimchi/src/circuits/polynomials/varbasemul.rs
+++ b/kimchi/src/circuits/polynomials/varbasemul.rs
@@ -12,13 +12,15 @@
 
 use crate::circuits::{
     argument::{Argument, ArgumentEnv, ArgumentType},
-    expr::{constraints::ExprOps, Cache, Column, Variable},
+    expr::{constraints::ExprOps, Cache, Column, Variable as VariableGen},
     gate::{CircuitGate, CurrOrNext, GateType},
     wires::{GateWires, COLUMNS},
 };
 use ark_ff::{FftField, PrimeField};
 use std::marker::PhantomData;
 use CurrOrNext::{Curr, Next};
+
+type Variable = VariableGen<Column>;
 
 //~ We implement custom Plonk constraints for short Weierstrass curve variable base scalar multiplication.
 //~

--- a/kimchi/src/circuits/polynomials/varbasemul.rs
+++ b/kimchi/src/circuits/polynomials/varbasemul.rs
@@ -12,7 +12,8 @@
 
 use crate::circuits::{
     argument::{Argument, ArgumentEnv, ArgumentType},
-    expr::{constraints::ExprOps, Cache, Column, Variable as VariableGen},
+    berkeley_columns::Column,
+    expr::{constraints::ExprOps, Cache, Variable as VariableGen},
     gate::{CircuitGate, CurrOrNext, GateType},
     wires::{GateWires, COLUMNS},
 };

--- a/kimchi/src/error.rs
+++ b/kimchi/src/error.rs
@@ -69,10 +69,10 @@ pub enum VerifyError {
     IncorrectRuntimeProof,
 
     #[error("the evaluation for {0:?} is missing")]
-    MissingEvaluation(crate::circuits::expr::Column),
+    MissingEvaluation(crate::circuits::berkeley_columns::Column),
 
     #[error("the commitment for {0:?} is missing")]
-    MissingCommitment(crate::circuits::expr::Column),
+    MissingCommitment(crate::circuits::berkeley_columns::Column),
 }
 
 /// Errors that can arise when preparing the setup

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -23,8 +23,9 @@ use crate::circuits::polynomials::{
 };
 
 use crate::circuits::{
+    berkeley_columns::Column,
     constraints::FeatureFlags,
-    expr::{Column, ConstantExpr, Expr, FeatureFlag, Linearization, PolishToken},
+    expr::{ConstantExpr, Expr, FeatureFlag, Linearization, PolishToken},
     gate::GateType,
     wires::COLUMNS,
 };

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -38,7 +38,7 @@ use ark_ff::{FftField, PrimeField, SquareRootField, Zero};
 pub fn constraints_expr<F: PrimeField + SquareRootField>(
     feature_flags: Option<&FeatureFlags>,
     generic: bool,
-) -> (Expr<ConstantExpr<F>>, Alphas<F>) {
+) -> (Expr<ConstantExpr<F>, Column>, Alphas<F>) {
     // register powers of alpha so that we don't reuse them across mutually inclusive constraints
     let mut powers_of_alpha = Alphas::<F>::default();
 

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -319,7 +319,7 @@ pub fn linearization_columns<F: FftField + SquareRootField>(
 pub fn expr_linearization<F: PrimeField + SquareRootField>(
     feature_flags: Option<&FeatureFlags>,
     generic: bool,
-) -> (Linearization<Vec<PolishToken<F>>>, Alphas<F>) {
+) -> (Linearization<Vec<PolishToken<F, Column>>>, Alphas<F>) {
     let evaluated_cols = linearization_columns::<F>(feature_flags);
 
     let (expr, powers_of_alpha) = constraints_expr(feature_flags, generic);

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -319,7 +319,10 @@ pub fn linearization_columns<F: FftField + SquareRootField>(
 pub fn expr_linearization<F: PrimeField + SquareRootField>(
     feature_flags: Option<&FeatureFlags>,
     generic: bool,
-) -> (Linearization<Vec<PolishToken<F, Column>>>, Alphas<F>) {
+) -> (
+    Linearization<Vec<PolishToken<F, Column>>, Column>,
+    Alphas<F>,
+) {
     let evaluated_cols = linearization_columns::<F>(feature_flags);
 
     let (expr, powers_of_alpha) = constraints_expr(feature_flags, generic);

--- a/kimchi/src/proof.rs
+++ b/kimchi/src/proof.rs
@@ -1,7 +1,7 @@
 //! This module implements the data structures of a proof.
 
 use crate::circuits::{
-    expr::Column,
+    berkeley_columns::Column,
     gate::GateType,
     wires::{COLUMNS, PERMUTS},
 };

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -4,7 +4,7 @@ use crate::{
     alphas::Alphas,
     circuits::{
         constraints::{ColumnEvaluations, ConstraintSystem},
-        expr::{Linearization, PolishToken},
+        expr::{Column, Linearization, PolishToken},
     },
     curve::KimchiCurve,
     linearization::expr_linearization,
@@ -28,7 +28,7 @@ pub struct ProverIndex<G: KimchiCurve> {
 
     /// The symbolic linearization of our circuit, which can compile to concrete types once certain values are learned in the protocol.
     #[serde(skip)]
-    pub linearization: Linearization<Vec<PolishToken<G::ScalarField>>>,
+    pub linearization: Linearization<Vec<PolishToken<G::ScalarField, Column>>>,
 
     /// The mapping between powers of alpha and constraints
     #[serde(skip)]

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -28,7 +28,7 @@ pub struct ProverIndex<G: KimchiCurve> {
 
     /// The symbolic linearization of our circuit, which can compile to concrete types once certain values are learned in the protocol.
     #[serde(skip)]
-    pub linearization: Linearization<Vec<PolishToken<G::ScalarField, Column>>>,
+    pub linearization: Linearization<Vec<PolishToken<G::ScalarField, Column>>, Column>,
 
     /// The mapping between powers of alpha and constraints
     #[serde(skip)]

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -3,8 +3,9 @@
 use crate::{
     alphas::Alphas,
     circuits::{
+        berkeley_columns::Column,
         constraints::{ColumnEvaluations, ConstraintSystem},
-        expr::{Column, Linearization, PolishToken},
+        expr::{Linearization, PolishToken},
     },
     curve::KimchiCurve,
     linearization::expr_linearization,

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -3,8 +3,9 @@
 use crate::{
     circuits::{
         argument::ArgumentType,
+        berkeley_columns::Column,
         constraints::ConstraintSystem,
-        expr::{Column, Constants, PolishToken},
+        expr::{Constants, PolishToken},
         gate::GateType,
         lookup::tables::combine_table,
         polynomials::permutation,

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -4,7 +4,8 @@
 use crate::{
     alphas::Alphas,
     circuits::{
-        expr::{Column, Linearization, PolishToken},
+        berkeley_columns::Column,
+        expr::{Linearization, PolishToken},
         lookup::{index::LookupSelectors, lookups::LookupInfo},
         polynomials::permutation::{zk_polynomial, zk_w3},
         wires::{COLUMNS, PERMUTS},

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -142,7 +142,7 @@ pub struct VerifierIndex<G: KimchiCurve> {
     pub lookup_index: Option<LookupVerifierIndex<G>>,
 
     #[serde(skip)]
-    pub linearization: Linearization<Vec<PolishToken<G::ScalarField, Column>>>,
+    pub linearization: Linearization<Vec<PolishToken<G::ScalarField, Column>>, Column>,
     /// The mapping between powers of alpha and constraints
     #[serde(skip)]
     pub powers_of_alpha: Alphas<G::ScalarField>,

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -4,7 +4,7 @@
 use crate::{
     alphas::Alphas,
     circuits::{
-        expr::{Linearization, PolishToken},
+        expr::{Column, Linearization, PolishToken},
         lookup::{index::LookupSelectors, lookups::LookupInfo},
         polynomials::permutation::{zk_polynomial, zk_w3},
         wires::{COLUMNS, PERMUTS},
@@ -142,7 +142,7 @@ pub struct VerifierIndex<G: KimchiCurve> {
     pub lookup_index: Option<LookupVerifierIndex<G>>,
 
     #[serde(skip)]
-    pub linearization: Linearization<Vec<PolishToken<G::ScalarField>>>,
+    pub linearization: Linearization<Vec<PolishToken<G::ScalarField, Column>>>,
     /// The mapping between powers of alpha and constraints
     #[serde(skip)]
     pub powers_of_alpha: Alphas<G::ScalarField>,


### PR DESCRIPTION
This PR generalizes the `Expr` framework, abstracting over the columns and separating the berkeley columns into their own dedicated type.

This allows for the description of gates and proof configurations that don't explicitly depend on the configuration used by the Mina berkeley / SnarkyJS proof system.