### PR TITLE
[easy] Clean-up of Keccak lookups (no-op)

### DIFF
--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::mips::interpreter::{Lookup, LookupTable, Signed};
 use ark_ff::Field;
-use kimchi::circuits::polynomials::keccak::constants::{QUARTERS, SHIFTS_LEN, STATE_LEN};
+use kimchi::circuits::polynomials::keccak::constants::{QUARTERS, SHIFTS, SHIFTS_LEN, STATE_LEN};
 
 pub(crate) trait Lookups {
     type Column;
@@ -37,167 +37,153 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
         // SPONGE LOOKUPS
         {
             // PADDING LOOKUPS
-            {
-                // Power of two corresponds to 2^pad_length
-                // Pad suffixes correspond to 10*1 rule
+            // Power of two corresponds to 2^pad_length
+            // Pad suffixes correspond to 10*1 rule
+            // Note: When FlagLength=0, TwoToPad=1, and all PadSuffix=0
+            self.add_lookup(Lookup {
+                numerator: Signed::read_one(),
+                table_id: LookupTable::PadLookup,
+                value: vec![
+                    self.keccak_state[KeccakColumn::FlagLength].clone(),
+                    self.two_to_pad(),
+                    self.pad_suffix(0),
+                    self.pad_suffix(1),
+                    self.pad_suffix(2),
+                    self.pad_suffix(3),
+                    self.pad_suffix(4),
+                ],
+            });
+            // BYTES LOOKUPS
+            for i in 0..200 {
+                // Bytes are <2^8
                 self.add_lookup(Lookup {
                     numerator: Signed::read_one(),
-                    table_id: LookupTable::PadLookup,
-                    value: vec![
-                        self.keccak_state[KeccakColumn::FlagLength].clone(),
-                        self.two_to_pad(),
-                        self.pad_suffix(0),
-                        self.pad_suffix(1),
-                        self.pad_suffix(2),
-                        self.pad_suffix(3),
-                        self.pad_suffix(4),
-                    ],
+                    table_id: LookupTable::ByteLookup,
+                    value: vec![self.sponge_bytes(i)],
                 })
-                // Note: When FlagLength=0, TwoToPad=1, and all PadSuffix=0
-            }
-            // BYTES LOOKUPS
-            {
-                // Bytes are <2^8
-                for i in 0..200 {
-                    self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
-                        table_id: LookupTable::ByteLookup,
-                        value: vec![self.sponge_bytes(i)],
-                    })
-                }
             }
             // SHIFTS LOOKUPS
-            {
+            for i in 100..SHIFTS_LEN {
                 // Shifts1, Shifts2, Shifts3 are in the Sparse table
-                for i in 100..SHIFTS_LEN {
-                    self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
-                        table_id: LookupTable::SparseLookup,
-                        value: vec![self.sponge_shift(i)],
-                    })
-                }
+                self.add_lookup(Lookup {
+                    numerator: Signed::read_one(),
+                    table_id: LookupTable::SparseLookup,
+                    value: vec![self.sponge_shift(i)],
+                })
+            }
+            for i in 0..STATE_LEN {
                 // Shifts0 together with Bits composition by pairs are in the Reset table
-                for i in 0..STATE_LEN {
-                    self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
-                        table_id: LookupTable::ResetLookup,
-                        value: vec![
-                            self.sponge_bytes(2 * i)
-                                + self.sponge_bytes(2 * i + 1) * Self::two_pow(8),
-                            self.sponge_shift(i),
-                        ],
-                    })
-                }
+                self.add_lookup(Lookup {
+                    numerator: Signed::read_one(),
+                    table_id: LookupTable::ResetLookup,
+                    value: vec![
+                        self.sponge_bytes(2 * i) + self.sponge_bytes(2 * i + 1) * Self::two_pow(8),
+                        self.sponge_shift(i),
+                    ],
+                })
             }
         }
 
         // ROUND LOOKUPS
         {
             // THETA LOOKUPS
-            {
-                for i in 0..20 {
-                    // Check ThetaShiftC0 is the expansion of ThetaDenseC
+            for i in 0..20 {
+                // Check that ThetaRemainderC < 2^64
+                self.add_lookup(Lookup {
+                    numerator: Signed::read_one(),
+                    table_id: LookupTable::RangeCheck16Lookup,
+                    value: vec![self.keccak_state.theta_remainder_c[i].clone()],
+                });
+                // Check ThetaExpandRotC is the expansion of ThetaDenseRotC
+                self.add_lookup(Lookup {
+                    numerator: Signed::read_one(),
+                    table_id: LookupTable::ResetLookup,
+                    value: vec![
+                        self.keccak_state.theta_dense_rot_c[i].clone(),
+                        self.keccak_state.theta_expand_rot_c[i].clone(),
+                    ],
+                });
+                // Check ThetaShiftC0 is the expansion of ThetaDenseC
+                self.add_lookup(Lookup {
+                    numerator: Signed::read_one(),
+                    table_id: LookupTable::ResetLookup,
+                    value: vec![
+                        self.keccak_state.theta_dense_c[i].clone(),
+                        self.keccak_state.theta_shifts_c[i].clone(),
+                    ],
+                });
+                // Check that the rest of ThetaShiftsC are in the Sparse table
+                for j in 1..SHIFTS {
                     self.add_lookup(Lookup {
                         numerator: Signed::read_one(),
-                        table_id: LookupTable::ResetLookup,
-                        value: vec![
-                            self.keccak_state.theta_dense_c[i].clone(),
-                            self.keccak_state.theta_shifts_c[i].clone(),
-                        ],
-                    });
-                    // Check ThetaExpandRotC is the expansion of ThetaDenseRotC
-                    self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
-                        table_id: LookupTable::ResetLookup,
-                        value: vec![
-                            self.keccak_state.theta_dense_rot_c[i].clone(),
-                            self.keccak_state.theta_expand_rot_c[i].clone(),
-                        ],
-                    });
-                    // Check that the rest of ThetaShiftsC are in the Sparse table
-                    for j in 1..4 {
-                        self.add_lookup(Lookup {
-                            numerator: Signed::read_one(),
-                            table_id: LookupTable::SparseLookup,
-                            value: vec![self.keccak_state.theta_shifts_c[i + 20 * j].clone()],
-                        });
-                    }
-                    // Check that ThetaRemainderC < 2^64
-                    self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
-                        table_id: LookupTable::RangeCheck16Lookup,
-                        value: vec![self.keccak_state.theta_remainder_c[i].clone()],
+                        table_id: LookupTable::SparseLookup,
+                        value: vec![self.keccak_state.theta_shifts_c[i + 20 * j].clone()],
                     });
                 }
             }
             // PIRHO LOOKUPS
