### PR TITLE
[easy] Implement `hash` function inside `KeccakInterpreter`

### DIFF
--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -5,6 +5,7 @@ use crate::mips::column::Column;
 pub mod column;
 pub mod environment;
 pub mod interpreter;
+pub mod witness;
 
 pub const ZKVM_KECCAK_COLS: usize = 1965 + 6;
 pub const RATE: usize = 1088;

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -29,14 +29,60 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         self.prev_block = vec![0u64; QUARTERS * DIM * DIM];
 
         // Pad preimage
-        self.padded = pad(&preimage);
+        self.padded = Keccak::pad(&preimage);
         self.block_idx = 0;
         self.pad_len = (self.padded.len() - preimage.len()) as u64;
 
         // Run all steps of hash
         while self.curr_step.is_some() {
             self.step();
-            self.update_step();
+            //self.update_step();
         }
+    }
+
+    fn step(&mut self) {
+        todo!()
+    }
+
+    fn add_constraint(&mut self, _assert_equals_zero: Self::Variable) {
+        todo!()
+    }
+
+    fn set_flag_round(&mut self, _round: u64) {
+        todo!()
+    }
+    fn set_flag_absorb(&mut self, _absorb: Absorb) {
+        todo!()
+    }
+    fn set_flag_root(&mut self) {
+        todo!()
+    }
+    fn set_flag_pad(&mut self) {
+        todo!()
+    }
+
+    fn run_sponge(&mut self, _sponge: Sponge) {
+        todo!()
+    }
+    fn run_absorb(&mut self, _absorb: Absorb) {
+        todo!()
+    }
+    fn run_squeeze(&mut self) {
+        todo!()
+    }
+    fn run_round(&mut self, _round: u64) {
+        todo!()
+    }
+    fn run_theta(&mut self, _state_a: &[u64]) -> Vec<u64> {
+        todo!()
+    }
+    fn run_pirho(&mut self, _state_e: &[u64]) -> Vec<u64> {
+        todo!()
+    }
+    fn run_chi(&mut self, _state_b: &[u64]) -> Vec<u64> {
+        todo!()
+    }
+    fn run_iota(&mut self, _state_f: &[u64], _rc: &[u64]) {
+        todo!()
     }
 }


### PR DESCRIPTION
This is a preliminary trigger for the Keccak interpreter, on input the preimage data. More PRs are coming. In particular, take into account that this still does not implement the communication channel, so the preimage is passed as input instead of being read from memory.