### PR TITLE
Lookup tables: introduce width method to get the width

### DIFF
--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -296,7 +296,7 @@ impl<F: PrimeField + SquareRootField> LookupConstraintSystem<F> {
                 //~    that a lookup table can have.
                 let max_table_width = lookup_tables
                     .iter()
-                    .map(|table| table.data.len())
+                    .map(|table| table.width())
                     .max()
                     .unwrap_or(0);
 
@@ -373,7 +373,7 @@ impl<F: PrimeField + SquareRootField> LookupConstraintSystem<F> {
                     }
 
                     //~~ * Fill in any unused columns with 0 (to match the dummy value)
-                    for lookup_table in lookup_table.iter_mut().skip(table.data.len()) {
+                    for lookup_table in lookup_table.iter_mut().skip(table.width()) {
                         lookup_table.extend(repeat_n(F::zero(), table_len));
                     }
                 }

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -47,6 +47,13 @@ where
         false
     }
 
+    /// Returns the number of columns, i.e. the width of the table.
+    /// It is less error prone to introduce this method than using the public
+    /// field data.
+    pub fn width(&self) -> usize {
+        self.data.len()
+    }
+
     /// Returns the length of the table.
     pub fn len(&self) -> usize {
         self.data[0].len()


### PR DESCRIPTION
Using `self.data.len()` can be error-prone, and an index is easily introduced. It is also always better to abstract with an API using methods. In the future, I would recommend making the data field abstract.

Also, the length method is not fully correct. It supposes the user built the lookup table and know that all columns must have the same length. The first column, by construction, might have a different length.