### PR TITLE
Deduplicate lookup tables

### DIFF
--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -5,7 +5,11 @@ use crate::{
         domain_constant_evaluation::DomainConstantEvaluations,
         domains::EvaluationDomains,
         gate::{CircuitGate, GateType},
-        lookup::{index::LookupConstraintSystem, lookups::LookupFeatures, tables::LookupTable},
+        lookup::{
+            index::LookupConstraintSystem,
+            lookups::LookupFeatures,
+            tables::{GateLookupTables, LookupTable},
+        },
         polynomial::{WitnessEvals, WitnessOverDomains, WitnessShifts},
         polynomials::permutation::Shifts,
         wires::*,
@@ -752,10 +756,17 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
             }
             // And we add the built-in tables, depending on the features.
             let LookupFeatures { patterns, .. } = &feature_flags.lookup_features;
+            let mut gate_lookup_tables = GateLookupTables {
+                xor: false,
+                range_check: false,
+            };
             for pattern in patterns.into_iter() {
                 if let Some(gate_table) = pattern.table() {
-                    lookup_domain_size += gate_table.table_size();
+                    gate_lookup_tables[gate_table] = true
                 }
+            }
+            for gate_table in gate_lookup_tables.into_iter() {
+                lookup_domain_size += gate_table.table_size();
             }
             lookup_domain_size
         };

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -20,6 +20,53 @@ pub enum GateLookupTable {
     RangeCheck,
 }
 
+/// Enumerates the different 'fixed' lookup tables used by individual gates
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct GateLookupTables {
+    pub xor: bool,
+    pub range_check: bool,
+}
+
+impl std::ops::Index<GateLookupTable> for GateLookupTables {
+    type Output = bool;
+
+    fn index(&self, index: GateLookupTable) -> &Self::Output {
+        match index {
+            GateLookupTable::Xor => &self.xor,
+            GateLookupTable::RangeCheck => &self.range_check,
+        }
+    }
+}
+
+impl std::ops::IndexMut<GateLookupTable> for GateLookupTables {
+    fn index_mut(&mut self, index: GateLookupTable) -> &mut Self::Output {
+        match index {
+            GateLookupTable::Xor => &mut self.xor,
+            GateLookupTable::RangeCheck => &mut self.range_check,
+        }
+    }
+}
+
+impl IntoIterator for GateLookupTables {
+    type Item = GateLookupTable;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        // Destructor pattern to make sure we add new lookup patterns.
+        let GateLookupTables { xor, range_check } = self;
+
+        let mut patterns = Vec::with_capacity(2);
+
+        if xor {
+            patterns.push(GateLookupTable::Xor)
+        }
+        if range_check {
+            patterns.push(GateLookupTable::RangeCheck)
+        }
+        patterns.into_iter()
+    }
+}
+
 /// A table of values that can be used for a lookup, along with the ID for the table.
 #[derive(Debug, Clone)]
 pub struct LookupTable<F> {


### PR DESCRIPTION
This PR fixes a bug in the domain size computed for lookup tables. This allows us to prove with a smaller domain size when ffmul and some other range check lookup gate is used, and also to revert the workaround [here](https://github.com/MinaProtocol/mina/pull/14405/commits/c2d9b3b844630ddb3d604ec8b9ea76edd5360ab5).