### PR TITLE
Remove commitment shifting functionality

### DIFF
--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1230,7 +1230,7 @@ where
 
         let mut polynomials = polys
             .iter()
-            .map(|(p, d1_size)| (coefficients_form(p), None, non_hiding(*d1_size)))
+            .map(|(p, d1_size)| (coefficients_form(p), non_hiding(*d1_size)))
             .collect::<Vec<_>>();
 
         let fixed_hiding = |d1_size: usize| PolyComm {
@@ -1245,48 +1245,38 @@ where
         //~~ * the poseidon selector
         //~~ * the 15 registers/witness columns
         //~~ * the 6 sigmas
-        polynomials.push((
-            coefficients_form(&public_poly),
-            None,
-            fixed_hiding(num_chunks),
-        ));
-        polynomials.push((coefficients_form(&ft), None, blinding_ft));
-        polynomials.push((coefficients_form(&z_poly), None, z_comm.blinders));
+        polynomials.push((coefficients_form(&public_poly), fixed_hiding(num_chunks)));
+        polynomials.push((coefficients_form(&ft), blinding_ft));
+        polynomials.push((coefficients_form(&z_poly), z_comm.blinders));
         polynomials.push((
             evaluations_form(&index.column_evaluations.generic_selector4),
-            None,
             fixed_hiding(num_chunks),
         ));
         polynomials.push((
             evaluations_form(&index.column_evaluations.poseidon_selector8),
-            None,
             fixed_hiding(num_chunks),
         ));
         polynomials.push((
             evaluations_form(&index.column_evaluations.complete_add_selector4),
-            None,
             fixed_hiding(num_chunks),
         ));
         polynomials.push((
             evaluations_form(&index.column_evaluations.mul_selector8),
-            None,
             fixed_hiding(num_chunks),
         ));
         polynomials.push((
             evaluations_form(&index.column_evaluations.emul_selector8),
-            None,
             fixed_hiding(num_chunks),
         ));
         polynomials.push((
             evaluations_form(&index.column_evaluations.endomul_scalar_selector8),
-            None,
             fixed_hiding(num_chunks),
         ));
         polynomials.extend(
             witness_poly
                 .iter()
                 .zip(w_comm.iter())
-                .map(|(w, c)| (coefficients_form(w), None, c.blinders.clone()))
+                .map(|(w, c)| (coefficients_form(w), c.blinders.clone()))
                 .collect::<Vec<_>>(),
         );
         polynomials.extend(
@@ -1294,13 +1284,13 @@ where
                 .column_evaluations
                 .coefficients8
                 .iter()
-                .map(|coefficientm| (evaluations_form(coefficientm), None, non_hiding(num_chunks)))
+                .map(|coefficientm| (evaluations_form(coefficientm), non_hiding(num_chunks)))
                 .collect::<Vec<_>>(),
         );
         polynomials.extend(
             index.column_evaluations.permutation_coefficients8[0..PERMUTS - 1]
                 .iter()
-                .map(|w| (evaluations_form(w), None, non_hiding(num_chunks)))
+                .map(|w| (evaluations_form(w), non_hiding(num_chunks)))
                 .collect::<Vec<_>>(),
         );
 
@@ -1310,7 +1300,6 @@ where
         {
             polynomials.push((
                 evaluations_form(range_check0_selector8),
-                None,
                 non_hiding(num_chunks),
             ));
         }
@@ -1319,7 +1308,6 @@ where
         {
             polynomials.push((
                 evaluations_form(range_check1_selector8),
-                None,
                 non_hiding(num_chunks),
             ));
         }
@@ -1330,7 +1318,6 @@ where
         {
             polynomials.push((
                 evaluations_form(foreign_field_add_selector8),
-                None,
                 non_hiding(num_chunks),
             ));
         }
@@ -1341,23 +1328,14 @@ where
         {
             polynomials.push((
                 evaluations_form(foreign_field_mul_selector8),
-                None,
                 non_hiding(num_chunks),
             ));
         }
         if let Some(xor_selector8) = index.column_evaluations.xor_selector8.as_ref() {
-            polynomials.push((
-                evaluations_form(xor_selector8),
-                None,
-                non_hiding(num_chunks),
-            ));
+            polynomials.push((evaluations_form(xor_selector8), non_hiding(num_chunks)));
         }
         if let Some(rot_selector8) = index.column_evaluations.rot_selector8.as_ref() {
-            polynomials.push((
-                evaluations_form(rot_selector8),
-                None,
-                non_hiding(num_chunks),
-            ));
+            polynomials.push((evaluations_form(rot_selector8), non_hiding(num_chunks)));
         }
 
         //~~ * optionally, the runtime table
@@ -1368,17 +1346,13 @@ where
             let sorted_comms = lookup_context.sorted_comms.as_ref().unwrap();
 
             for (poly, comm) in sorted_poly.iter().zip(sorted_comms) {
-                polynomials.push((coefficients_form(poly), None, comm.blinders.clone()));
+                polynomials.push((coefficients_form(poly), comm.blinders.clone()));
             }
 
             //~~ * add the lookup aggreg polynomial
             let aggreg_poly = lookup_context.aggreg_coeffs.as_ref().unwrap();
             let aggreg_comm = lookup_context.aggreg_comm.as_ref().unwrap();
-            polynomials.push((
-                coefficients_form(aggreg_poly),
-                None,
-                aggreg_comm.blinders.clone(),
-            ));
+            polynomials.push((coefficients_form(aggreg_poly), aggreg_comm.blinders.clone()));
 
             //~~ * add the combined table polynomial
             let table_blinding = if lcs.runtime_selector.is_some() {
@@ -1399,7 +1373,7 @@ where
 
             let joint_lookup_table = lookup_context.joint_lookup_table.as_ref().unwrap();
 
-            polynomials.push((coefficients_form(joint_lookup_table), None, table_blinding));
+            polynomials.push((coefficients_form(joint_lookup_table), table_blinding));
 
             //~~ * if present, add the runtime table polynomial
             if lcs.runtime_selector.is_some() {
@@ -1408,7 +1382,6 @@ where
 
                 polynomials.push((
                     coefficients_form(runtime_table),
-                    None,
                     runtime_table_comm.blinders.clone(),
                 ));
             }
@@ -1418,27 +1391,21 @@ where
             if let Some(runtime_lookup_table_selector) = lcs.runtime_selector.as_ref() {
                 polynomials.push((
                     evaluations_form(runtime_lookup_table_selector),
-                    None,
                     non_hiding(1),
                 ))
             }
             if let Some(xor_lookup_selector) = lcs.lookup_selectors.xor.as_ref() {
-                polynomials.push((evaluations_form(xor_lookup_selector), None, non_hiding(1)))
+                polynomials.push((evaluations_form(xor_lookup_selector), non_hiding(1)))
             }
             if let Some(lookup_gate_selector) = lcs.lookup_selectors.lookup.as_ref() {
-                polynomials.push((evaluations_form(lookup_gate_selector), None, non_hiding(1)))
+                polynomials.push((evaluations_form(lookup_gate_selector), non_hiding(1)))
             }
             if let Some(range_check_lookup_selector) = lcs.lookup_selectors.range_check.as_ref() {
-                polynomials.push((
-                    evaluations_form(range_check_lookup_selector),
-                    None,
-                    non_hiding(1),
-                ))
+                polynomials.push((evaluations_form(range_check_lookup_selector), non_hiding(1)))
             }
             if let Some(foreign_field_mul_lookup_selector) = lcs.lookup_selectors.ffmul.as_ref() {
                 polynomials.push((
                     evaluations_form(foreign_field_mul_lookup_selector),
-                    None,
                     non_hiding(1),
                 ))
             }

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1154,7 +1154,6 @@ where
                 unshifted: vec![
                     blinding_f - (zeta_to_domain_size - G::ScalarField::one()) * blinding_t,
                 ],
-                shifted: None,
             }
         };
 
