### PR TITLE
Lookup tables: get length using method instead of relying on struct f…

### DIFF
--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -348,7 +348,7 @@ impl<F: PrimeField + SquareRootField> LookupConstraintSystem<F> {
                 let mut has_table_id_0_with_zero_entry = false;
 
                 for table in &lookup_tables {
-                    let table_len = table.data[0].len();
+                    let table_len = table.len();
 
                     if table.id == 0 {
                         has_table_id_0 = true;

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -35,7 +35,7 @@ where
     pub fn has_zero_entry(&self) -> bool {
         // reminder: a table is written as a list of columns,
         // not as a list of row entries.
-        for row in 0..self.data[0].len() {
+        for row in 0..self.len() {
             for col in &self.data {
                 if !col[row].is_zero() {
                     continue;


### PR DESCRIPTION
…ield