### PR TITLE
[easy] Making some Keccak structs publicly accessible for MIPS

### DIFF
--- a/kimchi/src/circuits/polynomials/keccak/witness.rs
+++ b/kimchi/src/circuits/polynomials/keccak/witness.rs
@@ -105,6 +105,7 @@ impl Rotation {
     }
 }
 
+/// Values involved in Theta permutation step
 pub struct Theta {
     shifts_c: Vec<u64>,
     dense_c: Vec<u64>,
@@ -185,6 +186,7 @@ impl Theta {
     }
 }
 
+/// Values involved in PiRho permutation step
 pub struct PiRho {
     shifts_e: Vec<u64>,
     dense_e: Vec<u64>,
@@ -230,6 +232,7 @@ impl PiRho {
     }
 }
 
+/// Values involved in Chi permutation step
 pub struct Chi {
     shifts_b: Vec<u64>,
     shifts_sum: Vec<u64>,
@@ -269,6 +272,7 @@ impl Chi {
     }
 }
 
+/// Values involved in Iota permutation step
 pub struct Iota {
     state_g: Vec<u64>,
 }

--- a/kimchi/src/circuits/polynomials/keccak/witness.rs
+++ b/kimchi/src/circuits/polynomials/keccak/witness.rs
@@ -55,7 +55,7 @@ fn field<F: PrimeField>(input: &[u64]) -> Vec<F> {
 
 // Contains the quotient, remainder, bound, dense rotated as quarters of at most 16 bits each
 // Contains the expansion of the rotated word
-struct Rotation {
+pub struct Rotation {
     quotient: Vec<u64>,
     remainder: Vec<u64>,
     dense_rot: Vec<u64>,
@@ -105,7 +105,7 @@ impl Rotation {
     }
 }
 
-struct Theta {
+pub struct Theta {
     shifts_c: Vec<u64>,
     dense_c: Vec<u64>,
     quotient_c: Vec<u64>,
@@ -185,7 +185,7 @@ impl Theta {
     }
 }
 
-struct PiRho {
+pub struct PiRho {
     shifts_e: Vec<u64>,
     dense_e: Vec<u64>,
     quotient_e: Vec<u64>,
@@ -230,7 +230,7 @@ impl PiRho {
     }
 }
 
-struct Chi {
+pub struct Chi {
     shifts_b: Vec<u64>,
     shifts_sum: Vec<u64>,
     state_f: Vec<u64>,
@@ -269,7 +269,7 @@ impl Chi {
     }
 }
 
-struct Iota {
+pub struct Iota {
     state_g: Vec<u64>,
 }
 


### PR DESCRIPTION
This PR makes some structs accessible from other crates to avoid code duplication for the Keccak integration of MIPS.