### PR TITLE
Bump up actions/checkout to v3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
     name: Run some basic checks and tests
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # as action-rs does not seem to be maintained anymore, building from
       # scratch the environment using rustup


### PR DESCRIPTION
Addressing https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

There are always warnings when you go in the actions tab. This PR will fix these warnings. We should keep an eye on it.