### PR TITLE
Resurrect lookup PR1263 [do not merge]

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1648,8 +1648,8 @@ If lookup is used, the following values are added to the common index:
 To create the index, follow these steps:
 
 1. If no lookup is used in the circuit, do not create a lookup index
-2. Get the lookup selectors and lookup tables (TODO: how?)
-3. Concatenate runtime lookup tables with the ones used by gates
+2. Get the lookup selectors and lookup tables that are specified implicitly
+3. Concatenate explicit runtime lookup tables with the ones (implicitly) used by gates.
 4. Get the highest number of columns `max_table_width`
    that a lookup table can have.
 5. Create the concatenated table of all the fixed lookup tables.

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -739,16 +739,12 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
             let mut has_table_with_id_0 = false;
             let mut lookup_domain_size: usize = lookup_tables
                 .iter()
-                .map(|LookupTable { id, data }| {
+                .map(|lt| {
                     // See below for the reason
-                    if *id == 0_i32 {
+                    if lt.id() == 0_i32 {
                         has_table_with_id_0 = true
                     }
-                    if data.is_empty() {
-                        0
-                    } else {
-                        data[0].len()
-                    }
+                    lt.len()
                 })
                 .sum();
             // After that on the runtime tables
@@ -872,7 +868,7 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
             &domain,
             zk_rows as usize,
         )
-        .map_err(|e| SetupError::ConstraintSystem(e.to_string()))?;
+        .map_err(SetupError::LookupCreation)?;
 
         let sid = shifts.map[0].clone();
 

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -683,7 +683,9 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
     /// If not invoked, it is `vec![]` by default.
     ///
     /// **Warning:** you have to make sure that the IDs of the lookup tables,
-    /// are unique and  not colliding with IDs of built-in lookup tables
+    /// are unique and not colliding with IDs of built-in lookup tables, otherwise
+    /// the error will be raised.
+    ///
     /// (see [crate::circuits::lookup::tables]).
     pub fn lookup(mut self, lookup_tables: Vec<LookupTable<F>>) -> Self {
         self.lookup_tables = lookup_tables;
@@ -693,8 +695,10 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
     /// Set up the runtime tables.
     /// If not invoked, it is `None` by default.
     ///
-    /// **Warning:** you have to make sure that the IDs of the runtime lookup tables,
-    /// are unique and not colliding with IDs of built-in lookup tables
+    /// **Warning:** you have to make sure that the IDs of the runtime
+    /// lookup tables, are unique, i.e. not colliding internaly (with other runtime tables),
+    /// otherwise error will be raised.
+    ///
     /// (see [crate::circuits::lookup::tables]).
     pub fn runtime(mut self, runtime_tables: Option<Vec<RuntimeTableCfg<F>>>) -> Self {
         self.runtime_tables = runtime_tables;

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -266,12 +266,8 @@ impl<F: PrimeField + SquareRootField> LookupConstraintSystem<F> {
                         let runtime_tables_ids: Vec<i32> =
                             runtime_tables.iter().map(|rt| rt.id).collect();
                         check_id_duplicates(runtime_tables_ids.iter(), "runtime table duplicates")?;
-                        check_id_duplicates(
-                            runtime_tables_ids
-                                .iter()
-                                .chain(fixed_lookup_tables_ids.iter()),
-                            "duplicates between runtime and fixed tables",
-                        )?;
+                        // Runtime table IDs may collide with lookup
+                        // table IDs, so we intentionally do not perform another potential check.
 
                         // save the offset of the end of the table
                         let mut runtime_table_offset = 0;
@@ -488,7 +484,7 @@ mod tests {
     use mina_curves::pasta::Fp;
 
     #[test]
-    fn colliding_table_ids() {
+    fn test_colliding_table_ids() {
         let (_, gates) = CircuitGate::<Fp>::create_multi_range_check(0);
         let collision_id: i32 = 5;
 
@@ -568,13 +564,8 @@ mod tests {
             .build();
 
         assert!(
-            matches!(
-                cs,
-                Err(SetupError::LookupCreation(
-                    LookupError::LookupTableIdCollision { .. }
-                ))
-            ),
-            "LookupConstraintSystem::create(...) must fail, collision between runtime and lookup ids"
+            cs.is_ok(),
+            "LookupConstraintSystem::create(...) must not fail when there is a collision between runtime and lookup ids"
         );
     }
 }

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -1,10 +1,10 @@
-use super::runtime_tables::{RuntimeTableCfg, RuntimeTableSpec};
 use crate::circuits::{
     domains::EvaluationDomains,
     gate::CircuitGate,
     lookup::{
         constraints::LookupConfiguration,
         lookups::{LookupInfo, LookupPattern},
+        runtime_tables::{RuntimeTableCfg, RuntimeTableSpec},
         tables::LookupTable,
     },
 };
@@ -21,17 +21,15 @@ use std::iter;
 use thiserror::Error;
 
 /// Represents an error found when computing the lookup constraint system
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone)]
 pub enum LookupError {
-    #[error("One of the lookup tables has columns of different lengths")]
-    InconsistentTableLength,
     #[error("The combined lookup table is larger than allowed by the domain size. Observed: {length}, expected: {maximum_allowed}")]
     LookupTableTooLong {
         length: usize,
         maximum_allowed: usize,
     },
-    #[error("The table with id 0 must have an entry of all zeros")]
-    TableIDZeroMustHaveZeroEntry,
+    #[error("Cannot create a combined table since ids for sub-tables are colliding. The collision type is: {collision_type}")]
+    LookupTableIdCollision { collision_type: String },
 }
 
 /// Lookup selectors
@@ -200,7 +198,7 @@ impl<F: PrimeField + SquareRootField> LookupConstraintSystem<F> {
     /// Will give error if inputs validation do not match.
     pub fn create(
         gates: &[CircuitGate<F>],
-        lookup_tables: Vec<LookupTable<F>>,
+        fixed_lookup_tables: Vec<LookupTable<F>>,
         runtime_tables: Option<Vec<RuntimeTableCfg<F>>>,
         domain: &EvaluationDomains<F>,
         zk_rows: usize,
@@ -217,21 +215,64 @@ impl<F: PrimeField + SquareRootField> LookupConstraintSystem<F> {
                 // product is 1, we cannot use those rows to store any values.
                 let max_num_entries = d1_size - zk_rows - 1;
 
-                //~ 2. Get the lookup selectors and lookup tables (TODO: how?)
+                //~ 2. Get the lookup selectors and lookup tables that are specified implicitly
+                // by the lookup gates.
                 let (lookup_selectors, gate_lookup_tables) =
                     lookup_info.selector_polynomials_and_tables(domain, gates);
 
-                //~ 3. Concatenate runtime lookup tables with the ones used by gates
-                let mut lookup_tables: Vec<_> = gate_lookup_tables
+                // Checks whether an iterator contains any duplicates, and if yes, raises
+                // a corresponding LookupTableIdCollision error.
+                fn check_id_duplicates<'a, I: Iterator<Item = &'a i32>>(
+                    iter: I,
+                    msg: &str,
+                ) -> Result<(), LookupError> {
+                    use itertools::Itertools;
+                    match iter.duplicates().collect::<Vec<_>>() {
+                        dups if !dups.is_empty() => Err(LookupError::LookupTableIdCollision {
+                            collision_type: format!("{}: {:?}", msg, dups).to_string(),
+                        }),
+                        _ => Ok(()),
+                    }
+                }
+
+                // If there is a gate using a lookup table, this table must not be added
+                // explicitly to the constraint system.
+                let fixed_gate_joint_ids: Vec<i32> = fixed_lookup_tables
+                    .iter()
+                    .map(|lt| lt.id())
+                    .chain(gate_lookup_tables.iter().map(|lt| lt.id()))
+                    .collect();
+                check_id_duplicates(
+                    fixed_gate_joint_ids.iter(),
+                    "duplicates between fixed given and fixed from-gate tables",
+                )?;
+
+                //~ 3. Concatenate explicit runtime lookup tables with the ones (implicitly) used by gates.
+                let mut lookup_tables: Vec<LookupTable<_>> = fixed_lookup_tables
                     .into_iter()
-                    .chain(lookup_tables)
+                    .chain(gate_lookup_tables)
                     .collect();
 
-                let mut has_table_id_0 = false;
+                let fixed_lookup_tables_ids: Vec<i32> =
+                    lookup_tables.iter().map(|lt| lt.id()).collect();
+                check_id_duplicates(
+                    fixed_lookup_tables_ids.iter(),
+                    "fixed lookup table duplicates",
+                )?;
 
                 // if we are using runtime tables
                 let (runtime_table_offset, runtime_selector) =
                     if let Some(runtime_tables) = &runtime_tables {
+                        let runtime_tables_ids: Vec<i32> =
+                            runtime_tables.iter().map(|rt| rt.id).collect();
+                        check_id_duplicates(runtime_tables_ids.iter(), "runtime table duplicates")?;
+                        check_id_duplicates(
+                            runtime_tables_ids
+                                .iter()
+                                .chain(fixed_lookup_tables_ids.iter()),
+                            "duplicates between runtime and fixed tables",
+                        )?;
+
                         // save the offset of the end of the table
                         let mut runtime_table_offset = 0;
                         for table in &lookup_tables {
@@ -272,18 +313,15 @@ impl<F: PrimeField + SquareRootField> LookupConstraintSystem<F> {
                             let (id, first_column) =
                                 (runtime_table.id, runtime_table.first_column.clone());
 
-                            // record if table ID 0 is used in one of the runtime tables
-                            // note: the check later will still force you to have a fixed table with ID 0
-                            if id == 0 {
-                                has_table_id_0 = true;
-                            }
-
                             // important: we still need a placeholder column to make sure that
                             // if all other tables have a single column
                             // we don't use the second table as table ID column.
                             let placeholders = vec![F::zero(); first_column.len()];
                             let data = vec![first_column, placeholders];
-                            let table = LookupTable { id, data };
+                            // TODO Check it does not fail actually. Maybe this should throw a different error.
+                            let table = LookupTable::create(id, data)
+                                .expect("Runtime table creation must succeed");
+
                             lookup_tables.push(table);
                         }
 
@@ -345,31 +383,21 @@ impl<F: PrimeField + SquareRootField> LookupConstraintSystem<F> {
                 let mut table_ids: Vec<F> = Vec::with_capacity(d1_size);
 
                 let mut non_zero_table_id = false;
-                let mut has_table_id_0_with_zero_entry = false;
 
                 for table in &lookup_tables {
                     let table_len = table.len();
 
-                    if table.id == 0 {
-                        has_table_id_0 = true;
-                        if table.has_zero_entry() {
-                            has_table_id_0_with_zero_entry = true;
-                        }
-                    } else {
+                    if table.id() != 0 {
                         non_zero_table_id = true;
                     }
 
                     //~~ * Update the corresponding entries in a table id vector (of size the domain as well)
                     //~    with the table ID of the table.
-                    let table_id: F = i32_to_field(table.id);
+                    let table_id: F = i32_to_field(table.id());
                     table_ids.extend(repeat_n(table_id, table_len));
 
                     //~~ * Copy the entries from the table to new rows in the corresponding columns of the concatenated table.
-                    for (i, col) in table.data.iter().enumerate() {
-                        // See GH issue: https://github.com/MinaProtocol/mina/issues/14097
-                        if col.len() != table_len {
-                            return Err(LookupError::InconsistentTableLength);
-                        }
+                    for (i, col) in table.data().iter().enumerate() {
                         lookup_table[i].extend(col);
                     }
 
@@ -377,12 +405,6 @@ impl<F: PrimeField + SquareRootField> LookupConstraintSystem<F> {
                     for lookup_table in lookup_table.iter_mut().skip(table.width()) {
                         lookup_table.extend(repeat_n(F::zero(), table_len));
                     }
-                }
-
-                // If a table has ID 0, then it must have a zero entry.
-                // This is for the dummy lookups to work.
-                if has_table_id_0 && !has_table_id_0_with_zero_entry {
-                    return Err(LookupError::TableIDZeroMustHaveZeroEntry);
                 }
 
                 // Note: we use `>=` here to leave space for the dummy value.
@@ -420,6 +442,8 @@ impl<F: PrimeField + SquareRootField> LookupConstraintSystem<F> {
                     lookup_table8.push(eval);
                 }
 
+                // @volhovm: Do we need to enforce that there is at least one table
+                // with id 0?
                 //~ 9. pre-compute polynomial and evaluation form for the table IDs,
                 //~    only if a table with an ID different from zero was used.
                 let (table_ids, table_ids8) = if non_zero_table_id {
@@ -450,5 +474,107 @@ impl<F: PrimeField + SquareRootField> LookupConstraintSystem<F> {
                 }))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::{LookupError, LookupTable, RuntimeTableCfg};
+    use crate::{
+        circuits::constraints::ConstraintSystem, circuits::gate::CircuitGate,
+        circuits::lookup::tables::xor, circuits::polynomials::range_check, error::SetupError,
+    };
+    use mina_curves::pasta::Fp;
+
+    #[test]
+    fn colliding_table_ids() {
+        let (_, gates) = CircuitGate::<Fp>::create_multi_range_check(0);
+        let collision_id: i32 = 5;
+
+        let cs = ConstraintSystem::<Fp>::create(gates.clone())
+            .lookup(vec![range_check::gadget::lookup_table()])
+            .build();
+
+        assert!(
+            matches!(
+                cs,
+                Err(SetupError::LookupCreation(
+                    LookupError::LookupTableIdCollision { .. }
+                ))
+            ),
+            "LookupConstraintSystem::create(...) must fail due to range table passed twice"
+        );
+
+        let cs = ConstraintSystem::<Fp>::create(gates.clone())
+            .lookup(vec![xor::xor_table()])
+            .build();
+
+        assert!(
+            cs.is_ok(),
+            "LookupConstraintSystem::create(...) must succeed, no duplicates exist"
+        );
+
+        let cs = ConstraintSystem::<Fp>::create(gates.clone())
+            .lookup(vec![
+                LookupTable::create(collision_id, vec![vec![From::from(0); 16]]).unwrap(),
+                LookupTable::create(collision_id, vec![vec![From::from(1); 16]]).unwrap(),
+            ])
+            .build();
+
+        assert!(
+            matches!(
+                cs,
+                Err(SetupError::LookupCreation(
+                    LookupError::LookupTableIdCollision { .. }
+                ))
+            ),
+            "LookupConstraintSystem::create(...) must fail, collision in fixed ids"
+        );
+
+        let cs = ConstraintSystem::<Fp>::create(gates.clone())
+            .runtime(Some(vec![
+                RuntimeTableCfg {
+                    id: collision_id,
+                    first_column: vec![From::from(0); 16],
+                },
+                RuntimeTableCfg {
+                    id: collision_id,
+                    first_column: vec![From::from(1); 16],
+                },
+            ]))
+            .build();
+
+        assert!(
+            matches!(
+                cs,
+                Err(SetupError::LookupCreation(
+                    LookupError::LookupTableIdCollision { .. }
+                ))
+            ),
+            "LookupConstraintSystem::create(...) must fail, collision in runtime ids"
+        );
+
+        let cs = ConstraintSystem::<Fp>::create(gates.clone())
+            .lookup(vec![LookupTable::create(
+                collision_id,
+                vec![vec![From::from(0); 16]],
+            )
+            .unwrap()])
+            .runtime(Some(vec![RuntimeTableCfg {
+                id: collision_id,
+                first_column: vec![From::from(1); 16],
+            }]))
+            .build();
+
+        assert!(
+            matches!(
+                cs,
+                Err(SetupError::LookupCreation(
+                    LookupError::LookupTableIdCollision { .. }
+                ))
+            ),
+            "LookupConstraintSystem::create(...) must fail, collision between runtime and lookup ids"
+        );
     }
 }

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -222,7 +222,7 @@ impl LookupInfo {
         };
 
         // TODO: is take(n) useful here? I don't see why we need this
-        for (i, gate) in gates.iter().enumerate().take(n) {
+        for (i, gate) in gates.iter().take(n).enumerate() {
             let typ = gate.typ;
 
             if let Some(lookup_pattern) = LookupPattern::from_gate(typ, CurrOrNext::Curr) {

--- a/kimchi/src/circuits/lookup/runtime_tables.rs
+++ b/kimchi/src/circuits/lookup/runtime_tables.rs
@@ -18,6 +18,8 @@ pub struct RuntimeTableSpec {
     pub len: usize,
 }
 
+/// A configuration of the runtime table as known at setup time.
+///
 /// Use this type at setup time, to list all the runtime tables.
 ///
 /// Note: care must be taken as table IDs can collide with IDs of other types of lookup tables.
@@ -25,7 +27,8 @@ pub struct RuntimeTableSpec {
 pub struct RuntimeTableCfg<F> {
     /// The table ID.
     pub id: i32,
-    /// The content of the first column of the runtime table.
+    /// The content of the first column of the runtime table, i.e.
+    /// keys when a table is viewed as a (k,v) array.
     pub first_column: Vec<F>,
 }
 
@@ -56,12 +59,13 @@ impl<F> From<RuntimeTableCfg<F>> for RuntimeTableSpec {
 }
 
 /// A runtime table. Runtime tables must match the configuration
-/// that was specified in [`RuntimeTableCfg`].
+/// specified in [`RuntimeTableCfg`].
 #[derive(Debug, Clone)]
 pub struct RuntimeTable<F> {
     /// The table id.
     pub id: i32,
-    /// A single column.
+    /// A single column. Represents runtime table values, where
+    /// ['RuntimeTableCfg'] defines compile-time keys.
     pub data: Vec<F>,
 }
 

--- a/kimchi/src/circuits/lookup/tables/mod.rs
+++ b/kimchi/src/circuits/lookup/tables/mod.rs
@@ -1,12 +1,103 @@
-use ark_ff::{FftField, One, Zero};
+use ark_ff::{Field, One, Zero};
 use poly_commitment::PolyComm;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 pub mod range_check;
 pub mod xor;
 
 // If you add new tables, update ../../../../../book/src/kimchi/lookup.md
 // accordingly
+
+/// A table of values that can be used for a lookup, along with the ID for the table.
+#[derive(Debug, Clone)]
+pub struct LookupTable<F> {
+    id: i32,
+    data: Vec<Vec<F>>,
+}
+
+/// Represents inconsistency errors during table construction and composition.
+#[derive(Debug, Error)]
+pub enum LookupTableError {
+    #[error("Table must be nonempty")]
+    InputTableDataEmpty,
+    #[error("One of the lookup tables has columns of different lengths")]
+    InconsistentTableLength,
+    #[error("The table with id 0 must have an entry of all zeros")]
+    TableIDZeroMustHaveZeroEntry,
+}
+
+impl<F> LookupTable<F>
+where
+    F: Field,
+{
+    pub fn create(id: i32, data: Vec<Vec<F>>) -> Result<Self, LookupTableError> {
+        let res = LookupTable { id, data };
+
+        // Empty tables are not allowed
+        if res.data.is_empty() {
+            return Err(LookupTableError::InputTableDataEmpty);
+        }
+
+        // All columns in the table must have same length
+        let table_len = res.len();
+        for col in res.data.iter() {
+            if col.len() != table_len {
+                return Err(LookupTableError::InconsistentTableLength);
+            }
+        }
+
+        // If a table has ID 0, then it must have a zero entry.
+        // This is for the dummy lookups to work.
+        if id == 0 && !res.has_zero_entry() {
+            return Err(LookupTableError::TableIDZeroMustHaveZeroEntry);
+        }
+
+        Ok(res)
+    }
+
+    /// Return true if the table has an entry (row) containing all zeros.
+    pub fn has_zero_entry(&self) -> bool {
+        // reminder: a table is written as a list of columns,
+        // not as a list of row entries.
+        for row in 0..self.len() {
+            if self.data.iter().all(|col| col[row].is_zero()) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Returns the number of columns, i.e. the width of the table.
+    /// It is less error prone to introduce this method than using the public
+    /// field data.
+    pub fn width(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns the length (height) of the table.
+    pub fn len(&self) -> usize {
+        if self.is_empty() {
+            panic!("LookupTable#len() is called on an empty table")
+        }
+        self.data[0].len()
+    }
+
+    /// Returns `true` if the lookup table is empty, `false` otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Returns table id.
+    pub fn id(&self) -> i32 {
+        self.id
+    }
+
+    /// Returns table data.
+    pub fn data(&self) -> &Vec<Vec<F>> {
+        &self.data
+    }
+}
 
 //~ spec:startcode
 /// The table ID associated with the XOR lookup table.
@@ -70,49 +161,8 @@ impl IntoIterator for GateLookupTables {
     }
 }
 
-/// A table of values that can be used for a lookup, along with the ID for the table.
-#[derive(Debug, Clone)]
-pub struct LookupTable<F> {
-    pub id: i32,
-    pub data: Vec<Vec<F>>,
-}
-
-impl<F> LookupTable<F>
-where
-    F: FftField,
-{
-    /// Return true if the table has an entry (row) containing all zeros.
-    pub fn has_zero_entry(&self) -> bool {
-        // reminder: a table is written as a list of columns,
-        // not as a list of row entries.
-        for row in 0..self.len() {
-            if self.data.iter().all(|col| col[row].is_zero()) {
-                return true;
-            }
-        }
-        false
-    }
-
-    /// Returns the number of columns, i.e. the width of the table.
-    /// It is less error prone to introduce this method than using the public
-    /// field data.
-    pub fn width(&self) -> usize {
-        self.data.len()
-    }
-
-    /// Returns the length of the table.
-    pub fn len(&self) -> usize {
-        self.data[0].len()
-    }
-
-    /// Returns `true` if the lookup table is empty, `false` otherwise.
-    pub fn is_empty(&self) -> bool {
-        self.data.is_empty()
-    }
-}
-
 /// Returns the lookup table associated to a [`GateLookupTable`].
-pub fn get_table<F: FftField>(table_name: GateLookupTable) -> LookupTable<F> {
+pub fn get_table<F: Field>(table_name: GateLookupTable) -> LookupTable<F> {
     match table_name {
         GateLookupTable::Xor => xor::xor_table(),
         GateLookupTable::RangeCheck => range_check::range_check_table(),
@@ -154,6 +204,7 @@ where
     F: Zero + One + Clone,
     I: DoubleEndedIterator<Item = &'a F>,
 {
+    // TODO: unnecessary cloning if binops between F and &F are supported
     v.rev()
         .fold(F::zero(), |acc, x| joint_combiner.clone() * acc + x.clone())
         + table_id_combiner.clone() * table_id.clone()
@@ -252,5 +303,52 @@ pub mod caml {
                     .collect(),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use mina_curves::pasta::Fp;
+
+    #[test]
+    fn test_zero_table_zero_row() {
+        let lookup_r: u64 = 32;
+        // Table column that /does not/ contain zeros
+        let lookup_table_values_1: Vec<_> = (1..lookup_r + 1).map(From::from).collect();
+        // Another table column that /does/ contain zeros.
+        let lookup_table_values_2: Vec<_> = (0..lookup_r).map(From::from).collect();
+
+        // Jointly two columns /do not/ have a full zero now.
+        let table: Result<LookupTable<Fp>, _> =
+            LookupTable::create(0, vec![lookup_table_values_1, lookup_table_values_2]);
+
+        assert!(
+            matches!(table, Err(LookupTableError::TableIDZeroMustHaveZeroEntry)),
+            "LookupTable::create(...) must fail when zero table has no zero rows"
+        );
+    }
+
+    #[test]
+    fn test_invalid_data_inputs() {
+        let table: Result<LookupTable<Fp>, _> = LookupTable::create(0, vec![]);
+        assert!(
+            matches!(table, Err(LookupTableError::InputTableDataEmpty)),
+            "LookupTable::create(...) must fail when empty table creation is attempted"
+        );
+
+        let lookup_r: u64 = 32;
+        // Two columns of different lengths
+        let lookup_table_values_1: Vec<_> = (0..2 * lookup_r).map(From::from).collect();
+        let lookup_table_values_2: Vec<_> = (0..lookup_r).map(From::from).collect();
+
+        let table: Result<LookupTable<Fp>, _> =
+            LookupTable::create(0, vec![lookup_table_values_1, lookup_table_values_2]);
+
+        assert!(
+            matches!(table, Err(LookupTableError::InconsistentTableLength)),
+            "LookupTable::create(...) must fail when columns are not of the same length"
+        );
     }
 }

--- a/kimchi/src/circuits/lookup/tables/range_check.rs
+++ b/kimchi/src/circuits/lookup/tables/range_check.rs
@@ -14,11 +14,9 @@ pub fn range_check_table<F>() -> LookupTable<F>
 where
     F: Field,
 {
-    let table = vec![(0..RANGE_CHECK_UPPERBOUND).map(F::from).collect()];
-    LookupTable {
-        id: RANGE_CHECK_TABLE_ID,
-        data: table,
-    }
+    let data = vec![(0..RANGE_CHECK_UPPERBOUND).map(F::from).collect()];
+    LookupTable::create(RANGE_CHECK_TABLE_ID, data)
+        .expect("range_check_table creation must succeed")
 }
 
 pub const TABLE_SIZE: usize = RANGE_CHECK_UPPERBOUND as usize;

--- a/kimchi/src/circuits/lookup/tables/xor.rs
+++ b/kimchi/src/circuits/lookup/tables/xor.rs
@@ -37,10 +37,8 @@ pub fn xor_table<F: Field>() -> LookupTable<F> {
         // Just to be safe.
         assert!(r[r.len() - 1].is_zero());
     }
-    LookupTable {
-        id: XOR_TABLE_ID,
-        data,
-    }
+
+    LookupTable::create(XOR_TABLE_ID, data).expect("xor_table creation must succeed")
 }
 
 pub const TABLE_SIZE: usize = 256;

--- a/kimchi/src/error.rs
+++ b/kimchi/src/error.rs
@@ -1,5 +1,6 @@
 //! This module implements the [`ProverError`] type.
 
+use crate::circuits::lookup::index::LookupError; // not sure about hierarchy
 use poly_commitment::error::CommitmentError;
 use thiserror::Error;
 
@@ -100,6 +101,9 @@ pub enum SetupError {
 
     #[error("the domain could not be constructed: {0}")]
     DomainCreation(DomainCreationError),
+
+    #[error("the lookup constraint system cannot not be constructed: {0}")]
+    LookupCreation(LookupError),
 }
 
 /// Errors that can arise when creating a verifier index

--- a/kimchi/src/precomputed_srs.rs
+++ b/kimchi/src/precomputed_srs.rs
@@ -33,6 +33,9 @@ where
     let file =
         File::open(srs_path.clone()).unwrap_or_else(|_| panic!("missing SRS file: {srs_path:?}"));
     let reader = BufReader::new(file);
+    // Note: In tests, this read takes significant amount of time (2 min) due
+    // to -O0 optimisation level. Compile tests with -O1 or --release flag.
+    // See: https://github.com/o1-labs/proof-systems/blob/develop/CONTRIBUTING.md#development
     rmp_serde::from_read(reader).unwrap()
 }
 

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -211,6 +211,7 @@ pub mod testing {
             override_srs_size,
             |d1: D<G::ScalarField>, size: usize| {
                 let log2_size = size.ilog2();
+                // Run test_srs_serialization test to generate test SRS & enable this
                 let mut srs = if log2_size <= precomputed_srs::SERIALIZED_SRS_SIZE {
                     // TODO: we should trim it if it's smaller
                     precomputed_srs::get_srs()

--- a/kimchi/src/tests/and.rs
+++ b/kimchi/src/tests/and.rs
@@ -255,6 +255,7 @@ fn verify_bad_and_decomposition<G: KimchiCurve>(
             );
             witness[col][and_row] += G::ScalarField::one();
         }
+
         if col == 2 {
             assert_eq!(
                 cs.gates[0].verify_witness::<G>(0, witness, &cs, &witness[0][0..cs.public]),

--- a/kimchi/src/tests/foreign_field_add.rs
+++ b/kimchi/src/tests/foreign_field_add.rs
@@ -1490,7 +1490,6 @@ fn test_ffadd_finalization() {
 
     let index = {
         let cs = ConstraintSystem::create(gates.clone())
-            .lookup(vec![range_check::gadget::lookup_table()])
             .public(num_public_inputs)
             .build()
             .unwrap();

--- a/kimchi/src/tests/range_check.rs
+++ b/kimchi/src/tests/range_check.rs
@@ -68,7 +68,10 @@ fn create_test_prover_index(
         gates,
         public_size,
         0,
-        vec![range_check::gadget::lookup_table()],
+        // specifying lookup table is not necessary,
+        // since it's already passed through patterns implicitly
+        //vec![range_check::gadget::lookup_table()],
+        vec![],
         None,
         false,
         None,

--- a/kimchi/src/tests/rot.rs
+++ b/kimchi/src/tests/rot.rs
@@ -355,7 +355,6 @@ fn test_rot_finalization() {
     let index = {
         let cs = ConstraintSystem::create(gates.clone())
             .public(num_public_inputs)
-            .lookup(vec![rot::lookup_table()])
             .build()
             .unwrap();
         let mut srs = SRS::<Vesta>::create(cs.domain.d1.size());

--- a/kimchi/src/tests/xor.rs
+++ b/kimchi/src/tests/xor.rs
@@ -392,7 +392,6 @@ fn test_xor_finalization() {
 
     let index = {
         let cs = ConstraintSystem::create(gates.clone())
-            .lookup(vec![xor::lookup_table()])
             .public(num_inputs)
             .build()
             .unwrap();


### PR DESCRIPTION
This resurrects https://github.com/o1-labs/proof-systems/pull/1263 which was reverted in https://github.com/o1-labs/proof-systems/pull/1378 due to the bug that is to be understood within this PR.

Important! Note that the first commit /still/ has the bug MinaProtocol/mina#14657. It will be fixed in the following commits explicitly, so that the bug can be hunted down.

Plan before this can be re-merged:
- [X] Resurrect the PR as it is, squashing it all into a single commit, resolve conflicts
- [X] Check that the `zero_row_zero_id` still makes sense
- [X] Explicitly revert the "colliding runtime+lookup ids" behaviour.
- [ ] Understand why the panic-within-panic bug happened in `mina`
- [ ] Make desired changes, confirm the bug does not reproduce anymore, cover it with a test if possible
