### PR TITLE
Changes to proof system to support Keccak gates (#1267 Revival)

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -2029,6 +2029,10 @@ pub struct ProofEvaluations<Evals, const COLUMNS: usize = KIMCHI_COLS> {
     pub xor_selector: Option<Evals>,
     /// evaluation of the Rot selector polynomial
     pub rot_selector: Option<Evals>,
+    /// evaluation of the KeccakRound selector polynomial
+    pub keccak_round_selector: Option<Evals>,
+    /// evaluation of the KeccakRound selector polynomial
+    pub keccak_sponge_selector: Option<Evals>,
 
     // lookup-related evaluations
     /// evaluation of lookup aggregation polynomial
@@ -2051,6 +2055,10 @@ pub struct ProofEvaluations<Evals, const COLUMNS: usize = KIMCHI_COLS> {
     pub range_check_lookup_selector: Option<Evals>,
     /// evaluation of the ForeignFieldMul range check pattern selector polynomial
     pub foreign_field_mul_lookup_selector: Option<Evals>,
+    /// evaluation of the KeccakRound pattern selector polynomial
+    pub keccak_round_lookup_selector: Option<Evals>,
+    /// evaluation of the KeccakSponge pattern selector polynomial
+    pub keccak_sponge_lookup_selector: Option<Evals>,
 }
 
 /// Commitments linked to the lookup feature

--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1856,6 +1856,14 @@ pub struct VerifierIndex<
     #[serde(bound = "Option<PolyComm<G>>: Serialize + DeserializeOwned")]
     pub rot_comm: Option<PolyComm<G>>,
 
+    /// Keccak round commitments
+    #[serde(bound = "Option<PolyComm<G>>: Serialize + DeserializeOwned")]
+    pub keccak_round_comm: Option<PolyComm<G>>,
+
+    /// Keccak sponge commitments
+    #[serde(bound = "Option<PolyComm<G>>: Serialize + DeserializeOwned")]
+    pub keccak_sponge_comm: Option<PolyComm<G>>,
+
     /// wire coordinate shifts
     #[serde_as(as = "[o1_utils::serialization::SerdeAs; PERMUTS]")]
     pub shift: [G::ScalarField; PERMUTS],

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -138,11 +138,11 @@ pub struct ColumnEvaluations<F: PrimeField, const COLUMNS: usize = KIMCHI_COLS> 
 
     /// Keccak round gate selector over domain d4
     #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]
-    pub keccak_round_selector4: Option<E<F, D<F>>>,
+    pub keccak_round_selector8: Option<E<F, D<F>>>,
 
     /// Keccak sponge gate selector over domain d4
     #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]
-    pub keccak_sponge_selector4: Option<E<F, D<F>>>,
+    pub keccak_sponge_selector8: Option<E<F, D<F>>>,
 }
 
 #[serde_as]
@@ -604,7 +604,7 @@ impl<F: PrimeField + SquareRootField> ConstraintSystem<F> {
             }
         };
 
-        let keccak_round_selector4 = {
+        let keccak_round_selector8 = {
             if !self.feature_flags.keccak_round {
                 None
             } else {
@@ -612,13 +612,13 @@ impl<F: PrimeField + SquareRootField> ConstraintSystem<F> {
                     GateType::KeccakRound,
                     &self.gates,
                     &self.domain,
-                    &self.domain.d4,
+                    &self.domain.d8,
                     self.disable_gates_checks,
                 ))
             }
         };
 
-        let keccak_sponge_selector4 = {
+        let keccak_sponge_selector8 = {
             if !self.feature_flags.keccak_sponge {
                 None
             } else {
@@ -626,7 +626,7 @@ impl<F: PrimeField + SquareRootField> ConstraintSystem<F> {
                     GateType::KeccakSponge,
                     &self.gates,
                     &self.domain,
-                    &self.domain.d4,
+                    &self.domain.d8,
                     self.disable_gates_checks,
                 ))
             }
@@ -653,8 +653,8 @@ impl<F: PrimeField + SquareRootField> ConstraintSystem<F> {
             foreign_field_mul_selector8,
             xor_selector8,
             rot_selector8,
-            keccak_round_selector4,
-            keccak_sponge_selector4,
+            keccak_round_selector8,
+            keccak_sponge_selector8,
         }
     }
 }

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -138,11 +138,11 @@ pub struct ColumnEvaluations<F: PrimeField, const COLUMNS: usize = KIMCHI_COLS> 
 
     /// Keccak round gate selector over domain d4
     #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]