@@ -1224,7 +1223,6 @@ where
         //~    First, include the previous challenges, in case we are in a recursive prover.
         let non_hiding = |d1_size: usize| PolyComm {
             unshifted: vec![G::ScalarField::zero(); d1_size],
-            shifted: None,
         };
 
         let coefficients_form = DensePolynomialOrEvaluations::DensePolynomial;
@@ -1237,7 +1235,6 @@ where
 
         let fixed_hiding = |d1_size: usize| PolyComm {
             unshifted: vec![G::ScalarField::one(); d1_size],
-            shifted: None,
         };
 
         //~ 1. Then, include:
@@ -1395,10 +1392,7 @@ where
                     .map(|blinding| *joint_combiner * blinding)
                     .collect();
 
-                PolyComm {
-                    unshifted,
-                    shifted: None,
-                }
+                PolyComm { unshifted }
             } else {
                 non_hiding(num_chunks)
             };

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1359,14 +1359,14 @@ where
                 let runtime_comm = lookup_context.runtime_table_comm.as_ref().unwrap();
                 let joint_combiner = lookup_context.joint_combiner.as_ref().unwrap();
 
-                let unshifted = runtime_comm
+                let elems = runtime_comm
                     .blinders
                     .elems
                     .iter()
                     .map(|blinding| *joint_combiner * blinding)
                     .collect();
 
-                PolyComm { elems: unshifted }
+                PolyComm { elems }
             } else {
                 non_hiding(num_chunks)
             };

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -260,7 +260,7 @@ where
         .interpolate();
 
         //~ 1. Commit (non-hiding) to the negated public input polynomial.
-        let public_comm = index.srs.commit_non_hiding(&public_poly, num_chunks, None);
+        let public_comm = index.srs.commit_non_hiding(&public_poly, num_chunks);
         let public_comm = {
             index
                 .srs
@@ -393,7 +393,7 @@ where
                 let runtime_table_comm =
                     index
                         .srs
-                        .commit(&runtime_table_contribution, num_chunks, None, rng);
+                        .commit(&runtime_table_contribution, num_chunks, rng);
 
                 // absorb the commitment
                 absorb_commitment(&mut fq_sponge, &runtime_table_comm.commitment);
@@ -607,7 +607,7 @@ where
         let z_poly = index.perm_aggreg(&witness, &beta, &gamma, rng)?;
 
         //~ 1. Commit (hidding) to the permutation aggregation polynomial $z$.
-        let z_comm = index.srs.commit(&z_poly, num_chunks, None, rng);
+        let z_comm = index.srs.commit(&z_poly, num_chunks, rng);
 
         //~ 1. Absorb the permutation aggregation polynomial $z$ with the Fq-Sponge.
         absorb_commitment(&mut fq_sponge, &z_comm.commitment);
@@ -866,7 +866,7 @@ where
         };
 
         //~ 1. commit (hiding) to the quotient polynomial $t$
