### PR TITLE
Add constraints, use them for `test_zero` and friends

### DIFF
--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -214,6 +214,16 @@ pub trait InterpreterEnv {
         self.add_constraint(assert_equals_zero);
     }
 
+    /// Check that the witness values in `x` and `y` are equal; otherwise abort.
+    fn check_equal(x: &Self::Variable, y: &Self::Variable);
+
+    /// Assert that the values `x` and `y` are equal, and add a constraint in the proof system.
+    fn assert_equal(&mut self, x: Self::Variable, y: Self::Variable) {
+        // NB: We use a different function to give a better error message for debugging.
+        Self::check_equal(&x, &y);
+        self.add_constraint(x - y);
+    }
+
     fn add_lookup(&mut self, lookup: Lookup<Self::Variable>);
 
     fn instruction_counter(&self) -> Self::Variable;

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -202,6 +202,8 @@ pub trait InterpreterEnv {
         + std::ops::Mul<Self::Variable, Output = Self::Variable>
         + std::fmt::Debug;
 
+    fn add_constraint(&mut self, assert_equals_zero: Self::Variable);
+
     fn add_lookup(&mut self, lookup: Lookup<Self::Variable>);
 
     fn instruction_counter(&self) -> Self::Variable;

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -224,6 +224,15 @@ pub trait InterpreterEnv {
         self.add_constraint(x - y);
     }
 
+    /// Check that the witness value `x` is a boolean (`0` or `1`); otherwise abort.
+    fn check_boolean(x: &Self::Variable);
+
+    /// Assert that the value `x` is boolean, and add a constraint in the proof system.
+    fn assert_boolean(&mut self, x: Self::Variable) {
+        Self::check_boolean(&x);
+        self.add_constraint(x.clone() * x.clone() - x);
+    }
+
     fn add_lookup(&mut self, lookup: Lookup<Self::Variable>);
 
     fn instruction_counter(&self) -> Self::Variable;

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -202,6 +202,7 @@ pub trait InterpreterEnv {
         + std::ops::Mul<Self::Variable, Output = Self::Variable>
         + std::fmt::Debug;
 
+    /// Add a constraint to the proof system, asserting that `assert_equals_zero` is 0.
     fn add_constraint(&mut self, assert_equals_zero: Self::Variable);
 
     fn add_lookup(&mut self, lookup: Lookup<Self::Variable>);

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -840,16 +840,8 @@ pub fn interpret_rtype<Env: InterpreterEnv>(env: &mut Env, instr: RTypeInstructi
         RTypeInstruction::SyscallFcntl => (),
         RTypeInstruction::SyscallOther => {
             let syscall_num = env.read_register(&Env::constant(2));
-            let is_sysbrk = {
-                // FIXME: Requires constraints
-                let pos = env.alloc_scratch();
-                unsafe { env.test_zero(&(syscall_num.clone() - Env::constant(4045)), pos) }
-            };
-            let is_sysclone = {
-                // FIXME: Requires constraints
-                let pos = env.alloc_scratch();
-                unsafe { env.test_zero(&(syscall_num.clone() - Env::constant(4120)), pos) }
-            };
+            let is_sysbrk = env.equal(&syscall_num, &Env::constant(4045));
+            let is_sysclone = env.equal(&syscall_num, &Env::constant(4120));
             let v0 = { is_sysbrk * Env::constant(0x40000000) + is_sysclone };
             let v1 = Env::constant(0);
             env.write_register(&Env::constant(2), v0);
@@ -1059,11 +1051,7 @@ pub fn interpret_itype<Env: InterpreterEnv>(env: &mut Env, instr: ITypeInstructi
             let offset = env.sign_extend(&(immediate * Env::constant(1 << 2)), 18);
             let rs = env.read_register(&rs);
             let rt = env.read_register(&rt);
-            let equals = {
-                // FIXME: Requires constraints
-                let pos = env.alloc_scratch();
-                unsafe { env.test_zero(&(rs - rt), pos) }
-            };
+            let equals = env.equal(&rs, &rt);
             let offset = (Env::constant(1) - equals.clone()) * Env::constant(4) + equals * offset;
             let addr = {
                 let pos = env.alloc_scratch();
@@ -1078,11 +1066,7 @@ pub fn interpret_itype<Env: InterpreterEnv>(env: &mut Env, instr: ITypeInstructi
             let offset = env.sign_extend(&(immediate * Env::constant(1 << 2)), 18);
             let rs = env.read_register(&rs);
             let rt = env.read_register(&rt);
-            let equals = {
-                // FIXME: Requires constraints
-                let pos = env.alloc_scratch();
-                unsafe { env.test_zero(&(rs - rt), pos) }
-            };
+            let equals = env.equal(&rs, &rt);
             let offset = equals.clone() * Env::constant(4) + (Env::constant(1) - equals) * offset;
             let addr = {
                 let pos = env.alloc_scratch();

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -205,6 +205,15 @@ pub trait InterpreterEnv {
     /// Add a constraint to the proof system, asserting that `assert_equals_zero` is 0.
     fn add_constraint(&mut self, assert_equals_zero: Self::Variable);
 
+    /// Check that the witness value in `assert_equals_zero` is 0; otherwise abort.
+    fn check_is_zero(assert_equals_zero: &Self::Variable);
+
+    /// Assert that the value `assert_equals_zero` is 0, and add a constraint in the proof system.
+    fn assert_is_zero(&mut self, assert_equals_zero: Self::Variable) {
+        Self::check_is_zero(&assert_equals_zero);
+        self.add_constraint(assert_equals_zero);
+    }
+
     fn add_lookup(&mut self, lookup: Lookup<Self::Variable>);
 
     fn instruction_counter(&self) -> Self::Variable;

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -275,6 +275,20 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         res
     }
 
+    unsafe fn inverse_or_zero(
+        &mut self,
+        x: &Self::Variable,
+        position: Self::Position,
+    ) -> Self::Variable {
+        if *x == 0 {
+            self.write_column(position, 0);
+            0
+        } else {
+            self.write_field_column(position, Fp::from(*x as u64).inverse().unwrap());
+            1 // Placeholder value
+        }
+    }
+
     unsafe fn test_less_than(
         &mut self,
         x: &Self::Variable,
@@ -415,8 +429,12 @@ impl<Fp: Field> Env<Fp> {
     }
 
     pub fn write_column(&mut self, column: Column, value: u64) {
+        self.write_field_column(column, value.into())
+    }
+
+    pub fn write_field_column(&mut self, column: Column, value: Fp) {
         match column {
-            Column::ScratchState(idx) => self.scratch_state[idx] = value.into(),
+            Column::ScratchState(idx) => self.scratch_state[idx] = value,
         }
     }
 

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -106,6 +106,12 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
 
     type Variable = u32;
 
+    fn add_constraint(&mut self, _assert_equals_zero: Self::Variable) {
+        // No-op for witness
+        // Do not assert that _assert_equals_zero is zero here! Some variables may have
+        // placeholders that do not faithfully represent the underlying values.
+    }
+
     fn add_lookup(&mut self, _lookup: interpreter::Lookup<Self::Variable>) {
         // FIXME: Track the lookup values in the environment.
     }

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -116,6 +116,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         assert_eq!(*assert_equals_zero, 0);
     }
 
+    fn check_equal(x: &Self::Variable, y: &Self::Variable) {
+        assert_eq!(*x, *y);
+    }
+
     fn add_lookup(&mut self, _lookup: interpreter::Lookup<Self::Variable>) {
         // FIXME: Track the lookup values in the environment.
     }

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -120,6 +120,12 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         assert_eq!(*x, *y);
     }
 
+    fn check_boolean(x: &Self::Variable) {
+        if !(*x == 0 || *x == 1) {
+            panic!("The value {} is not a boolean", *x);
+        }
+    }
+
     fn add_lookup(&mut self, _lookup: interpreter::Lookup<Self::Variable>) {
         // FIXME: Track the lookup values in the environment.
     }

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -112,6 +112,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         // placeholders that do not faithfully represent the underlying values.
     }
 
+    fn check_is_zero(assert_equals_zero: &Self::Variable) {
+        assert_eq!(*assert_equals_zero, 0);
+    }
+
     fn add_lookup(&mut self, _lookup: interpreter::Lookup<Self::Variable>) {
         // FIXME: Track the lookup values in the environment.
     }


### PR DESCRIPTION
This PR
* adds an `add_constraint` helper
* adds assertions `assert_is_zero`, `assert_equal`, and `assert_boolean`
* adds `is_zero` and `equal` helper functions
* replaces existing unsafe uses of `test_zero` with `is_zero` or `equal`.