### PR TITLE
Remove noisy `debug_sponge`

### DIFF
--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -37,4 +37,3 @@ ark-serialize = "0.3.0"
 [features]
 default = []
 ocaml_types = [ "ocaml", "ocaml-gen", ]
-debug_sponge = []

--- a/poseidon/src/poseidon.rs
+++ b/poseidon/src/poseidon.rs
@@ -1,8 +1,5 @@
 //! This module implements Poseidon Hash Function primitive
 
-#[cfg(feature = "debug_sponge")]
-use std::sync::atomic::{AtomicU64, Ordering::SeqCst};
-
 use crate::constants::SpongeConstants;
 use crate::permutation::{full_round, poseidon_block_cipher};
 use ark_ff::Field;
@@ -52,8 +49,6 @@ pub struct ArithmeticSponge<F: Field, SC: SpongeConstants> {
     pub state: Vec<F>,
     params: &'static ArithmeticSpongeParams<F>,
     pub constants: std::marker::PhantomData<SC>,
-    #[cfg(feature = "debug_sponge")]
-    pub id: u64,
 }
 
 impl<F: Field, SC: SpongeConstants> ArithmeticSponge<F, SC> {
@@ -77,17 +72,12 @@ impl<F: Field, SC: SpongeConstants> Sponge<F, F> for ArithmeticSponge<F, SC> {
             state.push(F::zero());
         }
 
-        #[cfg(feature = "debug_sponge")]
-        static COUNTER: AtomicU64 = AtomicU64::new(0);
-
         ArithmeticSponge {
             state,
             rate,
             sponge_state: SpongeState::Absorbed(0),
             params,
             constants: std::marker::PhantomData,
-            #[cfg(feature = "debug_sponge")]
-            id: COUNTER.fetch_add(1, SeqCst),
         }
     }
 


### PR DESCRIPTION
This PR removes the `debug_sponge` feature. This currently makes the test output extremely noisy, and the OCaml counterpart that would have made this useful was never implemented.