### PR TITLE
Add columns and environment helpers for padding

### DIFF
--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -13,6 +13,9 @@ pub enum KeccakColumn {
     FlagRoot,                                 // Coeff Root = 0 | 1
     FlagPad,                                  // Coeff Pad = 0 | 1
     FlagLength,                               // Coeff Length 0 | 1 .. 136
+    TwoToPad,                                 // 2^PadLength
+    FlagsBytes(usize),                        // 136 boolean values
+    PadSuffix(usize),                         // 5 values with padding suffix
     RoundConstants(usize),                    // Round constants
     ThetaStateA(usize, usize, usize),         // Round Curr[0..100)
     ThetaShiftsC(usize, usize, usize),        // Round Curr[100..180)
@@ -44,6 +47,9 @@ pub struct KeccakColumns<T> {
     pub flag_root: T,                // Coeff Root = 0 | 1
     pub flag_pad: T,                 // Coeff Pad = 0 | 1
     pub flag_length: T,              // Coeff Length 0 | 1 .. 136
+    pub two_to_pad: T,               // 2^PadLength
+    pub flags_bytes: Vec<T>,         // 136 boolean values
+    pub pad_suffix: Vec<T>,          // 5 values with padding suffix
     pub round_constants: Vec<T>,     // Round constants
     pub theta_state_a: Vec<T>,       // Round Curr[0..100)
     pub theta_shifts_c: Vec<T>,      // Round Curr[100..180)
@@ -76,6 +82,9 @@ impl<T: Zero + Clone> Default for KeccakColumns<T> {
             flag_root: T::zero(),
             flag_pad: T::zero(),
             flag_length: T::zero(),
+            two_to_pad: T::zero(),
+            flags_bytes: vec![T::zero(); 136],
+            pad_suffix: vec![T::zero(); 5],
             round_constants: vec![T::zero(); 4],
             theta_state_a: vec![T::zero(); 100],
             theta_shifts_c: vec![T::zero(); 80],
@@ -112,6 +121,9 @@ impl<A> Index<KeccakColumn> for KeccakColumns<A> {
             KeccakColumn::FlagRoot => &self.flag_root,
             KeccakColumn::FlagPad => &self.flag_pad,
             KeccakColumn::FlagLength => &self.flag_length,
+            KeccakColumn::TwoToPad => &self.two_to_pad,
+            KeccakColumn::FlagsBytes(i) => &self.flags_bytes[i],
+            KeccakColumn::PadSuffix(i) => &self.pad_suffix[i],
             KeccakColumn::RoundConstants(q) => &self.round_constants[q],
             KeccakColumn::ThetaStateA(y, x, q) => &self.theta_state_a[grid_index(100, 0, y, x, q)],
             KeccakColumn::ThetaShiftsC(i, x, q) => &self.theta_shifts_c[grid_index(80, i, 0, x, q)],
@@ -164,6 +176,9 @@ impl<A> IndexMut<KeccakColumn> for KeccakColumns<A> {
             KeccakColumn::FlagRoot => &mut self.flag_root,
             KeccakColumn::FlagPad => &mut self.flag_pad,
             KeccakColumn::FlagLength => &mut self.flag_length,
+            KeccakColumn::TwoToPad => &mut self.two_to_pad,
+            KeccakColumn::FlagsBytes(i) => &mut self.flags_bytes[i],
+            KeccakColumn::PadSuffix(i) => &mut self.pad_suffix[i],
             KeccakColumn::RoundConstants(q) => &mut self.round_constants[q],
             KeccakColumn::ThetaStateA(y, x, q) => {
                 &mut self.theta_state_a[grid_index(100, 0, y, x, q)]

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -38,6 +38,7 @@ impl<Fp: Field> KeccakEnv<Fp> {
     pub fn write_column(&mut self, column: KeccakColumn, value: u64) {
         self.keccak_state[column] = Self::constant(value.into());
     }
+
     pub fn null_state(&mut self) {
         self.keccak_state = KeccakColumns::default();
     }
@@ -148,6 +149,18 @@ pub(crate) trait KeccakEnvironment {
 
     fn length(&self) -> Self::Variable;
 
+    fn two_to_pad(&self) -> Self::Variable;
+
+    fn in_padding(&self, i: usize) -> Self::Variable;
+
+    fn pad_suffix(&self, i: usize) -> Self::Variable;
+
+    fn bytes_block(&self, i: usize) -> Vec<Self::Variable>;
+
+    fn flags_block(&self, i: usize) -> Vec<Self::Variable>;
+
+    fn block_in_padding(&self, i: usize) -> Self::Variable;
+
     fn round_constants(&self) -> Vec<Self::Variable>;
 
     fn old_state(&self, i: usize) -> Self::Variable;
@@ -159,6 +172,8 @@ pub(crate) trait KeccakEnvironment {
     fn sponge_zeros(&self) -> Vec<Self::Variable>;
 
     fn sponge_shifts(&self) -> Vec<Self::Variable>;
+
+    fn sponge_bytes(&self, i: usize) -> Self::Variable;
 
     fn state_a(&self, y: usize, x: usize, q: usize) -> Self::Variable;
 
@@ -280,6 +295,52 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
         self.keccak_state[KeccakColumn::FlagLength].clone()
     }
 
+    fn two_to_pad(&self) -> Self::Variable {
+        self.keccak_state[KeccakColumn::TwoToPad].clone()
+    }
+
+    fn in_padding(&self, i: usize) -> Self::Variable {
+        self.keccak_state[KeccakColumn::FlagsBytes(i)].clone()
+    }
+
+    fn pad_suffix(&self, i: usize) -> Self::Variable {
+        self.keccak_state[KeccakColumn::PadSuffix(i)].clone()
+    }
+
+    fn bytes_block(&self, i: usize) -> Vec<Self::Variable> {
+        match i {
+            0 => self.keccak_state.sponge_bytes[0..12].to_vec().clone(),
+            1..=4 => self.keccak_state.sponge_bytes[12 + (i - 1) * 31..12 + i * 31]
+                .to_vec()
+                .clone(),
+            _ => panic!("No more blocks of bytes can be part of padding"),
+        }
+    }
+
+    fn flags_block(&self, i: usize) -> Vec<Self::Variable> {
+        match i {
+            0 => self.keccak_state.flags_bytes[0..12].to_vec().clone(),
+            1..=4 => self.keccak_state.flags_bytes[12 + (i - 1) * 31..12 + i * 31]
+                .to_vec()
+                .clone(),
+            _ => panic!("No more blocks of flags can be part of padding"),
+        }
+    }
+
+    fn block_in_padding(&self, i: usize) -> Self::Variable {
+        let bytes = self.bytes_block(i);
+        let flags = self.flags_block(i);
+        assert_eq!(bytes.len(), flags.len());
+        let pad = bytes
+            .iter()
+            .zip(flags)
+            .fold(Self::constant(Fp::zero()), |acc, (byte, flag)| {
+                acc + byte.clone() * flag * Self::constant(Self::Fp::from(256u16))
+            });
+
+        pad
+    }
+
     fn round_constants(&self) -> Vec<Self::Variable> {
         self.keccak_state.round_constants.clone()
     }
@@ -298,6 +359,10 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
 
     fn sponge_zeros(&self) -> Vec<Self::Variable> {
         self.keccak_state.sponge_new_state[68..100].to_vec().clone()
+    }
+
+    fn sponge_bytes(&self, i: usize) -> Self::Variable {
+        self.keccak_state[KeccakColumn::SpongeBytes(i)].clone()
     }
 
     fn sponge_shifts(&self) -> Vec<Self::Variable> {


### PR DESCRIPTION
This is the first of a series of PRs meant to add support for padding in the MIPS Keccak module. 

This PR adds a few columns needed to select bytes involved in the padding, access the value $2^{len}$, and the claimed correct padding for a given length. 

It also provides some helpers in the environment to access these columns, and combinations of them that will be used inside the constraints.