### PR TITLE
Domain computation: runtime table cfg is given as option, not list

### DIFF
--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -670,8 +670,7 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
                 )
                 .sum();
             // After that on the runtime tables
-            if runtime_tables.is_some() {
-                let runtime_tables = runtime_tables.as_ref().unwrap();
+            if let Some(runtime_tables) = runtime_tables.as_ref() {
                 for runtime_table in runtime_tables.iter() {
                     lookup_domain_size += runtime_table.len();
                 }

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -668,8 +668,11 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
                     },
                 )
                 .sum();
-            for runtime_table in runtime_tables.iter() {
-                num_lookups += runtime_table.len();
+            if runtime_tables.is_some() {
+                let runtime_tables = runtime_tables.as_ref().unwrap();
+                for runtime_table in runtime_tables.iter() {
+                    num_lookups += runtime_table.len();
+                }
             }
             let LookupFeatures { patterns, .. } = &lookup_features;
             for pattern in patterns.into_iter() {


### PR DESCRIPTION
iter() was applied on the option, not the list.

Fixes https://github.com/MinaProtocol/mina/issues/14072