### PR TITLE
Expose `InterpreterEnv::instruction_counter`

### DIFF
--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -203,6 +203,8 @@ pub trait InterpreterEnv {
         + std::ops::Mul<Self::Variable, Output = Self::Variable>
         + std::fmt::Debug;
 
+    fn instruction_counter(&self) -> Self::Variable;
+
     fn overwrite_register_checked(&mut self, register_idx: &Self::Variable, value: &Self::Variable);
 
     fn fetch_register_checked(&self, register_idx: &Self::Variable) -> Self::Variable;


### PR DESCRIPTION
This PR builds upon https://github.com/o1-labs/proof-systems/pull/1383, making the instruction counter available for use in the VM interpreter.

Currently, the counter is hard-coded to `u32`. This limit will not be big enough, but should be fine until we reach full e2e testing.