### PR TITLE
[easy] Add `curr` and `next` row vectors inside `KeccakColumns`

### DIFF
--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -3,7 +3,7 @@ use std::ops::{Index, IndexMut};
 use ark_ff::{One, Zero};
 use serde::{Deserialize, Serialize};
 
-use super::grid_index;
+use super::{grid_index, ZKVM_KECCAK_COLS_CURR, ZKVM_KECCAK_COLS_NEXT};
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum KeccakColumn {
@@ -75,6 +75,28 @@ pub struct KeccakColumns<T> {
     pub sponge_bytes: Vec<T>,        // Sponge Curr[200..400)
     pub sponge_shifts: Vec<T>,       // Sponge Curr[400..800)
     pub sponge_xor_state: Vec<T>,    // Absorb Next[0..100)
+    pub curr: Vec<T>,                // Curr[0..1965)
+    pub next: Vec<T>,                // Next[0..100)
+}
+
+impl<T: Clone> KeccakColumns<T> {
+    fn _curr(&self, offset: usize, length: usize, i: usize, y: usize, x: usize, q: usize) -> &T {
+        &self.curr[offset + grid_index(length, i, y, x, q)]
+    }
+    fn _mut_curr(
+        &mut self,
+        offset: usize,
+        length: usize,
+        i: usize,
+        y: usize,
+        x: usize,
+        q: usize,
+    ) -> &mut T {
+        &mut self.curr[offset + grid_index(length, i, y, x, q)]
+    }
+    pub fn chunk(&self, offset: usize, length: usize) -> Vec<T> {
+        self.curr[offset..offset + length].to_vec().clone()
+    }
 }
 
 impl<T: Zero + One + Clone> Default for KeccakColumns<T> {
@@ -112,6 +134,8 @@ impl<T: Zero + One + Clone> Default for KeccakColumns<T> {
             sponge_bytes: vec![T::zero(); 200],
             sponge_shifts: vec![T::zero(); 400],
             sponge_xor_state: vec![T::zero(); 100],
+            curr: vec![T::zero(); ZKVM_KECCAK_COLS_CURR],
+            next: vec![T::zero(); ZKVM_KECCAK_COLS_NEXT],
         }
     }
 }

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -1,6 +1,6 @@
 use kimchi::circuits::{
     expr::{ConstantExpr, Expr},
-    polynomials::keccak::constants::{DIM, KECCAK_COLS, QUARTERS},
+    polynomials::keccak::constants::{DIM, KECCAK_COLS, QUARTERS, STATE_LEN},
 };
 
 use self::column::KeccakColumn;
@@ -15,13 +15,14 @@ pub mod witness;
 pub(crate) const HASH_BITLENGTH: usize = 256;
 pub(crate) const HASH_BYTELENGTH: usize = HASH_BITLENGTH / 8;
 pub(crate) const WORD_LENGTH_IN_BITS: usize = 64;
-pub(crate) const _ZKVM_KECCAK_COLS: usize = KECCAK_COLS + 4 + 6;
+pub(crate) const ZKVM_KECCAK_COLS_CURR: usize = KECCAK_COLS;
+pub(crate) const ZKVM_KECCAK_COLS_NEXT: usize = STATE_LEN;
 pub(crate) const WORDS_IN_HASH: usize = HASH_BITLENGTH / WORD_LENGTH_IN_BITS;
 
 pub(crate) type E<F> = Expr<ConstantExpr<F>, KeccakColumn>;
 
-fn grid_index(size: usize, i: usize, y: usize, x: usize, q: usize) -> usize {
-    match size {
+fn grid_index(length: usize, i: usize, y: usize, x: usize, q: usize) -> usize {
+    match length {
         5 => x,
         20 => q + QUARTERS * x,
         80 => q + QUARTERS * (x + DIM * i),


### PR DESCRIPTION
This PR adds two more elements inside the `KeccakColumns` struct in order to keep track of the columns located in the `Curr` and `Next` rows of the Kimchi implementation. The goal of this addition is to be able to remove 800 columns eventually by providing an unified "storage", but allowing for a fine-grained access to each `KeccakColumn` variant.

This PR is meant to make the diff look smaller. Coming PR will actually remove those redundant columns.