-    pub keccak_round_selector8: Option<E<F, D<F>>>,
+    pub keccak_round_selector4: Option<E<F, D<F>>>,
 
     /// Keccak sponge gate selector over domain d4
     #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]
-    pub keccak_sponge_selector8: Option<E<F, D<F>>>,
+    pub keccak_sponge_selector4: Option<E<F, D<F>>>,
 }
 
 #[serde_as]
@@ -604,7 +604,7 @@ impl<F: PrimeField + SquareRootField> ConstraintSystem<F> {
             }
         };
 
-        let keccak_round_selector8 = {
+        let keccak_round_selector4 = {
             if !self.feature_flags.keccak_round {
                 None
             } else {
@@ -612,13 +612,13 @@ impl<F: PrimeField + SquareRootField> ConstraintSystem<F> {
                     GateType::KeccakRound,
                     &self.gates,
                     &self.domain,
-                    &self.domain.d8,
+                    &self.domain.d4,
                     self.disable_gates_checks,
                 ))
             }
         };
 
-        let keccak_sponge_selector8 = {
+        let keccak_sponge_selector4 = {
             if !self.feature_flags.keccak_sponge {
                 None
             } else {
@@ -626,7 +626,7 @@ impl<F: PrimeField + SquareRootField> ConstraintSystem<F> {
                     GateType::KeccakSponge,
                     &self.gates,
                     &self.domain,
-                    &self.domain.d8,
+                    &self.domain.d4,
                     self.disable_gates_checks,
                 ))
             }
@@ -653,8 +653,8 @@ impl<F: PrimeField + SquareRootField> ConstraintSystem<F> {
             foreign_field_mul_selector8,
             xor_selector8,
             rot_selector8,
-            keccak_round_selector8,
-            keccak_sponge_selector8,
+            keccak_round_selector4,
+            keccak_sponge_selector4,
         }
     }
 }

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -46,10 +46,8 @@ pub struct FeatureFlags {
     pub xor: bool,
     /// ROT gate
     pub rot: bool,
-    /// Keccak round gate
-    pub keccak_round: bool,
-    /// Keccak sponge gate
-    pub keccak_sponge: bool,
+    /// Keccak gates
+    pub keccak: bool,
     /// Lookup features
     pub lookup_features: LookupFeatures,
 }
@@ -136,13 +134,13 @@ pub struct ColumnEvaluations<F: PrimeField, const COLUMNS: usize = KIMCHI_COLS> 
     #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]
     pub rot_selector8: Option<E<F, D<F>>>,
 
-    /// Keccak round gate selector over domain d4
+    /// Keccak round gate selector over domain d8
     #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]
-    pub keccak_round_selector4: Option<E<F, D<F>>>,
+    pub keccak_round_selector8: Option<E<F, D<F>>>,
 
-    /// Keccak sponge gate selector over domain d4
+    /// Keccak sponge gate selector over domain d8
     #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]
-    pub keccak_sponge_selector4: Option<E<F, D<F>>>,
+    pub keccak_sponge_selector8: Option<E<F, D<F>>>,
 }
 
 #[serde_as]
@@ -604,29 +602,29 @@ impl<F: PrimeField + SquareRootField> ConstraintSystem<F> {
             }
         };
 
