### PR TITLE
Adding sparse lookup tables (`Sparse`, `Reset`,  `Bits16`)

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -344,8 +344,15 @@ pub const XOR_TABLE_ID: i32 = 0;
 /// The range check table ID.
 pub const RANGE_CHECK_TABLE_ID: i32 = 1;
 
-/// The table ID associated with the sparse lookup table.
-pub const SPARSE_TABLE_ID: i32 = 2;
+/// The table ID associated with the 16-bit lookup table.
+pub const BITS16_TABLE_ID: i32 = 2;
+
+/// The table ID associated with the 1-column sparse lookup table.
+pub const SPARSE_TABLE_ID: i32 = 3;
+
+/// The table ID associated with the 2-column sparse lookup table.
+pub const RESET_TABLE_ID: i32 = 4;
+
 ```
 
 

--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -343,6 +343,9 @@ pub const XOR_TABLE_ID: i32 = 0;
 
 /// The range check table ID.
 pub const RANGE_CHECK_TABLE_ID: i32 = 1;
+
+/// The table ID associated with the sparse lookup table.
+pub const SPARSE_TABLE_ID: i32 = 2;
 ```
 
 

--- a/kimchi/src/circuits/lookup/tables/bits16.rs
+++ b/kimchi/src/circuits/lookup/tables/bits16.rs
@@ -6,10 +6,6 @@ use super::BITS16_TABLE_ID;
 //~ The lookup table for 16-bits
 
 /// Returns the lookup table for all 16-bit values
-///
-/// # Panics
-///
-/// Will panic if `data` is invalid.
 pub fn bits16_table<F: Field>() -> LookupTable<F> {
     let mut data = vec![vec![]; 1];
 

--- a/kimchi/src/circuits/lookup/tables/bits16.rs
+++ b/kimchi/src/circuits/lookup/tables/bits16.rs
@@ -1,0 +1,27 @@
+use crate::circuits::lookup::tables::LookupTable;
+use ark_ff::Field;
+
+use super::BITS16_TABLE_ID;
+
+//~ The lookup table for 16-bits
+
+/// Returns the lookup table for all 16-bit values
+///
+/// # Panics
+///
+/// Will panic if `data` is invalid.
+pub fn bits16_table<F: Field>() -> LookupTable<F> {
+    let mut data = vec![vec![]; 1];
+
+    // All of the 16-bit values
+    for i in 0u64..=0xFFFF {
+        data[0].push(F::from(i));
+    }
+
+    LookupTable {
+        id: BITS16_TABLE_ID,
+        data,
+    }
+}
+
+pub const TABLE_SIZE: usize = 65536;

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -2,7 +2,9 @@ use ark_ff::{FftField, One, Zero};
 use poly_commitment::PolyComm;
 use serde::{Deserialize, Serialize};
 
+pub mod bits16;
 pub mod range_check;
+pub mod reset;
 pub mod sparse;
 pub mod xor;
 
@@ -13,8 +15,15 @@ pub const XOR_TABLE_ID: i32 = 0;
 /// The range check table ID.
 pub const RANGE_CHECK_TABLE_ID: i32 = 1;
 
-/// The table ID associated with the sparse lookup table.
-pub const SPARSE_TABLE_ID: i32 = 2;
+/// The table ID associated with the 16-bit lookup table.
+pub const BITS16_TABLE_ID: i32 = 2;
+
+/// The table ID associated with the 1-column sparse lookup table.
+pub const SPARSE_TABLE_ID: i32 = 3;
+
+/// The table ID associated with the 2-column sparse lookup table.
+pub const RESET_TABLE_ID: i32 = 4;
+
 //~ spec:endcode
 
 /// Enumerates the different 'fixed' lookup tables used by individual gates
@@ -22,7 +31,9 @@ pub const SPARSE_TABLE_ID: i32 = 2;
 pub enum GateLookupTable {
     Xor,
     RangeCheck,
+    Bits16,
     Sparse,
+    Reset,
 }
 
 /// A table of values that can be used for a lookup, along with the ID for the table.
@@ -75,17 +86,21 @@ pub fn get_table<F: FftField>(table_name: GateLookupTable) -> LookupTable<F> {
     match table_name {
         GateLookupTable::Xor => xor::xor_table(),
         GateLookupTable::RangeCheck => range_check::range_check_table(),
+        GateLookupTable::Bits16 => bits16::bits16_table(),
         GateLookupTable::Sparse => sparse::sparse_table(),
+        GateLookupTable::Reset => reset::reset_table(),
     }
 }
 
 impl GateLookupTable {
-    /// Returns the lookup table associated to a [`GateLookupTable`].
+    /// Returns the size of a lookup table associated to a [`GateLookupTable`].
     pub fn table_size(&self) -> usize {
         match self {
             GateLookupTable::Xor => xor::TABLE_SIZE,
             GateLookupTable::RangeCheck => range_check::TABLE_SIZE,
-            GateLookupTable::Sparse => sparse::TABLE_SIZE,
+            GateLookupTable::Bits16 | GateLookupTable::Reset | GateLookupTable::Sparse => {
+                sparse::TABLE_SIZE
+            }
         }
     }
 }

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -3,6 +3,7 @@ use poly_commitment::PolyComm;
 use serde::{Deserialize, Serialize};
 
 pub mod range_check;
+pub mod sparse;
 pub mod xor;
 
 //~ spec:startcode
@@ -11,6 +12,9 @@ pub const XOR_TABLE_ID: i32 = 0;
 
 /// The range check table ID.
 pub const RANGE_CHECK_TABLE_ID: i32 = 1;
+
+/// The table ID associated with the sparse lookup table.
+pub const SPARSE_TABLE_ID: i32 = 2;
 //~ spec:endcode
 
 /// Enumerates the different 'fixed' lookup tables used by individual gates
@@ -18,6 +22,7 @@ pub const RANGE_CHECK_TABLE_ID: i32 = 1;
 pub enum GateLookupTable {
     Xor,
     RangeCheck,
+    Sparse,
 }
 
 /// A table of values that can be used for a lookup, along with the ID for the table.
@@ -70,6 +75,7 @@ pub fn get_table<F: FftField>(table_name: GateLookupTable) -> LookupTable<F> {
     match table_name {
         GateLookupTable::Xor => xor::xor_table(),
         GateLookupTable::RangeCheck => range_check::range_check_table(),
+        GateLookupTable::Sparse => sparse::sparse_table(),
     }
 }
 
@@ -79,6 +85,7 @@ impl GateLookupTable {
         match self {
             GateLookupTable::Xor => xor::TABLE_SIZE,
             GateLookupTable::RangeCheck => range_check::TABLE_SIZE,
+            GateLookupTable::Sparse => sparse::TABLE_SIZE,
         }
     }
 }

