### PR TITLE
Single row Keccak optimizations (without proof-systems modifications)

### DIFF
--- a/kimchi/src/circuits/polynomials/keccak/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/keccak/circuitgates.rs
@@ -1,19 +1,13 @@
 //! Keccak gadget
-//! -------------
-//! The Keccak gadget is a circuit that implements the Keccak hash function
-//! for 64-bit words, output length of 256 bits and bit rate of 1088 bits.
-//!
-//! It is composed of 1 absorb sponge gate, followed by 24 rounds of permutation per block
-//! and 1 final squeeze sponge gate that outputs the 256-bit hash.
-//!
-//! NOTE: The constraints used in this gadget assume a field size of at least 65 bits to be sound.
-//!
 use super::{DIM, OFF, QUARTERS};
 use crate::{
     auto_clone, auto_clone_array,
     circuits::{
         argument::{Argument, ArgumentEnv, ArgumentType},
-        expr::{constraints::ExprOps, Cache},
+        expr::{
+            constraints::{boolean, ExprOps},
+            Cache,
+        },
         gate::GateType,
     },
     grid,
@@ -59,26 +53,28 @@ macro_rules! from_shifts {
     };
 }
 
-//~ | `KeccakRound` | [0...440) | [440...1540) | [1540...2344) |
+//~
+//~ | `KeccakRound` | [0...265) | [265...1165) | [1165...1965) |
 //~ | ------------- | --------- | ------------ | ------------- |
 //~ | Curr          | theta     | pirho        | chi           |
 //~
 //~ | `KeccakRound` | [0...100) |
 //~ | ------------- | --------- |
 //~ | Next          | iota      |
+//~
 //~ -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 //~
-//~ | Columns  | [0...100) | [100...120) | [120...200) | [200...220) | [220...240) | [240...260)  | [260...280) | [280...300)  | [300...320)  | [320...340) | [340...440) |
-//~ | -------- | --------- | ----------- | ----------- | ----------- | ----------- | ------------ | ----------- | ------------ | ------------ | ----------- | ----------- |
-//~ | theta    | state_a   | state_c     | shifts_c    | dense_c     | quotient_c  | remainder_c  | bound_c     | dense_rot_c  | expand_rot_c | state_d     | state_e     |
+//~ | Columns  | [0...100) | [100...180) | [180...200) | [200...205) | [205...225)  | [225...245)  | [245...265)  |
+//~ | -------- | --------- | ----------- | ----------- | ----------- | ------------ | ------------ | ------------ |
+//~ | theta    | state_a   | shifts_c    | dense_c     | quotient_c  | remainder_c  | dense_rot_c  | expand_rot_c |
 //~
-//~ | Columns  | [440...840) | [840...940) | [940...1040) | [1040...1140) | [1140...1240) | [1240...1340) | [1340...1440) | [1440...1540) |
-//~ | -------- | ----------- | ----------- | ------------ | ------------- | ------------- | ------------- | ------------- | ------------- |
-//~ | pirho    | shifts_e    | dense_e     | quotient_e   | remainder_e   | bound_e       | dense_rot_e   | expand_rot_e  | state_b       |
+//~ | Columns  | [265...665) | [665...765) | [765...865)  | [865...965) | [965...1065) | [1065...1165) |
+//~ | -------- | ----------- | ----------- | ------------ | ----------- | ------------ | ------------- |
+//~ | pirho    | shifts_e    | dense_e     | quotient_e   | remainder_e | dense_rot_e  | expand_rot_e  |
 //~
-//~ | Columns  | [1540...1940) | [1940...2340) | [2340...2344 |
-//~ | -------- | ------------- | ------------- | ------------ |
-//~ | chi      | shifts_b      | shifts_sum    | f00          |
+//~ | Columns  | [1165...1565) | [1565...1965) |
+//~ | -------- | ------------- | ------------- |
+//~ | chi      | shifts_b      | shifts_sum    |
 //~
 //~ | Columns  | [0...4) | [4...100) |
 //~ | -------- | ------- | --------- |
