### PR TITLE
Improve errors around domain creation

### DIFF
--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -11,7 +11,7 @@ use crate::{
         wires::*,
     },
     curve::KimchiCurve,
-    error::SetupError,
+    error::{DomainCreationError, SetupError},
     prover_index::ProverIndex,
 };
 use ark_ff::{PrimeField, SquareRootField, Zero};
@@ -752,7 +752,7 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
                 while {
                     let domain_size = D::<F>::compute_size_of_domain(domain_size_lower_bound)
                         .ok_or(SetupError::DomainCreation(
-                            "could not compute size of domain",
+                            DomainCreationError::DomainSizeFailed(domain_size_lower_bound),
                         ))?;
                     let num_chunks = domain_size / max_poly_size;
                     zk_rows = (zk_rows_strict_lower_bound(num_chunks) + 1) as u64;
@@ -766,7 +766,8 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
         //~ 1. Create a domain for the circuit. That is,
         //~    compute the smallest subgroup of the field that
         //~    has order greater or equal to `n + zk_rows` elements.
-        let domain = EvaluationDomains::<F>::create(domain_size_lower_bound)?;
+        let domain = EvaluationDomains::<F>::create(domain_size_lower_bound)
+            .map_err(SetupError::DomainCreation)?;
 
         assert!(domain.d1.size > zk_rows);
 

--- a/kimchi/src/circuits/domains.rs
+++ b/kimchi/src/circuits/domains.rs
@@ -3,7 +3,7 @@ use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-use crate::error::SetupError;
+use crate::error::DomainCreationError;
 
 #[serde_as]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -22,26 +22,29 @@ impl<F: FftField> EvaluationDomains<F> {
     /// Creates 4 evaluation domains `d1` (of size `n`), `d2` (of size `2n`), `d4` (of size `4n`),
     /// and `d8` (of size `8n`). If generator of `d8` is `g`, the generator
     /// of `d4` is `g^2`, the generator of `d2` is `g^4`, and the generator of `d1` is `g^8`.
-    pub fn create(n: usize) -> Result<Self, SetupError> {
-        let n = Domain::<F>::compute_size_of_domain(n).ok_or(SetupError::DomainCreation(
-            "could not compute size of domain",
-        ))?;
+    pub fn create(n: usize) -> Result<Self, DomainCreationError> {
+        let n = Domain::<F>::compute_size_of_domain(n)
+            .ok_or(DomainCreationError::DomainSizeFailed(n))?;
 
-        let d1 = Domain::<F>::new(n).ok_or(SetupError::DomainCreation(
-            "construction of domain d1 did not work as intended",
+        let d1 = Domain::<F>::new(n).ok_or(DomainCreationError::DomainConstructionFailed(
+            "d1".to_string(),
+            n,
         ))?;
 
         // we also create domains of larger sizes
         // to efficiently operate on polynomials in evaluation form.
         // (in evaluation form, the domain needs to grow as the degree of a polynomial grows)
-        let d2 = Domain::<F>::new(2 * n).ok_or(SetupError::DomainCreation(
-            "construction of domain d2 did not work as intended",
+        let d2 = Domain::<F>::new(2 * n).ok_or(DomainCreationError::DomainConstructionFailed(
+            "d2".to_string(),
+            2 * n,
         ))?;
-        let d4 = Domain::<F>::new(4 * n).ok_or(SetupError::DomainCreation(
-            "construction of domain d4 did not work as intended",
+        let d4 = Domain::<F>::new(4 * n).ok_or(DomainCreationError::DomainConstructionFailed(
+            "d4".to_string(),
+            4 * n,
         ))?;
-        let d8 = Domain::<F>::new(8 * n).ok_or(SetupError::DomainCreation(
-            "construction of domain d8 did not work as intended",
+        let d8 = Domain::<F>::new(8 * n).ok_or(DomainCreationError::DomainConstructionFailed(
+            "d8".to_string(),
+            8 * n,
         ))?;
 
         // ensure the relationship between the three domains in case the library's behavior changes

--- a/kimchi/src/error.rs
+++ b/kimchi/src/error.rs
@@ -84,12 +84,22 @@ pub enum VerifyError {
 
 /// Errors that can arise when preparing the setup
 #[derive(Error, Debug, Clone)]
+pub enum DomainCreationError {
+    #[error("could not compute the size of domain for {0}")]
+    DomainSizeFailed(usize),
+
+    #[error("construction of domain {0} for size {1} failed")]
+    DomainConstructionFailed(String, usize),
+}
+
+/// Errors that can arise when preparing the setup
+#[derive(Error, Debug, Clone)]
 pub enum SetupError {
     #[error("the domain could not be constructed: {0}")]
     ConstraintSystem(String),
 
     #[error("the domain could not be constructed: {0}")]
-    DomainCreation(&'static str),
+    DomainCreation(DomainCreationError),
 }
 
 /// Errors that can arise when creating a verifier index


### PR DESCRIPTION
This PR tweaks the errors returned around domain creation so that they have informative content.

This comes from the debugging for chunking, where the current messages are effectively useless.