### PR TITLE
Store instruction pointers in registers

### DIFF
--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -1,5 +1,5 @@
-use log::debug;
 use crate::mips::registers::{REGISTER_CURRENT_IP, REGISTER_NEXT_IP};
+use log::debug;
 use strum_macros::{EnumCount, EnumIter};
 
 pub const FD_STDIN: u32 = 0;

--- a/optimism/src/mips/registers.rs
+++ b/optimism/src/mips/registers.rs
@@ -1,18 +1,25 @@
 use serde::{Deserialize, Serialize};
 use std::ops::{Index, IndexMut};
 
-pub const NUM_REGISTERS: usize = 34;
+pub const NUM_REGISTERS: usize = 36;
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub struct Registers<T> {
     pub general_purpose: [T; 32],
     pub hi: T,
     pub lo: T,
+    pub current_instruction_pointer: T,
+    pub next_instruction_pointer: T,
 }
 
 impl<T> Registers<T> {
     pub fn iter(&self) -> impl Iterator<Item = &T> {
-        self.general_purpose.iter().chain([&self.hi, &self.lo])
+        self.general_purpose.iter().chain([
+            &self.hi,
+            &self.lo,
+            &self.current_instruction_pointer,
+            &self.next_instruction_pointer,
+        ])
     }
 }
 
@@ -26,6 +33,10 @@ impl<T: Clone> Index<usize> for Registers<T> {
             &self.hi
         } else if index == 33 {
             &self.lo
+        } else if index == 34 {
+            &self.current_instruction_pointer
+        } else if index == 35 {
+            &self.next_instruction_pointer
         } else {
             panic!("Index out of bounds");
         }
@@ -40,6 +51,10 @@ impl<T: Clone> IndexMut<usize> for Registers<T> {
             &mut self.hi
         } else if index == 33 {
             &mut self.lo
+        } else if index == 34 {
+            &mut self.current_instruction_pointer
+        } else if index == 35 {
+            &mut self.next_instruction_pointer
         } else {
             panic!("Index out of bounds");
         }

--- a/optimism/src/mips/registers.rs
+++ b/optimism/src/mips/registers.rs
@@ -1,6 +1,11 @@
 use serde::{Deserialize, Serialize};
 use std::ops::{Index, IndexMut};
 
