### PR TITLE
[easy] Set mode flags in the interpreter

### DIFF
--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -71,10 +71,11 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         match absorb {
             Absorb::First => self.set_flag_root(),
             Absorb::Last => self.set_flag_pad(),
-            _ => {
+            Absorb::FirstAndLast => {
                 self.set_flag_root();
                 self.set_flag_pad()
             }
+            Absorb::Middle => (),
         }
     }
 


### PR DESCRIPTION
These flags will be used in the constraints to "select" the right constraints for each mode of operation, depending on the type of step being executed.