### PR TITLE
[easy] Read/Write modes for Signed numerators in Lookups

### DIFF
--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -3,7 +3,7 @@ use super::{
     environment::{KeccakEnv, KeccakEnvironment},
     ArithOps, E,
 };
-use crate::mips::interpreter::{Lookup, LookupMode, LookupTable, Signed};
+use crate::mips::interpreter::{Lookup, LookupTable};
 use ark_ff::Field;
 use kimchi::circuits::polynomials::keccak::constants::{
     DIM, QUARTERS, SHIFTS, SHIFTS_LEN, STATE_LEN,
@@ -42,11 +42,10 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
             // Power of two corresponds to 2^pad_length
             // Pad suffixes correspond to 10*1 rule
             // Note: When FlagLength=0, TwoToPad=1, and all PadSuffix=0
-            self.add_lookup(Lookup {
-                numerator: Signed::new(LookupMode::Read, None),
-                table_id: LookupTable::PadLookup,
-                value: vec![
-                    self.keccak_state[KeccakColumn::FlagLength].clone(),
+            self.add_lookup(Lookup::read_one(
+                LookupTable::PadLookup,
+                vec![
+                    self.length(),
                     self.two_to_pad(),
                     self.pad_suffix(0),
                     self.pad_suffix(1),
@@ -54,35 +53,32 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
                     self.pad_suffix(3),
                     self.pad_suffix(4),
                 ],
-            });
+            ));
             // BYTES LOOKUPS
             for i in 0..200 {
                 // Bytes are <2^8
-                self.add_lookup(Lookup {
-                    numerator: Signed::new(LookupMode::Read, None),
-                    table_id: LookupTable::ByteLookup,
-                    value: vec![self.sponge_bytes(i)],
-                })
+                self.add_lookup(Lookup::read_one(
+                    LookupTable::ByteLookup,
+                    vec![self.sponge_bytes(i)],
+                ));
             }
             // SHIFTS LOOKUPS
             for i in 100..SHIFTS_LEN {
                 // Shifts1, Shifts2, Shifts3 are in the Sparse table
-                self.add_lookup(Lookup {
-                    numerator: Signed::new(LookupMode::Read, None),
-                    table_id: LookupTable::SparseLookup,
-                    value: vec![self.sponge_shifts(i)],
-                })
+                self.add_lookup(Lookup::read_one(
+                    LookupTable::SparseLookup,
+                    vec![self.sponge_shifts(i)],
+                ));
             }
             for i in 0..STATE_LEN {
                 // Shifts0 together with Bits composition by pairs are in the Reset table
-                self.add_lookup(Lookup {
-                    numerator: Signed::new(LookupMode::Read, None),
-                    table_id: LookupTable::ResetLookup,
-                    value: vec![
+                self.add_lookup(Lookup::read_one(
+                    LookupTable::ResetLookup,
+                    vec![
                         self.sponge_bytes(2 * i) + self.sponge_bytes(2 * i + 1) * Self::two_pow(8),
                         self.sponge_shifts(i),
                     ],
-                })
+                ));
             }
         }
 
@@ -92,30 +88,26 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
             for q in 0..QUARTERS {
                 for x in 0..DIM {
                     // Check that ThetaRemainderC < 2^64
-                    self.add_lookup(Lookup {
-                        numerator: Signed::new(LookupMode::Read, None),
-                        table_id: LookupTable::RangeCheck16Lookup,
-                        value: vec![self.remainder_c(x, q).clone()],
-                    });
+                    self.add_lookup(Lookup::read_one(
+                        LookupTable::RangeCheck16Lookup,
+                        vec![self.remainder_c(x, q)],
+                    ));
                     // Check ThetaExpandRotC is the expansion of ThetaDenseRotC
-                    self.add_lookup(Lookup {
-                        numerator: Signed::new(LookupMode::Read, None),
-                        table_id: LookupTable::ResetLookup,
-                        value: vec![self.dense_rot_c(x, q), self.expand_rot_c(x, q)],
-                    });
+                    self.add_lookup(Lookup::read_one(
+                        LookupTable::ResetLookup,
+                        vec![self.dense_rot_c(x, q), self.expand_rot_c(x, q)],
+                    ));
                     // Check ThetaShiftC0 is the expansion of ThetaDenseC
-                    self.add_lookup(Lookup {
-                        numerator: Signed::new(LookupMode::Read, None),
-                        table_id: LookupTable::ResetLookup,
-                        value: vec![self.dense_c(x, q), self.shifts_c(0, x, q)],
-                    });
+                    self.add_lookup(Lookup::read_one(
+                        LookupTable::ResetLookup,
+                        vec![self.dense_c(x, q), self.shifts_c(0, x, q)],
+                    ));
                     // Check that the rest of ThetaShiftsC are in the Sparse table
                     for i in 1..SHIFTS {
-                        self.add_lookup(Lookup {
-                            numerator: Signed::new(LookupMode::Read, None),
-                            table_id: LookupTable::SparseLookup,
-                            value: vec![self.shifts_c(i, x, q)],
-                        });
+                        self.add_lookup(Lookup::read_one(
+                            LookupTable::SparseLookup,
+                            vec![self.shifts_c(i, x, q)],
+                        ));
                     }
                 }
             }
@@ -124,35 +116,30 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
                 for x in 0..DIM {
                     for y in 0..DIM {
                         // Check that PiRhoRemainderE < 2^64 and PiRhoQuotientE < 2^64
-                        self.add_lookup(Lookup {
-                            numerator: Signed::new(LookupMode::Read, None),
-                            table_id: LookupTable::RangeCheck16Lookup,
-                            value: vec![self.remainder_e(y, x, q)],
-                        });
-                        self.add_lookup(Lookup {
-                            numerator: Signed::new(LookupMode::Read, None),
-                            table_id: LookupTable::RangeCheck16Lookup,
-                            value: vec![self.quotient_e(y, x, q)],
-                        });
+                        self.add_lookup(Lookup::read_one(
+                            LookupTable::RangeCheck16Lookup,
+                            vec![self.remainder_e(y, x, q)],
+                        ));
+                        self.add_lookup(Lookup::read_one(
+                            LookupTable::RangeCheck16Lookup,
+                            vec![self.quotient_e(y, x, q)],
+                        ));
                         // Check PiRhoExpandRotE is the expansion of PiRhoDenseRotE
-                        self.add_lookup(Lookup {
-                            numerator: Signed::new(LookupMode::Read, None),
-                            table_id: LookupTable::ResetLookup,
-                            value: vec![self.dense_rot_e(y, x, q), self.expand_rot_e(y, x, q)],
-                        });
+                        self.add_lookup(Lookup::read_one(
+                            LookupTable::ResetLookup,
+                            vec![self.dense_rot_e(y, x, q), self.expand_rot_e(y, x, q)],
+                        ));
                         // Check PiRhoShift0E is the expansion of PiRhoDenseE
-                        self.add_lookup(Lookup {
-                            numerator: Signed::new(LookupMode::Read, None),
-                            table_id: LookupTable::ResetLookup,
-                            value: vec![self.dense_e(y, x, q), self.shifts_e(0, y, x, q)],
-                        });
+                        self.add_lookup(Lookup::read_one(
+                            LookupTable::ResetLookup,
+                            vec![self.dense_e(y, x, q), self.shifts_e(0, y, x, q)],
+                        ));
                         // Check that the rest of PiRhoShiftsE are in the Sparse table
                         for i in 1..SHIFTS {
-                            self.add_lookup(Lookup {
-                                numerator: Signed::new(LookupMode::Read, None),
-                                table_id: LookupTable::SparseLookup,
-                                value: vec![self.shifts_e(i, y, x, q)],
-                            });
+                            self.add_lookup(Lookup::read_one(
+                                LookupTable::SparseLookup,
+                                vec![self.shifts_e(i, y, x, q)],
+                            ));
                         }
                     }
                 }
@@ -160,25 +147,22 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
             // CHI LOOKUPS
             for i in 0..SHIFTS_LEN {
                 // Check ChiShiftsB and ChiShiftsSum are in the Sparse table
-                self.add_lookup(Lookup {
-                    numerator: Signed::new(LookupMode::Read, None),
-                    table_id: LookupTable::SparseLookup,
-                    value: vec![self.vec_shifts_b()[i].clone()],
-                });
-                self.add_lookup(Lookup {
-                    numerator: Signed::new(LookupMode::Read, None),
-                    table_id: LookupTable::SparseLookup,
-                    value: vec![self.vec_shifts_sum()[i].clone()],
-                });
+                self.add_lookup(Lookup::read_one(
+                    LookupTable::SparseLookup,
+                    vec![self.vec_shifts_b()[i].clone()],
+                ));
+                self.add_lookup(Lookup::read_one(
+                    LookupTable::SparseLookup,
+                    vec![self.vec_shifts_sum()[i].clone()],
+                ));
             }
             // IOTA LOOKUPS
             for i in 0..QUARTERS {
                 // Check round constants correspond with the current round
-                self.add_lookup(Lookup {
-                    numerator: Signed::new(LookupMode::Read, None),
-                    table_id: LookupTable::RoundConstantsLookup,
-                    value: vec![self.round(), self.round_constants()[i].clone()],
-                });
+                self.add_lookup(Lookup::read_one(
+                    LookupTable::ResetLookup,
+                    vec![self.round(), self.round_constants()[i].clone()],
+                ));
             }
         }
     }

