### PR TITLE
Add other accessors necessary for zkVM memory

### DIFF
--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -221,13 +221,19 @@ pub trait InterpreterEnv {
 
     /// Set the memory value at address `addr` to `value`.
     ///
-    /// This is unsafe: no lookups or other constraints are added as part of this operation.
+    /// # Safety
+    ///
+    /// No lookups or other constraints are added as part of this operation. The caller must
+    /// manually add the lookups for this memory operation.
     unsafe fn push_memory(&mut self, addr: &Self::Variable, value: Self::Variable);
 
     /// Fetch the last 'access index' that the memory at address `addr` was written at, and store
     /// it in local position `output`.
     ///
-    /// This is unsafe: no lookups or other constraints are added as part of this operation.
+    /// # Safety
+    ///
+    /// No lookups or other constraints are added as part of this operation. The caller must
+    /// manually add the lookups for this memory operation.
     unsafe fn fetch_memory_access(
         &mut self,
         addr: &Self::Variable,
@@ -236,7 +242,10 @@ pub trait InterpreterEnv {
 
     /// Set the last 'access index' for the memory at address `addr` to `value`.
     ///
-    /// This is unsafe: no lookups or other constraints are added as part of this operation.
+    /// # Safety
+    ///
+    /// No lookups or other constraints are added as part of this operation. The caller must
+    /// manually add the lookups for this memory operation.
     unsafe fn push_memory_access(&mut self, addr: &Self::Variable, value: Self::Variable);
 
     fn set_instruction_pointer(&mut self, ip: Self::Variable);

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -216,6 +216,11 @@ pub trait InterpreterEnv {
         output: Self::Position,
     ) -> Self::Variable;
 
+    /// Set the memory value at address `addr` to `value`.
+    ///
+    /// This is unsafe: no lookups or other constraints are added as part of this operation.
+    unsafe fn push_memory(&mut self, addr: &Self::Variable, value: Self::Variable);
+
     /// Fetch the last 'access index' that the memory at address `addr` was written at, and store
     /// it in local position `output`.
     ///
@@ -225,6 +230,11 @@ pub trait InterpreterEnv {
         addr: &Self::Variable,
         output: Self::Position,
     ) -> Self::Variable;
+
+    /// Set the last 'access index' for the memory at address `addr` to `value`.
+    ///
+    /// This is unsafe: no lookups or other constraints are added as part of this operation.
+    unsafe fn push_memory_access(&mut self, addr: &Self::Variable, value: Self::Variable);
 
     fn set_instruction_pointer(&mut self, ip: Self::Variable);
 

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -216,6 +216,16 @@ pub trait InterpreterEnv {
         output: Self::Position,
     ) -> Self::Variable;
 
+    /// Fetch the last 'access index' that the memory at address `addr` was written at, and store
+    /// it in local position `output`.
+    ///
+    /// This is unsafe: no lookups or other constraints are added as part of this operation.
+    unsafe fn fetch_memory_access(
+        &mut self,
+        addr: &Self::Variable,
+        output: Self::Position,
+    ) -> Self::Variable;
+
     fn set_instruction_pointer(&mut self, ip: Self::Variable);
 
     fn get_immediate(&self) -> Self::Variable {

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -150,6 +150,18 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         panic!("Could not access address")
     }
 
+    unsafe fn push_memory(&mut self, addr: &Self::Variable, value: Self::Variable) {
+        let page = addr >> PAGE_ADDRESS_SIZE;
+        let page_address = (addr & PAGE_ADDRESS_MASK) as usize;
+        for (page_index, memory) in self.memory.iter_mut() {
+            if *page_index == page {
+                memory[page_address] = value.try_into().expect("push_memory values fit in a u8");
+                return;
+            }
+        }
+        panic!("Could not write to address")
+    }
+
     unsafe fn fetch_memory_access(
         &mut self,
         addr: &Self::Variable,
@@ -165,6 +177,18 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
             }
         }
         panic!("Could not access address")
+    }
+
+    unsafe fn push_memory_access(&mut self, addr: &Self::Variable, value: Self::Variable) {
+        let page = addr >> PAGE_ADDRESS_SIZE;
+        let page_address = (addr & PAGE_ADDRESS_MASK) as usize;
+        for (page_index, memory_write_index) in self.memory_write_index.iter_mut() {
+            if *page_index == page {
+                memory_write_index[page_address] = value.into();
+                return;
+            }
+        }
+        panic!("Could not write to address")
     }
 
     fn set_instruction_pointer(&mut self, ip: Self::Variable) {

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -173,7 +173,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
             if *page_index == page {
                 let value = memory_write_index[page_address];
                 self.write_column(output, value.into());
-                return value.into();
+                return value;
             }
         }
         panic!("Could not access address")
@@ -184,7 +184,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         let page_address = (addr & PAGE_ADDRESS_MASK) as usize;
         for (page_index, memory_write_index) in self.memory_write_index.iter_mut() {
             if *page_index == page {
-                memory_write_index[page_address] = value.into();
+                memory_write_index[page_address] = value;
                 return;
             }
         }


### PR DESCRIPTION
This PR builds upon https://github.com/o1-labs/proof-systems/pull/1382, adding counterpart operations for
* writing to memory
* reading the 'access index' for a memory address
* writing the 'access index' for a memory address.

These primitives are essential for the correct operation of RAMLookup, ensuring that reads are 'temporal' (i.e. you can't read a value in the past that you wrote in the future).