### PR TITLE
Witness creation for Iota permutation in the interpreter

### DIFF
--- a/kimchi/src/circuits/polynomials/keccak/witness.rs
+++ b/kimchi/src/circuits/polynomials/keccak/witness.rs
@@ -355,16 +355,25 @@ impl Chi {
 /// Values involved in Iota permutation step
 pub struct Iota {
     state_g: Vec<u64>,
+    rc: Vec<u64>,
 }
 
 impl Iota {
-    fn create(state_f: Vec<u64>, round: usize) -> Self {
+    pub fn create(state_f: &[u64], round: usize) -> Self {
         let rc = Keccak::sparse(RC[round]);
-        let mut state_g = state_f.clone();
+        let mut state_g = state_f.to_vec();
         for (i, c) in rc.iter().enumerate() {
             state_g[i] = state_f[i] + *c;
         }
-        Self { state_g }
+        Self { state_g, rc }
+    }
+
+    pub fn state_g(&self, i: usize) -> u64 {
+        self.state_g[i]
+    }
+
+    pub fn rc(&self, i: usize) -> u64 {
+        self.rc[i]
     }
 }
 
@@ -428,7 +437,7 @@ pub fn extend_keccak_witness<F: PrimeField>(witness: &mut [Vec<F>; KECCAK_COLS],
             let chi = Chi::create(&pirho.state_b);
 
             // Iota
-            let iota = Iota::create(chi.state_f, round);
+            let iota = Iota::create(&chi.state_f, round);
 
             // Initialize the round row
             witness::init(

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -50,5 +50,5 @@ pub trait KeccakInterpreter {
     fn run_theta(&mut self, state_a: &[u64]) -> Vec<u64>;
     fn run_pirho(&mut self, state_e: &[u64]) -> Vec<u64>;
     fn run_chi(&mut self, state_b: &[u64]) -> Vec<u64>;
-    fn run_iota(&mut self, state_f: &[u64], rc: &[u64]);
+    fn run_iota(&mut self, state_f: &[u64], round: usize);
 }

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -1,8 +1,8 @@
 use ark_ff::Field;
 use kimchi::{
     circuits::polynomials::keccak::{
-        witness::{Chi, PiRho, Theta},
-        Keccak, CAPACITY_IN_BYTES, RATE_IN_BYTES, RC, ROUNDS,
+        witness::{Chi, Iota, PiRho, Theta},
+        Keccak, CAPACITY_IN_BYTES, RATE_IN_BYTES, ROUNDS,
     },
     grid,
 };
@@ -162,12 +162,11 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
     fn run_round(&mut self, round: u64) {
         self.set_flag_round(round);
 
-        let rc = Keccak::sparse(RC[round as usize]);
         let state_a = self.prev_block.clone();
         let state_e = self.run_theta(&state_a);
         let state_b = self.run_pirho(&state_e);
         let state_f = self.run_chi(&state_b);
-        self.run_iota(&state_f, &rc);
+        self.run_iota(&state_f, round as usize);
 
         // Compute witness values
     }
@@ -257,7 +256,15 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         chi.state_f()
     }
 
-    fn run_iota(&mut self, _state_f: &[u64], _rc: &[u64]) {
-        todo!()
+    fn run_iota(&mut self, state_f: &[u64], round: usize) {
+        let iota = Iota::create(state_f, round);
+
+        // Update columns
+        for i in 0..QUARTERS * DIM * DIM {
+            self.write_column(KeccakColumn::NextState(i), iota.state_g(i));
+        }
+        for i in 0..QUARTERS {
+            self.write_column(KeccakColumn::RoundConstants(i), iota.rc(i));
+        }
     }
 }


### PR DESCRIPTION
This reuses the witness code in Kimchi. It adds some methods to obtain the fields of the Iota struct.