### PR TITLE
[easy] Split `NextState` column across 2 variants for readability

### DIFF
--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -33,11 +33,12 @@ pub enum KeccakColumn {
     PiRhoExpandRotE(usize, usize, usize),     // Round Curr[1065..1165)
     ChiShiftsB(usize, usize, usize, usize),   // Round Curr[1165..1565)
     ChiShiftsSum(usize, usize, usize, usize), // Round Curr[1565..1965)
+    IotaStateG(usize),                        // Round Next[0..100)
     SpongeOldState(usize),                    // Sponge Curr[0..100)
     SpongeNewState(usize),                    // Sponge Curr[100..200)
     SpongeBytes(usize),                       // Sponge Curr[200..400)
     SpongeShifts(usize),                      // Sponge Curr[400..800)
-    NextState(usize),                         // Sponge Next[0..100)
+    SpongeXorState(usize),                    // Absorb Next[0..100)
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -68,11 +69,12 @@ pub struct KeccakColumns<T> {
     pub pi_rho_expand_rot_e: Vec<T>, // Round Curr[1065..1165)
     pub chi_shifts_b: Vec<T>,        // Round Curr[1165..1565)
     pub chi_shifts_sum: Vec<T>,      // Round Curr[1565..1965)
+    pub iota_state_g: Vec<T>,        // Round Next[0..100)
     pub sponge_old_state: Vec<T>,    // Sponge Curr[0..100)
     pub sponge_new_state: Vec<T>,    // Sponge Curr[100..200)
     pub sponge_bytes: Vec<T>,        // Sponge Curr[200..400)
     pub sponge_shifts: Vec<T>,       // Sponge Curr[400..800)
-    pub next_state: Vec<T>,          // Sponge Next[0..100)
+    pub sponge_xor_state: Vec<T>,    // Absorb Next[0..100)
 }
 
 impl<T: Zero + One + Clone> Default for KeccakColumns<T> {
@@ -104,11 +106,12 @@ impl<T: Zero + One + Clone> Default for KeccakColumns<T> {
             pi_rho_expand_rot_e: vec![T::zero(); 100],
             chi_shifts_b: vec![T::zero(); 400],
             chi_shifts_sum: vec![T::zero(); 400],
+            iota_state_g: vec![T::zero(); 100],
             sponge_old_state: vec![T::zero(); 100],
             sponge_new_state: vec![T::zero(); 100],
             sponge_bytes: vec![T::zero(); 200],
             sponge_shifts: vec![T::zero(); 400],
-            next_state: vec![T::zero(); 100],
+            sponge_xor_state: vec![T::zero(); 100],
         }
     }
 }
@@ -162,11 +165,12 @@ impl<A> Index<KeccakColumn> for KeccakColumns<A> {
             KeccakColumn::ChiShiftsSum(i, y, x, q) => {
                 &self.chi_shifts_sum[grid_index(400, i, y, x, q)]
             }
+            KeccakColumn::IotaStateG(i) => &self.iota_state_g[i],
             KeccakColumn::SpongeOldState(i) => &self.sponge_old_state[i],
             KeccakColumn::SpongeNewState(i) => &self.sponge_new_state[i],
             KeccakColumn::SpongeBytes(i) => &self.sponge_bytes[i],
             KeccakColumn::SpongeShifts(i) => &self.sponge_shifts[i],
-            KeccakColumn::NextState(i) => &self.next_state[i],
+            KeccakColumn::SpongeXorState(i) => &self.sponge_xor_state[i],
         }
     }
 }
