### PR TITLE
Use 'fixed hiding' for selector commitments

### DIFF
--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1146,22 +1146,22 @@ where
         polynomials.push((
             evaluations_form(&index.column_evaluations.complete_add_selector4),
             None,
-            non_hiding(1),
+            fixed_hiding(1),
         ));
         polynomials.push((
             evaluations_form(&index.column_evaluations.mul_selector8),
             None,
-            non_hiding(1),
+            fixed_hiding(1),
         ));
         polynomials.push((
             evaluations_form(&index.column_evaluations.emul_selector8),
             None,
-            non_hiding(1),
+            fixed_hiding(1),
         ));
         polynomials.push((
             evaluations_form(&index.column_evaluations.endomul_scalar_selector8),
             None,
-            non_hiding(1),
+            fixed_hiding(1),
         ));
         polynomials.extend(
             witness_poly

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -233,21 +233,23 @@ impl<G: KimchiCurve> ProverIndex<G> {
                 &self.column_evaluations.poseidon_selector8,
             )),
 
-            complete_add_comm: self.srs.commit_evaluations_non_hiding(
+            complete_add_comm: mask_fixed(self.srs.commit_evaluations_non_hiding(
                 domain,
                 &self.column_evaluations.complete_add_selector4,
+            )),
+            mul_comm: mask_fixed(
+                self.srs
+                    .commit_evaluations_non_hiding(domain, &self.column_evaluations.mul_selector8),
             ),
-            mul_comm: self
-                .srs
-                .commit_evaluations_non_hiding(domain, &self.column_evaluations.mul_selector8),
-            emul_comm: self
-                .srs
-                .commit_evaluations_non_hiding(domain, &self.column_evaluations.emul_selector8),
+            emul_comm: mask_fixed(
+                self.srs
+                    .commit_evaluations_non_hiding(domain, &self.column_evaluations.emul_selector8),
+            ),
 
-            endomul_scalar_comm: self.srs.commit_evaluations_non_hiding(
+            endomul_scalar_comm: mask_fixed(self.srs.commit_evaluations_non_hiding(
                 domain,
                 &self.column_evaluations.endomul_scalar_selector8,
-            ),
+            )),
 
             range_check0_comm: self
                 .column_evaluations


### PR DESCRIPTION
This PR is a follow-on from #1106, adjusting the blinding factor of selector commitments for the remaining optional gates, so that a 'zero' commitment does not occur for an unused gate.