@@ -92,7 +88,7 @@ where
     F: PrimeField,
 {
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::KeccakRound);
-    const CONSTRAINTS: u32 = 754;
+    const CONSTRAINTS: u32 = 389;
 
     // Constraints for one round of the Keccak permutation function
     fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, _cache: &mut Cache) -> Vec<T> {
@@ -104,94 +100,81 @@ where
         // LOAD STATES FROM WITNESS LAYOUT
         // THETA
         let state_a = grid!(100, env.witness_curr_chunk(0, 100));
-        let state_c = grid!(20, env.witness_curr_chunk(100, 120));
-        let shifts_c = grid!(80, env.witness_curr_chunk(120, 200));
-        let dense_c = grid!(20, env.witness_curr_chunk(200, 220));
-        let quotient_c = grid!(20, env.witness_curr_chunk(220, 240));
-        let remainder_c = grid!(20, env.witness_curr_chunk(240, 260));
-        let bound_c = grid!(20, env.witness_curr_chunk(260, 280));
-        let dense_rot_c = grid!(20, env.witness_curr_chunk(280, 300));
-        let expand_rot_c = grid!(20, env.witness_curr_chunk(300, 320));
-        let state_d = grid!(20, env.witness_curr_chunk(320, 340));
-        let state_e = grid!(100, env.witness_curr_chunk(340, 440));
+        let shifts_c = grid!(80, env.witness_curr_chunk(100, 180));
+        let dense_c = grid!(20, env.witness_curr_chunk(180, 200));
+        let quotient_c = grid!(5, env.witness_curr_chunk(200, 205));
+        let remainder_c = grid!(20, env.witness_curr_chunk(205, 225));
+        let dense_rot_c = grid!(20, env.witness_curr_chunk(225, 245));
+        let expand_rot_c = grid!(20, env.witness_curr_chunk(245, 265));
         // PI-RHO
-        let shifts_e = grid!(400, env.witness_curr_chunk(440, 840));
-        let dense_e = grid!(100, env.witness_curr_chunk(840, 940));
-        let quotient_e = grid!(100, env.witness_curr_chunk(940, 1040));
-        let remainder_e = grid!(100, env.witness_curr_chunk(1040, 1140));
-        let bound_e = grid!(100, env.witness_curr_chunk(1140, 1240));
-        let dense_rot_e = grid!(100, env.witness_curr_chunk(1240, 1340));
-        let expand_rot_e = grid!(100, env.witness_curr_chunk(1340, 1440));
-        let state_b = grid!(100, env.witness_curr_chunk(1440, 1540));
+        let shifts_e = grid!(400, env.witness_curr_chunk(265, 665));
+        let dense_e = grid!(100, env.witness_curr_chunk(665, 765));
+        let quotient_e = grid!(100, env.witness_curr_chunk(765, 865));
+        let remainder_e = grid!(100, env.witness_curr_chunk(865, 965));
+        let dense_rot_e = grid!(100, env.witness_curr_chunk(965, 1065));
+        let expand_rot_e = grid!(100, env.witness_curr_chunk(1065, 1165));
         // CHI
-        let shifts_b = grid!(400, env.witness_curr_chunk(1540, 1940));
-        let shifts_sum = grid!(400, env.witness_curr_chunk(1940, 2340));
-        let mut state_f: Vec<T> = env.witness_curr_chunk(2340, 2344);
-        let mut tail = env.witness_next_chunk(4, 100);
-        state_f.append(&mut tail);
-        let state_f = grid!(100, state_f);
+        let shifts_b = grid!(400, env.witness_curr_chunk(1165, 1565));
+        let shifts_sum = grid!(400, env.witness_curr_chunk(1565, 1965));
         // IOTA
-        let mut state_g = env.witness_next_chunk(0, 4);
-        let mut tail = env.witness_next_chunk(4, 100);
-        state_g.append(&mut tail);
-        let state_g = grid!(100, state_g);
+        let state_g = grid!(100, env.witness_next_chunk(0, 100));
 
-        // STEP theta: 5 * ( 3 + 4 * (3 + 5 * 1) ) = 175 constraints
+        // Define vectors containing witness expressions which are not in the layout for efficiency
+        let mut state_c: Vec<Vec<T>> = vec![vec![T::zero(); QUARTERS]; DIM];
+        let mut state_d: Vec<Vec<T>> = vec![vec![T::zero(); QUARTERS]; DIM];
+        let mut state_e: Vec<Vec<Vec<T>>> = vec![vec![vec![T::zero(); QUARTERS]; DIM]; DIM];
+        let mut state_b: Vec<Vec<Vec<T>>> = vec![vec![vec![T::zero(); QUARTERS]; DIM]; DIM];
+        let mut state_f: Vec<Vec<Vec<T>>> = vec![vec![vec![T::zero(); QUARTERS]; DIM]; DIM];
+
+        // STEP theta: 5 * ( 3 + 4 * 1 ) = 35 constraints
         for x in 0..DIM {
             let word_c = from_quarters!(dense_c, x);
-            let quo_c = from_quarters!(quotient_c, x);
             let rem_c = from_quarters!(remainder_c, x);
-            let bnd_c = from_quarters!(bound_c, x);
             let rot_c = from_quarters!(dense_rot_c, x);
+
             constraints
-                .push(word_c * T::two_pow(1) - (quo_c.clone() * T::two_pow(64) + rem_c.clone()));
-            constraints.push(rot_c - (quo_c.clone() + rem_c));
-            constraints.push(bnd_c - (quo_c + T::two_pow(64) - T::two_pow(1)));
+                .push(word_c * T::two_pow(1) - (quotient_c(x) * T::two_pow(64) + rem_c.clone()));
+            constraints.push(rot_c - (quotient_c(x) + rem_c));
+            constraints.push(boolean(&quotient_c(x)));
 
             for q in 0..QUARTERS {
-                constraints.push(
-                    state_c(x, q)
-                        - (state_a(0, x, q)
-                            + state_a(1, x, q)
-                            + state_a(2, x, q)
-                            + state_a(3, x, q)
-                            + state_a(4, x, q)),
-                );
-                constraints.push(state_c(x, q) - from_shifts!(shifts_c, x, q));
-                constraints.push(
-                    state_d(x, q)
-                        - (shifts_c(0, (x + DIM - 1) % DIM, q) + expand_rot_c((x + 1) % DIM, q)),
-                );
+                state_c[x][q] = state_a(0, x, q)
+                    + state_a(1, x, q)
+                    + state_a(2, x, q)
+                    + state_a(3, x, q)
+                    + state_a(4, x, q);
+                constraints.push(state_c[x][q].clone() - from_shifts!(shifts_c, x, q));
+
+                state_d[x][q] =
+                    shifts_c(0, (x + DIM - 1) % DIM, q) + expand_rot_c((x + 1) % DIM, q);
 
                 for y in 0..DIM {
-                    constraints.push(state_e(y, x, q) - (state_a(y, x, q) + state_d(x, q)));
+                    state_e[y][x][q] = state_a(y, x, q) + state_d[x][q].clone();
                 }
             }
         } // END theta
 
-        // STEP pirho: 5 * 5 * (3 + 4 * 2) = 275 constraints
+        // STEP pirho: 5 * 5 * (2 + 4 * 1) = 150 constraints
         for (y, col) in OFF.iter().enumerate() {
             for (x, off) in col.iter().enumerate() {
                 let word_e = from_quarters!(dense_e, y, x);
                 let quo_e = from_quarters!(quotient_e, y, x);
                 let rem_e = from_quarters!(remainder_e, y, x);
-                let bnd_e = from_quarters!(bound_e, y, x);
                 let rot_e = from_quarters!(dense_rot_e, y, x);
 
                 constraints.push(
                     word_e * T::two_pow(*off) - (quo_e.clone() * T::two_pow(64) + rem_e.clone()),
                 );
                 constraints.push(rot_e - (quo_e.clone() + rem_e));
-                constraints.push(bnd_e - (quo_e + T::two_pow(64) - T::two_pow(*off)));
 
                 for q in 0..QUARTERS {
-                    constraints.push(state_e(y, x, q) - from_shifts!(shifts_e, y, x, q));
-                    constraints.push(state_b((2 * x + 3 * y) % DIM, y, q) - expand_rot_e(y, x, q));
+                    constraints.push(state_e[y][x][q].clone() - from_shifts!(shifts_e, y, x, q));
+                    state_b[(2 * x + 3 * y) % DIM][y][q] = expand_rot_e(y, x, q);
                 }
             }
         } // END pirho
 
-        // STEP chi: 4 * 5 * 5 * 3 = 300 constraints
+        // STEP chi: 4 * 5 * 5 * 2 = 200 constraints
         for q in 0..QUARTERS {
             for x in 0..DIM {
                 for y in 0..DIM {
@@ -199,16 +182,17 @@ where
                         - shifts_b(0, y, (x + 1) % DIM, q);
                     let sum = not + shifts_b(0, y, (x + 2) % DIM, q);
                     let and = shifts_sum(1, y, x, q);
-                    constraints.push(state_b(y, x, q) - from_shifts!(shifts_b, y, x, q));
+
+                    constraints.push(state_b[y][x][q].clone() - from_shifts!(shifts_b, y, x, q));
                     constraints.push(sum - from_shifts!(shifts_sum, y, x, q));
-                    constraints.push(state_f(y, x, q) - (shifts_b(0, y, x, q) + and));
+                    state_f[y][x][q] = shifts_b(0, y, x, q) + and;
                 }
             }
         } // END chi
 
         // STEP iota: 4 constraints
         for (q, c) in rc.iter().enumerate() {
-            constraints.push(state_g(0, 0, q) - (state_f(0, 0, q) + c.clone()));
+            constraints.push(state_g(0, 0, q) - (state_f[0][0][q].clone() + c.clone()));
         } // END iota
 
         constraints
@@ -229,7 +213,7 @@ where
     F: PrimeField,
 {
     const ARGUMENT_TYPE: ArgumentType = ArgumentType::Gate(GateType::KeccakSponge);
-    const CONSTRAINTS: u32 = 568;
+    const CONSTRAINTS: u32 = 532;
 
     // Constraints for the Keccak sponge
     fn constraint_checks<T: ExprOps<F>>(env: &ArgumentEnv<F, T>, _cache: &mut Cache) -> Vec<T> {
@@ -260,7 +244,7 @@ where
         auto_clone_array!(flags);
         auto_clone_array!(pad);
 
-        // 32 + 100 * 4 + 136 = 568
+        // 32 + 100 * 3 + 64 + 136 = 532
         for z in zeros {
             // Absorb phase pads with zeros the new state
             constraints.push(absorb() * z);
@@ -272,6 +256,8 @@ where
             constraints.push(absorb() * (xor_state(i) - (old_state(i) + new_block(i))));
             // In absorb, Check shifts correspond to the decomposition of the new state
             constraints.push(absorb() * (new_block(i) - from_shifts!(shifts, i)));
+        }
+        for i in 0..64 {
             // In squeeze, Check shifts correspond to the 256-bit prefix digest of the old state (current)
             constraints.push(squeeze() * (old_state(i) - from_shifts!(shifts, i)));
         }

--- a/kimchi/src/circuits/polynomials/keccak/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/keccak/circuitgates.rs
@@ -148,8 +148,8 @@ where
                 state_d[x][q] =
                     shifts_c(0, (x + DIM - 1) % DIM, q) + expand_rot_c((x + 1) % DIM, q);
 
-                for y in 0..DIM {
-                    state_e[y][x][q] = state_a(y, x, q) + state_d[x][q].clone();
+                for (y, column_e) in state_e.iter_mut().enumerate() {
+                    column_e[x][q] = state_a(y, x, q) + state_d[x][q].clone();
                 }
             }
         } // END theta

--- a/kimchi/src/tests/keccak.rs
+++ b/kimchi/src/tests/keccak.rs
@@ -56,15 +56,6 @@ fn eprint_witness<F: Field>(witness: &[Vec<F>; KECCAK_COLS], round: usize) {
         bytes.reverse();
         bytes.iter().fold(0, |acc: u64, x| (acc << 8) + *x as u64)
     }
-    fn eprint_line(state: &[u64]) {
-        eprint!("         ");
-        for x in 0..5 {
-            let quarters = &state[4 * x..4 * (x + 1)];
-            let word = Keccak::compose(&Keccak::collapse(&Keccak::reset(&Keccak::shift(quarters))));
-            eprint!("{:016x} ", word);
-        }
-        eprintln!();
-    }
     fn eprint_matrix(state: &[u64]) {
         for x in 0..5 {
             eprint!("         ");
@@ -91,21 +82,6 @@ fn eprint_witness<F: Field>(witness: &[Vec<F>; KECCAK_COLS], round: usize) {
     eprintln!("ROUND {}", round);
     eprintln!("State A:");
     eprint_matrix(&row[0..100]);
-    eprintln!("State C:");
-    eprint_line(&row[100..120]);
-    eprintln!("State D:");
-    eprint_line(&row[320..340]);
-    eprintln!("State E:");
-    eprint_matrix(&row[340..440]);
-    eprintln!("State B:");
-    eprint_matrix(&row[1440..1540]);
-
-    let mut state_f = row[2340..2344].to_vec();
-    let mut tail = next[4..100].to_vec();
-    state_f.append(&mut tail);
-
-    eprintln!("State F:");
-    eprint_matrix(&state_f);
     eprintln!("State G:");
     eprint_matrix(&next[0..100]);
 }


### PR DESCRIPTION
This contains the changes from https://github.com/o1-labs/proof-systems/pull/1301, ignoring the changes to the proof system. 

It gets rid of redundancy in the Keccak layout to reduce the number of columns by ~400. 

- Remove intermediate states and embed them in constraints
- Simplify rotation inside Theta removing bound_c and lookups for quotient_c (which just needs a boolean check)
- Remove bound_e following the discussion about optimizing rotation with the product team
- 64 Less constraints in squeeze, only for the 256-bits of the output instead of the whole state.

The main reason for getting these changes in, is to be able to avoid code duplication between the kimchi crate and the mips crate (mainly regarding witness creation).