### PR TITLE
[berkeley] Use the same cache for all constraints, to avoid accidental aliasing

### DIFF
--- a/kimchi/src/circuits/gate.rs
+++ b/kimchi/src/circuits/gate.rs
@@ -277,6 +277,8 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
             }
         }
 
+        let mut cache = expr::Cache::default();
+
         // Perform witness verification on each constraint for this gate
         let results = match self.typ {
             GateType::Zero => {
@@ -286,33 +288,39 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
                 // TODO: implement the verification for the generic gate
                 vec![]
             }
-            GateType::Poseidon => poseidon::Poseidon::constraint_checks(&env),
-            GateType::CompleteAdd => complete_add::CompleteAdd::constraint_checks(&env),
-            GateType::VarBaseMul => varbasemul::VarbaseMul::constraint_checks(&env),
-            GateType::EndoMul => endosclmul::EndosclMul::constraint_checks(&env),
-            GateType::EndoMulScalar => endomul_scalar::EndomulScalar::constraint_checks(&env),
+            GateType::Poseidon => poseidon::Poseidon::constraint_checks(&env, &mut cache),
+            GateType::CompleteAdd => complete_add::CompleteAdd::constraint_checks(&env, &mut cache),
+            GateType::VarBaseMul => varbasemul::VarbaseMul::constraint_checks(&env, &mut cache),
+            GateType::EndoMul => endosclmul::EndosclMul::constraint_checks(&env, &mut cache),
+            GateType::EndoMulScalar => {
+                endomul_scalar::EndomulScalar::constraint_checks(&env, &mut cache)
+            }
             GateType::Lookup => {
                 // TODO: implement the verification for the lookup gate
                 vec![]
             }
-            GateType::CairoClaim => turshi::Claim::constraint_checks(&env),
-            GateType::CairoInstruction => turshi::Instruction::constraint_checks(&env),
-            GateType::CairoFlags => turshi::Flags::constraint_checks(&env),
-            GateType::CairoTransition => turshi::Transition::constraint_checks(&env),
+            GateType::CairoClaim => turshi::Claim::constraint_checks(&env, &mut cache),
+            GateType::CairoInstruction => turshi::Instruction::constraint_checks(&env, &mut cache),
+            GateType::CairoFlags => turshi::Flags::constraint_checks(&env, &mut cache),
+            GateType::CairoTransition => turshi::Transition::constraint_checks(&env, &mut cache),
             GateType::RangeCheck0 => {
-                range_check::circuitgates::RangeCheck0::constraint_checks(&env)
+                range_check::circuitgates::RangeCheck0::constraint_checks(&env, &mut cache)
             }
             GateType::RangeCheck1 => {
-                range_check::circuitgates::RangeCheck1::constraint_checks(&env)
+                range_check::circuitgates::RangeCheck1::constraint_checks(&env, &mut cache)
             }
             GateType::ForeignFieldAdd => {
-                foreign_field_add::circuitgates::ForeignFieldAdd::constraint_checks(&env)
+                foreign_field_add::circuitgates::ForeignFieldAdd::constraint_checks(
+                    &env, &mut cache,
+                )
             }
             GateType::ForeignFieldMul => {
-                foreign_field_mul::circuitgates::ForeignFieldMul::constraint_checks(&env)
+                foreign_field_mul::circuitgates::ForeignFieldMul::constraint_checks(
+                    &env, &mut cache,
+                )
             }
-            GateType::Xor16 => xor::Xor16::constraint_checks(&env),
-            GateType::Rot64 => rot::Rot64::constraint_checks(&env),
+            GateType::Xor16 => xor::Xor16::constraint_checks(&env, &mut cache),
+            GateType::Rot64 => rot::Rot64::constraint_checks(&env, &mut cache),
         };
 
         // Check for failed constraints