@@ -226,11 +230,12 @@ impl<A> IndexMut<KeccakColumn> for KeccakColumns<A> {
             KeccakColumn::ChiShiftsSum(i, y, x, q) => {
                 &mut self.chi_shifts_sum[grid_index(400, i, y, x, q)]
             }
+            KeccakColumn::IotaStateG(i) => &mut self.iota_state_g[i],
             KeccakColumn::SpongeOldState(i) => &mut self.sponge_old_state[i],
             KeccakColumn::SpongeNewState(i) => &mut self.sponge_new_state[i],
             KeccakColumn::SpongeBytes(i) => &mut self.sponge_bytes[i],
             KeccakColumn::SpongeShifts(i) => &mut self.sponge_shifts[i],
-            KeccakColumn::NextState(i) => &mut self.next_state[i],
+            KeccakColumn::SpongeXorState(i) => &mut self.sponge_xor_state[i],
         }
     }
 }

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -83,7 +83,7 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
                 // Absorbs the new block by performing XOR with the old state
                 self.constrain(
                     self.is_absorb()
-                        * (self.next_state(i) - (self.old_state(i) + self.new_block(i))),
+                        * (self.xor_state(i) - (self.old_state(i) + self.new_block(i))),
                 );
                 // In absorb, Check shifts correspond to the decomposition of the new state
                 self.constrain(
@@ -246,7 +246,7 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
             // STEP iota: 4 constraints
             for (q, c) in self.round_constants().iter().enumerate() {
                 self.constrain(
-                    self.is_round() * (self.next_state(q) - (state_f[0][0][q].clone() + c.clone())),
+                    self.is_round() * (self.state_g(q) - (state_f[0][0][q].clone() + c.clone())),
                 );
             } // END iota
         }

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -83,12 +83,12 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
                 // Absorbs the new block by performing XOR with the old state
                 self.constrain(
                     self.is_absorb()
-                        * (self.xor_state(i) - (self.old_state(i) + self.new_block(i))),
+                        * (self.xor_state(i) - (self.old_state(i) + self.new_state(i))),
                 );
                 // In absorb, Check shifts correspond to the decomposition of the new state
                 self.constrain(
                     self.is_absorb()
-                        * (self.new_block(i)
+                        * (self.new_state(i)
                             - Self::from_shifts(
                                 &self.keccak_state.sponge_shifts,
                                 Some(i),

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -186,7 +186,7 @@ pub(crate) trait KeccakEnvironment {
 
     fn new_block(&self, i: usize) -> Self::Variable;
 
-    fn next_state(&self, i: usize) -> Self::Variable;
+    fn xor_state(&self, i: usize) -> Self::Variable;
 
     fn sponge_zeros(&self) -> Vec<Self::Variable>;
 
@@ -225,6 +225,8 @@ pub(crate) trait KeccakEnvironment {
     fn shifts_b(&self, i: usize, y: usize, x: usize, q: usize) -> Self::Variable;
 
     fn shifts_sum(&self, i: usize, y: usize, x: usize, q: usize) -> Self::Variable;
+
+    fn state_g(&self, i: usize) -> Self::Variable;
 }
 
 impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
@@ -378,8 +380,8 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
         self.keccak_state[KeccakColumn::SpongeNewState(i)].clone()
     }
 
-    fn next_state(&self, i: usize) -> Self::Variable {
-        self.keccak_state[KeccakColumn::NextState(i)].clone()
+    fn xor_state(&self, i: usize) -> Self::Variable {
+        self.keccak_state[KeccakColumn::SpongeXorState(i)].clone()
     }
 
     fn sponge_zeros(&self) -> Vec<Self::Variable> {
@@ -456,5 +458,9 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
 
     fn shifts_sum(&self, i: usize, y: usize, x: usize, q: usize) -> Self::Variable {
         self.keccak_state[KeccakColumn::ChiShiftsSum(i, y, x, q)].clone()
+    }
+
+    fn state_g(&self, i: usize) -> Self::Variable {
+        self.keccak_state[KeccakColumn::SpongeXorState(i)].clone()
     }
 }

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -184,7 +184,7 @@ pub(crate) trait KeccakEnvironment {
 
     fn old_state(&self, i: usize) -> Self::Variable;
 
-    fn new_block(&self, i: usize) -> Self::Variable;
+    fn new_state(&self, i: usize) -> Self::Variable;
 
     fn xor_state(&self, i: usize) -> Self::Variable;
 
@@ -376,7 +376,7 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
         self.keccak_state[KeccakColumn::SpongeOldState(i)].clone()
     }
 
-    fn new_block(&self, i: usize) -> Self::Variable {
+    fn new_state(&self, i: usize) -> Self::Variable {
         self.keccak_state[KeccakColumn::SpongeNewState(i)].clone()
     }
 

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -460,7 +460,7 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
         self.keccak_state[KeccakColumn::ChiShiftsSum(i, y, x, q)].clone()
     }
 
-    fn state_g(&self, i: usize) -> Self::Variable {
-        self.keccak_state[KeccakColumn::SpongeXorState(i)].clone()
+    fn state_g(&self, q: usize) -> Self::Variable {
+        self.keccak_state[KeccakColumn::IotaStateG(q)].clone()
     }
 }

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -186,7 +186,7 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         for i in 0..QUARTERS * DIM * DIM {
             self.write_column(KeccakColumn::SpongeOldState(i), old_state[i]);
             self.write_column(KeccakColumn::SpongeNewState(i), new_state[i]);
-            self.write_column(KeccakColumn::NextState(i), xor_state[i]);
+            self.write_column(KeccakColumn::SpongeXorState(i), xor_state[i]);
         }
         for (i, value) in bytes.iter().enumerate() {
             self.write_column(KeccakColumn::SpongeBytes(i), *value);
@@ -307,7 +307,7 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
 
         // Update columns
         for i in 0..STATE_LEN {
-            self.write_column(KeccakColumn::NextState(i), iota.state_g(i));
+            self.write_column(KeccakColumn::IotaStateG(i), iota.state_g(i));
         }
         for i in 0..QUARTERS {
             self.write_column(KeccakColumn::RoundConstants(i), iota.rc(i));


### PR DESCRIPTION
Even if this PR seems to increase the number of total columns by 100, a coming PR will eventually reduce it by 800. This is just a preliminary step so the diff is smaller.

It also fixes a notation deviation between `new_block` (which referred in Kimchi to just 1088 bits) and `new_state` (which refers to all 1600 bits).