### PR TITLE
Implement mmap syscall

### DIFF
--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -886,7 +886,7 @@ pub fn interpret_rtype<Env: InterpreterEnv>(env: &mut Env, instr: RTypeInstructi
             let size_in_pages = {
                 // FIXME: Requires a range check
                 let pos = env.alloc_scratch();
-                unsafe { env.bitmask(&instruction, 32, PAGE_ADDRESS_SIZE, pos) }
+                unsafe { env.bitmask(&requested_alloc_size, 32, PAGE_ADDRESS_SIZE, pos) }
             };
             let requires_extra_page = {
                 let remainder = requested_alloc_size

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -230,13 +230,29 @@ pub trait InterpreterEnv {
         output: Self::Position,
     ) -> Self::Variable;
 
+    /// Set the last 'access index' for the general purpose register with index `idx` to `value` if
+    /// `if_is_true` is true.
+    ///
+    /// # Safety
+    ///
+    /// No lookups or other constraints are added as part of this operation. The caller must
+    /// manually add the lookups for this operation.
+    unsafe fn push_register_access_if(
+        &mut self,
+        idx: &Self::Variable,
+        value: Self::Variable,
+        if_is_true: &Self::Variable,
+    );
+
     /// Set the last 'access index' for the general purpose register with index `idx` to `value`.
     ///
     /// # Safety
     ///
     /// No lookups or other constraints are added as part of this operation. The caller must
     /// manually add the lookups for this operation.
-    unsafe fn push_register_access(&mut self, idx: &Self::Variable, value: Self::Variable);
+    unsafe fn push_register_access(&mut self, idx: &Self::Variable, value: Self::Variable) {
+        self.push_register_access_if(idx, value, &Self::constant(1))
+    }
 
     /// Access the general purpose register with index `idx`, adding constraints asserting that the
     /// old value was `old_value` and that the new value will be `new_value`.

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -194,13 +194,28 @@ pub trait InterpreterEnv {
         output: Self::Position,
     ) -> Self::Variable;
 
+    /// Set the general purpose register with index `idx` to `value` if `if_is_true` is true.
+    ///
+    /// # Safety
+    ///
+    /// No lookups or other constraints are added as part of this operation. The caller must
+    /// manually add the lookups for this operation.
+    unsafe fn push_register_if(
+        &mut self,
+        idx: &Self::Variable,
+        value: Self::Variable,
+        if_is_true: &Self::Variable,
+    );
+
     /// Set the general purpose register with index `idx` to `value`.
     ///
     /// # Safety
     ///
     /// No lookups or other constraints are added as part of this operation. The caller must
     /// manually add the lookups for this operation.
-    unsafe fn push_register(&mut self, idx: &Self::Variable, value: Self::Variable);
+    unsafe fn push_register(&mut self, idx: &Self::Variable, value: Self::Variable) {
+        self.push_register_if(idx, value, &Self::constant(1))
+    }
 
     /// Fetch the last 'access index' for the general purpose register with index `idx`, and store
     /// it in local position `output`.

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -763,10 +763,10 @@ pub trait InterpreterEnv {
         };
         let new_ptr = old_ptr.clone() + by_amount.clone();
         unsafe {
-            self.access_register_if(&idx, &old_ptr, &new_ptr, &if_is_true);
+            self.access_register_if(&idx, &old_ptr, &new_ptr, if_is_true);
         };
         unsafe {
-            self.push_register_if(&idx, new_ptr, &if_is_true);
+            self.push_register_if(&idx, new_ptr, if_is_true);
         };
         old_ptr
     }

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -910,6 +910,7 @@ pub fn interpret_rtype<Env: InterpreterEnv>(env: &mut Env, instr: RTypeInstructi
             env.write_register(&Env::constant(7), Env::constant(0));
             env.set_instruction_pointer(next_instruction_pointer.clone());
             env.set_next_instruction_pointer(next_instruction_pointer + Env::constant(4u32));
+            return;
         }
         RTypeInstruction::SyscallExitGroup => (),
         RTypeInstruction::SyscallReadHint => (),

--- a/optimism/src/mips/registers.rs
+++ b/optimism/src/mips/registers.rs
@@ -5,8 +5,9 @@ pub const REGISTER_HI: usize = 32;
 pub const REGISTER_LO: usize = 33;
 pub const REGISTER_CURRENT_IP: usize = 34;
 pub const REGISTER_NEXT_IP: usize = 35;
+pub const REGISTER_HEAP_POINTER: usize = 36;
 
-pub const NUM_REGISTERS: usize = 36;
+pub const NUM_REGISTERS: usize = 37;
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub struct Registers<T> {
@@ -15,6 +16,7 @@ pub struct Registers<T> {
     pub lo: T,
     pub current_instruction_pointer: T,
     pub next_instruction_pointer: T,
+    pub heap_pointer: T,
 }
 
 impl<T> Registers<T> {
@@ -24,6 +26,7 @@ impl<T> Registers<T> {
             &self.lo,
             &self.current_instruction_pointer,
             &self.next_instruction_pointer,
+            &self.heap_pointer,
         ])
     }
 }
