### PR TITLE
Witness creation for Chi permutation in the interpreter

### DIFF
--- a/kimchi/src/circuits/polynomials/keccak/witness.rs
+++ b/kimchi/src/circuits/polynomials/keccak/witness.rs
@@ -306,7 +306,7 @@ pub struct Chi {
 }
 
 impl Chi {
-    fn create(state_b: &[u64]) -> Self {
+    pub fn create(state_b: &[u64]) -> Self {
         let shifts_b = Keccak::shift(state_b);
         let shiftsb = grid!(400, shifts_b);
         let mut sum = vec![];
@@ -335,6 +335,20 @@ impl Chi {
             shifts_sum,
             state_f,
         }
+    }
+
+    pub fn shifts_b(&self, i: usize, y: usize, x: usize, q: usize) -> u64 {
+        let shifts_b = grid!(400, &self.shifts_b);
+        shifts_b(i, y, x, q)
+    }
+
+    pub fn shifts_sum(&self, i: usize, y: usize, x: usize, q: usize) -> u64 {
+        let shifts_sum = grid!(400, &self.shifts_sum);
+        shifts_sum(i, y, x, q)
+    }
+
+    pub fn state_f(&self) -> Vec<u64> {
+        self.state_f.clone()
     }
 }
 

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -1,7 +1,7 @@
 use ark_ff::Field;
 use kimchi::{
     circuits::polynomials::keccak::{
-        witness::{PiRho, Theta},
+        witness::{Chi, PiRho, Theta},
         Keccak, CAPACITY_IN_BYTES, RATE_IN_BYTES, RC, ROUNDS,
     },
     grid,
@@ -234,9 +234,29 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         pirho.state_b()
     }
 
-    fn run_chi(&mut self, _state_b: &[u64]) -> Vec<u64> {
-        todo!()
+    fn run_chi(&mut self, state_b: &[u64]) -> Vec<u64> {
+        let chi = Chi::create(state_b);
+
+        // Write Chi-related columns
+        for i in 0..DIM {
+            for y in 0..DIM {
+                for x in 0..DIM {
+                    for q in 0..QUARTERS {
+                        self.write_column(
+                            KeccakColumn::ChiShiftsB(i, y, x, q),
+                            chi.shifts_b(i, y, x, q),
+                        );
+                        self.write_column(
+                            KeccakColumn::ChiShiftsSum(i, y, x, q),
+                            chi.shifts_sum(i, y, x, q),
+                        );
+                    }
+                }
+            }
+        }
+        chi.state_f()
     }
+
     fn run_iota(&mut self, _state_f: &[u64], _rc: &[u64]) {
         todo!()
     }


### PR DESCRIPTION
This reuses the witness code in Kimchi. It adds some methods to obtain the fields of the Chi struct.