### PR TITLE
Save preimage in Env/State, and add it in the snapshot

### DIFF
--- a/optimism/src/cannon.rs
+++ b/optimism/src/cannon.rs
@@ -67,6 +67,7 @@ pub struct State {
     pub step: u64,
     pub registers: [u32; 32],
     pub last_hint: Option<Vec<u8>>,
+    pub preimage: Option<Vec<u8>>,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -625,7 +625,7 @@ impl<Fp: Field> Env<Fp> {
             halt: state.exited,
             syscall_env,
             preimage_oracle,
-            preimage: None,
+            preimage: state.preimage,
             keccak_env: None,
         }
     }
@@ -957,6 +957,7 @@ impl<Fp: Field> Env<Fp> {
                 preimage_offset: self.registers.preimage_offset,
                 preimage_key,
                 memory,
+                preimage: self.preimage.clone(),
             };
             let _ = serde_json::to_writer(&mut writer, &s);
             info!(


### PR DESCRIPTION
Aims to fix
```
thread 'main' panicked at 'to have a preimage if we're requesting it at a non-zero offset'
```
when we use a snapshot with a non-zero preimage offset.