### PR TITLE
Include basic operations for constraints as used in mips-demo

### DIFF
--- a/optimism/src/mips/constraints.rs
+++ b/optimism/src/mips/constraints.rs
@@ -1,0 +1,5 @@
+use kimchi::circuits::expr::{ConstantExpr, Expr};
+
+use super::column::Column;
+
+type _E<F> = Expr<ConstantExpr<F>, Column>;

--- a/optimism/src/mips/constraints.rs
+++ b/optimism/src/mips/constraints.rs
@@ -21,7 +21,3 @@ pub fn combine<F: Field>(constraints: impl Iterator<Item = E<F>>) -> E<F> {
 pub fn curr_cell<F: Field>(col: Column) -> E<F> {
     Expr::cell(col, CurrOrNext::Curr)
 }
-
-pub fn next_cell<F: Field>(col: Column) -> E<F> {
-    Expr::cell(col, CurrOrNext::Next)
-}

--- a/optimism/src/mips/constraints.rs
+++ b/optimism/src/mips/constraints.rs
@@ -1,5 +1,27 @@
-use kimchi::circuits::expr::{ConstantExpr, Expr};
+use ark_ff::{Field, One, Zero};
+use kimchi::circuits::{
+    expr::{ConstantExpr, Expr},
+    gate::CurrOrNext,
+};
 
 use super::column::Column;
 
-type _E<F> = Expr<ConstantExpr<F>, Column>;
+type E<F> = Expr<ConstantExpr<F>, Column>;
+
+pub fn boolean<F: Field>(x: E<F>) -> E<F> {
+    x.clone() * (x - Expr::one())
+}
+
+pub fn combine<F: Field>(constraints: impl Iterator<Item = E<F>>) -> E<F> {
+    constraints
+        .reduce(|acc, x| Expr::constant(ConstantExpr::Alpha) * acc + x)
+        .unwrap_or(E::zero())
+}
+
+pub fn curr_cell<F: Field>(col: Column) -> E<F> {
+    Expr::cell(col, CurrOrNext::Curr)
+}
+
+pub fn next_cell<F: Field>(col: Column) -> E<F> {
+    Expr::cell(col, CurrOrNext::Next)
+}

--- a/optimism/src/mips/mod.rs
+++ b/optimism/src/mips/mod.rs
@@ -1,4 +1,5 @@
 pub mod column;
+pub mod constraints;
 pub mod interpreter;
 pub mod registers;
 pub mod witness;


### PR DESCRIPTION
This PR adds the type `E<F>` and ports the functions `boolean`, `combine`, and `curr_cell`.

I thought we might not be using `next_cell` after all, but it including it again is straightforward.