### PR TITLE
Add safe helpers for reading and writing memory

### DIFF
--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -590,8 +590,8 @@ mod tests {
         let addr: u32 = rng.gen_range(0u32..100u32);
         let aligned_addr: u32 = (addr / 4) * 4;
         dummy_env.registers[REGISTER_SP as usize] = aligned_addr;
-        let mem = dummy_env.memory[0].clone();
-        let mem = mem.1;
+        let mem = &dummy_env.memory[0];
+        let mem = &mem.1;
         let v0 = mem[aligned_addr as usize];
         let v1 = mem[(aligned_addr + 1) as usize];
         let v2 = mem[(aligned_addr + 2) as usize];

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -546,7 +546,7 @@ mod tests {
             instruction_counter: 0,
             // Only 4kb of memory (one PAGE_ADDRESS_SIZE)
             memory: vec![(0, vec![rng.gen(); PAGE_SIZE as usize])],
-            memory_write_index: vec![],
+            memory_write_index: vec![(0, vec![0; PAGE_SIZE as usize])],
             registers: Registers::default(),
             registers_write_index: Registers::default(),
             instruction_pointer: 0,

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -489,39 +489,10 @@ pub fn interpret_itype<Env: InterpreterEnv>(env: &mut Env, instr: ITypeInstructi
                 addr.clone()
             );
             // We load 4 bytes, i.e. one word.
-            let v0 = unsafe {
-                // FIXME: A safe wrapper should be exposed in the trait, and it must add the
-                // constraints that are missing here.
-                let output_location = env.alloc_scratch();
-                env.fetch_memory(&addr_with_offset, output_location)
-            };
-            let v1 = unsafe {
-                // FIXME: A safe wrapper should be exposed in the trait, and it must add the
-                // constraints that are missing here.
-                let output_location = env.alloc_scratch();
-                env.fetch_memory(
-                    &(addr_with_offset.clone() + Env::constant(1)),
-                    output_location,
-                )
-            };
-            let v2 = unsafe {
-                // FIXME: A safe wrapper should be exposed in the trait, and it must add the
-                // constraints that are missing here.
-                let output_location = env.alloc_scratch();
-                env.fetch_memory(
-                    &(addr_with_offset.clone() + Env::constant(2)),
-                    output_location,
-                )
-            };
-            let v3 = unsafe {
-                // FIXME: A safe wrapper should be exposed in the trait, and it must add the
-                // constraints that are missing here.
-                let output_location = env.alloc_scratch();
-                env.fetch_memory(
-                    &(addr_with_offset.clone() + Env::constant(3)),
-                    output_location,
-                )
-            };
+            let v0 = env.read_memory(&addr_with_offset);
+            let v1 = env.read_memory(&(addr_with_offset.clone() + Env::constant(1)));
+            let v2 = env.read_memory(&(addr_with_offset.clone() + Env::constant(2)));
+            let v3 = env.read_memory(&(addr_with_offset.clone() + Env::constant(3)));
             let value = (v0 * Env::constant(1 << 24))
                 + (v1 * Env::constant(1 << 16))
                 + (v2 * Env::constant(1 << 8))


### PR DESCRIPTION
This PR adds helpers for safely reading and writing memory. This PR builds upon https://github.com/o1-labs/proof-systems/pull/1385 and its ancestors, emitting lookups for the RAMLookup read/write operations.

This PR also adds a stub `range_check64` helper; this is easy to fill in later, and orthogonal to the main body of the PR.