### PR TITLE
Extension to frequency specification

### DIFF
--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -775,6 +775,9 @@ impl<Fp: Field> Env<Fp> {
             StepFrequency::Always => true,
             StepFrequency::Exactly(n) => *n == m,
             StepFrequency::Every(n) => m % *n == 0,
+            StepFrequency::Range(lo, hi_opt) => {
+                m >= *lo && (hi_opt.is_none() || m < hi_opt.unwrap())
+            }
         }
     }
 


### PR DESCRIPTION
Allow to define a range in a `rust`-like manner `lo..[hi]`, that is from `lo` until `hi` (excluded) if specified, or until the end if not.