-        let t_comm = { index.srs.commit(&quotient_poly, 7 * num_chunks, None, rng) };
+        let t_comm = { index.srs.commit(&quotient_poly, 7 * num_chunks, rng) };
 
         //~ 1. Absorb the the commitment of the quotient polynomial with the Fq-Sponge.
         absorb_commitment(&mut fq_sponge, &t_comm.commitment);

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1151,7 +1151,7 @@ where
 
             PolyComm {
                 // blinding_f - Z_H(zeta) * blinding_t
-                unshifted: vec![
+                elems: vec![
                     blinding_f - (zeta_to_domain_size - G::ScalarField::one()) * blinding_t,
                 ],
             }
@@ -1187,7 +1187,7 @@ where
             .map(|RecursionChallenge { chals, comm }| {
                 (
                     DensePolynomial::from_coefficients_vec(b_poly_coefficients(chals)),
-                    comm.unshifted.len(),
+                    comm.elems.len(),
                 )
             })
             .collect::<Vec<_>>();
@@ -1222,7 +1222,7 @@ where
         //~    (and evaluation proofs) in the protocol.
         //~    First, include the previous challenges, in case we are in a recursive prover.
         let non_hiding = |d1_size: usize| PolyComm {
-            unshifted: vec![G::ScalarField::zero(); d1_size],
+            elems: vec![G::ScalarField::zero(); d1_size],
         };
 
         let coefficients_form = DensePolynomialOrEvaluations::DensePolynomial;
@@ -1234,7 +1234,7 @@ where
             .collect::<Vec<_>>();
 
         let fixed_hiding = |d1_size: usize| PolyComm {
-            unshifted: vec![G::ScalarField::one(); d1_size],
+            elems: vec![G::ScalarField::one(); d1_size],
         };
 
         //~ 1. Then, include:
@@ -1387,12 +1387,12 @@ where
 
                 let unshifted = runtime_comm
                     .blinders
-                    .unshifted
+                    .elems
                     .iter()
                     .map(|blinding| *joint_combiner * blinding)
                     .collect();
 
-                PolyComm { unshifted }
+                PolyComm { elems: unshifted }
             } else {
                 non_hiding(num_chunks)
             };

--- a/kimchi/src/tests/recursion.rs
+++ b/kimchi/src/tests/recursion.rs
@@ -43,7 +43,7 @@ fn test_recursion() {
         let comm = {
             let coeffs = b_poly_coefficients(&chals);
             let b = DensePolynomial::from_coefficients_vec(coeffs);
-            index.srs.commit_non_hiding(&b, 1, None)
+            index.srs.commit_non_hiding(&b, 1)
         };
         RecursionChallenge::new(chals, comm)
     };

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -453,10 +453,10 @@ where
                 let ft_eval1 = vec![self.ft_eval1];
 
                 #[allow(clippy::type_complexity)]
-                let mut es: Vec<(Vec<Vec<G::ScalarField>>, Option<usize>)> =
-                    polys.iter().map(|(_, e)| (e.clone(), None)).collect();
-                es.push((public_evals.to_vec(), None));
-                es.push((vec![ft_eval0, ft_eval1], None));
+                let mut es: Vec<Vec<Vec<G::ScalarField>>> =
+                    polys.iter().map(|(_, e)| e.clone()).collect();
+                es.push(public_evals.to_vec());
+                es.push(vec![ft_eval0, ft_eval1]);
                 for col in [
                     Column::Z,
                     Column::Index(GateType::Generic),
@@ -551,19 +551,16 @@ where
                         .into_iter()
                         .flatten(),
                 ) {
-                    es.push((
-                        {
-                            let evals = self
-                                .evals
-                                .get_column(col)
-                                .ok_or(VerifyError::MissingEvaluation(col))?;
-                            vec![evals.zeta.clone(), evals.zeta_omega.clone()]
-                        },
-                        None,
-                    ))
+                    es.push({
+                        let evals = self
+                            .evals
+                            .get_column(col)
+                            .ok_or(VerifyError::MissingEvaluation(col))?;
+                        vec![evals.zeta.clone(), evals.zeta_omega.clone()]
+                    })
                 }
 
-                combined_inner_product(&evaluation_points, &v, &u, &es, index.srs().max_poly_size())
+                combined_inner_product(&v, &u, &es)
             };
 
         let oracles = RandomOracles {

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -226,11 +226,11 @@ where
         let alpha = alpha_chal.to_field(endo_r);
 
         //~ 1. Enforce that the length of the $t$ commitment is of size 7.
-        if self.commitments.t_comm.unshifted.len() > chunk_size * 7 {
+        if self.commitments.t_comm.elems.len() > chunk_size * 7 {
             return Err(VerifyError::IncorrectCommitmentLength(
                 "t",
                 chunk_size * 7,
-                self.commitments.t_comm.unshifted.len(),
+                self.commitments.t_comm.elems.len(),
             ));
         }
 

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -911,21 +911,18 @@ where
     evaluations.extend(polys.into_iter().map(|(c, e)| Evaluation {
         commitment: c,
         evaluations: e,
-        degree_bound: None,
     }));
 
     //~~ * public input commitment
     evaluations.push(Evaluation {
         commitment: public_comm,
         evaluations: public_evals.to_vec(),
-        degree_bound: None,
     });
 
     //~~ * ft commitment (chunks of it)
     evaluations.push(Evaluation {
         commitment: ft_comm,
         evaluations: vec![vec![ft_eval0], vec![proof.ft_eval1]],
-        degree_bound: None,
     });
 
     for col in [
@@ -1009,7 +1006,6 @@ where
                 .ok_or(VerifyError::MissingCommitment(col))?
                 .clone(),
             evaluations: vec![evals.zeta.clone(), evals.zeta_omega.clone()],
-            degree_bound: None,
         });
     }
 
@@ -1054,7 +1050,6 @@ where
         evaluations.push(Evaluation {
             commitment: table_comm,
             evaluations: vec![lookup_table.zeta.clone(), lookup_table.zeta_omega.clone()],
-            degree_bound: None,
         });
 
         // add evaluation of the runtime table polynomial
@@ -1071,7 +1066,6 @@ where
             evaluations.push(Evaluation {
                 commitment: runtime.clone(),
                 evaluations: vec![runtime_eval.zeta, runtime_eval.zeta_omega],
-                degree_bound: None,
             });
         }
     }
@@ -1122,7 +1116,6 @@ where
                 .ok_or(VerifyError::MissingCommitment(col))?
                 .clone(),
             evaluations: vec![evals.zeta.clone(), evals.zeta_omega.clone()],