-        let keccak_round_selector4 = {
-            if !self.feature_flags.keccak_round {
+        let keccak_round_selector8 = {
+            if !self.feature_flags.keccak {
                 None
             } else {
                 Some(selector_polynomial(
                     GateType::KeccakRound,
                     &self.gates,
                     &self.domain,
-                    &self.domain.d4,
+                    &self.domain.d8,
                     self.disable_gates_checks,
                 ))
             }
         };
 
-        let keccak_sponge_selector4 = {
-            if !self.feature_flags.keccak_sponge {
+        let keccak_sponge_selector8 = {
+            if !self.feature_flags.keccak {
                 None
             } else {
                 Some(selector_polynomial(
                     GateType::KeccakSponge,
                     &self.gates,
                     &self.domain,
-                    &self.domain.d4,
+                    &self.domain.d8,
                     self.disable_gates_checks,
                 ))
             }
@@ -653,8 +651,8 @@ impl<F: PrimeField + SquareRootField> ConstraintSystem<F> {
             foreign_field_mul_selector8,
             xor_selector8,
             rot_selector8,
-            keccak_round_selector4,
-            keccak_sponge_selector4,
+            keccak_round_selector8,
+            keccak_sponge_selector8,
         }
     }
 }
@@ -846,8 +844,7 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
             foreign_field_mul: false,
             xor: false,
             rot: false,
-            keccak_round: false,
-            keccak_sponge: false,
+            keccak: false,
         };
 
         for gate in &gates {
@@ -858,8 +855,7 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
                 GateType::ForeignFieldMul => feature_flags.foreign_field_mul = true,
                 GateType::Xor16 => feature_flags.xor = true,
                 GateType::Rot64 => feature_flags.rot = true,
-                GateType::KeccakRound => feature_flags.keccak_round = true,
-                GateType::KeccakSponge => feature_flags.keccak_sponge = true,
+                GateType::KeccakRound | GateType::KeccakSponge => feature_flags.keccak = true,
                 _ => (),
             }
         }

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -402,6 +402,8 @@ pub enum FeatureFlag {
     ForeignFieldMul,
     Xor,
     Rot,
+    KeccakRound,
+    KeccakSponge,
     LookupTables,
     RuntimeLookupTables,
     LookupPattern(LookupPattern),
@@ -560,6 +562,8 @@ impl<C: Zero + One + Neg<Output = C> + PartialEq + Clone, Column: Clone + Partia
                         ForeignFieldMul => features.foreign_field_mul,
                         Xor => features.xor,
                         Rot => features.rot,
+                        KeccakRound => features.keccak_round,
+                        KeccakSponge => features.keccak_sponge,
                         LookupTables => {
                             features.lookup_features.patterns != LookupPatterns::default()
                         }

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -402,8 +402,7 @@ pub enum FeatureFlag {
     ForeignFieldMul,
     Xor,
     Rot,
-    KeccakRound,
-    KeccakSponge,
+    Keccak,
     LookupTables,
     RuntimeLookupTables,
     LookupPattern(LookupPattern),
@@ -562,8 +561,7 @@ impl<C: Zero + One + Neg<Output = C> + PartialEq + Clone, Column: Clone + Partia
                         ForeignFieldMul => features.foreign_field_mul,
                         Xor => features.xor,
                         Rot => features.rot,
-                        KeccakRound => features.keccak_round,
-                        KeccakSponge => features.keccak_sponge,
+                        Keccak => features.keccak,
                         LookupTables => {
                             features.lookup_features.patterns != LookupPatterns::default()
                         }

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -733,6 +733,8 @@ impl LookupPattern {
             }
             (ForeignFieldMul, Curr | Next) => Some(LookupPattern::ForeignFieldMul),
             (Xor16, Curr) => Some(LookupPattern::Xor),
+            (KeccakRound, Curr) => Some(LookupPattern::KeccakRound),
+            (KeccakSponge, Curr) => Some(LookupPattern::KeccakSponge),
             _ => None,
         }
     }

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -9,6 +9,7 @@ use crate::circuits::lookup::{
     lookups::{LookupFeatures, LookupInfo, LookupPattern, LookupPatterns},
 };
 use crate::circuits::polynomials::keccak;
+use crate::circuits::polynomials::keccak::circuitgates::KeccakRound;
 use crate::circuits::polynomials::{
     complete_add::CompleteAdd,
     endomul_scalar::EndomulScalar,
@@ -45,7 +46,12 @@ pub fn constraints_expr<F: PrimeField + SquareRootField, const COLUMNS: usize>(
 
     // Set up powers of alpha. Only the max number of constraints matters.
     // The gate type argument can just be the zero gate.
-    let max_exponents = VarbaseMul::<F>::CONSTRAINTS;
+    let mut max_exponents = VarbaseMul::<F>::CONSTRAINTS;
+    if let Some(feature_flags) = feature_flags {
+        if feature_flags.keccak_round {
+            max_exponents = KeccakRound::<F>::CONSTRAINTS;
+        }
+    }
     powers_of_alpha.register(ArgumentType::Gate(GateType::Zero), max_exponents);
 
     let mut cache = expr::Cache::default();

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -252,14 +252,16 @@ pub fn linearization_columns<F: FftField + SquareRootField, const COLUMNS: usize
                 foreign_field_mul: true,
                 xor: true,
                 rot: true,
+                keccak_round: true,
+                keccak_sponge: true,
                 lookup_features: LookupFeatures {
                     patterns: LookupPatterns {
                         xor: true,
                         lookup: true,
                         range_check: true,
                         foreign_field_mul: true,
-                        keccak_round: false,
-                        keccak_sponge: false,
+                        keccak_round: true,
+                        keccak_sponge: true,
                     },
                     joint_lookup_used: true,
                     uses_runtime_tables: true,

--- a/kimchi/src/plonk_sponge.rs
+++ b/kimchi/src/plonk_sponge.rs
@@ -78,6 +78,8 @@ impl<Fr: PrimeField, const COLUMNS: usize> FrSponge<Fr, COLUMNS> for DefaultFrSp
             foreign_field_mul_selector,
             xor_selector,
             rot_selector,
+            keccak_round_selector,
+            keccak_sponge_selector,
             lookup_aggregation,
             lookup_table,
             lookup_sorted,
@@ -87,6 +89,8 @@ impl<Fr: PrimeField, const COLUMNS: usize> FrSponge<Fr, COLUMNS> for DefaultFrSp
             lookup_gate_lookup_selector,
             range_check_lookup_selector,
             foreign_field_mul_lookup_selector,
+            keccak_round_lookup_selector,
+            keccak_sponge_lookup_selector,
         } = e;
 
         let mut points = vec![
@@ -122,6 +126,12 @@ impl<Fr: PrimeField, const COLUMNS: usize> FrSponge<Fr, COLUMNS> for DefaultFrSp
         if let Some(rot_selector) = rot_selector.as_ref() {
             points.push(rot_selector)
         }
+        if let Some(keccak_round_selector) = keccak_round_selector.as_ref() {
+            points.push(keccak_round_selector)
+        }
+        if let Some(keccak_sponge_selector) = keccak_sponge_selector.as_ref() {
+            points.push(keccak_sponge_selector)
+        }
         if let Some(lookup_aggregation) = lookup_aggregation.as_ref() {
             points.push(lookup_aggregation)
         }
@@ -151,6 +161,12 @@ impl<Fr: PrimeField, const COLUMNS: usize> FrSponge<Fr, COLUMNS> for DefaultFrSp
         if let Some(foreign_field_mul_lookup_selector) = foreign_field_mul_lookup_selector.as_ref()
         {
             points.push(foreign_field_mul_lookup_selector)
+        }
+        if let Some(keccak_round_lookup_selector) = keccak_round_lookup_selector.as_ref() {
+            points.push(keccak_round_lookup_selector)
+        }
+        if let Some(keccak_sponge_lookup_selector) = keccak_sponge_lookup_selector.as_ref() {
+            points.push(keccak_sponge_lookup_selector)
         }
 
         points.into_iter().for_each(|p| {

--- a/kimchi/src/proof.rs
+++ b/kimchi/src/proof.rs
@@ -82,6 +82,10 @@ pub struct ProofEvaluations<Evals, const COLUMNS: usize = KIMCHI_COLS> {
     pub xor_selector: Option<Evals>,
     /// evaluation of the Rot selector polynomial
     pub rot_selector: Option<Evals>,
+    /// evaluation of the KeccakRound selector polynomial
+    pub keccak_round_selector: Option<Evals>,
+    /// evaluation of the KeccakRound selector polynomial
+    pub keccak_sponge_selector: Option<Evals>,
 
     // lookup-related evaluations
     /// evaluation of lookup aggregation polynomial
@@ -104,6 +108,10 @@ pub struct ProofEvaluations<Evals, const COLUMNS: usize = KIMCHI_COLS> {
     pub range_check_lookup_selector: Option<Evals>,
     /// evaluation of the ForeignFieldMul range check pattern selector polynomial
     pub foreign_field_mul_lookup_selector: Option<Evals>,
+    /// evaluation of the KeccakRound pattern selector polynomial
+    pub keccak_round_lookup_selector: Option<Evals>,
+    /// evaluation of the KeccakSponge pattern selector polynomial
+    pub keccak_sponge_lookup_selector: Option<Evals>,
 }
 
 /// Commitments linked to the lookup feature
@@ -215,6 +223,8 @@ impl<Eval, const COLUMNS: usize> ProofEvaluations<Eval, COLUMNS> {
             foreign_field_mul_selector,
             xor_selector,
             rot_selector,
+            keccak_round_selector,
+            keccak_sponge_selector,
             lookup_aggregation,
             lookup_table,
             lookup_sorted,
@@ -224,6 +234,8 @@ impl<Eval, const COLUMNS: usize> ProofEvaluations<Eval, COLUMNS> {
             lookup_gate_lookup_selector,
             range_check_lookup_selector,
             foreign_field_mul_lookup_selector,
+            keccak_round_lookup_selector,
+            keccak_sponge_lookup_selector,
         } = self;
         ProofEvaluations {
             public: public.map(f),
@@ -243,6 +255,8 @@ impl<Eval, const COLUMNS: usize> ProofEvaluations<Eval, COLUMNS> {
             foreign_field_mul_selector: foreign_field_mul_selector.map(f),
             xor_selector: xor_selector.map(f),
             rot_selector: rot_selector.map(f),
+            keccak_round_selector: keccak_round_selector.map(f),
+            keccak_sponge_selector: keccak_sponge_selector.map(f),
             lookup_aggregation: lookup_aggregation.map(f),
             lookup_table: lookup_table.map(f),
             lookup_sorted: lookup_sorted.map(|x| x.map(f)),
@@ -252,6 +266,8 @@ impl<Eval, const COLUMNS: usize> ProofEvaluations<Eval, COLUMNS> {
             lookup_gate_lookup_selector: lookup_gate_lookup_selector.map(f),
             range_check_lookup_selector: range_check_lookup_selector.map(f),
             foreign_field_mul_lookup_selector: foreign_field_mul_lookup_selector.map(f),
+            keccak_round_lookup_selector: keccak_round_lookup_selector.map(f),
+            keccak_sponge_lookup_selector: keccak_sponge_lookup_selector.map(f),
         }
     }
 
@@ -277,6 +293,8 @@ impl<Eval, const COLUMNS: usize> ProofEvaluations<Eval, COLUMNS> {
             foreign_field_mul_selector,
             xor_selector,
             rot_selector,
+            keccak_round_selector,
+            keccak_sponge_selector,
             lookup_aggregation,
             lookup_table,
             lookup_sorted,
@@ -286,6 +304,8 @@ impl<Eval, const COLUMNS: usize> ProofEvaluations<Eval, COLUMNS> {
             lookup_gate_lookup_selector,
             range_check_lookup_selector,
             foreign_field_mul_lookup_selector,
+            keccak_round_lookup_selector,
+            keccak_sponge_lookup_selector,
         } = self;
         ProofEvaluations {
             public: public.as_ref().map(f),
@@ -305,6 +325,8 @@ impl<Eval, const COLUMNS: usize> ProofEvaluations<Eval, COLUMNS> {
             foreign_field_mul_selector: foreign_field_mul_selector.as_ref().map(f),
             xor_selector: xor_selector.as_ref().map(f),
             rot_selector: rot_selector.as_ref().map(f),
+            keccak_round_selector: keccak_round_selector.as_ref().map(f),
+            keccak_sponge_selector: keccak_sponge_selector.as_ref().map(f),
             lookup_aggregation: lookup_aggregation.as_ref().map(f),
             lookup_table: lookup_table.as_ref().map(f),
             lookup_sorted: array::from_fn(|i| lookup_sorted[i].as_ref().map(f)),
@@ -314,6 +336,8 @@ impl<Eval, const COLUMNS: usize> ProofEvaluations<Eval, COLUMNS> {
             lookup_gate_lookup_selector: lookup_gate_lookup_selector.as_ref().map(f),
             range_check_lookup_selector: range_check_lookup_selector.as_ref().map(f),
             foreign_field_mul_lookup_selector: foreign_field_mul_lookup_selector.as_ref().map(f),
+            keccak_round_lookup_selector: keccak_round_lookup_selector.as_ref().map(f),
+            keccak_sponge_lookup_selector: keccak_sponge_lookup_selector.as_ref().map(f),
         }
     }
 }
@@ -392,6 +416,8 @@ impl<F: Zero + Copy, const COLUMNS: usize> ProofEvaluations<PointEvaluations<F>,
             foreign_field_mul_selector: None,
             xor_selector: None,
             rot_selector: None,
+            keccak_round_selector: None,
+            keccak_sponge_selector: None,
             lookup_aggregation: None,
             lookup_table: None,
             lookup_sorted: array::from_fn(|_| None),
@@ -401,6 +427,8 @@ impl<F: Zero + Copy, const COLUMNS: usize> ProofEvaluations<PointEvaluations<F>,
             lookup_gate_lookup_selector: None,
             range_check_lookup_selector: None,
             foreign_field_mul_lookup_selector: None,
+            keccak_round_lookup_selector: None,
+            keccak_sponge_lookup_selector: None,
         }
     }
 }
@@ -435,8 +463,12 @@ impl<F, const COLUMNS: usize> ProofEvaluations<F, COLUMNS> {
             Column::LookupKindIndex(LookupPattern::ForeignFieldMul) => {
                 self.foreign_field_mul_lookup_selector.as_ref()
             }
-            Column::LookupKindIndex(LookupPattern::KeccakRound) => todo!(),
-            Column::LookupKindIndex(LookupPattern::KeccakSponge) => todo!(),
+            Column::LookupKindIndex(LookupPattern::KeccakRound) => {
+                self.keccak_round_lookup_selector.as_ref()
+            }
+            Column::LookupKindIndex(LookupPattern::KeccakSponge) => {
+                self.keccak_sponge_lookup_selector.as_ref()
+            }
             Column::LookupRuntimeSelector => self.runtime_lookup_table_selector.as_ref(),
             Column::LookupRuntimeTable => self.runtime_lookup_table.as_ref(),
             Column::Index(GateType::Generic) => Some(&self.generic_selector),
@@ -451,6 +483,8 @@ impl<F, const COLUMNS: usize> ProofEvaluations<F, COLUMNS> {
             Column::Index(GateType::ForeignFieldMul) => self.foreign_field_mul_selector.as_ref(),
             Column::Index(GateType::Xor16) => self.xor_selector.as_ref(),
             Column::Index(GateType::Rot64) => self.rot_selector.as_ref(),
+            Column::Index(GateType::KeccakRound) => self.keccak_round_selector.as_ref(),
+            Column::Index(GateType::KeccakSponge) => self.keccak_sponge_selector.as_ref(),
             Column::Index(_) => None,
             Column::Coefficient(i) => Some(&self.coefficients[i]),
             Column::Permutation(i) => Some(&self.s[i]),

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -704,11 +704,11 @@ where
                 index_evals.insert(GateType::Rot64, selector);
             }
 
-            if let Some(selector) = index.column_evaluations.keccak_round_selector4.as_ref() {
+            if let Some(selector) = index.column_evaluations.keccak_round_selector8.as_ref() {
                 index_evals.insert(GateType::KeccakRound, selector);
             }
 
-            if let Some(selector) = index.column_evaluations.keccak_sponge_selector4.as_ref() {
+            if let Some(selector) = index.column_evaluations.keccak_sponge_selector8.as_ref() {
                 index_evals.insert(GateType::KeccakSponge, selector);
             }
 
@@ -786,9 +786,9 @@ where
                 let xor_enabled = index.column_evaluations.xor_selector8.is_some();
                 let rot_enabled = index.column_evaluations.rot_selector8.is_some();
                 let keccak_round_enabled =
-                    index.column_evaluations.keccak_round_selector4.is_some();
+                    index.column_evaluations.keccak_round_selector8.is_some();
                 let keccak_sponge_enabled =
-                    index.column_evaluations.keccak_sponge_selector4.is_some();
+                    index.column_evaluations.keccak_sponge_selector8.is_some();
 
                 for gate in [
                     (

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -13,7 +13,9 @@ use crate::{
             endosclmul::EndosclMul,
             foreign_field_add::circuitgates::ForeignFieldAdd,
             foreign_field_mul::{self, circuitgates::ForeignFieldMul},
-            generic, permutation,
+            generic,
+            keccak::circuitgates::{KeccakRound, KeccakSponge},
+            permutation,
             poseidon::Poseidon,
             range_check::circuitgates::{RangeCheck0, RangeCheck1},
             rot::Rot64,
@@ -702,6 +704,14 @@ where
                 index_evals.insert(GateType::Rot64, selector);
             }
 
+            if let Some(selector) = index.column_evaluations.keccak_round_selector4.as_ref() {
+                index_evals.insert(GateType::KeccakRound, selector);
+            }
+
+            if let Some(selector) = index.column_evaluations.keccak_sponge_selector4.as_ref() {
+                index_evals.insert(GateType::KeccakSponge, selector);
+            }
+
             let mds = &G::sponge_params().mds;
             Environment {
                 constants: Constants {
@@ -775,6 +785,10 @@ where
                     .is_some();
                 let xor_enabled = index.column_evaluations.xor_selector8.is_some();
                 let rot_enabled = index.column_evaluations.rot_selector8.is_some();
+                let keccak_round_enabled =
+                    index.column_evaluations.keccak_round_selector4.is_some();
+                let keccak_sponge_enabled =
+                    index.column_evaluations.keccak_sponge_selector4.is_some();
 
                 for gate in [
                     (
@@ -799,6 +813,10 @@ where
                     (&Xor16::default(), xor_enabled),
                     // Rot gate
                     (&Rot64::default(), rot_enabled),
+                    // Keccak round gate
+                    (&KeccakRound::default(), keccak_round_enabled),
+                    // Keccak sponge gate
+                    (&KeccakSponge::default(), keccak_sponge_enabled),
                 ]
                 .into_iter()
                 .filter_map(|(gate, is_enabled)| if is_enabled { Some(gate) } else { None })

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1072,6 +1072,16 @@ where
                 .rot_selector8
                 .as_ref()
                 .map(chunked_evals_for_selector),
+            keccak_round_selector: index
+                .column_evaluations
+                .keccak_round_selector8
+                .as_ref()
+                .map(chunked_evals_for_selector),
+            keccak_sponge_selector: index
+                .column_evaluations
+                .keccak_sponge_selector8
+                .as_ref()
+                .map(chunked_evals_for_selector),
 
             runtime_lookup_table_selector: index.cs.lookup_constraint_system.as_ref().and_then(
                 |lcs| {
@@ -1106,6 +1116,22 @@ where
                 |lcs| {
                     lcs.lookup_selectors
                         .ffmul
+                        .as_ref()
+                        .map(chunked_evals_for_selector)
+                },
+            ),
+            keccak_round_lookup_selector: index.cs.lookup_constraint_system.as_ref().and_then(
+                |lcs| {
+                    lcs.lookup_selectors
+                        .keccak_round
+                        .as_ref()
+                        .map(chunked_evals_for_selector)
+                },
+            ),
+            keccak_sponge_lookup_selector: index.cs.lookup_constraint_system.as_ref().and_then(
+                |lcs| {
+                    lcs.lookup_selectors
+                        .keccak_sponge
                         .as_ref()
                         .map(chunked_evals_for_selector)
                 },

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -635,6 +635,8 @@ where
         foreign_field_mul_selector,
         xor_selector,
         rot_selector,
+        keccak_round_selector,
+        keccak_sponge_selector,
         lookup_aggregation,
         lookup_table,
         lookup_sorted,
@@ -644,6 +646,8 @@ where
         lookup_gate_lookup_selector,
         range_check_lookup_selector,
         foreign_field_mul_lookup_selector,
+        keccak_round_lookup_selector,
+        keccak_sponge_lookup_selector,
     } = &proof.evals;
 
     let check_eval_len = |eval: &PointEvaluations<Vec<_>>, str: &'static str| -> Result<()> {
@@ -721,6 +725,12 @@ where
     if let Some(rot_selector) = rot_selector {
         check_eval_len(rot_selector, "rot selector")?
     }
+    if let Some(keccak_round_selector) = keccak_round_selector {
+        check_eval_len(keccak_round_selector, "keccak round selector")?
+    }
+    if let Some(keccak_sponge_selector) = keccak_sponge_selector {
+        check_eval_len(keccak_sponge_selector, "keccak sponge selector")?
+    }
 
     // Lookup selectors
 
@@ -743,6 +753,15 @@ where
         check_eval_len(
             foreign_field_mul_lookup_selector,
             "foreign field mul lookup selector",
+        )?
+    }
+    if let Some(keccak_round_lookup_selector) = keccak_round_lookup_selector {
+        check_eval_len(keccak_round_lookup_selector, "keccak round lookup selector")?
+    }
+    if let Some(keccak_sponge_lookup_selector) = keccak_sponge_lookup_selector {
+        check_eval_len(
+            keccak_sponge_lookup_selector,
+            "keccak sponge lookup selector",
         )?
     }
 

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -93,8 +93,8 @@ impl<'a, G: KimchiCurve, OpeningProof: OpenProof<G>, const COLUMNS: usize>
                     ForeignFieldMul => Some(self.verifier_index.foreign_field_mul_comm.as_ref()?),
                     Xor16 => Some(self.verifier_index.xor_comm.as_ref()?),
                     Rot64 => Some(self.verifier_index.rot_comm.as_ref()?),
-                    KeccakRound => todo!(),
-                    KeccakSponge => todo!(),
+                    KeccakRound => Some(self.verifier_index.keccak_round_comm.as_ref()?),
+                    KeccakSponge => Some(self.verifier_index.keccak_sponge_comm.as_ref()?),
                 }
             }
         }

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -306,15 +306,15 @@ where
 
             keccak_round_comm: self
                 .column_evaluations
-                .keccak_round_selector4
+                .keccak_round_selector8
                 .as_ref()
-                .map(|eval4| self.srs.commit_evaluations_non_hiding(domain, eval4)),
+                .map(|eval8| self.srs.commit_evaluations_non_hiding(domain, eval8)),
 
             keccak_sponge_comm: self
                 .column_evaluations
-                .keccak_sponge_selector4
+                .keccak_sponge_selector8
                 .as_ref()
-                .map(|eval4| self.srs.commit_evaluations_non_hiding(domain, eval4)),
+                .map(|eval8| self.srs.commit_evaluations_non_hiding(domain, eval8)),
 
             shift: self.cs.shift,
             permutation_vanishing_polynomial_m: {

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -306,13 +306,13 @@ where
 
             keccak_round_comm: self
                 .column_evaluations
-                .keccak_round_selector8
+                .keccak_round_selector4
                 .as_ref()
                 .map(|eval4| self.srs.commit_evaluations_non_hiding(domain, eval4)),
 
             keccak_sponge_comm: self
                 .column_evaluations
-                .keccak_sponge_selector8
+                .keccak_sponge_selector4
                 .as_ref()
                 .map(|eval4| self.srs.commit_evaluations_non_hiding(domain, eval4)),
 

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -131,6 +131,14 @@ pub struct VerifierIndex<
     #[serde(bound = "Option<PolyComm<G>>: Serialize + DeserializeOwned")]
     pub rot_comm: Option<PolyComm<G>>,
 
+    /// Keccak round commitments
+    #[serde(bound = "Option<PolyComm<G>>: Serialize + DeserializeOwned")]
+    pub keccak_round_comm: Option<PolyComm<G>>,
+
+    /// Keccak sponge commitments
+    #[serde(bound = "Option<PolyComm<G>>: Serialize + DeserializeOwned")]
+    pub keccak_sponge_comm: Option<PolyComm<G>>,
+
     /// wire coordinate shifts
     #[serde_as(as = "[o1_utils::serialization::SerdeAs; PERMUTS]")]
     pub shift: [G::ScalarField; PERMUTS],
@@ -296,6 +304,18 @@ where
                 .as_ref()
                 .map(|eval8| self.srs.commit_evaluations_non_hiding(domain, eval8)),
 
+            keccak_round_comm: self
+                .column_evaluations
+                .keccak_round_selector8
+                .as_ref()
+                .map(|eval4| self.srs.commit_evaluations_non_hiding(domain, eval4)),
+
+            keccak_sponge_comm: self
+                .column_evaluations
+                .keccak_sponge_selector8
+                .as_ref()
+                .map(|eval4| self.srs.commit_evaluations_non_hiding(domain, eval4)),
+
             shift: self.cs.shift,
             permutation_vanishing_polynomial_m: {
                 let cell = OnceCell::new();
@@ -431,6 +451,8 @@ impl<G: KimchiCurve, OpeningProof: OpenProof<G>, const COLUMNS: usize>
             foreign_field_mul_comm,
             xor_comm,
             rot_comm,
+            keccak_round_comm,
+            keccak_sponge_comm,
 
             // Lookup index; optional
             lookup_index,
@@ -483,6 +505,14 @@ impl<G: KimchiCurve, OpeningProof: OpenProof<G>, const COLUMNS: usize>
 
         if let Some(rot_comm) = rot_comm {
             fq_sponge.absorb_g(&rot_comm.unshifted);
+        }
+
+        if let Some(keccak_round_comm) = keccak_round_comm {
+            fq_sponge.absorb_g(&keccak_round_comm.unshifted);
+        }
+
+        if let Some(keccak_sponge_comm) = keccak_sponge_comm {
+            fq_sponge.absorb_g(&keccak_sponge_comm.unshifted);
         }
 
         // Lookup index; optional


### PR DESCRIPTION
Revival of https://github.com/o1-labs/proof-systems/pull/1267 which got merged non-intendedly

Tests of this alive in https://github.com/o1-labs/proof-systems/pull/1281.