### PR TITLE
Arithmetic operations for Keccak environment

### DIFF
--- a/kimchi/src/circuits/polynomials/keccak/mod.rs
+++ b/kimchi/src/circuits/polynomials/keccak/mod.rs
@@ -15,6 +15,9 @@ use ark_ff::PrimeField;
 
 #[macro_export]
 macro_rules! grid {
+    (5, $v:expr) => {{
+        |x: usize| $v[x].clone()
+    }};
     (20, $v:expr) => {{
         |x: usize, q: usize| $v[q + QUARTERS * x].clone()
     }};

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -43,3 +43,16 @@ pub(crate) trait BoolOps {
 
     fn either_false(x: Self::Variable, y: Self::Variable) -> Self::Variable;
 }
+
+pub(crate) trait ArithOps {
+    type Column;
+    type Variable: std::ops::Mul<Self::Variable, Output = Self::Variable>
+        + std::ops::Add<Self::Variable, Output = Self::Variable>
+        + std::ops::Sub<Self::Variable, Output = Self::Variable>
+        + Clone;
+    type Fp: std::ops::Neg<Output = Self::Fp>;
+
+    fn constant(x: Self::Fp) -> Self::Variable;
+
+    fn two_pow(x: u64) -> Self::Variable;
+}


### PR DESCRIPTION
This PR adds a few basic arithmetic operations for the Keccak environment (that will be used inside constraints). It updates the KeccakEnvironment trait to use them in functions to create expressions from quarters of words and of shifts of words.