### PR TITLE
[easy] Move write_column for Keccak to its own environment

### DIFF
--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -59,7 +59,6 @@ pub struct KeccakColumns<T> {
     pub pi_rho_expand_rot_e: Vec<T>, // Round Curr[1065..1165)
     pub chi_shifts_b: Vec<T>,        // Round Curr[1165..1565)
     pub chi_shifts_sum: Vec<T>,      // Round Curr[1565..1965)
-    pub iota_rc: Vec<T>,             // Round Curr[1965..1969)
     pub sponge_old_state: Vec<T>,    // Sponge Curr[0..100)
     pub sponge_new_state: Vec<T>,    // Sponge Curr[100..200)
     pub sponge_bytes: Vec<T>,        // Sponge Curr[200..400)

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -14,6 +14,12 @@ pub struct KeccakEnv<Fp> {
     pub(crate) keccak_state: KeccakColumns<E<Fp>>,
 }
 
+impl<Fp: Field> KeccakEnv<Fp> {
+    pub fn write_column(&mut self, column: KeccakColumn, value: u64) {
+        self.keccak_state[column] = Self::constant(value.into());
+    }
+}
+
 impl<Fp: Field> BoolOps for KeccakEnv<Fp> {
     type Column = KeccakColumn;
     type Variable = E<Fp>;

--- a/optimism/src/mips/column.rs
+++ b/optimism/src/mips/column.rs
@@ -1,7 +1,4 @@
-use crate::keccak::column::KeccakColumn;
-
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Column {
     ScratchState(usize),
-    KeccakState(KeccakColumn),
 }

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -4,7 +4,7 @@ use crate::{
         Hint, Meta, Start, StepFrequency, VmConfiguration, PAGE_ADDRESS_MASK, PAGE_ADDRESS_SIZE,
         PAGE_SIZE,
     },
-    keccak::{environment::KeccakEnv, E},
+    keccak::environment::KeccakEnv,
     mips::{
         column::Column,
         interpreter::{
@@ -17,7 +17,6 @@ use crate::{
 };
 use ark_ff::Field;
 use core::panic;
-use kimchi::circuits::expr::ConstantExpr::Literal;
 use log::{debug, info};
 use std::array;
 use std::fs::File;

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -642,13 +642,6 @@ impl<Fp: Field> Env<Fp> {
     pub fn write_field_column(&mut self, column: Column, value: Fp) {
         match column {
             Column::ScratchState(idx) => self.scratch_state[idx] = value,
-            Column::KeccakState(col) => {
-                if let Some(keccak_env) = &mut self.keccak_env {
-                    keccak_env.keccak_state[col] = E::constant(Literal(value))
-                } else {
-                    panic!("Keccak state not initialized")
-                }
-            }
         }
     }
 


### PR DESCRIPTION
This way helps with separation of concerns between mips and keccak.