--- a/kimchi/src/circuits/lookup/tables/reset.rs
+++ b/kimchi/src/circuits/lookup/tables/reset.rs
@@ -1,0 +1,34 @@
+use crate::circuits::lookup::tables::LookupTable;
+use ark_ff::Field;
+
+use super::RESET_TABLE_ID;
+
+//~ The lookup table for 16-bit expansion for Keccak words encoding.
+//~ This is a 2-column table containing the reset sparse representation of the 16-bit values.
+//~ The first column contains the 16-bit values, and the second column contains their expansion to 64-bit values.
+
+/// Returns the sparse lookup table
+///
+/// # Panics
+///
+/// Will panic if `data` is invalid.
+pub fn reset_table<F: Field>() -> LookupTable<F> {
+    let mut data = vec![vec![]; 2];
+
+    // Sparse expansion table for all of the 16-bit values
+    for i in 0u64..=0xFFFF {
+        data[0].push(F::from(i));
+        // Uses the fact that the expansion coincides with the hexadecimal interpretation of the index expressed in binary
+        // (i.e. expanding 1b gives 0x0001, expanding 0b gives 0x0000)
+        data[1].push(F::from(
+            u64::from_str_radix(&format!("{:b}", i), 16).unwrap(),
+        ));
+    }
+
+    LookupTable {
+        id: RESET_TABLE_ID,
+        data,
+    }
+}
+
+pub const TABLE_SIZE: usize = 65536;

--- a/kimchi/src/circuits/lookup/tables/reset.rs
+++ b/kimchi/src/circuits/lookup/tables/reset.rs
@@ -8,10 +8,6 @@ use super::RESET_TABLE_ID;
 //~ The first column contains the 16-bit values, and the second column contains their expansion to 64-bit values.
 
 /// Returns the sparse lookup table
