### PR TITLE
Add helpers for setting INFO_AT and STOP_AT in the runner script

### DIFF
--- a/optimism/run-op-program.sh
+++ b/optimism/run-op-program.sh
@@ -21,8 +21,9 @@ set -x
 
 ./ethereum-optimism/cannon/bin/cannon run \
     --pprof.cpu \
-    --info-at '%10000000' \
+    --info-at "${INFO_AT:-%10000000}" \
     --proof-at never \
+    --stop-at "${STOP_AT:-never}" \
     --input ./state.json \
     -- \
     ./ethereum-optimism/op-program/bin/op-program \

--- a/optimism/run-vm.sh
+++ b/optimism/run-vm.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 cargo run --release -p kimchi_optimism -- \
     --pprof-cpu \
-    --info-at '%10000000' \
+    --info-at "${INFO_AT:-%10000000}" \
     --proof-at never \
+    --stop-at "${STOP_AT:-never}" \
     --input ./state.json \
     -- \
     ./ethereum-optimism/op-program/bin/op-program \


### PR DESCRIPTION
This PR adds the ability to pass `INFO_AT` and `STOP_AT` to the scripts for running cannon and the zkVM. This makes it significantly easier to debug / bisect for inconsistencies.