### PR TITLE
Add (stubbed) lookups to InterpreterEnv

### DIFF
--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -193,6 +193,16 @@ pub enum ITypeInstruction {
     StoreWordRight,               // swr
 }
 
+#[derive(Copy, Clone, Debug)]
+pub enum LookupTable {}
+
+#[derive(Clone, Debug)]
+pub struct Lookup<Fp> {
+    pub numerator: Fp,
+    pub table_id: LookupTable,
+    pub value: Vec<Fp>,
+}
+
 pub trait InterpreterEnv {
     type Position;
 
@@ -202,6 +212,8 @@ pub trait InterpreterEnv {
         + std::ops::Add<Self::Variable, Output = Self::Variable>
         + std::ops::Mul<Self::Variable, Output = Self::Variable>
         + std::fmt::Debug;
+
+    fn add_lookup(&mut self, lookup: Lookup<Self::Variable>);
 
     fn instruction_counter(&self) -> Self::Variable;
 

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -109,6 +109,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
 
     type Variable = u32;
 
+    fn add_lookup(&mut self, _lookup: interpreter::Lookup<Self::Variable>) {
+        // FIXME: Track the lookup values in the environment.
+    }
+
     fn instruction_counter(&self) -> Self::Variable {
         self.instruction_counter
     }


### PR DESCRIPTION
This PR builds upon https://github.com/o1-labs/proof-systems/pull/1384. This adds the minimal interface for adding lookups from within the interpreter, by exposing `add_lookup` from the interpreter environment.