### PR TITLE
Constraints for flags configuration

### DIFF
--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -1,4 +1,8 @@
-use crate::keccak::{column::KeccakColumn, environment::KeccakEnv};
+use crate::keccak::{
+    column::KeccakColumn,
+    environment::{KeccakEnv, KeccakEnvironment},
+    BoolOps,
+};
 use ark_ff::Field;
 
 use super::E;
@@ -26,8 +30,38 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
     }
 
     fn constraints(&mut self) {
-        todo!();
         // CORRECTNESS OF FLAGS
+        {
+            // TODO: remove redundancy if any
+
+            // Booleanity of sponge flags
+            {
+                // Absorb is either true or false
+                self.constrain(Self::boolean(self.absorb()));
+                // Squeeze is either true or false
+                self.constrain(Self::boolean(self.squeeze()));
+                // Root is either true or false
+                self.constrain(Self::boolean(self.root()));
+                // Pad is either true or false
+                self.constrain(Self::boolean(self.pad()));
+            }
+            // Mutually exclusiveness of flags
+            {
+                // Squeeze and Root are not both true
+                self.constrain(Self::either_false(self.squeeze(), self.root()));
+                // Squeeze and Pad are not both true
+                self.constrain(Self::either_false(self.squeeze(), self.pad()));
+                // Round and Pad are not both true
+                self.constrain(Self::either_false(self.is_round(), self.pad()));
+                // Round and Root are not both true
+                self.constrain(Self::either_false(self.is_round(), self.root()));
+                // Absorb and Squeeze cannot happen at the same time
+                self.constrain(Self::either_false(self.absorb(), self.squeeze()));
+                // Round and Sponge cannot happen at the same time
+                self.constrain(Self::either_false(self.round(), self.is_sponge()));
+                // Trivially, is_sponge and is_round are mutually exclusive
+            }
+        }
 
         // SPONGE CONSTRAINTS
 


### PR DESCRIPTION
These constraints were not in the Kimchi gate because flags were publicly accessible as gate coefficients encoding the mode of operation.