### PR TITLE
Normalize the runtime table configuration to "custom"

### DIFF
--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -269,14 +269,8 @@ impl<F: PrimeField + SquareRootField> LookupConstraintSystem<F> {
 
                         // create fixed tables for indexing the runtime tables
                         for runtime_table in runtime_tables {
-                            use RuntimeTableCfg::{Custom, Indexed};
-                            let (id, first_column) = match runtime_table {
-                                &Indexed(RuntimeTableSpec { id, len }) => {
-                                    let indexes = (0..(len as u32)).map(F::from).collect();
-                                    (id, indexes)
-                                }
-                                Custom { id, first_column } => (*id, first_column.clone()),
-                            };
+                            let (id, first_column) =
+                                (runtime_table.id, runtime_table.first_column.clone());
 
                             // record if table ID 0 is used in one of the runtime tables
                             // note: the check later will still force you to have a fixed table with ID 0

--- a/kimchi/src/circuits/lookup/runtime_tables.rs
+++ b/kimchi/src/circuits/lookup/runtime_tables.rs
@@ -22,56 +22,35 @@ pub struct RuntimeTableSpec {
 ///
 /// Note: care must be taken as table IDs can collide with IDs of other types of lookup tables.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum RuntimeTableCfg<F> {
-    /// An indexed runtime table has a counter (starting at zero) in its first column.
-    Indexed(RuntimeTableSpec),
-    /// A custom runtime table can contain arbitrary values in its first column.
-    Custom {
-        /// The table ID.
-        id: i32,
-        /// The content of the first column of the runtime table.
-        first_column: Vec<F>,
-    },
+pub struct RuntimeTableCfg<F> {
+    /// The table ID.
+    pub id: i32,
+    /// The content of the first column of the runtime table.
+    pub first_column: Vec<F>,
 }
 
 impl<F> RuntimeTableCfg<F> {
     /// Returns the ID of the runtime table.
     pub fn id(&self) -> i32 {
-        use RuntimeTableCfg::{Custom, Indexed};
-        match self {
-            Indexed(cfg) => cfg.id,
-            &Custom { id, .. } => id,
-        }
+        self.id
     }
 
     /// Returns the length of the runtime table.
     pub fn len(&self) -> usize {
-        use RuntimeTableCfg::{Custom, Indexed};
-        match self {
-            Indexed(cfg) => cfg.len,
-            Custom { first_column, .. } => first_column.len(),
-        }
+        self.first_column.len()
     }
 
     /// Returns `true` if the runtime table is empty.
     pub fn is_empty(&self) -> bool {
-        use RuntimeTableCfg::{Custom, Indexed};
-        match self {
-            Indexed(cfg) => cfg.len == 0,
-            Custom { first_column, .. } => first_column.is_empty(),
-        }
+        self.first_column.is_empty()
     }
 }
 
 impl<F> From<RuntimeTableCfg<F>> for RuntimeTableSpec {
-    fn from(from: RuntimeTableCfg<F>) -> Self {
-        use RuntimeTableCfg::{Custom, Indexed};
-        match from {
-            Indexed(cfg) => cfg,
-            Custom { id, first_column } => RuntimeTableSpec {
-                id,
-                len: first_column.len(),
-            },
+    fn from(rt_cfg: RuntimeTableCfg<F>) -> Self {
+        Self {
+            id: rt_cfg.id,
+            len: rt_cfg.first_column.len(),
         }
     }
 }

--- a/kimchi/src/tests/lookup.rs
+++ b/kimchi/src/tests/lookup.rs
@@ -2,7 +2,7 @@ use super::framework::{print_witness, TestFramework};
 use crate::circuits::{
     gate::{CircuitGate, GateType},
     lookup::{
-        runtime_tables::{RuntimeTable, RuntimeTableCfg, RuntimeTableSpec},
+        runtime_tables::{RuntimeTable, RuntimeTableCfg},
         tables::LookupTable,
     },
     polynomial::COLUMNS,
@@ -125,20 +125,13 @@ fn lookup_gate_rejects_bad_lookups_multiple_tables() {
     setup_lookup_proof(false, 500, vec![100, 50, 50, 2, 2])
 }
 
-fn runtime_table(num: usize, indexed: bool) {
+fn runtime_table(num: usize) {
     // runtime
     let mut runtime_tables_setup = vec![];
     for table_id in 0..num {
-        let cfg = if indexed {
-            RuntimeTableCfg::Indexed(RuntimeTableSpec {
-                id: table_id as i32,
-                len: 5,
-            })
-        } else {
-            RuntimeTableCfg::Custom {
-                id: table_id as i32,
-                first_column: [8u32, 9, 8, 7, 1].into_iter().map(Into::into).collect(),
-            }
+        let cfg = RuntimeTableCfg {
+            id: table_id as i32,
+            first_column: [8u32, 9, 8, 7, 1].into_iter().map(Into::into).collect(),
         };
         runtime_tables_setup.push(cfg);
     }
@@ -176,7 +169,7 @@ fn runtime_table(num: usize, indexed: bool) {
             // create queries into our runtime lookup table
             let lookup_cols = &mut lookup_cols[1..];
             for chunk in lookup_cols.chunks_mut(2) {
-                chunk[0][row] = if indexed { 1u32.into() } else { 9u32.into() }; // index
+                chunk[0][row] = 9u32.into(); // index
                 chunk[1][row] = 2u32.into(); // value
             }
         }
@@ -197,13 +190,8 @@ fn runtime_table(num: usize, indexed: bool) {
 }
 
 #[test]
-fn test_indexed_runtime_table() {
-    runtime_table(5, true);
-}
-
-#[test]
 fn test_custom_runtime_table() {
-    runtime_table(5, false);
+    runtime_table(5);
 }
 
 // TODO: add a test with a runtime table with ID 0 (it should panic)


### PR DESCRIPTION
Previously, we were considering two types of runtime table configurations, indexed and custom.
Indexed where supposed to represent "standard" array access, using indexed from 0 to N, which can be easily represented as a "custom" runtime table configurations whose first columns is from 0 to N.

It also simplifies the wasm binding as enum with structure values can not be represented using wasm-bindgen.