### PR TITLE
Add support for scratch_state to MIPS VM

### DIFF
--- a/optimism/src/mips/column.rs
+++ b/optimism/src/mips/column.rs
@@ -1,0 +1,4 @@
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Column {
+    ScratchState(usize),
+}

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -194,6 +194,10 @@ pub enum ITypeInstruction {
 }
 
 pub trait InterpreterEnv {
+    type Position;
+
+    fn alloc_scratch(&mut self) -> Self::Position;
+
     type Variable: Clone
         + std::ops::Add<Self::Variable, Output = Self::Variable>
         + std::ops::Mul<Self::Variable, Output = Self::Variable>

--- a/optimism/src/mips/mod.rs
+++ b/optimism/src/mips/mod.rs
@@ -1,3 +1,4 @@
+pub mod column;
 pub mod interpreter;
 pub mod registers;
 pub mod witness;

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -4,6 +4,7 @@ use crate::{
         PAGE_SIZE,
     },
     mips::{
+        column::Column,
         interpreter::{
             self, ITypeInstruction, Instruction, InstructionPart, InstructionParts, InterpreterEnv,
             JTypeInstruction, RTypeInstruction,
@@ -208,6 +209,12 @@ impl<Fp: Field> Env<Fp> {
             halt: state.exited,
             syscall_env,
             preimage_oracle,
+        }
+    }
+
+    pub fn write_column(&mut self, column: Column, value: u64) {
+        match column {
+            Column::ScratchState(idx) => self.scratch_state[idx] = value.into(),
         }
     }
 

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -99,6 +99,14 @@ fn memory_size(total: usize) -> String {
 }
 
 impl<Fp: Field> InterpreterEnv for Env<Fp> {
+    type Position = Column;
+
+    fn alloc_scratch(&mut self) -> Self::Position {
+        let scratch_idx = self.scratch_state_idx;
+        self.scratch_state_idx += 1;
+        Column::ScratchState(scratch_idx)
+    }
+
     type Variable = u32;
 
     fn overwrite_register_checked(


### PR DESCRIPTION
This PR builds upon https://github.com/o1-labs/proof-systems/pull/1380, adding the `alloc_scratch` helper to the environment trait. This will be the basis of all intermediate storage for the gate constraints.

In order to do this, this PR adds
* a `Column` type (currently missing: `InstructionCounter`, since it's unused here)
* a `Position` type to the trait
* `alloc_scratch` to allocate a new position in the scratch state
* a `write_column` helper in the witness environment, to allow for writing to the scratch state (currently unused).