-///
-/// # Panics
-///
-/// Will panic if `data` is invalid.
 pub fn reset_table<F: Field>() -> LookupTable<F> {
     let mut data = vec![vec![]; 2];
 

--- a/kimchi/src/circuits/lookup/tables/sparse.rs
+++ b/kimchi/src/circuits/lookup/tables/sparse.rs
@@ -10,7 +10,7 @@ use ark_ff::Field;
 ///
 /// Will panic if `data` is invalid.
 pub fn sparse_table<F: Field>() -> LookupTable<F> {
-    let mut data = vec![vec![]; 2];
+    let mut data = vec![vec![]; 1];
 
     // Sparse expansion table
     for i in 0u64..=0xFFFF {

--- a/kimchi/src/circuits/lookup/tables/sparse.rs
+++ b/kimchi/src/circuits/lookup/tables/sparse.rs
@@ -1,0 +1,32 @@
+use crate::circuits::lookup::tables::{LookupTable, SPARSE_TABLE_ID};
+use ark_ff::Field;
+
+//~ The lookup table for 16-bit expansion for Keccak words encoding.
+//~ This is a 2-column table containing the sparse representation of the 16-bit values.
+//~ The first column contains the 16-bit values, and the second column contains their expansion to 64-bit values.
+
+/// Returns the sparse lookup table
+///
+/// # Panics
+///
+/// Will panic if `data` is invalid.
+pub fn sparse_table<F: Field>() -> LookupTable<F> {
+    let mut data = vec![vec![]; 2];
+
+    // Sparse expansion table for all of the 16-bit values
+    for i in 0u64..=0xFFFF {
+        data[0].push(F::from(i));
+        // Uses the fact that the expansion coincides with the hexadecimal interpretation of the index expressed in binary
+        // (i.e. expanding 1b gives 0x0001, expanding 0b gives 0x0000)
+        data[1].push(F::from(
+            u64::from_str_radix(&format!("{:b}", i), 16).unwrap(),
+        ));
+    }
+
+    LookupTable {
+        id: SPARSE_TABLE_ID,
+        data,
+    }
+}
+
+pub const TABLE_SIZE: usize = 65536;

--- a/kimchi/src/circuits/lookup/tables/sparse.rs
+++ b/kimchi/src/circuits/lookup/tables/sparse.rs
@@ -2,8 +2,7 @@ use crate::circuits::lookup::tables::{LookupTable, SPARSE_TABLE_ID};
 use ark_ff::Field;
 
 //~ The lookup table for 16-bit expansion for Keccak words encoding.
-//~ This is a 2-column table containing the sparse representation of the 16-bit values.
-//~ The first column contains the 16-bit values, and the second column contains their expansion to 64-bit values.
+//~ This is a 1-column table containing the sparse representation of all 16-bit preimages.
 
 /// Returns the sparse lookup table
 ///
@@ -13,12 +12,9 @@ use ark_ff::Field;
 pub fn sparse_table<F: Field>() -> LookupTable<F> {
     let mut data = vec![vec![]; 2];
 
-    // Sparse expansion table for all of the 16-bit values
+    // Sparse expansion table
     for i in 0u64..=0xFFFF {
-        data[0].push(F::from(i));
-        // Uses the fact that the expansion coincides with the hexadecimal interpretation of the index expressed in binary
-        // (i.e. expanding 1b gives 0x0001, expanding 0b gives 0x0000)
-        data[1].push(F::from(
+        data[0].push(F::from(
             u64::from_str_radix(&format!("{:b}", i), 16).unwrap(),
         ));
     }

--- a/kimchi/src/circuits/lookup/tables/sparse.rs
+++ b/kimchi/src/circuits/lookup/tables/sparse.rs
@@ -5,10 +5,6 @@ use ark_ff::Field;
 //~ This is a 1-column table containing the sparse representation of all 16-bit preimages.
 
 /// Returns the sparse lookup table
-///
-/// # Panics
-///
-/// Will panic if `data` is invalid.
 pub fn sparse_table<F: Field>() -> LookupTable<F> {
     let mut data = vec![vec![]; 1];
 

--- a/kimchi/src/circuits/lookup/tables/xor.rs
+++ b/kimchi/src/circuits/lookup/tables/xor.rs
@@ -14,10 +14,6 @@ use ark_ff::Field;
 //~ will translate into a scalar multiplication by 0, which is free.
 
 /// Returns the XOR lookup table
-///
-/// # Panics
-///
-/// Will panic if `data` is invalid.
 pub fn xor_table<F: Field>() -> LookupTable<F> {
     let mut data = vec![vec![]; 3];
 


### PR DESCRIPTION
Needed for Keccak, making this PR independent of the chain of PRs so it can be merged in advanced.

Revival of https://github.com/o1-labs/proof-systems/pull/1243 which got merged non-intendedly.

It creates a 2-column lookup table containing the 2^16 elements and their expansion to 64 bits.

~Still pending to figure out if this is enough (together with some logic changes in the lookup argument to look at single columns) or if we need 3 tables instead (to have access to each column separately), or if we prefer to have more columns in the gate.~

It additionally creates two more tables containing the above columns separately.

Closes https://github.com/o1-labs/proof-systems/issues/1223