--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -3,7 +3,7 @@ use super::{
     environment::{KeccakEnv, KeccakEnvironment},
     ArithOps, E,
 };
-use crate::mips::interpreter::{Lookup, LookupTable, Signed};
+use crate::mips::interpreter::{Lookup, LookupMode, LookupTable, Signed};
 use ark_ff::Field;
 use kimchi::circuits::polynomials::keccak::constants::{
     DIM, QUARTERS, SHIFTS, SHIFTS_LEN, STATE_LEN,
@@ -43,7 +43,7 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
             // Pad suffixes correspond to 10*1 rule
             // Note: When FlagLength=0, TwoToPad=1, and all PadSuffix=0
             self.add_lookup(Lookup {
-                numerator: Signed::read_one(),
+                numerator: Signed::new(LookupMode::Read, None),
                 table_id: LookupTable::PadLookup,
                 value: vec![
                     self.keccak_state[KeccakColumn::FlagLength].clone(),
@@ -59,7 +59,7 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
             for i in 0..200 {
                 // Bytes are <2^8
                 self.add_lookup(Lookup {
-                    numerator: Signed::read_one(),
+                    numerator: Signed::new(LookupMode::Read, None),
                     table_id: LookupTable::ByteLookup,
                     value: vec![self.sponge_bytes(i)],
                 })
@@ -68,7 +68,7 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
             for i in 100..SHIFTS_LEN {
                 // Shifts1, Shifts2, Shifts3 are in the Sparse table
                 self.add_lookup(Lookup {
-                    numerator: Signed::read_one(),
+                    numerator: Signed::new(LookupMode::Read, None),
                     table_id: LookupTable::SparseLookup,
                     value: vec![self.sponge_shifts(i)],
                 })
@@ -76,7 +76,7 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
             for i in 0..STATE_LEN {
                 // Shifts0 together with Bits composition by pairs are in the Reset table
                 self.add_lookup(Lookup {
-                    numerator: Signed::read_one(),
+                    numerator: Signed::new(LookupMode::Read, None),
                     table_id: LookupTable::ResetLookup,
                     value: vec![
                         self.sponge_bytes(2 * i) + self.sponge_bytes(2 * i + 1) * Self::two_pow(8),
@@ -93,26 +93,26 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
                 for x in 0..DIM {
                     // Check that ThetaRemainderC < 2^64
                     self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
+                        numerator: Signed::new(LookupMode::Read, None),
                         table_id: LookupTable::RangeCheck16Lookup,
                         value: vec![self.remainder_c(x, q).clone()],
                     });
                     // Check ThetaExpandRotC is the expansion of ThetaDenseRotC
                     self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
+                        numerator: Signed::new(LookupMode::Read, None),
                         table_id: LookupTable::ResetLookup,
                         value: vec![self.dense_rot_c(x, q), self.expand_rot_c(x, q)],
                     });
                     // Check ThetaShiftC0 is the expansion of ThetaDenseC
                     self.add_lookup(Lookup {
-                        numerator: Signed::read_one(),
+                        numerator: Signed::new(LookupMode::Read, None),
                         table_id: LookupTable::ResetLookup,
                         value: vec![self.dense_c(x, q), self.shifts_c(0, x, q)],
                     });
                     // Check that the rest of ThetaShiftsC are in the Sparse table
                     for i in 1..SHIFTS {
                         self.add_lookup(Lookup {
-                            numerator: Signed::read_one(),
+                            numerator: Signed::new(LookupMode::Read, None),
                             table_id: LookupTable::SparseLookup,
                             value: vec![self.shifts_c(i, x, q)],
                         });
@@ -125,31 +125,31 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
                     for y in 0..DIM {
                         // Check that PiRhoRemainderE < 2^64 and PiRhoQuotientE < 2^64
                         self.add_lookup(Lookup {
-                            numerator: Signed::read_one(),
+                            numerator: Signed::new(LookupMode::Read, None),
                             table_id: LookupTable::RangeCheck16Lookup,
                             value: vec![self.remainder_e(y, x, q)],
                         });
                         self.add_lookup(Lookup {
-                            numerator: Signed::read_one(),
+                            numerator: Signed::new(LookupMode::Read, None),
                             table_id: LookupTable::RangeCheck16Lookup,
                             value: vec![self.quotient_e(y, x, q)],
                         });
                         // Check PiRhoExpandRotE is the expansion of PiRhoDenseRotE
                         self.add_lookup(Lookup {
-                            numerator: Signed::read_one(),
+                            numerator: Signed::new(LookupMode::Read, None),
                             table_id: LookupTable::ResetLookup,
                             value: vec![self.dense_rot_e(y, x, q), self.expand_rot_e(y, x, q)],
                         });
                         // Check PiRhoShift0E is the expansion of PiRhoDenseE
                         self.add_lookup(Lookup {
-                            numerator: Signed::read_one(),
+                            numerator: Signed::new(LookupMode::Read, None),
                             table_id: LookupTable::ResetLookup,
                             value: vec![self.dense_e(y, x, q), self.shifts_e(0, y, x, q)],
                         });
                         // Check that the rest of PiRhoShiftsE are in the Sparse table
                         for i in 1..SHIFTS {
                             self.add_lookup(Lookup {
-                                numerator: Signed::read_one(),
+                                numerator: Signed::new(LookupMode::Read, None),
                                 table_id: LookupTable::SparseLookup,
                                 value: vec![self.shifts_e(i, y, x, q)],
                             });
@@ -161,12 +161,12 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
             for i in 0..SHIFTS_LEN {
                 // Check ChiShiftsB and ChiShiftsSum are in the Sparse table
                 self.add_lookup(Lookup {
-                    numerator: Signed::read_one(),
+                    numerator: Signed::new(LookupMode::Read, None),
                     table_id: LookupTable::SparseLookup,
                     value: vec![self.vec_shifts_b()[i].clone()],
                 });
                 self.add_lookup(Lookup {
-                    numerator: Signed::read_one(),
+                    numerator: Signed::new(LookupMode::Read, None),
                     table_id: LookupTable::SparseLookup,
                     value: vec![self.vec_shifts_sum()[i].clone()],
                 });
@@ -175,7 +175,7 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
             for i in 0..QUARTERS {
                 // Check round constants correspond with the current round
                 self.add_lookup(Lookup {
-                    numerator: Signed::read_one(),
+                    numerator: Signed::new(LookupMode::Read, None),
                     table_id: LookupTable::RoundConstantsLookup,
                     value: vec![self.round(), self.round_constants()[i].clone()],
                 });

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -149,6 +149,14 @@ impl<T: One> Signed<T> {
             },
         }
     }
+
+    pub fn read_one() -> Self {
+        Self::new(LookupMode::Read, None)
+    }
+
+    pub fn write_one() -> Self {
+        Self::new(LookupMode::Write, None)
+    }
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -127,17 +127,26 @@ pub struct Signed<T> {
     pub magnitude: T,
 }
 
+#[derive(Copy, Clone)]
+pub enum LookupMode {
+    Read,
+    Write,
+}
+
 impl<T: One> Signed<T> {
-    pub fn read_one() -> Self {
-        Self {
-            sign: Sign::Neg,
-            magnitude: T::one(),
-        }
-    }
-    pub fn write_one() -> Self {
-        Self {
-            sign: Sign::Pos,
-            magnitude: T::one(),
+    /// Creates a new Signed element, either a Read or a Write, and can be null if the flag is zero
+    // TODO: if the flag trick works, then RC does not need to be length 25 anymore nor nonzero default column values
+    // FIXME: check what is the value of the flags at the witness stage
+    pub fn new(rw: LookupMode, flag: Option<T>) -> Self {
+        match rw {
+            LookupMode::Read => Self {
+                sign: Sign::Neg,
+                magnitude: flag.unwrap_or_else(|| T::one()),
+            },
+            LookupMode::Write => Self {
+                sign: Sign::Pos,
+                magnitude: flag.unwrap_or_else(|| T::one()),
+            },
         }
     }
 }


### PR DESCRIPTION
This PR adds an enum `LookupMode` whose variants are `Read` and `Write`, which act as wrappers for the positive and negative signs of the numerator of RAMLookups. Together with a flag selector argument which acts as the magnitude of elements added to the tables, these changes will facilitate the creation of lookups inside the Keccak workflow. In particular:

- thanks to the mode, witness and constraints will be able to reuse the same `lookups()` function to either "create" or "consume" the values in the table; and,
- thanks to the flag, lookups will be easily "switched on/off" depending on whether the Keccak step is a sponge or a round, without conflicts due to the reused vector positions to save 800 columns.