-            degree_bound: None,
         });
     }
 

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -792,10 +792,7 @@ where
             .expect("pre-computed committed lagrange bases not found");
         let com: Vec<_> = lgr_comm.iter().take(verifier_index.public).collect();
         if public_input.is_empty() {
-            PolyComm::new(
-                vec![verifier_index.srs().blinding_commitment(); chunk_size],
-                None,
-            )
+            PolyComm::new(vec![verifier_index.srs().blinding_commitment(); chunk_size])
         } else {
             let elm: Vec<_> = public_input.iter().map(|s| -*s).collect();
             let public_comm = PolyComm::<G>::multi_scalar_mul(&com, &elm);

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -439,42 +439,42 @@ impl<G: KimchiCurve, OpeningProof: OpenProof<G>> VerifierIndex<G, OpeningProof> 
         // Always present
 
         for comm in sigma_comm.iter() {
-            fq_sponge.absorb_g(&comm.unshifted);
+            fq_sponge.absorb_g(&comm.elems);
         }
         for comm in coefficients_comm.iter() {
-            fq_sponge.absorb_g(&comm.unshifted);
+            fq_sponge.absorb_g(&comm.elems);
         }
-        fq_sponge.absorb_g(&generic_comm.unshifted);
-        fq_sponge.absorb_g(&psm_comm.unshifted);
-        fq_sponge.absorb_g(&complete_add_comm.unshifted);
-        fq_sponge.absorb_g(&mul_comm.unshifted);
-        fq_sponge.absorb_g(&emul_comm.unshifted);
-        fq_sponge.absorb_g(&endomul_scalar_comm.unshifted);
+        fq_sponge.absorb_g(&generic_comm.elems);
+        fq_sponge.absorb_g(&psm_comm.elems);
+        fq_sponge.absorb_g(&complete_add_comm.elems);
+        fq_sponge.absorb_g(&mul_comm.elems);
+        fq_sponge.absorb_g(&emul_comm.elems);
+        fq_sponge.absorb_g(&endomul_scalar_comm.elems);
 
         // Optional gates
 
         if let Some(range_check0_comm) = range_check0_comm {
-            fq_sponge.absorb_g(&range_check0_comm.unshifted);
+            fq_sponge.absorb_g(&range_check0_comm.elems);
         }
 
         if let Some(range_check1_comm) = range_check1_comm {
-            fq_sponge.absorb_g(&range_check1_comm.unshifted);
+            fq_sponge.absorb_g(&range_check1_comm.elems);
         }
 
         if let Some(foreign_field_mul_comm) = foreign_field_mul_comm {
-            fq_sponge.absorb_g(&foreign_field_mul_comm.unshifted);
+            fq_sponge.absorb_g(&foreign_field_mul_comm.elems);
         }
 
         if let Some(foreign_field_add_comm) = foreign_field_add_comm {
-            fq_sponge.absorb_g(&foreign_field_add_comm.unshifted);
+            fq_sponge.absorb_g(&foreign_field_add_comm.elems);
         }
 
         if let Some(xor_comm) = xor_comm {
-            fq_sponge.absorb_g(&xor_comm.unshifted);
+            fq_sponge.absorb_g(&xor_comm.elems);
         }
 
         if let Some(rot_comm) = rot_comm {
-            fq_sponge.absorb_g(&rot_comm.unshifted);
+            fq_sponge.absorb_g(&rot_comm.elems);
         }
 
         // Lookup index; optional
@@ -496,26 +496,26 @@ impl<G: KimchiCurve, OpeningProof: OpenProof<G>> VerifierIndex<G, OpeningProof> 
         }) = lookup_index
         {
             for entry in lookup_table {
-                fq_sponge.absorb_g(&entry.unshifted);
+                fq_sponge.absorb_g(&entry.elems);
             }
             if let Some(table_ids) = table_ids {
-                fq_sponge.absorb_g(&table_ids.unshifted);
+                fq_sponge.absorb_g(&table_ids.elems);
             }
             if let Some(runtime_tables_selector) = runtime_tables_selector {
-                fq_sponge.absorb_g(&runtime_tables_selector.unshifted);
+                fq_sponge.absorb_g(&runtime_tables_selector.elems);
             }
 
             if let Some(xor) = xor {
-                fq_sponge.absorb_g(&xor.unshifted);
+                fq_sponge.absorb_g(&xor.elems);
             }
             if let Some(lookup) = lookup {
-                fq_sponge.absorb_g(&lookup.unshifted);
+                fq_sponge.absorb_g(&lookup.elems);
             }
             if let Some(range_check) = range_check {
-                fq_sponge.absorb_g(&range_check.unshifted);
+                fq_sponge.absorb_g(&range_check.elems);
             }
             if let Some(ffmul) = ffmul {
-                fq_sponge.absorb_g(&ffmul.unshifted);
+                fq_sponge.absorb_g(&ffmul.elems);
             }
         }
         fq_sponge.digest_fq()

--- a/poly-commitment/src/chunked.rs
+++ b/poly-commitment/src/chunked.rs
@@ -9,7 +9,6 @@ where
     C: CommitmentCurve,
 {
     /// Multiplies each commitment chunk of f with powers of zeta^n
-    /// Note that it ignores the shifted part.
     // TODO(mimoo): better name for this function
     pub fn chunk_commitment(&self, zeta_n: C::ScalarField) -> Self {
         let mut res = C::Projective::zero();
@@ -23,7 +22,6 @@ where
 
         PolyComm {
             unshifted: vec![res.into_affine()],
-            shifted: self.shifted,
         }
     }
 }
