### PR TITLE
Fix round constants inside sponge steps

### DIFF
--- a/kimchi/src/circuits/polynomials/keccak/gadget.rs
+++ b/kimchi/src/circuits/polynomials/keccak/gadget.rs
@@ -35,7 +35,8 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
                 pad,
                 extra_bytes,
             ));
-            for round in 0..ROUNDS {
+            // Start by 1 to avoid the dummy entry
+            for round in 1..=ROUNDS {
                 gates.push(Self::create_keccak_round(new_row + gates.len(), round));
             }
         }

--- a/kimchi/src/circuits/polynomials/keccak/mod.rs
+++ b/kimchi/src/circuits/polynomials/keccak/mod.rs
@@ -53,7 +53,9 @@ pub const OFF: [[u64; DIM]; DIM] = [
     [18, 2, 61, 56, 14],
 ];
 
-pub const RC: [u64; 24] = [
+/// Contains the 24 round constants for Keccak and an initial dummy entry
+pub const RC: [u64; ROUNDS + 1] = [
+    0x0000000000000000,
     0x0000000000000001,
     0x0000000000008082,
     0x800000000000808a,

--- a/kimchi/src/circuits/polynomials/keccak/witness.rs
+++ b/kimchi/src/circuits/polynomials/keccak/witness.rs
@@ -426,7 +426,8 @@ pub fn extend_keccak_witness<F: PrimeField>(witness: &mut [Vec<F>; KECCAK_COLS],
 
         let mut ini_state = xor_state.clone();
 
-        for round in 0..ROUNDS {
+        // Start by 1 to avoid dummy entry
+        for round in 1..=ROUNDS {
             // Theta
             let theta = Theta::create(&ini_state);
 

--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -7,13 +7,14 @@ use super::grid_index;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum KeccakColumn {
-    FlagRound,                                // Coeff Round = 0 | 1
+    FlagRound,                                // Coeff Round = 0 | 1 .. 24
     FlagAbsorb,                               // Coeff Absorb = 0 | 1
     FlagSqueeze,                              // Coeff Squeeze = 0 | 1
     FlagRoot,                                 // Coeff Root = 0 | 1
     FlagPad,                                  // Coeff Pad = 0 | 1
     FlagLength,                               // Coeff Length 0 | 1 .. 136
     TwoToPad,                                 // 2^PadLength
+    InverseRound,                             // Round^-1
     FlagsBytes(usize),                        // 136 boolean values
     PadSuffix(usize),                         // 5 values with padding suffix
     RoundConstants(usize),                    // Round constants
@@ -41,13 +42,14 @@ pub enum KeccakColumn {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct KeccakColumns<T> {
-    pub flag_round: T,               // Coeff Round = [0..24)
+    pub flag_round: T,               // Coeff Round = 0 | 1 .. 24
     pub flag_absorb: T,              // Coeff Absorb = 0 | 1
     pub flag_squeeze: T,             // Coeff Squeeze = 0 | 1
     pub flag_root: T,                // Coeff Root = 0 | 1
     pub flag_pad: T,                 // Coeff Pad = 0 | 1
     pub flag_length: T,              // Coeff Length 0 | 1 .. 136
     pub two_to_pad: T,               // 2^PadLength
+    pub inverse_round: T,            // Round^-1
     pub flags_bytes: Vec<T>,         // 136 boolean values
     pub pad_suffix: Vec<T>,          // 5 values with padding suffix
     pub round_constants: Vec<T>,     // Round constants
@@ -83,9 +85,10 @@ impl<T: Zero + One + Clone> Default for KeccakColumns<T> {
             flag_pad: T::zero(),
             flag_length: T::zero(),
             two_to_pad: T::one(), // So that default 2^0 is in the table
+            inverse_round: T::zero(),
             flags_bytes: vec![T::zero(); 136],
             pad_suffix: vec![T::zero(); 5],
-            round_constants: vec![T::zero(); 4],
+            round_constants: vec![T::zero(); 4], // RC[0] is set to be all zeros
             theta_state_a: vec![T::zero(); 100],
             theta_shifts_c: vec![T::zero(); 80],
             theta_dense_c: vec![T::zero(); 20],
@@ -122,6 +125,7 @@ impl<A> Index<KeccakColumn> for KeccakColumns<A> {
             KeccakColumn::FlagPad => &self.flag_pad,
             KeccakColumn::FlagLength => &self.flag_length,
             KeccakColumn::TwoToPad => &self.two_to_pad,
+            KeccakColumn::InverseRound => &self.inverse_round,
             KeccakColumn::FlagsBytes(i) => &self.flags_bytes[i],
             KeccakColumn::PadSuffix(i) => &self.pad_suffix[i],
             KeccakColumn::RoundConstants(q) => &self.round_constants[q],
@@ -177,6 +181,7 @@ impl<A> IndexMut<KeccakColumn> for KeccakColumns<A> {
             KeccakColumn::FlagPad => &mut self.flag_pad,
             KeccakColumn::FlagLength => &mut self.flag_length,
             KeccakColumn::TwoToPad => &mut self.two_to_pad,
+            KeccakColumn::InverseRound => &mut self.inverse_round,
             KeccakColumn::FlagsBytes(i) => &mut self.flags_bytes[i],
             KeccakColumn::PadSuffix(i) => &mut self.pad_suffix[i],
             KeccakColumn::RoundConstants(q) => &mut self.round_constants[q],

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -60,8 +60,10 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
                 self.constrain(Self::either_false(self.is_round(), self.root()));
                 // Absorb and Squeeze cannot happen at the same time
                 self.constrain(Self::either_false(self.absorb(), self.squeeze()));
-                // Round and Sponge cannot happen at the same time
-                self.constrain(Self::either_false(self.round(), self.is_sponge()));
+                // Only one of Round and Sponge can be zero
+                // This means either Sponge is true or Round is nonzero -> has an inverse
+                self.constrain(self.is_sponge() * self.round());
+                self.constrain(self.is_round() * Self::is_one(self.round() * self.inverse_round()));
                 // Trivially, is_sponge and is_round are mutually exclusive
             }
         }

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -155,6 +155,8 @@ pub(crate) trait KeccakEnvironment {
 
     fn round(&self) -> Self::Variable;
 
+    fn inverse_round(&self) -> Self::Variable;
+
     fn absorb(&self) -> Self::Variable;
 
     fn squeeze(&self) -> Self::Variable;
@@ -291,6 +293,10 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
 
     fn round(&self) -> Self::Variable {
         self.keccak_state[KeccakColumn::FlagRound].clone()
+    }
+
+    fn inverse_round(&self) -> Self::Variable {
+        self.keccak_state[KeccakColumn::InverseRound].clone()
     }
 
     fn absorb(&self) -> Self::Variable {

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -107,8 +107,12 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
     }
 
     fn set_flag_round(&mut self, round: u64) {
-        assert!(round < ROUNDS as u64);
+        assert!(round <= ROUNDS as u64);
+        // Values between 0 (dummy, for sponges) and 24
         self.write_column(KeccakColumn::FlagRound, round);
+        if round != 0 {
+            self.write_column_field(KeccakColumn::FlagRound, Fp::from(round).inverse().unwrap());
+        }
     }
 
     fn run_sponge(&mut self, sponge: Sponge) {


### PR DESCRIPTION
This PR adds some changes to prevent the system from failing to fetch a valid (Round, RoundConstant) pair when the step being executed is a sponge. In those cases, the round should be 0 and there are no RC for it. To fix this, we add a dummy entry of all zeros to RC, which becomes length 25. Then, a series of changes are made to the caller functions in order to count "real" rounds starting on 1 instead of 0, leaving the 0 entry for sponge executions. 

In order to check that the round 0 won't happen in a Round execution, we need to constrain that is_sponge and round=0 cannot happen at the same time. This means, in Rounds we need to provide the inverse of the Round (between 1 and 24) so that we can prove that it is nonzero.