### PR TITLE
Adds trivial support for rotation by 0 and 64 bits

### DIFF
--- a/kimchi/src/circuits/polynomials/rot.rs
+++ b/kimchi/src/circuits/polynomials/rot.rs
@@ -328,8 +328,6 @@ pub fn extend_rot<F: PrimeField>(
     rot: u32,
     side: RotMode,
 ) {
-    assert!(rot < 64, "Rotation value must be less than 64");
-    assert_ne!(rot, 0, "Rotation value must be non-zero");
     let rot = if side == RotMode::Right {
         64 - rot
     } else {
@@ -343,8 +341,8 @@ pub fn extend_rot<F: PrimeField>(
     // shifted      [------] * 2^rot
     // rot    = [------|000]
     //        +        [---] excess
-    let shifted = (word as u128 * 2u128.pow(rot) % 2u128.pow(64)) as u64;
-    let excess = word / 2u64.pow(64 - rot);
+    let shifted = (word as u128) * 2u128.pow(rot) % 2u128.pow(64);
+    let excess = (word as u128) / 2u128.pow(64 - rot);
     let rotated = shifted + excess;
     // Value for the added value for the bound
     // Right input of the "FFAdd" for the bound equation

--- a/kimchi/src/circuits/polynomials/rot.rs
+++ b/kimchi/src/circuits/polynomials/rot.rs
@@ -328,6 +328,8 @@ pub fn extend_rot<F: PrimeField>(
     rot: u32,
     side: RotMode,
 ) {
+    assert!(rot <= 64, "Rotation value must be less or equal than 64");
+
     let rot = if side == RotMode::Right {
         64 - rot
     } else {

--- a/kimchi/src/tests/rot.rs
+++ b/kimchi/src/tests/rot.rs
@@ -169,22 +169,20 @@ fn test_rot_random() {
     test_rot::<Pallas>(word, rot, RotMode::Right);
 }
 
-#[should_panic]
 #[test]
 // Test that a bad rotation fails as expected
 fn test_zero_rot() {
     let rng = &mut StdRng::from_seed(RNG_SEED);
     let word = rng.gen_range(0..2u128.pow(64)) as u64;
-    create_rot_witness::<Vesta>(word, 0, RotMode::Left);
+    test_rot::<Pallas>(word, 0, RotMode::Left);
 }
 
-#[should_panic]
 #[test]
 // Test that a bad rotation fails as expected
 fn test_large_rot() {
     let rng = &mut StdRng::from_seed(RNG_SEED);
     let word = rng.gen_range(0..2u128.pow(64)) as u64;
-    create_rot_witness::<Vesta>(word, 64, RotMode::Left);
+    test_rot::<Pallas>(word, 64, RotMode::Left);
 }
 
 #[test]


### PR DESCRIPTION
This is to match the interface being created in o1js [in this PR](https://github.com/o1-labs/o1js/pull/1182).

This does not modify the constraints. This only affects the witness generation code for the Kimchi gadgets, which are only used for internal testing.

Now rotation by 0 and 64 bits are allowed. Nonetheless, it is not recommended since it adds 3 unneeded rows to the circuit, as it is trivial that the rotated word is just the same as the input.