### PR TITLE
Print the current instruction and step on halt

### DIFF
--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -862,12 +862,23 @@ impl<Fp: Field> Env<Fp> {
         // Force stops at given iteration
         if self.should_trigger_at(&config.stop_at) {
             self.halt = true;
+            println!(
+                "Halted as requested at step={} instruction={:?}",
+                self.instruction_counter, opcode
+            );
             return;
         }
 
         interpreter::interpret_instruction(self, opcode);
 
         self.instruction_counter += 1;
+
+        if self.halt {
+            println!(
+                "Halted at step={} instruction={:?}",
+                self.instruction_counter, opcode
+            );
+        }
     }
 
     fn should_trigger_at(&self, at: &StepFrequency) -> bool {


### PR DESCRIPTION
This PR aims to help us debug when the zkVM halts unexpectedly, by printing the offending instruction and step number so that we can reproduce it.