-            {
-                for i in 0..STATE_LEN {
-                    // Check PiRhoShift0E is the expansion of PiRhoDenseE
-                    self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
-                        table_id: LookupTable::ResetLookup,
-                        value: vec![
-                            self.keccak_state.pi_rho_dense_e[i].clone(),
-                            self.keccak_state.pi_rho_shifts_e[i].clone(),
-                        ],
-                    });
-                    // Check PiRhoExpandRotE is the expansion of PiRhoDenseRotE
-                    self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
-                        table_id: LookupTable::ResetLookup,
-                        value: vec![
-                            self.keccak_state.pi_rho_dense_rot_e[i].clone(),
-                            self.keccak_state.pi_rho_expand_rot_e[i].clone(),
-                        ],
-                    });
-                    // Check that PiRhoRemainderE < 2^64 and PiRhoQuotientE < 2^64
-                    self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
-                        table_id: LookupTable::RangeCheck16Lookup,
-                        value: vec![self.keccak_state.pi_rho_remainder_e[i].clone()],
-                    });
-                    self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
-                        table_id: LookupTable::RangeCheck16Lookup,
-                        value: vec![self.keccak_state.pi_rho_quotient_e[i].clone()],
-                    });
-                }
-                // Check that the rest of PiRhoShiftsE are in the Sparse table
-                for i in 100..SHIFTS_LEN {
-                    self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
-                        table_id: LookupTable::SparseLookup,
-                        value: vec![self.keccak_state.pi_rho_shifts_e[i].clone()],
-                    });
-                }
+            for i in 0..STATE_LEN {
+                // Check that PiRhoRemainderE < 2^64 and PiRhoQuotientE < 2^64
+                self.add_lookup(Lookup {
+                    numerator: Signed::read_one(),
+                    table_id: LookupTable::RangeCheck16Lookup,
+                    value: vec![self.keccak_state.pi_rho_remainder_e[i].clone()],
+                });
+                self.add_lookup(Lookup {
+                    numerator: Signed::read_one(),
+                    table_id: LookupTable::RangeCheck16Lookup,
+                    value: vec![self.keccak_state.pi_rho_quotient_e[i].clone()],
+                });
+                // Check PiRhoExpandRotE is the expansion of PiRhoDenseRotE
+                self.add_lookup(Lookup {
+                    numerator: Signed::read_one(),
+                    table_id: LookupTable::ResetLookup,
+                    value: vec![
+                        self.keccak_state.pi_rho_dense_rot_e[i].clone(),
+                        self.keccak_state.pi_rho_expand_rot_e[i].clone(),
+                    ],
+                });
+                // Check PiRhoShift0E is the expansion of PiRhoDenseE
+                self.add_lookup(Lookup {
+                    numerator: Signed::read_one(),
+                    table_id: LookupTable::ResetLookup,
+                    value: vec![
+                        self.keccak_state.pi_rho_dense_e[i].clone(),
+                        self.keccak_state.pi_rho_shifts_e[i].clone(),
+                    ],
+                });
             }