+pub const REGISTER_HI: usize = 32;
+pub const REGISTER_LO: usize = 33;
+pub const REGISTER_CURRENT_IP: usize = 34;
+pub const REGISTER_NEXT_IP: usize = 35;
+
 pub const NUM_REGISTERS: usize = 36;
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
@@ -29,13 +34,13 @@ impl<T: Clone> Index<usize> for Registers<T> {
     fn index(&self, index: usize) -> &Self::Output {
         if index < 32 {
             &self.general_purpose[index]
-        } else if index == 32 {
+        } else if index == REGISTER_HI {
             &self.hi
-        } else if index == 33 {
+        } else if index == REGISTER_LO {
             &self.lo
-        } else if index == 34 {
+        } else if index == REGISTER_CURRENT_IP {
             &self.current_instruction_pointer
-        } else if index == 35 {
+        } else if index == REGISTER_NEXT_IP {
             &self.next_instruction_pointer
         } else {
             panic!("Index out of bounds");
@@ -47,13 +52,13 @@ impl<T: Clone> IndexMut<usize> for Registers<T> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         if index < 32 {
             &mut self.general_purpose[index]
-        } else if index == 32 {
+        } else if index == REGISTER_HI {
             &mut self.hi
-        } else if index == 33 {
+        } else if index == REGISTER_LO {
             &mut self.lo
-        } else if index == 34 {
+        } else if index == REGISTER_CURRENT_IP {
             &mut self.current_instruction_pointer
-        } else if index == 35 {
+        } else if index == REGISTER_NEXT_IP {
             &mut self.next_instruction_pointer
         } else {
             panic!("Index out of bounds");

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -22,7 +22,7 @@ pub const NUM_DECODING_LOOKUP_TERMS: usize = 2;
 pub const NUM_INSTRUCTION_LOOKUP_TERMS: usize = 5;
 pub const NUM_LOOKUP_TERMS: usize =
     NUM_GLOBAL_LOOKUP_TERMS + NUM_DECODING_LOOKUP_TERMS + NUM_INSTRUCTION_LOOKUP_TERMS;
-pub const SCRATCH_SIZE: usize = 29;
+pub const SCRATCH_SIZE: usize = 31;
 
 #[derive(Clone, Default)]
 pub struct SyscallEnv {
@@ -198,22 +198,6 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
             }
         }
         panic!("Could not write to address")
-    }
-
-    fn set_instruction_pointer(&mut self, ip: Self::Variable) {
-        self.registers.current_instruction_pointer = ip;
-    }
-
-    fn get_instruction_pointer(&self) -> Self::Variable {
-        self.registers.current_instruction_pointer
-    }
-
-    fn set_next_instruction_pointer(&mut self, ip: Self::Variable) {
-        self.registers.next_instruction_pointer = ip;
-    }
-
-    fn get_next_instruction_pointer(&self) -> Self::Variable {
-        self.registers.next_instruction_pointer
     }
 
     fn constant(x: u32) -> Self::Variable {

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -49,8 +49,6 @@ pub struct Env<Fp> {
     pub memory_write_index: Vec<(u32, Vec<u32>)>, // TODO: u32 will not be big enough..
     pub registers: Registers<u32>,
     pub registers_write_index: Registers<u32>, // TODO: u32 will not be big enough..
-    pub instruction_pointer: u32,
-    pub next_instruction_pointer: u32,
     pub scratch_state_idx: usize,
     pub scratch_state: [Fp; SCRATCH_SIZE],
     pub halt: bool,
@@ -203,19 +201,19 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
     }
 
     fn set_instruction_pointer(&mut self, ip: Self::Variable) {
-        self.instruction_pointer = ip;
+        self.registers.current_instruction_pointer = ip;
     }
 
     fn get_instruction_pointer(&self) -> Self::Variable {
-        self.instruction_pointer
+        self.registers.current_instruction_pointer
     }
 
     fn set_next_instruction_pointer(&mut self, ip: Self::Variable) {
-        self.next_instruction_pointer = ip;
+        self.registers.next_instruction_pointer = ip;
     }
 
     fn get_next_instruction_pointer(&self) -> Self::Variable {
-        self.next_instruction_pointer
+        self.registers.next_instruction_pointer
     }
 
     fn constant(x: u32) -> Self::Variable {
@@ -284,6 +282,8 @@ impl<Fp: Field> Env<Fp> {
             lo: state.lo,
             hi: state.hi,
             general_purpose: state.registers,
+            current_instruction_pointer: initial_instruction_pointer,
+            next_instruction_pointer,
         };
 
         Env {
@@ -295,8 +295,6 @@ impl<Fp: Field> Env<Fp> {
                 .collect(),
             registers: initial_registers.clone(),
             registers_write_index: Registers::default(),
-            instruction_pointer: initial_instruction_pointer,
-            next_instruction_pointer,
             scratch_state_idx: 0,
             scratch_state: fresh_scratch_state(),
             halt: state.exited,
@@ -328,10 +326,13 @@ impl<Fp: Field> Env<Fp> {
     }
 
     pub fn decode_instruction(&self) -> (Instruction, u32) {
-        let instruction = ((self.get_memory_direct(self.instruction_pointer) as u32) << 24)
-            | ((self.get_memory_direct(self.instruction_pointer + 1) as u32) << 16)
-            | ((self.get_memory_direct(self.instruction_pointer + 2) as u32) << 8)
-            | (self.get_memory_direct(self.instruction_pointer + 3) as u32);
+        let instruction =
+            ((self.get_memory_direct(self.registers.current_instruction_pointer) as u32) << 24)
+                | ((self.get_memory_direct(self.registers.current_instruction_pointer + 1) as u32)
+                    << 16)
+                | ((self.get_memory_direct(self.registers.current_instruction_pointer + 2) as u32)
+                    << 8)
+                | (self.get_memory_direct(self.registers.current_instruction_pointer + 3) as u32);
         let opcode = {
             match instruction >> 26 {
                 0x00 => match instruction & 0x3F {
@@ -490,7 +491,7 @@ impl<Fp: Field> Env<Fp> {
     }
 
     fn page_address(&self) -> (u32, usize) {
-        let address = self.instruction_pointer;
+        let address = self.registers.current_instruction_pointer;
         let page = address >> PAGE_ADDRESS_SIZE;
         let page_address = (address & PAGE_ADDRESS_MASK) as usize;
         (page, page_address)
@@ -513,7 +514,7 @@ impl<Fp: Field> Env<Fp> {
         if self.should_trigger_at(at) {
             let elapsed = start.time.elapsed();
             let step = self.instruction_counter;
-            let pc = self.instruction_pointer;
+            let pc = self.registers.current_instruction_pointer;
 
             // Get the 32-bits opcode
             let insn = self.get_opcode().unwrap();


### PR DESCRIPTION
This PR builds upon https://github.com/o1-labs/proof-systems/pull/1404, moving the instruction pointers into the registers so that instructions may be executed out of sequence.