### PR TITLE
[easy] Rename confusing names of functions to precede with `is_`

### DIFF
--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -39,30 +39,30 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
             // Booleanity of sponge flags
             {
                 // Absorb is either true or false
-                self.constrain(Self::boolean(self.absorb()));
+                self.constrain(Self::is_boolean(self.is_absorb()));
                 // Squeeze is either true or false
-                self.constrain(Self::boolean(self.squeeze()));
+                self.constrain(Self::is_boolean(self.is_squeeze()));
                 // Root is either true or false
-                self.constrain(Self::boolean(self.root()));
+                self.constrain(Self::is_boolean(self.is_root()));
                 // Pad is either true or false
-                self.constrain(Self::boolean(self.pad()));
+                self.constrain(Self::is_boolean(self.is_pad()));
                 for i in 0..RATE_IN_BYTES {
                     // Bytes are either involved on padding or not
-                    self.constrain(Self::boolean(self.in_padding(i)));
+                    self.constrain(Self::is_boolean(self.in_padding(i)));
                 }
             }
             // Mutually exclusiveness of flags
             {
                 // Squeeze and Root are not both true
-                self.constrain(Self::either_false(self.squeeze(), self.root()));
+                self.constrain(Self::either_false(self.is_squeeze(), self.is_root()));
                 // Squeeze and Pad are not both true
-                self.constrain(Self::either_false(self.squeeze(), self.pad()));
+                self.constrain(Self::either_false(self.is_squeeze(), self.is_pad()));
                 // Round and Pad are not both true
-                self.constrain(Self::either_false(self.is_round(), self.pad()));
+                self.constrain(Self::either_false(self.is_round(), self.is_pad()));
                 // Round and Root are not both true
-                self.constrain(Self::either_false(self.is_round(), self.root()));
+                self.constrain(Self::either_false(self.is_round(), self.is_root()));
                 // Absorb and Squeeze cannot happen at the same time
-                self.constrain(Self::either_false(self.absorb(), self.squeeze()));
+                self.constrain(Self::either_false(self.is_absorb(), self.is_squeeze()));
                 // Only one of Round and Sponge can be zero
                 // This means either Sponge is true or Round is nonzero -> has an inverse
                 self.constrain(self.is_sponge() * self.round());
@@ -75,18 +75,19 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
         {
             for z in self.sponge_zeros() {
                 // Absorb phase pads with zeros the new state
-                self.constrain(self.absorb() * z.clone());
+                self.constrain(self.is_absorb() * z.clone());
             }
             for i in 0..QUARTERS * DIM * DIM {
                 // In first absorb, root state is all zeros
-                self.constrain(self.root() * self.old_state(i));
+                self.constrain(self.is_root() * self.old_state(i));
                 // Absorbs the new block by performing XOR with the old state
                 self.constrain(
-                    self.absorb() * (self.next_state(i) - (self.old_state(i) + self.new_block(i))),
+                    self.is_absorb()
+                        * (self.next_state(i) - (self.old_state(i) + self.new_block(i))),
                 );
                 // In absorb, Check shifts correspond to the decomposition of the new state
                 self.constrain(
-                    self.absorb()
+                    self.is_absorb()
                         * (self.new_block(i)
                             - Self::from_shifts(
                                 &self.keccak_state.sponge_shifts,
@@ -100,7 +101,7 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
             for i in 0..QUARTERS * WORDS_IN_HASH {
                 // In squeeze, Check shifts correspond to the 256-bit prefix digest of the old state (current)
                 self.constrain(
-                    self.squeeze()
+                    self.is_squeeze()
                         * (self.old_state(i)
                             - Self::from_shifts(
                                 &self.keccak_state.sponge_shifts,
@@ -115,24 +116,21 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
             let pad_at_end = (0..RATE_IN_BYTES).fold(Self::zero(), |acc, i| {
                 acc * Self::two() + self.sponge_bytes(i)
             });
-            self.constrain(self.pad() * (self.two_to_pad() - Self::one() - pad_at_end));
+            self.constrain(self.is_pad() * (self.two_to_pad() - Self::one() - pad_at_end));
             // Check that the padding value is correct
             for i in 0..5 {
-                self.constrain(self.pad() * (self.block_in_padding(i) - self.pad_suffix(i)));
+                self.constrain(self.is_pad() * (self.block_in_padding(i) - self.pad_suffix(i)));
             }
         }
 
         // ROUND CONSTRAINTS
         {
             // Define vectors storing expressions which are not in the witness layout for efficiency
-            let mut state_c: Vec<Vec<Self::Variable>> = vec![vec![Self::zero(); QUARTERS]; DIM];
-            let mut state_d: Vec<Vec<Self::Variable>> = vec![vec![Self::zero(); QUARTERS]; DIM];
-            let mut state_e: Vec<Vec<Vec<Self::Variable>>> =
-                vec![vec![vec![Self::zero(); QUARTERS]; DIM]; DIM];
-            let mut state_b: Vec<Vec<Vec<Self::Variable>>> =
-                vec![vec![vec![Self::zero(); QUARTERS]; DIM]; DIM];
-            let mut state_f: Vec<Vec<Vec<Self::Variable>>> =
-                vec![vec![vec![Self::zero(); QUARTERS]; DIM]; DIM];
+            let mut state_c = vec![vec![Self::zero(); QUARTERS]; DIM];
+            let mut state_d = vec![vec![Self::zero(); QUARTERS]; DIM];
+            let mut state_e = vec![vec![vec![Self::zero(); QUARTERS]; DIM]; DIM];
+            let mut state_b = vec![vec![vec![Self::zero(); QUARTERS]; DIM]; DIM];
+            let mut state_f = vec![vec![vec![Self::zero(); QUARTERS]; DIM]; DIM];
 
             // STEP theta: 5 * ( 3 + 4 * 1 ) = 35 constraints
             for x in 0..DIM {
@@ -146,7 +144,7 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
                             - (self.quotient_c(x) * Self::two_pow(64) + rem_c.clone())),
                 );
                 self.constrain(self.is_round() * (rot_c - (self.quotient_c(x) + rem_c)));
-                self.constrain(self.is_round() * (Self::boolean(self.quotient_c(x))));
+                self.constrain(self.is_round() * (Self::is_boolean(self.quotient_c(x))));
 
                 for q in 0..QUARTERS {
                     state_c[x][q] = self.state_a(0, x, q)

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -8,7 +8,7 @@ use ark_ff::{Field, One};
 use kimchi::circuits::expr::Operations;
 use kimchi::{
     auto_clone_array,
-    circuits::{expr::ConstantTerm::Literal, polynomials::keccak::constants::ROUNDS},
+    circuits::{expr::ConstantTerm::Literal, polynomials::keccak::constants::*},
     grid,
     o1_utils::Two,
 };
@@ -83,7 +83,7 @@ impl<Fp: Field> BoolOps for KeccakEnv<Fp> {
     type Variable = E<Fp>;
     type Fp = Fp;
 
-    fn boolean(x: Self::Variable) -> Self::Variable {
+    fn is_boolean(x: Self::Variable) -> Self::Variable {
         x.clone() * (x - Self::Variable::one())
     }
 
@@ -152,19 +152,19 @@ pub(crate) trait KeccakEnvironment {
 
     fn is_sponge(&self) -> Self::Variable;
 
+    fn is_absorb(&self) -> Self::Variable;
+
+    fn is_squeeze(&self) -> Self::Variable;
+
+    fn is_root(&self) -> Self::Variable;
+
+    fn is_pad(&self) -> Self::Variable;
+
     fn is_round(&self) -> Self::Variable;
 
     fn round(&self) -> Self::Variable;
 
     fn inverse_round(&self) -> Self::Variable;
-
-    fn absorb(&self) -> Self::Variable;
-
-    fn squeeze(&self) -> Self::Variable;
-
-    fn root(&self) -> Self::Variable;
-
-    fn pad(&self) -> Self::Variable;
 
     fn length(&self) -> Self::Variable;
 
@@ -285,7 +285,23 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
     }
 
     fn is_sponge(&self) -> Self::Variable {
-        Self::xor(self.absorb(), self.squeeze())
+        Self::xor(self.is_absorb(), self.is_squeeze())
+    }
+
+    fn is_absorb(&self) -> Self::Variable {
+        self.keccak_state[KeccakColumn::FlagAbsorb].clone()
+    }
+
+    fn is_squeeze(&self) -> Self::Variable {
+        self.keccak_state[KeccakColumn::FlagSqueeze].clone()
+    }
+
+    fn is_root(&self) -> Self::Variable {
+        self.keccak_state[KeccakColumn::FlagRoot].clone()
+    }
+
+    fn is_pad(&self) -> Self::Variable {
+        self.keccak_state[KeccakColumn::FlagPad].clone()
     }
 
     fn is_round(&self) -> Self::Variable {
@@ -298,22 +314,6 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
 
     fn inverse_round(&self) -> Self::Variable {
         self.keccak_state[KeccakColumn::InverseRound].clone()
-    }
-
-    fn absorb(&self) -> Self::Variable {
-        self.keccak_state[KeccakColumn::FlagAbsorb].clone()
-    }
-
-    fn squeeze(&self) -> Self::Variable {
-        self.keccak_state[KeccakColumn::FlagSqueeze].clone()
-    }
-
-    fn root(&self) -> Self::Variable {
-        self.keccak_state[KeccakColumn::FlagRoot].clone()
-    }
-
-    fn pad(&self) -> Self::Variable {
-        self.keccak_state[KeccakColumn::FlagPad].clone()
     }
 
     fn length(&self) -> Self::Variable {

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -38,7 +38,7 @@ pub(crate) trait BoolOps {
         + Clone;
     type Fp: std::ops::Neg<Output = Self::Fp>;
 
-    fn boolean(x: Self::Variable) -> Self::Variable;
+    fn is_boolean(x: Self::Variable) -> Self::Variable;
 
     fn not(x: Self::Variable) -> Self::Variable;
 


### PR DESCRIPTION
And some slight clean-up of the files where these are being used.