### PR TITLE
Update criterion benchmarks for kimchi

### DIFF
--- a/kimchi/README.md
+++ b/kimchi/README.md
@@ -6,7 +6,7 @@ Kimchi is based on [plonk](https://eprint.iacr.org/2019/953.pdf), a zk-SNARK pro
 
 To bench kimchi, we have two types of benchmark engines. 
 
-[Criterion](https://bheisler.github.io/criterion.rs/) is used to benchmark time:
+[Criterion](https://bheisler.github.io/criterion.rs/) is used to benchmark time. If you have installed [cargo-criterion](https://github.com/bheisler/cargo-criterion) and [gnuplot](http://www.gnuplot.info), you can run the benchmarks via
 
 ```console
 $ cargo criterion -p kimchi --bench proof_criterion

--- a/kimchi/benches/proof_criterion.rs
+++ b/kimchi/benches/proof_criterion.rs
@@ -9,7 +9,7 @@ pub fn bench_proof_creation(c: &mut Criterion) {
         let ctx = BenchmarkCtx::new(size);
 
         group.bench_function(
-            format!("proof creation ({} gates)", ctx.num_gates),
+            format!("proof creation (SRS size 2^{{{}}}, {} gates)", ctx.srs_size(), ctx.num_gates),
             |b| b.iter(|| black_box(ctx.create_proof())),
         );
     }
@@ -24,7 +24,7 @@ pub fn bench_proof_verification(c: &mut Criterion) {
         let proof_and_public = ctx.create_proof();
 
         group.bench_function(
-            format!("proof verification ({} gates)", ctx.num_gates),
+            format!("proof verification (SRS size 2^{{{}}}, {} gates)", ctx.srs_size(), ctx.num_gates),
             |b| b.iter(|| ctx.batch_verification(black_box(&vec![proof_and_public.clone()]))),
         );
     }

--- a/kimchi/benches/proof_criterion.rs
+++ b/kimchi/benches/proof_criterion.rs
@@ -9,7 +9,11 @@ pub fn bench_proof_creation(c: &mut Criterion) {
         let ctx = BenchmarkCtx::new(size);
 
         group.bench_function(
-            format!("proof creation (SRS size 2^{{{}}}, {} gates)", ctx.srs_size(), ctx.num_gates),
+            format!(
+                "proof creation (SRS size 2^{{{}}}, {} gates)",
+                ctx.srs_size(),
+                ctx.num_gates
+            ),
             |b| b.iter(|| black_box(ctx.create_proof())),
         );
     }
@@ -24,7 +28,11 @@ pub fn bench_proof_verification(c: &mut Criterion) {
         let proof_and_public = ctx.create_proof();
 
         group.bench_function(
-            format!("proof verification (SRS size 2^{{{}}}, {} gates)", ctx.srs_size(), ctx.num_gates),
+            format!(
+                "proof verification (SRS size 2^{{{}}}, {} gates)",
+                ctx.srs_size(),
+                ctx.num_gates
+            ),
             |b| b.iter(|| ctx.batch_verification(black_box(&vec![proof_and_public.clone()]))),
         );
     }

--- a/kimchi/benches/proof_criterion.rs
+++ b/kimchi/benches/proof_criterion.rs
@@ -5,26 +5,30 @@ pub fn bench_proof_creation(c: &mut Criterion) {
     let mut group = c.benchmark_group("Proof creation");
     group.sample_size(10).sampling_mode(SamplingMode::Flat); // for slow benchmarks
 
-    let ctx = BenchmarkCtx::new(10);
-    group.bench_function(
-        format!("proof creation ({} gates)", ctx.num_gates),
-        |b| b.iter(|| black_box(ctx.create_proof())),
-    );
+    for size in [10, 14] {
+        let ctx = BenchmarkCtx::new(size);
 
-    let ctx = BenchmarkCtx::new(14);
-    group.bench_function(
-        format!("proof creation ({} gates)", ctx.num_gates),
-        |b| b.iter(|| black_box(ctx.create_proof())),
-    );
-
-    let proof_and_public = ctx.create_proof();
-
-    group.sample_size(100).sampling_mode(SamplingMode::Auto);
-    group.bench_function(
-        format!("proof verification ({} gates)", ctx.num_gates),
-        |b| b.iter(|| ctx.batch_verification(black_box(&vec![proof_and_public.clone()]))),
-    );
+        group.bench_function(
+            format!("proof creation ({} gates)", ctx.num_gates),
+            |b| b.iter(|| black_box(ctx.create_proof())),
+        );
+    }
 }
 
-criterion_group!(benches, bench_proof_creation);
+pub fn bench_proof_verification(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Proof verification");
+    group.sample_size(100).sampling_mode(SamplingMode::Auto);
+
+    for size in [10, 14] {
+        let ctx = BenchmarkCtx::new(size);
+        let proof_and_public = ctx.create_proof();
+
+        group.bench_function(
+            format!("proof verification ({} gates)", ctx.num_gates),
+            |b| b.iter(|| ctx.batch_verification(black_box(&vec![proof_and_public.clone()]))),
+        );
+    }
+}
+
+criterion_group!(benches, bench_proof_creation, bench_proof_verification);
 criterion_main!(benches);

--- a/kimchi/benches/proof_criterion.rs
+++ b/kimchi/benches/proof_criterion.rs
@@ -7,13 +7,13 @@ pub fn bench_proof_creation(c: &mut Criterion) {
 
     let ctx = BenchmarkCtx::new(10);
     group.bench_function(
-        format!("proof creation (SRS size 2^{})", ctx.srs_size()),
+        format!("proof creation ({} gates)", ctx.num_gates),
         |b| b.iter(|| black_box(ctx.create_proof())),
     );
 
     let ctx = BenchmarkCtx::new(14);
     group.bench_function(
-        format!("proof creation (SRS size 2^{})", ctx.srs_size()),
+        format!("proof creation ({} gates)", ctx.num_gates),
         |b| b.iter(|| black_box(ctx.create_proof())),
     );
 
@@ -21,7 +21,7 @@ pub fn bench_proof_creation(c: &mut Criterion) {
 
     group.sample_size(100).sampling_mode(SamplingMode::Auto);
     group.bench_function(
-        format!("proof verification (SRS size 2^{})", ctx.srs_size()),
+        format!("proof verification ({} gates)", ctx.num_gates),
         |b| b.iter(|| ctx.batch_verification(black_box(&vec![proof_and_public.clone()]))),
     );
 }

--- a/kimchi/src/bench.rs
+++ b/kimchi/src/bench.rs
@@ -26,7 +26,7 @@ type BaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;
 type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
 
 pub struct BenchmarkCtx {
-    num_gates: usize,
+    pub num_gates: usize,
     group_map: BWParameters<VestaParameters>,
     index: ProverIndex<Vesta, OpeningProof<Vesta>>,
     verifier_index: VerifierIndex<Vesta, OpeningProof<Vesta>>,

--- a/kimchi/src/precomputed_srs.rs
+++ b/kimchi/src/precomputed_srs.rs
@@ -17,7 +17,7 @@ pub const SERIALIZED_SRS_SIZE: u32 = 16;
 
 /// The path of the serialized SRS.
 fn get_srs_path<G: KimchiCurve>() -> PathBuf {
-    let base_path = std::env::var("CARGO_MANIFEST_DIR").expect("failed to get manifest path");
+    let base_path = env!("CARGO_MANIFEST_DIR");
     PathBuf::from(base_path)
         .join("../srs")
         .join(format!("{}.srs", G::NAME))


### PR DESCRIPTION
Trying to run the criterion benchmarks for kimchi, I ran into a couple of minor issues (documentation, a macOS dependent thing, and duplicated names for different benchmarks which prevented criterion from running).

With these changes, I am able to run the criterion benchmarks for kimchi.

There's also a minor refactoring to remove some code duplication.