### PR TITLE
Remove evaluated columns from linearization

### DIFF
--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -675,6 +675,10 @@ impl Variable {
                 LookupRuntimeTable => l.and_then(|l| l.runtime.ok_or(ExprError::MissingRuntime)),
                 Index(GateType::Poseidon) => Ok(evals.poseidon_selector),
                 Index(GateType::Generic) => Ok(evals.generic_selector),
+                Index(GateType::CompleteAdd) => Ok(evals.complete_add_selector),
+                Index(GateType::VarBaseMul) => Ok(evals.mul_selector),
+                Index(GateType::EndoMul) => Ok(evals.emul_selector),
+                Index(GateType::EndoMulScalar) => Ok(evals.endomul_scalar_selector),
                 Permutation(i) => Ok(evals.s[i]),
                 Coefficient(i) => Ok(evals.coefficients[i]),
                 LookupKindIndex(_) | LookupRuntimeSelector | Index(_) => {

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -305,6 +305,11 @@ pub fn linearization_columns<F: FftField + SquareRootField>(
     // the generic selector polynomial
     h.insert(Index(GateType::Generic));
 
+    h.insert(Index(GateType::CompleteAdd));
+    h.insert(Index(GateType::VarBaseMul));
+    h.insert(Index(GateType::EndoMul));
+    h.insert(Index(GateType::EndoMulScalar));
+
     h
 }
 


### PR DESCRIPTION
This PR builds upon #1105, removing the newly-evaluated selectors from the linearization.

This PR is separated for the purposes of the corresponding Mina PR, where it results in the update of a large generated file, along with some other pickles changes.