+            // Check that the rest of PiRhoShiftsE are in the Sparse table
+            for i in 100..SHIFTS_LEN {
+                self.add_lookup(Lookup {
+                    numerator: Signed::read_one(),
+                    table_id: LookupTable::SparseLookup,
+                    value: vec![self.keccak_state.pi_rho_shifts_e[i].clone()],
+                });
+            }
+
             // CHI LOOKUPS
-            {
+            for i in 0..SHIFTS_LEN {
                 // Check ChiShiftsB and ChiShiftsSum are in the Sparse table
-                for i in 0..SHIFTS_LEN {
-                    self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
-                        table_id: LookupTable::SparseLookup,
-                        value: vec![self.keccak_state.chi_shifts_b[i].clone()],
-                    });
-                    self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
-                        table_id: LookupTable::SparseLookup,
-                        value: vec![self.keccak_state.chi_shifts_sum[i].clone()],
-                    });
-                }
+                self.add_lookup(Lookup {
+                    numerator: Signed::read_one(),
+                    table_id: LookupTable::SparseLookup,
+                    value: vec![self.keccak_state.chi_shifts_b[i].clone()],
+                });
+                self.add_lookup(Lookup {
+                    numerator: Signed::read_one(),
+                    table_id: LookupTable::SparseLookup,
+                    value: vec![self.keccak_state.chi_shifts_sum[i].clone()],
+                });
             }
             // IOTA LOOKUPS
-            {
+            for i in 0..QUARTERS {
                 // Check round constants correspond with the current round
-                for i in 0..QUARTERS {
-                    self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
-                        table_id: LookupTable::RoundConstantsLookup,
-                        value: vec![self.round(), self.keccak_state.round_constants[i].clone()],
-                    });
-                }
+                self.add_lookup(Lookup {
+                    numerator: Signed::read_one(),
+                    table_id: LookupTable::RoundConstantsLookup,
+                    value: vec![self.round(), self.keccak_state.round_constants[i].clone()],
+                });
             }
         }
     }


### PR DESCRIPTION
This is to make the coming structure of the columns more readable.

This PR is a no-op. It just moves code blocks around and gets rid of some indentations.