### PR TITLE
Constraints of Iota permutation step

### DIFF
--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -233,6 +233,13 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
                     }
                 }
             } // END chi
+
+            // STEP iota: 4 constraints
+            for (q, c) in self.round_constants().iter().enumerate() {
+                self.constrain(
+                    self.is_round() * (self.next_state(q) - (state_f[0][0][q].clone() + c.clone())),
+                );
+            } // END iota
         }
 
         // LOOKUP CONSTRAINTS


### PR DESCRIPTION
The difference between these and the ones found in the Kimchi gate is an extra degree due to multiplying by the `is_round()` selector.