### PR TITLE
Witness creation for PiRho permutation in the interpreter

### DIFF
--- a/kimchi/src/circuits/polynomials/keccak/witness.rs
+++ b/kimchi/src/circuits/polynomials/keccak/witness.rs
@@ -230,7 +230,7 @@ pub struct PiRho {
 }
 
 impl PiRho {
-    fn create(state_e: &[u64]) -> Self {
+    pub fn create(state_e: &[u64]) -> Self {
         let shifts_e = Keccak::shift(state_e);
         let dense_e = Keccak::collapse(&Keccak::reset(&shifts_e));
         let rotation_e = Rotation::many(
@@ -261,6 +261,40 @@ impl PiRho {
             expand_rot_e: rotation_e.expand_rot,
             state_b,
         }
+    }
+
+    pub fn shifts_e(&self, i: usize, y: usize, x: usize, q: usize) -> u64 {
+        let shifts_e = grid!(400, &self.shifts_e);
+        shifts_e(i, y, x, q)
+    }
+
+    pub fn dense_e(&self, y: usize, x: usize, q: usize) -> u64 {
+        let dense_e = grid!(100, &self.dense_e);
+        dense_e(y, x, q)
+    }
+
+    pub fn quotient_e(&self, y: usize, x: usize, q: usize) -> u64 {
+        let quotient_e = grid!(100, &self.quotient_e);
+        quotient_e(y, x, q)
+    }
+
+    pub fn remainder_e(&self, y: usize, x: usize, q: usize) -> u64 {
+        let remainder_e = grid!(100, &self.remainder_e);
+        remainder_e(y, x, q)
+    }
+
+    pub fn dense_rot_e(&self, y: usize, x: usize, q: usize) -> u64 {
+        let dense_rot_e = grid!(100, &self.dense_rot_e);
+        dense_rot_e(y, x, q)
+    }
+
+    pub fn expand_rot_e(&self, y: usize, x: usize, q: usize) -> u64 {
+        let expand_rot_e = grid!(100, &self.expand_rot_e);
+        expand_rot_e(y, x, q)
+    }
+
+    pub fn state_b(&self) -> Vec<u64> {
+        self.state_b.clone()
     }
 }
 

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -1,7 +1,8 @@
 use ark_ff::Field;
 use kimchi::{
     circuits::polynomials::keccak::{
-        witness::Theta, Keccak, CAPACITY_IN_BYTES, RATE_IN_BYTES, RC, ROUNDS,
+        witness::{PiRho, Theta},
+        Keccak, CAPACITY_IN_BYTES, RATE_IN_BYTES, RC, ROUNDS,
     },
     grid,
 };
@@ -197,9 +198,42 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         theta.state_e()
     }
 
-    fn run_pirho(&mut self, _state_e: &[u64]) -> Vec<u64> {
-        todo!()
+    fn run_pirho(&mut self, state_e: &[u64]) -> Vec<u64> {
+        let pirho = PiRho::create(state_e);
+
+        // Write PiRho-related columns
+        for y in 0..DIM {
+            for x in 0..DIM {
+                for q in 0..QUARTERS {
+                    self.write_column(KeccakColumn::PiRhoDenseE(y, x, q), pirho.dense_e(y, x, q));
+                    self.write_column(
+                        KeccakColumn::PiRhoQuotientE(y, x, q),
+                        pirho.quotient_e(y, x, q),
+                    );
+                    self.write_column(
+                        KeccakColumn::PiRhoRemainderE(y, x, q),
+                        pirho.remainder_e(y, x, q),
+                    );
+                    self.write_column(
+                        KeccakColumn::PiRhoDenseRotE(y, x, q),
+                        pirho.dense_rot_e(y, x, q),
+                    );
+                    self.write_column(
+                        KeccakColumn::PiRhoExpandRotE(y, x, q),
+                        pirho.expand_rot_e(y, x, q),
+                    );
+                    for i in 0..QUARTERS {
+                        self.write_column(
+                            KeccakColumn::PiRhoShiftsE(i, y, x, q),
+                            pirho.shifts_e(i, y, x, q),
+                        );
+                    }
+                }
+            }
+        }
+        pirho.state_b()
     }
+
     fn run_chi(&mut self, _state_b: &[u64]) -> Vec<u64> {
         todo!()
     }


### PR DESCRIPTION
This reuses the witness code in Kimchi. It adds some methods to obtain the fields of the PiRho struct.