--- a/kimchi/src/circuits/polynomials/complete_add.rs
+++ b/kimchi/src/circuits/polynomials/complete_add.rs
@@ -98,7 +98,7 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::CompleteAdd);
     const CONSTRAINTS: u32 = 7;
 
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, cache: &mut Cache) -> Vec<T> {
         // This function makes 2 + 1 + 1 + 1 + 2 = 7 constraints
         let x1 = env.witness_curr(0);
         let y1 = env.witness_curr(1);
@@ -118,8 +118,6 @@ where
 
         // This variable is used to constrain same_x
         let x21_inv = env.witness_curr(10);
-
-        let mut cache = Cache::default();
 
         let x21 = cache.cache(x2.clone() - x1.clone());
         let y21 = cache.cache(y2 - y1.clone());

--- a/kimchi/src/circuits/polynomials/endomul_scalar.rs
+++ b/kimchi/src/circuits/polynomials/endomul_scalar.rs
@@ -167,7 +167,7 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::EndoMulScalar);
     const CONSTRAINTS: u32 = 11;
 
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, cache: &mut Cache) -> Vec<T> {
         let n0 = env.witness_curr(0);
         let n8 = env.witness_curr(1);
         let a0 = env.witness_curr(2);
@@ -177,8 +177,6 @@ where
 
         // x0..x7
         let xs: [_; 8] = array::from_fn(|i| env.witness_curr(6 + i));
-
-        let mut cache = Cache::default();
 
         let c_coeffs = [
             F::zero(),

--- a/kimchi/src/circuits/polynomials/endosclmul.rs
+++ b/kimchi/src/circuits/polynomials/endosclmul.rs
@@ -150,7 +150,7 @@ impl<F: PrimeField> CircuitGate<F> {
         let evals: ProofEvaluations<PointEvaluations<G::ScalarField>> =
             ProofEvaluations::dummy_with_witness_evaluations(this, next);
 
-        let constraints = EndosclMul::constraints();
+        let constraints = EndosclMul::constraints(&mut Cache::default());
         for (i, c) in constraints.iter().enumerate() {
             match c.evaluate_(cs.domain.d1, pt, &evals, &constants) {
                 Ok(x) => {
@@ -185,7 +185,7 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::EndoMul);
     const CONSTRAINTS: u32 = 11;
 
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, cache: &mut Cache) -> Vec<T> {
         let b1 = env.witness_curr(11);
         let b2 = env.witness_curr(12);
         let b3 = env.witness_curr(13);
@@ -202,8 +202,6 @@ where
 
         let xr = env.witness_curr(7);
         let yr = env.witness_curr(8);
-
-        let mut cache = Cache::default();
 
         let s1 = env.witness_curr(9);
         let s3 = env.witness_curr(10);

--- a/kimchi/src/circuits/polynomials/foreign_field_add/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/circuitgates.rs
@@ -2,7 +2,10 @@
 
 use crate::circuits::{
     argument::{Argument, ArgumentEnv, ArgumentType},
-    expr::constraints::{compact_limb, ExprOps},
+    expr::{
+        constraints::{compact_limb, ExprOps},
+        Cache,
+    },
     gate::GateType,
 };
 use ark_ff::PrimeField;
@@ -139,7 +142,7 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::ForeignFieldAdd);
     const CONSTRAINTS: u32 = 4;
 
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, _cache: &mut Cache) -> Vec<T> {
         let foreign_modulus: [T; LIMB_COUNT] = array::from_fn(|i| env.coeff(i));
 
         // stored as coefficient for better correspondance with the relation being proved

--- a/kimchi/src/circuits/polynomials/foreign_field_mul/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_mul/circuitgates.rs
@@ -94,7 +94,7 @@ use crate::{
     auto_clone_array,
     circuits::{
         argument::{Argument, ArgumentEnv, ArgumentType},
-        expr::constraints::ExprOps,
+        expr::{constraints::ExprOps, Cache},
         gate::GateType,
     },
 };
@@ -206,7 +206,7 @@ where
     const CONSTRAINTS: u32 = 9;
     // DEGREE is 4
 
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, _cache: &mut Cache) -> Vec<T> {
         let mut constraints = vec![];
 
         //

--- a/kimchi/src/circuits/polynomials/foreign_field_mul/gadget.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_mul/gadget.rs
@@ -8,7 +8,7 @@ use crate::{
     alphas::Alphas,
     circuits::{
         argument::Argument,
-        expr::E,
+        expr::{Cache, E},
         gate::{CircuitGate, GateType},
         lookup::{
             self,
@@ -80,9 +80,13 @@ pub fn circuit_gates() -> [GateType; GATE_COUNT] {
 }
 
 /// Get combined constraints for a given foreign field multiplication circuit gate
-pub fn circuit_gate_constraints<F: PrimeField>(typ: GateType, alphas: &Alphas<F>) -> E<F> {
+pub fn circuit_gate_constraints<F: PrimeField>(
+    typ: GateType,
+    alphas: &Alphas<F>,
+    cache: &mut Cache,
+) -> E<F> {
     match typ {
-        GateType::ForeignFieldMul => ForeignFieldMul::combined_constraints(alphas),
+        GateType::ForeignFieldMul => ForeignFieldMul::combined_constraints(alphas, cache),
         _ => panic!("invalid gate type"),
     }
 }
@@ -96,8 +100,8 @@ pub fn circuit_gate_constraint_count<F: PrimeField>(typ: GateType) -> u32 {
 }
 
 /// Get the combined constraints for all foreign field multiplication circuit gates
-pub fn combined_constraints<F: PrimeField>(alphas: &Alphas<F>) -> E<F> {
-    ForeignFieldMul::combined_constraints(alphas)
+pub fn combined_constraints<F: PrimeField>(alphas: &Alphas<F>, cache: &mut Cache) -> E<F> {
+    ForeignFieldMul::combined_constraints(alphas, cache)
 }
 
 /// Get the foreign field multiplication lookup table

--- a/kimchi/src/circuits/polynomials/generic.rs
+++ b/kimchi/src/circuits/polynomials/generic.rs
@@ -35,7 +35,7 @@
 
 use crate::circuits::{
     argument::{Argument, ArgumentEnv, ArgumentType},
-    expr::constraints::ExprOps,
+    expr::{constraints::ExprOps, Cache},
     gate::{CircuitGate, GateType},
     polynomial::COLUMNS,
     wires::GateWires,
@@ -74,7 +74,7 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::Generic);
     const CONSTRAINTS: u32 = 2;
 
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, _cache: &mut Cache) -> Vec<T> {
         // First generic gate
         let left_coeff1 = env.coeff(0);
         let right_coeff1 = env.coeff(1);

--- a/kimchi/src/circuits/polynomials/poseidon.rs
+++ b/kimchi/src/circuits/polynomials/poseidon.rs
@@ -339,9 +339,8 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::Poseidon);
     const CONSTRAINTS: u32 = 15;
 
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, cache: &mut Cache) -> Vec<T> {
         let mut res = vec![];
-        let mut cache = Cache::default();
 
         let mut idx = 0;
 

--- a/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
@@ -118,7 +118,10 @@ use std::marker::PhantomData;
 
 use crate::circuits::{
     argument::{Argument, ArgumentEnv, ArgumentType},
-    expr::constraints::{crumb, ExprOps},
+    expr::{
+        constraints::{crumb, ExprOps},
+        Cache,
+    },
     gate::GateType,
     polynomial::COLUMNS,
 };
@@ -175,7 +178,7 @@ where
     //   * Operates on Curr row
     //   * Range constrain all limbs except vp0 and vp1 (barring plookup constraints, which are done elsewhere)
     //   * Constrain that combining all limbs equals the limb stored in column 0
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, _cache: &mut Cache) -> Vec<T> {
         // 1) Apply range constraints on the limbs
         //    * Columns 1-2 are 12-bit copy constraints
         //        * They are copied 3 rows ahead (to the final row) and are constrained by lookups
@@ -276,7 +279,7 @@ where
     //   * Operates on Curr and Next row
     //   * Range constrain all limbs (barring plookup constraints, which are done elsewhere)
     //   * Constrain that combining all limbs equals the value v2 stored in row Curr, column 0
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, _cache: &mut Cache) -> Vec<T> {
         // 1) Apply range constraints on limbs for Curr row
         //    * Column 2 is a 2-bit crumb
         let mut constraints = vec![crumb(&env.witness_curr(2))];

--- a/kimchi/src/circuits/polynomials/range_check/gadget.rs
+++ b/kimchi/src/circuits/polynomials/range_check/gadget.rs
@@ -6,7 +6,7 @@ use crate::{
     alphas::Alphas,
     circuits::{
         argument::Argument,
-        expr::E,
+        expr::{Cache, E},
         gate::{CircuitGate, Connect, GateType},
         lookup::{
             self,
@@ -136,17 +136,22 @@ pub fn circuit_gate_constraint_count<F: PrimeField>(typ: GateType) -> u32 {
 /// # Panics
 ///
 /// Will panic if `typ` is not `RangeCheck`-related gate type.
-pub fn circuit_gate_constraints<F: PrimeField>(typ: GateType, alphas: &Alphas<F>) -> E<F> {
+pub fn circuit_gate_constraints<F: PrimeField>(
+    typ: GateType,
+    alphas: &Alphas<F>,
+    cache: &mut Cache,
+) -> E<F> {
     match typ {
-        GateType::RangeCheck0 => RangeCheck0::combined_constraints(alphas),
-        GateType::RangeCheck1 => RangeCheck1::combined_constraints(alphas),
+        GateType::RangeCheck0 => RangeCheck0::combined_constraints(alphas, cache),
+        GateType::RangeCheck1 => RangeCheck1::combined_constraints(alphas, cache),
         _ => panic!("invalid gate type"),
     }
 }
 
 /// Get the combined constraints for all range check circuit gate types
-pub fn combined_constraints<F: PrimeField>(alphas: &Alphas<F>) -> E<F> {
-    RangeCheck0::combined_constraints(alphas) + RangeCheck1::combined_constraints(alphas)
+pub fn combined_constraints<F: PrimeField>(alphas: &Alphas<F>, cache: &mut Cache) -> E<F> {
+    RangeCheck0::combined_constraints(alphas, cache)
+        + RangeCheck1::combined_constraints(alphas, cache)
 }
 
 /// Get the range check lookup table

--- a/kimchi/src/circuits/polynomials/rot.rs
+++ b/kimchi/src/circuits/polynomials/rot.rs
@@ -4,7 +4,10 @@ use super::range_check::witness::range_check_0_row;
 use crate::{
     circuits::{
         argument::{Argument, ArgumentEnv, ArgumentType},
-        expr::constraints::{crumb, ExprOps},
+        expr::{
+            constraints::{crumb, ExprOps},
+            Cache,
+        },
         gate::{CircuitGate, Connect, GateType},
         lookup::{
             self,
@@ -198,7 +201,7 @@ where
     // (stored in coefficient as a power-of-two form)
     //   * Operates on Curr row
     //   * Shifts the words by `rot` bits and then adds the excess to obtain the rotated word.
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, _cache: &mut Cache) -> Vec<T> {
         // Check that the last 8 columns are 2-bit crumbs
         // C1..C8: x * (x - 1) * (x - 2) * (x - 3) = 0
         let mut constraints = (7..COLUMNS)

--- a/kimchi/src/circuits/polynomials/turshi.rs
+++ b/kimchi/src/circuits/polynomials/turshi.rs
@@ -208,7 +208,8 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
         alphas.register(ArgumentType::Gate(self.typ), Instruction::<F>::CONSTRAINTS);
 
         // Get constraints for this circuit gate
-        let constraints = circuit_gate_combined_constraints(self.typ, &alphas);
+        let constraints =
+            circuit_gate_combined_constraints(self.typ, &alphas, &mut Cache::default());
 
         // Linearize
         let linearized = constraints.linearize(polys).unwrap();
@@ -737,12 +738,16 @@ fn two<F: Field, T: ExprOps<F>>() -> T {
 /// # Panics
 ///
 /// Will panic if the `typ` is not `Cairo`-related gate type or `zero` gate type.
-pub fn circuit_gate_combined_constraints<F: PrimeField>(typ: GateType, alphas: &Alphas<F>) -> E<F> {
+pub fn circuit_gate_combined_constraints<F: PrimeField>(
+    typ: GateType,
+    alphas: &Alphas<F>,
+    cache: &mut Cache,
+) -> E<F> {
     match typ {
-        GateType::CairoClaim => Claim::combined_constraints(alphas),
-        GateType::CairoInstruction => Instruction::combined_constraints(alphas),
-        GateType::CairoFlags => Flags::combined_constraints(alphas),
-        GateType::CairoTransition => Transition::combined_constraints(alphas),
+        GateType::CairoClaim => Claim::combined_constraints(alphas, cache),
+        GateType::CairoInstruction => Instruction::combined_constraints(alphas, cache),
+        GateType::CairoFlags => Flags::combined_constraints(alphas, cache),
+        GateType::CairoTransition => Transition::combined_constraints(alphas, cache),
         GateType::Zero => E::literal(F::zero()),
         _ => panic!("invalid gate type"),
     }
@@ -759,7 +764,7 @@ where
 
     /// Generates the constraints for the Cairo initial claim and first memory checks
     ///     Accesses Curr and Next rows
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, _cache: &mut Cache) -> Vec<T> {
         let pc_ini = env.witness_curr(0); // copy from public input
         let ap_ini = env.witness_curr(1); // copy from public input
         let pc_fin = env.witness_curr(2); // copy from public input
@@ -796,7 +801,7 @@ where
 
     /// Generates the constraints for the Cairo instruction
     ///     Accesses Curr and Next rows
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, cache: &mut Cache) -> Vec<T> {
         // load all variables of the witness corresponding to Cairoinstruction gates
         let pc = env.witness_curr(0);
         let ap = env.witness_curr(1);
@@ -836,7 +841,6 @@ where
         // LIST OF CONSTRAINTS
         // -------------------
         let mut constraints: Vec<T> = vec![];
-        let mut cache = Cache::default();
 
         // INSTRUCTIONS RELATED
 
@@ -943,7 +947,7 @@ where
 
     /// Generates the constraints for the Cairo flags
     ///     Accesses Curr and Next rows
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, _cache: &mut Cache) -> Vec<T> {
         // Load current row
         let f_pc_abs = env.witness_curr(7);
         let f_pc_rel = env.witness_curr(8);
@@ -1010,7 +1014,7 @@ where
 
     /// Generates the constraints for the Cairo transition
     ///     Accesses Curr and Next rows (Next only first 3 entries)
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, _cache: &mut Cache) -> Vec<T> {
         // load computed updated registers
         let pcup = env.witness_curr(7);
         let apup = env.witness_curr(8);

--- a/kimchi/src/circuits/polynomials/varbasemul.rs
+++ b/kimchi/src/circuits/polynomials/varbasemul.rs
@@ -407,7 +407,7 @@ where
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::VarBaseMul);
     const CONSTRAINTS: u32 = 21;
 
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, cache: &mut Cache) -> Vec<T> {
         let Layout {
             base,
             accs,
@@ -417,8 +417,6 @@ where
             n_next,
         } = Layout::create().new_from_env::<F, T>(env);
 
-        let mut c = Cache::default();
-
         // n'
         // = 2^5 * n + 2^4 b0 + 2^3 b1 + 2^2 b2 + 2^1 b3 + b4
         // = b4 + 2 (b3 + 2 (b2 + 2 (b1 + 2(b0 + 2 n))))
@@ -427,7 +425,7 @@ where
 
         for i in 0..5 {
             res.append(&mut single_bit(
-                &mut c,
+                cache,
                 &bits[i],
                 base.clone(),
                 &ss[i],

--- a/kimchi/src/circuits/polynomials/xor.rs
+++ b/kimchi/src/circuits/polynomials/xor.rs
@@ -4,7 +4,7 @@
 use crate::{
     circuits::{
         argument::{Argument, ArgumentEnv, ArgumentType},
-        expr::constraints::ExprOps,
+        expr::{constraints::ExprOps, Cache},
         gate::{CircuitGate, Connect, GateType},
         lookup::{
             self,
@@ -150,7 +150,7 @@ where
     //   * Operates on Curr and Next rows
     //   * Constrain the decomposition of `in1`, `in2` and `out` of multiples of 16 bits
     //   * The actual XOR is performed thanks to the plookups of 4-bit XORs.
-    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>) -> Vec<T> {
+    fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, _cache: &mut Cache) -> Vec<T> {
         let two = T::from(2u64);
         // in1 = in1_0 + in1_1 * 2^4 + in1_2 * 2^8 + in1_3 * 2^12 + next_in1 * 2^16
         // in2 = in2_0 + in2_1 * 2^4 + in2_2 * 2^8 + in2_3 * 2^12 + next_in2 * 2^16

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -2,6 +2,7 @@
 
 use crate::alphas::Alphas;
 use crate::circuits::argument::{Argument, ArgumentType};
+use crate::circuits::expr;
 use crate::circuits::lookup;
 use crate::circuits::lookup::{
     constraints::LookupConfiguration,
@@ -48,14 +49,17 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
         VarbaseMul::<F>::CONSTRAINTS,
     );
 
-    let mut expr = Poseidon::combined_constraints(&powers_of_alpha);
-    expr += VarbaseMul::combined_constraints(&powers_of_alpha);
-    expr += CompleteAdd::combined_constraints(&powers_of_alpha);
-    expr += EndosclMul::combined_constraints(&powers_of_alpha);
-    expr += EndomulScalar::combined_constraints(&powers_of_alpha);
+    let mut cache = expr::Cache::default();
+
+    let mut expr = Poseidon::combined_constraints(&powers_of_alpha, &mut cache);
+    expr += VarbaseMul::combined_constraints(&powers_of_alpha, &mut cache);
+    expr += CompleteAdd::combined_constraints(&powers_of_alpha, &mut cache);
+    expr += EndosclMul::combined_constraints(&powers_of_alpha, &mut cache);
+    expr += EndomulScalar::combined_constraints(&powers_of_alpha, &mut cache);
 
     {
-        let range_check0_expr = || RangeCheck0::combined_constraints(&powers_of_alpha);
+        let mut range_check0_expr =
+            || RangeCheck0::combined_constraints(&powers_of_alpha, &mut cache);
 
         if let Some(feature_flags) = feature_flags {
             if feature_flags.range_check0 {
@@ -71,7 +75,8 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
     }
 
     {
-        let range_check1_expr = || RangeCheck1::combined_constraints(&powers_of_alpha);
+        let mut range_check1_expr =
+            || RangeCheck1::combined_constraints(&powers_of_alpha, &mut cache);
 
         if let Some(feature_flags) = feature_flags {
             if feature_flags.range_check1 {
@@ -87,7 +92,8 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
     }
 
     {
-        let foreign_field_add_expr = || ForeignFieldAdd::combined_constraints(&powers_of_alpha);
+        let mut foreign_field_add_expr =
+            || ForeignFieldAdd::combined_constraints(&powers_of_alpha, &mut cache);
         if let Some(feature_flags) = feature_flags {
             if feature_flags.foreign_field_add {
                 expr += foreign_field_add_expr();
@@ -102,7 +108,8 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
     }
 
     {
-        let foreign_field_mul_expr = || ForeignFieldMul::combined_constraints(&powers_of_alpha);
+        let mut foreign_field_mul_expr =
+            || ForeignFieldMul::combined_constraints(&powers_of_alpha, &mut cache);
         if let Some(feature_flags) = feature_flags {
             if feature_flags.foreign_field_mul {
                 expr += foreign_field_mul_expr();
@@ -117,7 +124,7 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
     }
 
     {
-        let xor_expr = || xor::Xor16::combined_constraints(&powers_of_alpha);
+        let mut xor_expr = || xor::Xor16::combined_constraints(&powers_of_alpha, &mut cache);
         if let Some(feature_flags) = feature_flags {
             if feature_flags.xor {
                 expr += xor_expr();
@@ -132,7 +139,7 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
     }
 
     {
-        let rot_expr = || rot::Rot64::combined_constraints(&powers_of_alpha);
+        let mut rot_expr = || rot::Rot64::combined_constraints(&powers_of_alpha, &mut cache);
         if let Some(feature_flags) = feature_flags {
             if feature_flags.rot {
                 expr += rot_expr();
@@ -147,7 +154,7 @@ pub fn constraints_expr<F: PrimeField + SquareRootField>(
     }
 
     if generic {
-        expr += generic::Generic::combined_constraints(&powers_of_alpha);
+        expr += generic::Generic::combined_constraints(&powers_of_alpha, &mut cache);
     }
 
     // permutation

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -3,7 +3,7 @@
 use crate::{
     circuits::{
         argument::{Argument, ArgumentType},
-        expr::{l0_1, Constants, Environment, LookupEnvironment},
+        expr::{self, l0_1, Constants, Environment, LookupEnvironment},
         gate::GateType,
         lookup::{self, runtime_tables::RuntimeTable, tables::combine_table_entry},
         polynomials::{
@@ -675,10 +675,13 @@ where
             }
         };
 
+        let mut cache = expr::Cache::default();
+
         let quotient_poly = {
             // generic
             let mut t4 = {
-                let generic_constraint = generic::Generic::combined_constraints(&all_alphas);
+                let generic_constraint =
+                    generic::Generic::combined_constraints(&all_alphas, &mut cache);
                 let generic4 = generic_constraint.evaluations(&env);
 
                 if cfg!(debug_assertions) {
@@ -746,7 +749,7 @@ where
                 .into_iter()
                 .filter_map(|(gate, is_enabled)| if is_enabled { Some(gate) } else { None })
                 {
-                    let constraint = gate.combined_constraints(&all_alphas);
+                    let constraint = gate.combined_constraints(&all_alphas, &mut cache);
                     let eval = constraint.evaluations(&env);
                     if eval.domain().size == t4.domain().size {
                         t4 += &eval;

--- a/tools/kimchi-visu/src/lib.rs
+++ b/tools/kimchi-visu/src/lib.rs
@@ -4,6 +4,7 @@ use ark_ff::PrimeField;
 use kimchi::{
     circuits::{
         argument::Argument,
+        expr,
         polynomials::{
             complete_add::CompleteAdd, endomul_scalar::EndomulScalar, endosclmul::EndosclMul,
             poseidon::Poseidon, varbasemul::VarbaseMul,
@@ -40,7 +41,10 @@ where
     F: PrimeField,
 {
     fn latex() -> Vec<Vec<String>> {
-        Self::constraints().iter().map(|c| c.latex_str()).collect()
+        Self::constraints(&mut expr::Cache::default())
+            .iter()
+            .map(|c| c.latex_str())
+            .collect()
     }
 }
 


### PR DESCRIPTION
This is #1048 rebased onto the berkeley branch, as part of the pickles fixes.