### PR TITLE
Make MIPS VM info more similar to cannon's

### DIFF
--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -625,7 +625,7 @@ impl<Fp: Field> Env<Fp> {
                 .unwrap_or_else(|| "n/a".to_string());
 
             info!(
-                "processing step={} pc={:#010x} insn={:#010x} ips={:.2} page={} mem={} name={}",
+                "processing step={} pc={:010x} insn={:010x} ips={:.2} page={} mem={} name={}",
                 step, pc, insn, ips, pages, mem, name
             );
         }

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -625,7 +625,7 @@ impl<Fp: Field> Env<Fp> {
                 .unwrap_or_else(|| "n/a".to_string());
 
             info!(
-                "processing step={} pc={:010x} insn={:010x} ips={:.2} page={} mem={} name={}",
+                "processing step={} pc={:010x} insn={:010x} ips={:.2} pages={} mem={} name={}",
                 step, pc, insn, ips, pages, mem, name
             );
         }


### PR DESCRIPTION
This PR
* tweaks the format of `pc` and `insn` printing to match cannon's
* fixes the typo `page=` to `pages=`, for similarity with cannon.

This makes it easier to compare (programmatically or at a glance) the output of the zkVM against cannon.