@@ -42,6 +45,8 @@ impl<T: Clone> Index<usize> for Registers<T> {
             &self.current_instruction_pointer
         } else if index == REGISTER_NEXT_IP {
             &self.next_instruction_pointer
+        } else if index == REGISTER_HEAP_POINTER {
+            &self.heap_pointer
         } else {
             panic!("Index out of bounds");
         }
@@ -60,6 +65,8 @@ impl<T: Clone> IndexMut<usize> for Registers<T> {
             &mut self.current_instruction_pointer
         } else if index == REGISTER_NEXT_IP {
             &mut self.next_instruction_pointer
+        } else if index == REGISTER_HEAP_POINTER {
+            &mut self.heap_pointer
         } else {
             panic!("Index out of bounds");
         }

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -22,7 +22,7 @@ pub const NUM_DECODING_LOOKUP_TERMS: usize = 2;
 pub const NUM_INSTRUCTION_LOOKUP_TERMS: usize = 5;
 pub const NUM_LOOKUP_TERMS: usize =
     NUM_GLOBAL_LOOKUP_TERMS + NUM_DECODING_LOOKUP_TERMS + NUM_INSTRUCTION_LOOKUP_TERMS;
-pub const SCRATCH_SIZE: usize = 36;
+pub const SCRATCH_SIZE: usize = 38;
 
 #[derive(Clone, Default)]
 pub struct SyscallEnv {

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -22,7 +22,7 @@ pub const NUM_DECODING_LOOKUP_TERMS: usize = 2;
 pub const NUM_INSTRUCTION_LOOKUP_TERMS: usize = 5;
 pub const NUM_LOOKUP_TERMS: usize =
     NUM_GLOBAL_LOOKUP_TERMS + NUM_DECODING_LOOKUP_TERMS + NUM_INSTRUCTION_LOOKUP_TERMS;
-pub const SCRATCH_SIZE: usize = 32;
+pub const SCRATCH_SIZE: usize = 36;
 
 #[derive(Clone, Default)]
 pub struct SyscallEnv {
@@ -383,6 +383,24 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
     fn copy(&mut self, x: &Self::Variable, position: Self::Position) -> Self::Variable {
         self.write_column(position, (*x).into());
         *x
+    }
+
+    unsafe fn get_heap_pointer(&mut self) -> Self::Variable {
+        self.syscall_env.heap
+    }
+
+    unsafe fn set_heap_pointer(
+        &mut self,
+        heap_pointer: Self::Variable,
+        if_is_true: &Self::Variable,
+    ) {
+        if *if_is_true == 1 {
+            self.syscall_env.heap = heap_pointer
+        } else if *if_is_true == 0 {
+            // No-op
+        } else {
+            panic!("Bad value for flag in set_heap_pointer: {}", if_is_true);
+        }
     }
 
     fn set_halted(&mut self, flag: Self::Variable) {

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -167,8 +167,19 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         res
     }
 
-    unsafe fn push_register_access(&mut self, idx: &Self::Variable, value: Self::Variable) {
-        self.registers_write_index[*idx as usize] = value
+    unsafe fn push_register_access_if(
+        &mut self,
+        idx: &Self::Variable,
+        value: Self::Variable,
+        if_is_true: &Self::Variable,
+    ) {
+        if *if_is_true == 1 {
+            self.registers_write_index[*idx as usize] = value
+        } else if *if_is_true == 0 {
+            // No-op
+        } else {
+            panic!("Bad value for flag in push_register: {}", *if_is_true);
+        }
     }
 
     unsafe fn fetch_memory(

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -405,24 +405,6 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         *x
     }
 
-    unsafe fn get_heap_pointer(&mut self) -> Self::Variable {
-        self.registers.heap_pointer
-    }
-
-    unsafe fn set_heap_pointer(
-        &mut self,
-        heap_pointer: Self::Variable,
-        if_is_true: &Self::Variable,
-    ) {
-        if *if_is_true == 1 {
-            self.registers.heap_pointer = heap_pointer
-        } else if *if_is_true == 0 {
-            // No-op
-        } else {
-            panic!("Bad value for flag in set_heap_pointer: {}", if_is_true);
-        }
-    }
-
     fn set_halted(&mut self, flag: Self::Variable) {
         if flag == 0 {
             self.halt = false

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -26,7 +26,6 @@ pub const SCRATCH_SIZE: usize = 36;
 
 #[derive(Clone, Default)]
 pub struct SyscallEnv {
-    pub heap: u32, // Heap pointer (actually unused in Cannon as of [2023-10-18])
     pub preimage_offset: u32,
     pub preimage_key: [u8; 32],
     pub last_hint: Option<Vec<u8>>,
@@ -35,7 +34,6 @@ pub struct SyscallEnv {
 impl SyscallEnv {
     pub fn create(state: &State) -> Self {
         SyscallEnv {
-            heap: state.heap,
             preimage_key: state.preimage_key,
             preimage_offset: state.preimage_offset,
             last_hint: state.last_hint.clone(),
@@ -386,7 +384,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
     }
 
     unsafe fn get_heap_pointer(&mut self) -> Self::Variable {
-        self.syscall_env.heap
+        self.registers.heap_pointer
     }
 
     unsafe fn set_heap_pointer(
@@ -395,7 +393,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         if_is_true: &Self::Variable,
     ) {
         if *if_is_true == 1 {
-            self.syscall_env.heap = heap_pointer
+            self.registers.heap_pointer = heap_pointer
         } else if *if_is_true == 0 {
             // No-op
         } else {
@@ -444,6 +442,7 @@ impl<Fp: Field> Env<Fp> {
             general_purpose: state.registers,
             current_instruction_pointer: initial_instruction_pointer,
             next_instruction_pointer,
+            heap_pointer: state.heap,
         };
 
         Env {

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -142,8 +142,19 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         res
     }
 
-    unsafe fn push_register(&mut self, idx: &Self::Variable, value: Self::Variable) {
-        self.registers[*idx as usize] = value
+    unsafe fn push_register_if(
+        &mut self,
+        idx: &Self::Variable,
+        value: Self::Variable,
+        if_is_true: &Self::Variable,
+    ) {
+        if *if_is_true == 1 {
+            self.registers[*idx as usize] = value
+        } else if *if_is_true == 0 {
+            // No-op
+        } else {
+            panic!("Bad value for flag in push_register: {}", *if_is_true);
+        }
     }
 
     unsafe fn fetch_register_access(


### PR DESCRIPTION
This PR implements the Mmap syscall. In order to do this, it
* adds support for optionally writing to registers,
* moves the heap pointer into the registers,
* adds a heap pointer increase function,
* implements the mmap syscall.