### PR TITLE
Fix zkVM IPC deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,6 +1332,7 @@ dependencies = [
  "groupmap",
  "hex",
  "kimchi",
+ "libc",
  "libflate",
  "log",
  "mina-curves",

--- a/optimism/Cargo.toml
+++ b/optimism/Cargo.toml
@@ -40,5 +40,6 @@ strum_macros = "0.24.0"
 log = "0.4.20"
 env_logger = "0.10.0"
 command-fds = "0.2.3"
-os_pipe = "1.1.4"
+os_pipe = { version = "1.1.4", features = [ "io_safety" ] }
 rand = "0.8.5"
+libc = "0.2.62"

--- a/optimism/src/mips/constraints.rs
+++ b/optimism/src/mips/constraints.rs
@@ -4,7 +4,7 @@ use crate::mips::{
 };
 use ark_ff::Field;
 use kimchi::circuits::{
-    expr::{ConstantExpr, Expr, Variable},
+    expr::{ConstantExpr, Expr, ExprInner, Variable},
     gate::CurrOrNext,
 };
 
@@ -45,10 +45,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
     }
 
     fn instruction_counter(&self) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: MIPSColumn::InstructionCounter,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn fetch_register(
@@ -56,10 +56,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _idx: &Self::Variable,
         output: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: output,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn push_register_if(
@@ -76,10 +76,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _idx: &Self::Variable,
         output: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: output,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn push_register_access_if(
@@ -96,10 +96,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _addr: &Self::Variable,
         output: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: output,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn push_memory(&mut self, _addr: &Self::Variable, _value: Self::Variable) {
@@ -111,10 +111,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _addr: &Self::Variable,
         output: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: output,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn push_memory_access(&mut self, _addr: &Self::Variable, _value: Self::Variable) {
@@ -132,10 +132,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _lowest_bit: u32,
         position: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: position,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn shift_left(
@@ -144,10 +144,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _by: &Self::Variable,
         position: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: position,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn shift_right(
@@ -156,10 +156,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _by: &Self::Variable,
         position: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: position,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn shift_right_arithmetic(
@@ -168,10 +168,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _by: &Self::Variable,
         position: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: position,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn test_zero(
@@ -179,10 +179,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _x: &Self::Variable,
         position: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: position,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn inverse_or_zero(
@@ -190,10 +190,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _x: &Self::Variable,
         position: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: position,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn test_less_than(
@@ -202,10 +202,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _y: &Self::Variable,
         position: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: position,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn test_less_than_signed(
@@ -214,10 +214,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _y: &Self::Variable,
         position: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: position,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn and_witness(
@@ -226,10 +226,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _y: &Self::Variable,
         position: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: position,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn nor_witness(
@@ -238,10 +238,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _y: &Self::Variable,
         position: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: position,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn or_witness(
@@ -250,10 +250,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _y: &Self::Variable,
         position: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: position,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn xor_witness(
@@ -262,10 +262,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _y: &Self::Variable,
         position: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: position,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn mul_signed_witness(
@@ -274,10 +274,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _y: &Self::Variable,
         position: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: position,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     unsafe fn mul_hi_lo_signed(
@@ -288,14 +288,14 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         position_lo: Self::Position,
     ) -> (Self::Variable, Self::Variable) {
         (
-            Expr::Cell(Variable {
+            Expr::Atom(ExprInner::Cell(Variable {
                 col: position_hi,
                 row: CurrOrNext::Curr,
-            }),
-            Expr::Cell(Variable {
+            })),
+            Expr::Atom(ExprInner::Cell(Variable {
                 col: position_lo,
                 row: CurrOrNext::Curr,
-            }),
+            })),
         )
     }
 
@@ -307,14 +307,14 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         position_lo: Self::Position,
     ) -> (Self::Variable, Self::Variable) {
         (
-            Expr::Cell(Variable {
+            Expr::Atom(ExprInner::Cell(Variable {
                 col: position_hi,
                 row: CurrOrNext::Curr,
-            }),
-            Expr::Cell(Variable {
+            })),
+            Expr::Atom(ExprInner::Cell(Variable {
                 col: position_lo,
                 row: CurrOrNext::Curr,
-            }),
+            })),
         )
     }
 
@@ -326,14 +326,14 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         position_remainder: Self::Position,
     ) -> (Self::Variable, Self::Variable) {
         (
-            Expr::Cell(Variable {
+            Expr::Atom(ExprInner::Cell(Variable {
                 col: position_quotient,
                 row: CurrOrNext::Curr,
-            }),
-            Expr::Cell(Variable {
+            })),
+            Expr::Atom(ExprInner::Cell(Variable {
                 col: position_remainder,
                 row: CurrOrNext::Curr,
-            }),
+            })),
         )
     }
 
@@ -345,14 +345,14 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         position_remainder: Self::Position,
     ) -> (Self::Variable, Self::Variable) {
         (
-            Expr::Cell(Variable {
+            Expr::Atom(ExprInner::Cell(Variable {
                 col: position_quotient,
                 row: CurrOrNext::Curr,
-            }),
-            Expr::Cell(Variable {
+            })),
+            Expr::Atom(ExprInner::Cell(Variable {
                 col: position_remainder,
                 row: CurrOrNext::Curr,
-            }),
+            })),
         )
     }
 
@@ -361,17 +361,17 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _x: &Self::Variable,
         position: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: position,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     fn copy(&mut self, x: &Self::Variable, position: Self::Position) -> Self::Variable {
-        let res = Expr::Cell(Variable {
+        let res = Expr::Atom(ExprInner::Cell(Variable {
             col: position,
             row: CurrOrNext::Curr,
-        });
+        }));
         self.constraints.push(x.clone() - res.clone());
         res
     }
@@ -388,10 +388,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         _len: &Self::Variable,
         pos: Self::Position,
     ) -> Self::Variable {
-        Expr::Cell(Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
             col: pos,
             row: CurrOrNext::Curr,
-        })
+        }))
     }
 
     fn request_hint_write(&mut self, _addr: &Self::Variable, _len: &Self::Variable) {

--- a/optimism/src/preimage_oracle.rs
+++ b/optimism/src/preimage_oracle.rs
@@ -228,50 +228,67 @@ mod tests {
     fn test_bidir_channels() {
         let (mut c0, mut c1) = create_bidirectional_channel().unwrap();
 
-        // 1. First send a single byte message
+        // Send a single byte message
         let msg = [42_u8];
         let mut buf = [0_u8; 1];
 
-        let r = c0.0.writer.write(&msg);
-        assert!(r.is_ok());
+        let writer_joiner = std::thread::spawn(move || {
+            let r = c0.0.writer.write(&msg);
+            assert!(r.is_ok());
+        });
 
-        let r = c1.0.reader.read_exact(&mut buf);
-        assert!(r.is_ok());
+        let reader_joiner = std::thread::spawn(move || {
+            let r = c1.0.reader.read_exact(&mut buf);
+            assert!(r.is_ok());
+            buf
+        });
 
-        // 2. Check that we correctly read the single byte message
+        // Retrieve the buffer from the reader
+        let buf = reader_joiner.join().unwrap();
+        // Ensure that the writer has completed
+        writer_joiner.join().unwrap();
+
+        // Check that we correctly read the single byte message
         assert_eq!(msg, buf);
 
-        // 3. Create a more structured message with the preimage format
+        // Create a more structured message with the preimage format
         //      +------------+--------------------+
         //      | length <8> | pre-image <length> |
         //      +---------------------------------+
         //   Here we'll use a length of 2
-        let len = 2_u64;
         let msg2 = vec![42_u8, 43_u8];
+        let len = msg2.len() as u64;
         let mut msg = u64::to_be_bytes(len).to_vec();
         msg.extend_from_slice(&msg2);
 
-        // 4. Write the message
-        let r = c1.0.writer.write(&msg);
-        assert!(r.is_ok());
+        // Write the message
+        let writer_joiner = std::thread::spawn(move || {
+            let r = c1.0.writer.write(&msg);
+            assert!(r.is_ok());
+            msg
+        });
 
-        // 5. Read back the length from the other end of the bidirectionnal
-        // channel
-        let mut len_buf: [u8; 8] = [0_u8; 8];
-        let r = c0.0.reader.read_exact(&mut len_buf);
-        assert!(r.is_ok());
+        // Read back the length from the other end of the bidirectionnal channel
+        let reader_joiner = std::thread::spawn(move || {
+            let mut response_vec = vec![];
+            // We do a single read to mirror go, even though we should *really* do 2. 'Go' figure.
+            let r = c0.0.reader.read_to_end(&mut response_vec);
+            assert!(r.is_ok());
 
-        // 6. Check it is the expected length
-        let n = u64::from_be_bytes(len_buf);
+            let n = u64::from_be_bytes(response_vec[0..8].try_into().unwrap());
+
+            let data = response_vec[8..(n + 8) as usize].to_vec();
+            (n, data)
+        });
+
+        // Retrieve the data from the reader
+        let (n, data) = reader_joiner.join().unwrap();
+
+        // Ensure that the writer has completed
+        writer_joiner.join().unwrap();
+
+        // Check that the responses are equal
         assert_eq!(n, len);
-
-        // 7. Read the data
-        let mut data = vec![0_u8; n as usize];
-        let mut h = c0.0.reader.take(len);
-        let r = h.read(&mut data);
-        assert!(r.is_ok());
-
-        // 8. Check they are equal to the message
         assert_eq!(data, msg2);
     }
 }


### PR DESCRIPTION
This PR fixes the halt caused by deadlocks between the zkVM and the preimage oracle, by setting the `DIRECT` flag in the pipes that we pass to the oracle process. There isn't a nice API for this, so there's some low-level detail here, but the zkVM now runs end-to-end unsupervised!

Massive thanks to @jspada talking over the problem and proposing the solution :heart: 