@@ -33,7 +31,6 @@ where
     F: Field,
 {
     /// Multiplies each blinding chunk of f with powers of zeta^n
-    /// Note that it ignores the shifted part.
     // TODO(mimoo): better name for this function
     pub fn chunk_blinding(&self, zeta_n: F) -> F {
         let mut res = F::zero();

--- a/poly-commitment/src/chunked.rs
+++ b/poly-commitment/src/chunked.rs
@@ -15,13 +15,13 @@ where
         // use Horner's to compute chunk[0] + z^n chunk[1] + z^2n chunk[2] + ...
         // as ( chunk[-1] * z^n + chunk[-2] ) * z^n + chunk[-3]
         // (https://en.wikipedia.org/wiki/Horner%27s_method)
-        for chunk in self.unshifted.iter().rev() {
+        for chunk in self.elems.iter().rev() {
             res *= zeta_n;
             res.add_assign_mixed(chunk);
         }
 
         PolyComm {
-            unshifted: vec![res.into_affine()],
+            elems: vec![res.into_affine()],
         }
     }
 }
@@ -37,7 +37,7 @@ where
         // use Horner's to compute chunk[0] + z^n chunk[1] + z^2n chunk[2] + ...
         // as ( chunk[-1] * z^n + chunk[-2] ) * z^n + chunk[-3]
         // (https://en.wikipedia.org/wiki/Horner%27s_method)
-        for chunk in self.unshifted.iter().rev() {
+        for chunk in self.elems.iter().rev() {
             res *= zeta_n;
             res += chunk
         }

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -1042,7 +1042,8 @@ pub mod caml {
 
     #[derive(Clone, Debug, ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
     pub struct CamlPolyComm<CamlG> {
-        pub elems: Vec<CamlG>,
+        pub unshifted: Vec<CamlG>,
+        pub shifted: Option<CamlG>,
     }
 
     // handy conversions
@@ -1054,7 +1055,8 @@ pub mod caml {
     {
         fn from(polycomm: PolyComm<G>) -> Self {
             Self {
-                elems: polycomm.elems.into_iter().map(Into::into).collect(),
+                unshifted: polycomm.elems.into_iter().map(Into::into).collect(),
+                shifted: None,
             }
         }
     }
@@ -1066,7 +1068,8 @@ pub mod caml {
     {
         fn from(polycomm: &'a PolyComm<G>) -> Self {
             Self {
-                elems: polycomm.elems.iter().map(Into::into).collect(),
+                unshifted: polycomm.elems.iter().map(Into::into).collect(),
+                shifted: None,
             }
         }
     }
@@ -1076,8 +1079,12 @@ pub mod caml {
         G: AffineCurve + From<CamlG>,
     {
         fn from(camlpolycomm: CamlPolyComm<CamlG>) -> PolyComm<G> {
+            assert!(
+                camlpolycomm.shifted.is_none(),
+                "mina#14628: Shifted commitments are deprecated and must not be used"
+            );
             PolyComm {
-                elems: camlpolycomm.elems.into_iter().map(Into::into).collect(),
+                elems: camlpolycomm.unshifted.into_iter().map(Into::into).collect(),
             }
         }
     }
@@ -1087,9 +1094,13 @@ pub mod caml {
         G: AffineCurve + From<&'a CamlG> + From<CamlG>,
     {
         fn from(camlpolycomm: &'a CamlPolyComm<CamlG>) -> PolyComm<G> {
+            assert!(
+                camlpolycomm.shifted.is_none(),
+                "mina#14628: Shifted commitments are deprecated and must not be used"
+            );
             PolyComm {
                 //FIXME something with as_ref()
-                elems: camlpolycomm.elems.iter().map(Into::into).collect(),
+                elems: camlpolycomm.unshifted.iter().map(Into::into).collect(),
             }
         }
     }

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -93,8 +93,8 @@ pub fn combine_polys<G: CommitmentCurve, D: EvaluationDomain<G::ScalarField>>(
                     .for_each(|(i, x)| {
                         *x += scale * evals[i * stride];
                     });
-                for j in 0..omegas.unshifted.len() {
-                    omega += &(omegas.unshifted[j] * scale);
+                for j in 0..omegas.elems.len() {
+                    omega += &(omegas.elems[j] * scale);
                     scale *= &polyscale;
                 }
                 // We assume here that we have no shifted segment.
@@ -106,13 +106,13 @@ pub fn combine_polys<G: CommitmentCurve, D: EvaluationDomain<G::ScalarField>>(
                 if let Some(m) = degree_bound {
                     assert!(p_i.coeffs.len() <= m + 1);
                 }
-                for j in 0..omegas.unshifted.len() {
+                for j in 0..omegas.elems.len() {
                     let segment = &p_i.coeffs[std::cmp::min(offset, p_i.coeffs.len())
                         ..std::cmp::min(offset + srs_length, p_i.coeffs.len())];
                     // always mixing in the unshifted segments
                     plnm.add_poly(scale, segment);
 
-                    omega += &(omegas.unshifted[j] * scale);
+                    omega += &(omegas.elems[j] * scale);
                     scale *= &polyscale;
                     offset += srs_length;
                 }
@@ -349,9 +349,9 @@ impl<G: CommitmentCurve> SRS<G> {
                     }
                 };
                 let chunked_polynomial =
-                    poly.to_chunked_polynomial(blinders.unshifted.len(), self.g.len());
+                    poly.to_chunked_polynomial(blinders.elems.len(), self.g.len());
                 let chunked_commitment =
-                    { self.commit_non_hiding(&poly, blinders.unshifted.len(), None) };
+                    { self.commit_non_hiding(&poly, blinders.elems.len(), None) };
                 let masked_commitment = match self.mask_custom(chunked_commitment, blinders) {
                     Ok(comm) => comm,
                     Err(err) => panic!("Error at index {i}: {err}"),

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -106,7 +106,7 @@ pub fn combine_polys<G: CommitmentCurve, D: EvaluationDomain<G::ScalarField>>(
                 for j in 0..omegas.elems.len() {
                     let segment = &p_i.coeffs[std::cmp::min(offset, p_i.coeffs.len())
                         ..std::cmp::min(offset + srs_length, p_i.coeffs.len())];
-                    // always mixing in the unshifted segments
+                    // always mixing in the "unshifted" (normal) segments
                     plnm.add_poly(scale, segment);
 
                     omega += &(omegas.elems[j] * scale);

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -350,8 +350,7 @@ impl<G: CommitmentCurve> SRS<G> {
                 };
                 let chunked_polynomial =
                     poly.to_chunked_polynomial(blinders.elems.len(), self.g.len());
-                let chunked_commitment =
-                    { self.commit_non_hiding(&poly, blinders.elems.len(), None) };
+                let chunked_commitment = { self.commit_non_hiding(&poly, blinders.elems.len()) };
                 let masked_commitment = match self.mask_custom(chunked_commitment, blinders) {
                     Ok(comm) => comm,
                     Err(err) => panic!("Error at index {i}: {err}"),

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -97,7 +97,6 @@ pub fn combine_polys<G: CommitmentCurve, D: EvaluationDomain<G::ScalarField>>(
                     omega += &(omegas.elems[j] * scale);
                     scale *= &polyscale;
                 }
-                // We assume here that we have no shifted segment.
             }
 
             DensePolynomialOrEvaluations::DensePolynomial(p_i) => {
@@ -106,7 +105,6 @@ pub fn combine_polys<G: CommitmentCurve, D: EvaluationDomain<G::ScalarField>>(
                 for j in 0..omegas.elems.len() {
                     let segment = &p_i.coeffs[std::cmp::min(offset, p_i.coeffs.len())
                         ..std::cmp::min(offset + srs_length, p_i.coeffs.len())];
-                    // always mixing in the "unshifted" (normal) segments
                     plnm.add_poly(scale, segment);
 
                     omega += &(omegas.elems[j] * scale);

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -86,7 +86,6 @@ pub trait SRS<G: CommitmentCurve> {
 /// Vector of triples (polynomial itself, degree bound, omegas).
 type PolynomialsToCombine<'a, G: CommitmentCurve, D: EvaluationDomain<G::ScalarField>> = &'a [(
     DensePolynomialOrEvaluations<'a, G::ScalarField, D>,
-    Option<usize>,
     PolyComm<G::ScalarField>,
 )];
 

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -37,7 +37,6 @@ pub trait SRS<G: CommitmentCurve> {
         &self,
         plnm: &DensePolynomial<G::ScalarField>,
         num_chunks: usize,
-        max: Option<usize>,
         rng: &mut (impl RngCore + CryptoRng),
     ) -> BlindedCommitment<G>;
 
@@ -60,15 +59,13 @@ pub trait SRS<G: CommitmentCurve> {
 
     /// This function commits a polynomial using the SRS' basis of size `n`.
     /// - `plnm`: polynomial to commit to with max size of sections
-    /// - `max`: maximal degree of the polynomial (not inclusive), if none, no degree bound
-    /// The function returns an unbounded commitment vector (which splits the commitment into several commitments of size at most `n`),
-    /// as well as an optional bounded commitment (if `max` is set).
-    /// Note that a maximum degree cannot (and doesn't need to) be enforced via a shift if `max` is a multiple of `n`.
+    /// - `num_chunks`: the number of commitments to be included in the output polynomial commitment
+    /// The function returns an unbounded commitment vector
+    /// (which splits the commitment into several commitments of size at most `n`).
     fn commit_non_hiding(
         &self,
         plnm: &DensePolynomial<G::ScalarField>,
         num_chunks: usize,
-        max: Option<usize>,
     ) -> PolyComm<G>;
 
     fn commit_evaluations_non_hiding(
@@ -86,6 +83,7 @@ pub trait SRS<G: CommitmentCurve> {
 }
 
 #[allow(type_alias_bounds)]
+/// Vector of triples (polynomial itself, degree bound, omegas).
 type PolynomialsToCombine<'a, G: CommitmentCurve, D: EvaluationDomain<G::ScalarField>> = &'a [(
     DensePolynomialOrEvaluations<'a, G::ScalarField, D>,
     Option<usize>,

--- a/poly-commitment/src/pairing_proof.rs
+++ b/poly-commitment/src/pairing_proof.rs
@@ -285,7 +285,7 @@ impl<
         let quotient = srs
             .full_srs
             .commit_non_hiding(&quotient_poly, 1, None)
-            .unshifted[0];
+            .elems[0];
 
         Some(PairingProof {
             quotient,
@@ -318,11 +318,11 @@ impl<
         let divisor_commitment = srs
             .verifier_srs
             .commit_non_hiding(&divisor_polynomial(elm), 1, None)
-            .unshifted[0];
+            .elems[0];
         let eval_commitment = srs
             .full_srs
             .commit_non_hiding(&eval_polynomial(elm, &evals), 1, None)
-            .unshifted[0]
+            .elems[0]
             .into_projective();
         let numerator_commitment = { poly_commitment - eval_commitment - blinding_commitment };
 

--- a/poly-commitment/src/pairing_proof.rs
+++ b/poly-commitment/src/pairing_proof.rs
@@ -164,10 +164,9 @@ impl<
         &self,
         plnm: &DensePolynomial<G::ScalarField>,
         num_chunks: usize,
-        max: Option<usize>,
         rng: &mut (impl RngCore + CryptoRng),
     ) -> BlindedCommitment<G> {
-        self.full_srs.commit(plnm, num_chunks, max, rng)
+        self.full_srs.commit(plnm, num_chunks, rng)
     }
 
     fn mask_custom(
@@ -190,9 +189,8 @@ impl<
         &self,
         plnm: &DensePolynomial<G::ScalarField>,
         num_chunks: usize,
-        max: Option<usize>,
     ) -> PolyComm<G> {
-        self.full_srs.commit_non_hiding(plnm, num_chunks, max)
+        self.full_srs.commit_non_hiding(plnm, num_chunks)
     }
 
     fn commit_evaluations_non_hiding(
@@ -282,10 +280,7 @@ impl<
             quotient
         };
 
-        let quotient = srs
-            .full_srs
-            .commit_non_hiding(&quotient_poly, 1, None)
-            .elems[0];
+        let quotient = srs.full_srs.commit_non_hiding(&quotient_poly, 1).elems[0];
 
         Some(PairingProof {
             quotient,
@@ -317,11 +312,11 @@ impl<
         let blinding_commitment = srs.full_srs.h.mul(self.blinding);
         let divisor_commitment = srs
             .verifier_srs
-            .commit_non_hiding(&divisor_polynomial(elm), 1, None)
+            .commit_non_hiding(&divisor_polynomial(elm), 1)
             .elems[0];
         let eval_commitment = srs
             .full_srs
-            .commit_non_hiding(&eval_polynomial(elm, &evals), 1, None)
+            .commit_non_hiding(&eval_polynomial(elm, &evals), 1)
             .elems[0]
             .into_projective();
         let numerator_commitment = { poly_commitment - eval_commitment - blinding_commitment };
@@ -380,7 +375,7 @@ mod tests {
 
         let comms: Vec<_> = polynomials
             .iter()
-            .map(|p| srs.full_srs.commit(p, 1, None, rng))
+            .map(|p| srs.full_srs.commit(p, 1, rng))
             .collect();
 
         let polynomials_and_blinders: Vec<(DensePolynomialOrEvaluations<_, D<_>>, _, _)> =

--- a/poly-commitment/src/srs.rs
+++ b/poly-commitment/src/srs.rs
@@ -199,32 +199,9 @@ impl<G: CommitmentCurve> SRS<G> {
             unshifted.push(lg)
         }
 
-        // If the srs size does not exactly divide the domain size
-        let shifted: Option<Vec<<G as AffineCurve>::Projective>> =
-            if n < srs_size || num_unshifteds * srs_size == n {
-                None
-            } else {
-                // Initialize the vector to zero
-                let mut lg: Vec<<G as AffineCurve>::Projective> =
-                    vec![<G as AffineCurve>::Projective::zero(); n];
-                // Overwrite the terms corresponding to the final chunk with the SRS curve points
-                // shifted to the right
-                let start_offset = (num_unshifteds - 1) * srs_size;
-                let num_terms = n - start_offset;
-                let srs_start_offset = srs_size - num_terms;
-                for j in 0..num_terms {
-                    lg[start_offset + j] = self.g[srs_start_offset + j].into_projective()
-                }
-                // Apply the IFFT
-                domain.ifft_in_place(&mut lg);
-                <G as AffineCurve>::Projective::batch_normalization(lg.as_mut_slice());
-                Some(lg)
-            };
-
         let chunked_commitments: Vec<_> = (0..n)
             .map(|i| PolyComm {
                 unshifted: unshifted.iter().map(|v| v[i].into_affine()).collect(),
-                shifted: shifted.as_ref().map(|v| v[i].into_affine()),
             })
             .collect();
         self.lagrange_bases.insert(n, chunked_commitments);

--- a/poly-commitment/src/srs.rs
+++ b/poly-commitment/src/srs.rs
@@ -178,11 +178,11 @@ impl<G: CommitmentCurve> SRS<G> {
         // By computing each of these, and recollecting the terms as a vector of polynomial
         // commitments, we obtain a chunked commitment to the L_i polynomials.
         let srs_size = self.g.len();
-        let num_unshifteds = (n + srs_size - 1) / srs_size;
-        let mut unshifted = Vec::with_capacity(num_unshifteds);
+        let num_elems = (n + srs_size - 1) / srs_size;
+        let mut elems = Vec::with_capacity(num_elems);
 
         // For each chunk
-        for i in 0..num_unshifteds {
+        for i in 0..num_elems {
             // Initialize the vector with zero curve points
             let mut lg: Vec<<G as AffineCurve>::Projective> =
                 vec![<G as AffineCurve>::Projective::zero(); n];
@@ -195,13 +195,13 @@ impl<G: CommitmentCurve> SRS<G> {
             // Apply the IFFT
             domain.ifft_in_place(&mut lg);
             <G as AffineCurve>::Projective::batch_normalization(lg.as_mut_slice());
-            // Append the 'partial Langrange polynomials' to the vector of unshifted chunks
-            unshifted.push(lg)
+            // Append the 'partial Langrange polynomials' to the vector of elems chunks
+            elems.push(lg)
         }
 
         let chunked_commitments: Vec<_> = (0..n)
             .map(|i| PolyComm {
-                elems: unshifted.iter().map(|v| v[i].into_affine()).collect(),
+                elems: elems.iter().map(|v| v[i].into_affine()).collect(),
             })
             .collect();
         self.lagrange_bases.insert(n, chunked_commitments);

--- a/poly-commitment/src/srs.rs
+++ b/poly-commitment/src/srs.rs
@@ -201,7 +201,7 @@ impl<G: CommitmentCurve> SRS<G> {
 
         let chunked_commitments: Vec<_> = (0..n)
             .map(|i| PolyComm {
-                unshifted: unshifted.iter().map(|v| v[i].into_affine()).collect(),
+                elems: unshifted.iter().map(|v| v[i].into_affine()).collect(),
             })
             .collect();
         self.lagrange_bases.insert(n, chunked_commitments);

--- a/poly-commitment/src/tests/batch_15_wires.rs
+++ b/poly-commitment/src/tests/batch_15_wires.rs
@@ -120,20 +120,9 @@ where
             let combined_inner_product = {
                 let es: Vec<_> = comm
                     .iter()
-                    .map(|(commitment, evaluations, degree_bound)| {
-                        let bound: Option<usize> = (|| {
-                            let b = (*degree_bound)?;
-                            let x = commitment.commitment.shifted?;
-                            if x.is_zero() {
-                                None
-                            } else {
-                                Some(b)
-                            }
-                        })();
-                        (evaluations.clone(), bound)
-                    })
+                    .map(|(commitment, evaluations, degree_bound)| evaluations.clone())
                     .collect();
-                combined_inner_product(&x, &polymask, &evalmask, &es, srs.g.len())
+                combined_inner_product(&polymask, &evalmask, &es)
             };
 
             (

--- a/poly-commitment/src/tests/batch_15_wires.rs
+++ b/poly-commitment/src/tests/batch_15_wires.rs
@@ -62,6 +62,8 @@ where
                     }
                 })
                 .collect::<Vec<_>>();
+
+            // TODO @volhovm remove?
             let bounds = a
                 .iter()
                 .enumerate()
@@ -96,12 +98,10 @@ where
             let polys: Vec<(
                 DensePolynomialOrEvaluations<_, Radix2EvaluationDomain<_>>,
                 _,
-                _,
             )> = (0..a.len())
                 .map(|i| {
                     (
                         DensePolynomialOrEvaluations::DensePolynomial(&a[i]),
-                        bounds[i],
                         (comm[i].0).blinders.clone(),
                     )
                 })
@@ -150,7 +150,6 @@ where
                 .map(|poly| Evaluation {
                     commitment: (poly.0).commitment.clone(),
                     evaluations: poly.1.clone(),
-                    degree_bound: poly.2,
                 })
                 .collect::<Vec<_>>(),
             opening: &proof.5,

--- a/poly-commitment/src/tests/batch_15_wires.rs
+++ b/poly-commitment/src/tests/batch_15_wires.rs
@@ -82,7 +82,7 @@ where
             let comm = (0..a.len())
                 .map(|i| {
                     (
-                        srs.commit(&a[i].clone(), num_chunks, bounds[i], rng),
+                        srs.commit(&a[i].clone(), num_chunks, rng),
                         x.iter()
                             .map(|xx| a[i].to_chunked_polynomial(1, size).evaluate_chunks(*xx))
                             .collect::<Vec<_>>(),
@@ -120,7 +120,7 @@ where
             let combined_inner_product = {
                 let es: Vec<_> = comm
                     .iter()
-                    .map(|(commitment, evaluations, degree_bound)| evaluations.clone())
+                    .map(|(_, evaluations, _)| evaluations.clone())
                     .collect();
                 combined_inner_product(&polymask, &evalmask, &es)
             };

--- a/poly-commitment/src/tests/commitment.rs
+++ b/poly-commitment/src/tests/commitment.rs
@@ -91,13 +91,7 @@ impl AggregatedEvaluationProof {
         let combined_inner_product = {
             let es: Vec<_> = coms
                 .iter()
-                .map(
-                    |Evaluation {
-                         commitment,
-                         evaluations,
-                         degree_bound,
-                     }| { evaluations.clone() },
-                )
+                .map(|Evaluation { evaluations, .. }| evaluations.clone())
                 .collect();
             combined_inner_product(&self.polymask, &self.evalmask, &es)
         };
@@ -159,7 +153,7 @@ fn test_randomised<RNG: Rng + CryptoRng>(mut rng: &mut RNG) {
             let BlindedCommitment {
                 commitment: chunked_commitment,
                 blinders: chunked_blinding,
-            } = srs.commit(&poly, num_chunks, bound, &mut rng);
+            } = srs.commit(&poly, num_chunks, &mut rng);
             time_commit += timer.elapsed();
 
             let mut chunked_evals = vec![];

--- a/poly-commitment/src/tests/commitment.rs
+++ b/poly-commitment/src/tests/commitment.rs
@@ -76,7 +76,6 @@ impl AggregatedEvaluationProof {
     /// This function converts an aggregated evaluation proof into something the verify API understands
     pub fn verify_type(
         &self,
-        srs: &SRS<Vesta>,
     ) -> BatchEvaluationProof<Vesta, DefaultFqSponge<VestaParameters, SC>, OpeningProof<Vesta>>
     {
         let mut coms = vec![];
@@ -97,27 +96,10 @@ impl AggregatedEvaluationProof {
                          commitment,
                          evaluations,
                          degree_bound,
-                     }| {
-                        let bound: Option<usize> = (|| {
-                            let b = (*degree_bound)?;
-                            let x = commitment.shifted?;
-                            if x.is_zero() {
-                                None
-                            } else {
-                                Some(b)
-                            }
-                        })();
-                        (evaluations.clone(), bound)
-                    },
+                     }| { evaluations.clone() },
                 )
                 .collect();
-            combined_inner_product(
-                &self.eval_points,
-                &self.polymask,
-                &self.evalmask,
-                &es,
-                srs.g.len(),
-            )
+            combined_inner_product(&self.polymask, &self.evalmask, &es)
         };
 
         BatchEvaluationProof {
@@ -257,7 +239,7 @@ fn test_randomised<RNG: Rng + CryptoRng>(mut rng: &mut RNG) {
     let timer = Instant::now();
 
     // batch verify all the proofs
-    let mut batch: Vec<_> = proofs.iter().map(|p| p.verify_type(&srs)).collect();
+    let mut batch: Vec<_> = proofs.iter().map(|p| p.verify_type()).collect();
     assert!(srs.verify::<DefaultFqSponge<VestaParameters, SC>, _>(&group_map, &mut batch, &mut rng));
 
     // TODO: move to bench


### PR DESCRIPTION
This removes the unused and obsolete functionality of shifted polynomial commitments from the `poly-commitments` crate, and from its usages in `kimchi`. 
- Resolves https://github.com/MinaProtocol/mina/issues/14628
- `mina` PR counterpart: https://github.com/MinaProtocol/mina/pull/15071

Probably better to review commit-by-commit.