### PR TITLE
Remove register names

### DIFF
--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -18,66 +18,6 @@ pub const SYSCALL_READ: u32 = 4003;
 pub const SYSCALL_WRITE: u32 = 4004;
 pub const SYSCALL_FCNTL: u32 = 4055;
 
-// Source: https://www.doc.ic.ac.uk/lab/secondyear/spim/node10.html
-// Reserved for assembler
-pub const REGISTER_AT: u32 = 1;
-// Argument 0
-pub const REGISTER_A0: u32 = 4;
-// Argument 1
-pub const REGISTER_A1: u32 = 5;
-// Argument 2
-pub const REGISTER_A2: u32 = 6;
-// Argument 3
-pub const REGISTER_A3: u32 = 7;
-// Temporary (not preserved across call)
-pub const REGISTER_T0: u32 = 8;
-// Temporary (not preserved across call)
-pub const REGISTER_T1: u32 = 9;
-// Temporary (not preserved across call)
-pub const REGISTER_T2: u32 = 10;
-// Temporary (not preserved across call)
-pub const REGISTER_T3: u32 = 11;
-// Temporary (not preserved across call)
-pub const REGISTER_T4: u32 = 12;
-// Temporary (not preserved across call)
-pub const REGISTER_T5: u32 = 13;
-// Temporary (not preserved across call)
-pub const REGISTER_T6: u32 = 14;
-// Temporary (not preserved across call)
-pub const REGISTER_T7: u32 = 15;
-// Saved temporary (preserved across call)
-pub const REGISTER_S0: u32 = 16;
-// Saved temporary (preserved across call)
-pub const REGISTER_S1: u32 = 17;
-// Saved temporary (preserved across call)
-pub const REGISTER_S2: u32 = 18;
-// Saved temporary (preserved across call)
-pub const REGISTER_S3: u32 = 19;
-// Saved temporary (preserved across call)
-pub const REGISTER_S4: u32 = 20;
-// Saved temporary (preserved across call)
-pub const REGISTER_S5: u32 = 21;
-// Saved temporary (preserved across call)
-pub const REGISTER_S6: u32 = 22;
-// Saved temporary (preserved across call)
-pub const REGISTER_S7: u32 = 23;
-// Temporary (not preserved across call)
-pub const REGISTER_T8: u32 = 24;
-// Temporary (not preserved across call)
-pub const REGISTER_T9: u32 = 25;
-// Reserved for OS kernel
-pub const REGISTER_K0: u32 = 26;
-// Reserved for OS kernel
-pub const REGISTER_K1: u32 = 27;
-// Pointer to global area
-pub const REGISTER_GP: u32 = 28;
-// Stack pointer
-pub const REGISTER_SP: u32 = 29;
-// Frame pointer
-pub const REGISTER_FP: u32 = 30;
-// Return address (used by function call)
-pub const REGISTER_RA: u32 = 31;
-
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Instruction {
     RType(RTypeInstruction),


### PR DESCRIPTION
This PR removes the list of register names from the VM.

The names clutter the interpreter file, and the semantic meanings are meant for users of MIPS (i.e. they provide a standard for how variables should be used so that functions etc. compose cleanly), but they only serve as a distraction/confusion for the VM implementation itself.