### PR TITLE
Fixup environment trait to avoid abstraction leaks

### DIFF
--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -199,7 +199,7 @@ pub trait InterpreterEnv {
         + std::ops::Mul<u32, Output = Self::Variable>
         + std::ops::Shl<u32, Output = Self::Variable>
         + std::ops::BitAnd<u32, Output = Self::Variable>
-        + std::fmt::Display;
+        + std::fmt::Debug;
 
     fn overwrite_register_checked(&mut self, register_idx: &Self::Variable, value: &Self::Variable);
 
@@ -326,7 +326,7 @@ pub fn interpret_itype<Env: InterpreterEnv>(env: &mut Env, instr: ITypeInstructi
         ITypeInstruction::AddImmediateUnsigned => {
             let rs = env.get_instruction_part(InstructionPart::RS);
             let rt = env.get_instruction_part(InstructionPart::RT);
-            debug!("Fetching register: {}", rs);
+            debug!("Fetching register: {:?}", rs);
             let register_rs = env.fetch_register_checked(&rs);
             let immediate = env.get_immediate();
             let res = register_rs + immediate;
@@ -358,7 +358,12 @@ pub fn interpret_itype<Env: InterpreterEnv>(env: &mut Env, instr: ITypeInstructi
             let addr = env.get_instruction_part(InstructionPart::RS);
             let offset = env.get_immediate();
             let addr_with_offset = addr.clone() + offset.clone();
-            debug!("lw {}, {}({})", dest.clone(), offset.clone(), addr.clone());
+            debug!(
+                "lw {:?}, {:?}({:?})",
+                dest.clone(),
+                offset.clone(),
+                addr.clone()
+            );
             // We load 4 bytes, i.e. one word.
             let v0 = env.fetch_memory(&addr_with_offset);
             let v1 = env.fetch_memory(&(addr_with_offset.clone() + Env::constant(1)));
@@ -366,7 +371,7 @@ pub fn interpret_itype<Env: InterpreterEnv>(env: &mut Env, instr: ITypeInstructi
             let v3 = env.fetch_memory(&(addr_with_offset.clone() + Env::constant(3)));
             let value = (v0 << 24) + (v1 << 16) + (v2 << 8) + v3;
             debug!(
-                "Loaded 32 bits value from {}: {}",
+                "Loaded 32 bits value from {:?}: {:?}",
                 addr_with_offset.clone(),
                 value
             );

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -197,7 +197,6 @@ pub trait InterpreterEnv {
     type Variable: Clone
         + std::ops::Add<Self::Variable, Output = Self::Variable>
         + std::ops::Mul<Self::Variable, Output = Self::Variable>
-        + std::ops::BitAnd<u32, Output = Self::Variable>
         + std::fmt::Debug;
 
     fn overwrite_register_checked(&mut self, register_idx: &Self::Variable, value: &Self::Variable);

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -196,7 +196,7 @@ pub enum ITypeInstruction {
 pub trait InterpreterEnv {
     type Variable: Clone
         + std::ops::Add<Self::Variable, Output = Self::Variable>
-        + std::ops::Mul<u32, Output = Self::Variable>
+        + std::ops::Mul<Self::Variable, Output = Self::Variable>
         + std::ops::Shl<u32, Output = Self::Variable>
         + std::ops::BitAnd<u32, Output = Self::Variable>
         + std::fmt::Debug;
@@ -295,7 +295,7 @@ pub fn interpret_jtype<Env: InterpreterEnv>(env: &mut Env, instr: JTypeInstructi
                 + (env.get_instruction_part(InstructionPart::RD) << 11)
                 + (env.get_instruction_part(InstructionPart::Shamt) << 6)
                 + (env.get_instruction_part(InstructionPart::Funct));
-            env.set_instruction_pointer(addr * 4);
+            env.set_instruction_pointer(addr * Env::constant(4));
             // REMOVEME: when all jtype instructions are implemented.
             return;
         }


### PR DESCRIPTION
This PR fixes the abstraction leak. `Variable` isn't `u32`, this PR unwinds the code that pretends that it always is.