### PR TITLE
Cli: `pprof.cpu` 

### DIFF
--- a/optimism/run-vm.sh
+++ b/optimism/run-vm.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 cargo run --bin kimchi_optimism --release -p kimchi_optimism -- \
-    --pprof-cpu \
+    --pprof.cpu \
     --info-at "${INFO_AT:-%10000000}" \
     --snapshot-state-at "${SNAPSHOT_STATE_AT:-%10000000}" \
     --proof-at never \

--- a/optimism/src/cannon_cli.rs
+++ b/optimism/src/cannon_cli.rs
@@ -46,7 +46,7 @@ pub fn main_cli() -> clap::Command {
         )
         .arg(
             Arg::new("pprof-cpu")
-                .long("pprof-cpu")
+                .long("pprof.cpu")
                 .action(ArgAction::SetTrue),
         )
         .arg(


### PR DESCRIPTION
There's a typo in our command line wrt cannon's: It's `pprof.cpu` not `pprof-cpu`