### PR TITLE
Relegate `InstructionParts` to debugging, decode instructions from memory 

### DIFF
--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -71,16 +71,16 @@ pub const REGISTER_FP: u32 = 30;
 pub const REGISTER_RA: u32 = 31;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Serialize, Deserialize)]
-pub struct InstructionParts<T> {
-    pub op_code: T,
-    pub rs: T,
-    pub rt: T,
-    pub rd: T,
-    pub shamt: T,
-    pub funct: T,
+pub struct InstructionParts {
+    pub op_code: u32,
+    pub rs: u32,
+    pub rt: u32,
+    pub rd: u32,
+    pub shamt: u32,
+    pub funct: u32,
 }
 
-impl InstructionParts<u32> {
+impl InstructionParts {
     pub fn decode(instruction: u32) -> Self {
         let op_code = (instruction >> 26) & ((1 << (32 - 26)) - 1);
         let rs = (instruction >> 21) & ((1 << (26 - 21)) - 1);
@@ -721,7 +721,7 @@ mod tests {
         }
     }
 
-    fn write_instruction(env: &mut Env<Fp>, instruction_parts: InstructionParts<u32>) {
+    fn write_instruction(env: &mut Env<Fp>, instruction_parts: InstructionParts) {
         let instr = instruction_parts.encode();
         env.memory[1].1[0] = ((instr >> 24) & 0xFF) as u8;
         env.memory[1].1[1] = ((instr >> 16) & 0xFF) as u8;

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -672,9 +672,19 @@ mod tests {
         Env {
             instruction_parts: InstructionParts::default(),
             instruction_counter: 0,
-            // Only 4kb of memory (one PAGE_ADDRESS_SIZE)
-            memory: vec![(0, vec![rng.gen(); PAGE_SIZE as usize])],
-            memory_write_index: vec![(0, vec![0; PAGE_SIZE as usize])],
+            // Only 8kb of memory (two PAGE_ADDRESS_SIZE)
+            memory: vec![
+                // Read/write memory
+                (0, vec![rng.gen(); PAGE_SIZE as usize]),
+                // Executable memory
+                (1, vec![0; PAGE_SIZE as usize]),
+            ],
+            memory_write_index: vec![
+                // Read/write memory
+                (0, vec![0; PAGE_SIZE as usize]),
+                // Executable memory
+                (1, vec![0; PAGE_SIZE as usize]),
+            ],
             registers: Registers::default(),
             registers_write_index: Registers::default(),
             instruction_pointer: 0,

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -108,6 +108,15 @@ impl InstructionParts<u32> {
             funct,
         }
     }
+
+    pub fn encode(self) -> u32 {
+        (self.op_code << 26)
+            | (self.rs << 21)
+            | (self.rt << 16)
+            | (self.rd << 11)
+            | (self.shamt << 6)
+            | self.funct
+    }
 }
 
 // To use InstructionParts[OpCode]

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -555,11 +555,27 @@ pub fn interpret_rtype<Env: InterpreterEnv>(env: &mut Env, instr: RTypeInstructi
 }
 
 pub fn interpret_jtype<Env: InterpreterEnv>(env: &mut Env, instr: JTypeInstruction) {
-    let addr = (env.get_instruction_part(InstructionPart::RS) * Env::constant(1 << 21))
-        + (env.get_instruction_part(InstructionPart::RT) * Env::constant(1 << 16))
-        + (env.get_instruction_part(InstructionPart::RD) * Env::constant(1 << 11))
-        + (env.get_instruction_part(InstructionPart::Shamt) * Env::constant(1 << 6))
-        + (env.get_instruction_part(InstructionPart::Funct));
+    let instruction = {
+        let instruction_pointer = env.get_instruction_pointer();
+        let v0 = env.read_memory(&instruction_pointer);
+        let v1 = env.read_memory(&(instruction_pointer.clone() + Env::constant(1)));
+        let v2 = env.read_memory(&(instruction_pointer.clone() + Env::constant(2)));
+        let v3 = env.read_memory(&(instruction_pointer + Env::constant(3)));
+        (v0 * Env::constant(1 << 24))
+            + (v1 * Env::constant(1 << 16))
+            + (v2 * Env::constant(1 << 8))
+            + v3
+    };
+    let _opcode = {
+        // FIXME: Requires a range check
+        let pos = env.alloc_scratch();
+        unsafe { env.bitmask(&instruction, 32, 26, pos) }
+    };
+    let addr = {
+        // FIXME: Requires a range check
+        let pos = env.alloc_scratch();
+        unsafe { env.bitmask(&instruction, 26, 0, pos) }
+    };
     match instr {
         JTypeInstruction::Jump => {
             // > The address stored in a j instruction is 26 bits of the address
@@ -579,9 +595,37 @@ pub fn interpret_jtype<Env: InterpreterEnv>(env: &mut Env, instr: JTypeInstructi
 }
 
 pub fn interpret_itype<Env: InterpreterEnv>(env: &mut Env, instr: ITypeInstruction) {
-    let rs = env.get_instruction_part(InstructionPart::RS);
-    let rt = env.get_instruction_part(InstructionPart::RT);
-    let immediate = env.get_immediate();
+    let instruction = {
+        let instruction_pointer = env.get_instruction_pointer();
+        let v0 = env.read_memory(&instruction_pointer);
+        let v1 = env.read_memory(&(instruction_pointer.clone() + Env::constant(1)));
+        let v2 = env.read_memory(&(instruction_pointer.clone() + Env::constant(2)));
+        let v3 = env.read_memory(&(instruction_pointer + Env::constant(3)));
+        (v0 * Env::constant(1 << 24))
+            + (v1 * Env::constant(1 << 16))
+            + (v2 * Env::constant(1 << 8))
+            + v3
+    };
+    let _opcode = {
+        // FIXME: Requires a range check
+        let pos = env.alloc_scratch();
+        unsafe { env.bitmask(&instruction, 32, 26, pos) }
+    };
+    let rs = {
+        // FIXME: Requires a range check
+        let pos = env.alloc_scratch();
+        unsafe { env.bitmask(&instruction, 26, 21, pos) }
+    };
+    let rt = {
+        // FIXME: Requires a range check
+        let pos = env.alloc_scratch();
+        unsafe { env.bitmask(&instruction, 21, 16, pos) }
+    };
+    let immediate = {
+        // FIXME: Requires a range check
+        let pos = env.alloc_scratch();
+        unsafe { env.bitmask(&instruction, 16, 0, pos) }
+    };
     match instr {
         ITypeInstruction::BranchEq => (),
         ITypeInstruction::BranchNeq => (),

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -1,6 +1,5 @@
 use log::debug;
 use serde::{Deserialize, Serialize};
-use std::ops::Index;
 use strum_macros::{EnumCount, EnumIter};
 
 pub const FD_STDIN: u32 = 0;
@@ -71,16 +70,6 @@ pub const REGISTER_FP: u32 = 30;
 // Return address (used by function call)
 pub const REGISTER_RA: u32 = 31;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter)]
-pub enum InstructionPart {
-    OpCode,
-    RS,
-    RT,
-    RD,
-    Shamt,
-    Funct,
-}
-
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct InstructionParts<T> {
     pub op_code: T,
@@ -116,22 +105,6 @@ impl InstructionParts<u32> {
             | (self.rd << 11)
             | (self.shamt << 6)
             | self.funct
-    }
-}
-
-// To use InstructionParts[OpCode]
-impl<A> Index<InstructionPart> for InstructionParts<A> {
-    type Output = A;
-
-    fn index(&self, index: InstructionPart) -> &Self::Output {
-        match index {
-            InstructionPart::OpCode => &self.op_code,
-            InstructionPart::RS => &self.rs,
-            InstructionPart::RT => &self.rt,
-            InstructionPart::RD => &self.rd,
-            InstructionPart::Shamt => &self.shamt,
-            InstructionPart::Funct => &self.funct,
-        }
     }
 }
 

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -478,6 +478,23 @@ pub trait InterpreterEnv {
 
     fn constant(x: u32) -> Self::Variable;
 
+    /// Extract the bits from the variable `x` between `highest_bit` and `lowest_bit`, and store
+    /// the result in `position`.
+    /// `lowest_bit` becomes the least-significant bit of the resulting value.
+    ///
+    /// # Safety
+    ///
+    /// There are no constraints on the returned value; callers must assert the relationship with
+    /// the source variable `x` and that the returned value fits in `highest_bit - lowest_bit`
+    /// bits.
+    unsafe fn bitmask(
+        &mut self,
+        x: &Self::Variable,
+        highest_bit: u32,
+        lowest_bit: u32,
+        position: Self::Position,
+    ) -> Self::Variable;
+
     fn set_halted(&mut self, flag: Self::Variable);
 }
 

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -465,16 +465,7 @@ pub trait InterpreterEnv {
 
     fn set_instruction_pointer(&mut self, ip: Self::Variable);
 
-    fn get_immediate(&self) -> Self::Variable {
-        // The immediate value is the last 16bits
-        (self.get_instruction_part(InstructionPart::RD) * Self::constant(1 << 11))
-            + (self.get_instruction_part(InstructionPart::Shamt) * Self::constant(1 << 6))
-            + (self.get_instruction_part(InstructionPart::Funct))
-    }
-
     fn get_instruction_pointer(&self) -> Self::Variable;
-
-    fn get_instruction_part(&self, part: InstructionPart) -> Self::Variable;
 
     fn constant(x: u32) -> Self::Variable;
 

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -722,7 +722,6 @@ mod tests {
         let mut rng = rand::thread_rng();
         let dummy_preimage_oracle = PreImageOracle::create(&host_program);
         Env {
-            instruction_parts: InstructionParts::default(),
             instruction_counter: 0,
             // Only 8kb of memory (two PAGE_ADDRESS_SIZE)
             memory: vec![
@@ -750,7 +749,6 @@ mod tests {
     }
 
     fn write_instruction(env: &mut Env<Fp>, instruction_parts: InstructionParts<u32>) {
-        env.instruction_parts = instruction_parts.clone();
         let instr = instruction_parts.encode();
         env.memory[1].1[0] = ((instr >> 24) & 0xFF) as u8;
         env.memory[1].1[1] = ((instr >> 16) & 0xFF) as u8;

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -1,5 +1,4 @@
 use log::debug;
-use serde::{Deserialize, Serialize};
 use strum_macros::{EnumCount, EnumIter};
 
 pub const FD_STDIN: u32 = 0;
@@ -69,44 +68,6 @@ pub const REGISTER_SP: u32 = 29;
 pub const REGISTER_FP: u32 = 30;
 // Return address (used by function call)
 pub const REGISTER_RA: u32 = 31;
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Serialize, Deserialize)]
-pub struct InstructionParts {
-    pub op_code: u32,
-    pub rs: u32,
-    pub rt: u32,
-    pub rd: u32,
-    pub shamt: u32,
-    pub funct: u32,
-}
-
-impl InstructionParts {
-    pub fn decode(instruction: u32) -> Self {
-        let op_code = (instruction >> 26) & ((1 << (32 - 26)) - 1);
-        let rs = (instruction >> 21) & ((1 << (26 - 21)) - 1);
-        let rt = (instruction >> 16) & ((1 << (21 - 16)) - 1);
-        let rd = (instruction >> 11) & ((1 << (16 - 11)) - 1);
-        let shamt = (instruction >> 6) & ((1 << (11 - 6)) - 1);
-        let funct = instruction & ((1 << 6) - 1);
-        InstructionParts {
-            op_code,
-            rs,
-            rt,
-            rd,
-            shamt,
-            funct,
-        }
-    }
-
-    pub fn encode(self) -> u32 {
-        (self.op_code << 26)
-            | (self.rs << 21)
-            | (self.rt << 16)
-            | (self.rd << 11)
-            | (self.shamt << 6)
-            | self.funct
-    }
-}
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Instruction {
@@ -676,10 +637,51 @@ pub fn interpret_itype<Env: InterpreterEnv>(env: &mut Env, instr: ITypeInstructi
     env.set_halted(Env::constant(1))
 }
 
+pub mod debugging {
+    use serde::{Deserialize, Serialize};
+    #[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Serialize, Deserialize)]
+    pub struct InstructionParts {
+        pub op_code: u32,
+        pub rs: u32,
+        pub rt: u32,
+        pub rd: u32,
+        pub shamt: u32,
+        pub funct: u32,
+    }
+
+    impl InstructionParts {
+        pub fn decode(instruction: u32) -> Self {
+            let op_code = (instruction >> 26) & ((1 << (32 - 26)) - 1);
+            let rs = (instruction >> 21) & ((1 << (26 - 21)) - 1);
+            let rt = (instruction >> 16) & ((1 << (21 - 16)) - 1);
+            let rd = (instruction >> 11) & ((1 << (16 - 11)) - 1);
+            let shamt = (instruction >> 6) & ((1 << (11 - 6)) - 1);
+            let funct = instruction & ((1 << 6) - 1);
+            InstructionParts {
+                op_code,
+                rs,
+                rt,
+                rd,
+                shamt,
+                funct,
+            }
+        }
+
+        pub fn encode(self) -> u32 {
+            (self.op_code << 26)
+                | (self.rs << 21)
+                | (self.rt << 16)
+                | (self.rd << 11)
+                | (self.shamt << 6)
+                | self.funct
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
-    use super::*;
+    use super::{debugging::*, *};
     use crate::cannon::{HostProgram, PAGE_SIZE};
     use crate::mips::registers::Registers;
     use crate::mips::witness::{Env, SyscallEnv, SCRATCH_SIZE};

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -91,6 +91,25 @@ pub struct InstructionParts<T> {
     pub funct: T,
 }
 
+impl InstructionParts<u32> {
+    pub fn decode(instruction: u32) -> Self {
+        let op_code = (instruction >> 26) & ((1 << (32 - 26)) - 1);
+        let rs = (instruction >> 21) & ((1 << (26 - 21)) - 1);
+        let rt = (instruction >> 16) & ((1 << (21 - 16)) - 1);
+        let rd = (instruction >> 11) & ((1 << (16 - 11)) - 1);
+        let shamt = (instruction >> 6) & ((1 << (11 - 6)) - 1);
+        let funct = instruction & ((1 << 6) - 1);
+        InstructionParts {
+            op_code,
+            rs,
+            rt,
+            rd,
+            shamt,
+            funct,
+        }
+    }
+}
+
 // To use InstructionParts[OpCode]
 impl<A> Index<InstructionPart> for InstructionParts<A> {
     type Output = A;

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -6,7 +6,7 @@ use crate::{
     mips::{
         column::Column,
         interpreter::{
-            self, ITypeInstruction, Instruction, InstructionParts, InterpreterEnv,
+            self, debugging::InstructionParts, ITypeInstruction, Instruction, InterpreterEnv,
             JTypeInstruction, RTypeInstruction,
         },
         registers::Registers,

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -422,7 +422,7 @@ impl<Fp: Field> Env<Fp> {
 
     pub fn step(&mut self, config: VmConfiguration, metadata: &Meta, start: &Start) {
         let (opcode, instruction) = self.decode_instruction();
-        let instruction_parts: InstructionParts<u32> = InstructionParts::<u32>::decode(instruction);
+        let instruction_parts: InstructionParts = InstructionParts::decode(instruction);
         debug!("instruction: {:?}", opcode);
         debug!("Instruction hex: {:#010x}", instruction);
         debug!("Instruction: {:#034b}", instruction);

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -418,28 +418,15 @@ impl<Fp: Field> Env<Fp> {
 
     pub fn step(&mut self, config: VmConfiguration, metadata: &Meta, start: &Start) {
         let (opcode, instruction) = self.decode_instruction();
-        let op_code = (instruction >> 26) & ((1 << (32 - 26)) - 1);
-        let rs = (instruction >> 21) & ((1 << (26 - 21)) - 1);
-        let rt = (instruction >> 16) & ((1 << (21 - 16)) - 1);
-        let rd = (instruction >> 11) & ((1 << (16 - 11)) - 1);
-        let shamt = (instruction >> 6) & ((1 << (11 - 6)) - 1);
-        let funct = instruction & ((1 << 6) - 1);
-        let instruction_parts: InstructionParts<u32> = InstructionParts {
-            op_code,
-            rs,
-            rt,
-            rd,
-            shamt,
-            funct,
-        };
+        let instruction_parts: InstructionParts<u32> = InstructionParts::<u32>::decode(instruction);
         debug!("instruction: {:?}", opcode);
         debug!("Instruction hex: {:#010x}", instruction);
         debug!("Instruction: {:#034b}", instruction);
-        debug!("Rs: {:#07b}", rs);
-        debug!("Rt: {:#07b}", rt);
-        debug!("Rd: {:#07b}", rd);
-        debug!("Shamt: {:#07b}", shamt);
-        debug!("Funct: {:#08b}", funct);
+        debug!("Rs: {:#07b}", instruction_parts.rs);
+        debug!("Rt: {:#07b}", instruction_parts.rt);
+        debug!("Rd: {:#07b}", instruction_parts.rd);
+        debug!("Shamt: {:#07b}", instruction_parts.shamt);
+        debug!("Funct: {:#08b}", instruction_parts.funct);
         self.instruction_parts = instruction_parts;
 
         self.pp_info(config.info_at, metadata, start);

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -44,7 +44,6 @@ impl SyscallEnv {
 }
 
 pub struct Env<Fp> {
-    pub instruction_parts: InstructionParts<u32>,
     pub instruction_counter: u32, // TODO: u32 will not be big enough..
     pub memory: Vec<(u32, Vec<u8>)>,
     pub memory_write_index: Vec<(u32, Vec<u32>)>, // TODO: u32 will not be big enough..
@@ -270,9 +269,6 @@ impl<Fp: Field> Env<Fp> {
         };
 
         Env {
-            // Will be modified by decode_instruction.
-            // We set the instruction parts to 0 to begin
-            instruction_parts: InstructionParts::default(),
             instruction_counter: state.step as u32,
             memory: initial_memory.clone(),
             memory_write_index: memory_offsets
@@ -435,7 +431,6 @@ impl<Fp: Field> Env<Fp> {
         debug!("Rd: {:#07b}", instruction_parts.rd);
         debug!("Shamt: {:#07b}", instruction_parts.shamt);
         debug!("Funct: {:#08b}", instruction_parts.funct);
-        self.instruction_parts = instruction_parts;
 
         self.pp_info(config.info_at, metadata, start);
 

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -220,6 +220,18 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         x
     }
 
+    unsafe fn bitmask(
+        &mut self,
+        x: &Self::Variable,
+        highest_bit: u32,
+        lowest_bit: u32,
+        position: Self::Position,
+    ) -> Self::Variable {
+        let res = (x >> lowest_bit) & ((1 << (highest_bit - lowest_bit)) - 1);
+        self.write_column(position, res.into());
+        res
+    }
+
     fn set_halted(&mut self, flag: Self::Variable) {
         if flag == 0 {
             self.halt = false

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -6,7 +6,7 @@ use crate::{
     mips::{
         column::Column,
         interpreter::{
-            self, ITypeInstruction, Instruction, InstructionPart, InstructionParts, InterpreterEnv,
+            self, ITypeInstruction, Instruction, InstructionParts, InterpreterEnv,
             JTypeInstruction, RTypeInstruction,
         },
         registers::Registers,
@@ -143,10 +143,6 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
 
     unsafe fn push_register_access(&mut self, idx: &Self::Variable, value: Self::Variable) {
         self.registers_write_index[*idx as usize] = value
-    }
-
-    fn get_instruction_part(&self, part: InstructionPart) -> Self::Variable {
-        self.instruction_parts[part]
     }
 
     unsafe fn fetch_memory(


### PR DESCRIPTION
This PR builds on https://github.com/o1-labs/proof-systems/pull/1388. This updates the interpreter to
* remove `InstructionParts`, except as a debugging aid and in tests;
* load and parse the instruction from memory;
  - this is currently unsafe, range-checks and equality assertions haven't been ported yet
* write the instructions for unit tests into an 'executable' memory page.