### PR TITLE
Add missing parsing for `bltz` and `bgez`

### DIFF
--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -134,6 +134,8 @@ pub enum ITypeInstruction {
     BranchNeq,                    // bne
     BranchLeqZero,                // blez
     BranchGtZero,                 // bgtz
+    BranchLtZero,                 // bltz
+    BranchGeqZero,                // bgez
     AddImmediate,                 // addi
     AddImmediateUnsigned,         // addiu
     SetLessThanImmediate,         // slti
@@ -946,6 +948,8 @@ pub fn interpret_itype<Env: InterpreterEnv>(env: &mut Env, instr: ITypeInstructi
         }
         ITypeInstruction::BranchLeqZero => (),
         ITypeInstruction::BranchGtZero => (),
+        ITypeInstruction::BranchLtZero => (),
+        ITypeInstruction::BranchGeqZero => (),
         ITypeInstruction::AddImmediate => {
             let register_rs = env.read_register(&rs);
             let offset = env.sign_extend(&immediate, 16);

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -461,6 +461,14 @@ impl<Fp: Field> Env<Fp> {
                         panic!("Unhandled instruction {:#X}", instruction)
                     }
                 },
+                0x01 => {
+                    // RegImm instructions
+                    match (instruction >> 16) & 0x1F {
+                        0x0 => Instruction::IType(ITypeInstruction::BranchLtZero),
+                        0x1 => Instruction::IType(ITypeInstruction::BranchGeqZero),
+                        _ => panic!("Unhandled instruction {:#X}", instruction),
+                    }
+                }
                 0x02 => Instruction::JType(JTypeInstruction::Jump),
                 0x03 => Instruction::JType(JTypeInstruction::JumpAndLink),
                 0x04 => Instruction::IType(ITypeInstruction::BranchEq),


### PR DESCRIPTION
These opcodes fall under the special `regimm` category, and were missed when transferring over the opcode parsing. 