### PR TITLE
[easy] Reuse code for lookups inside Keccak constraints and witness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,6 +1499,8 @@ name = "mina-book"
 version = "0.1.0"
 dependencies = [
  "cargo-spec",
+ "plist",
+ "time",
 ]
 
 [[package]]

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -1,11 +1,8 @@
-use crate::{
-    keccak::{
-        column::KeccakColumn,
-        environment::{KeccakEnv, KeccakEnvironment},
-        lookups::Lookups,
-        {ArithOps, BoolOps, E, WORDS_IN_HASH},
-    },
-    mips::interpreter::LookupMode,
+use crate::keccak::{
+    column::KeccakColumn,
+    environment::{KeccakEnv, KeccakEnvironment},
+    lookups::Lookups,
+    {ArithOps, BoolOps, E, WORDS_IN_HASH},
 };
 use ark_ff::Field;
 use kimchi::circuits::polynomials::keccak::{
@@ -254,7 +251,7 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
             } // END iota
         }
 
-        // LOOKUP CONSTRAINTS
-        self.lookups(LookupMode::Read);
+        // READ LOOKUP CONSTRAINTS
+        self.lookups();
     }
 }

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -1,7 +1,11 @@
-use crate::keccak::{
-    column::KeccakColumn,
-    environment::{KeccakEnv, KeccakEnvironment},
-    {ArithOps, BoolOps, E, WORDS_IN_HASH},
+use crate::{
+    keccak::{
+        column::KeccakColumn,
+        environment::{KeccakEnv, KeccakEnvironment},
+        lookups::Lookups,
+        {ArithOps, BoolOps, E, WORDS_IN_HASH},
+    },
+    mips::interpreter::LookupMode,
 };
 use ark_ff::Field;
 use kimchi::circuits::polynomials::keccak::{
@@ -249,5 +253,6 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
         }
 
         // LOOKUP CONSTRAINTS
+        self.lookups(LookupMode::Read);
     }
 }

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -1,3 +1,11 @@
+use super::{
+    column::KeccakColumn,
+    environment::KeccakEnv,
+    interpreter::{Absorb, KeccakInterpreter, KeccakStep, Sponge},
+    lookups::Lookups,
+    DIM, HASH_BYTELENGTH, QUARTERS, WORDS_IN_HASH,
+};
+use crate::mips::interpreter::LookupMode;
 use ark_ff::Field;
 use kimchi::{
     circuits::polynomials::keccak::{
@@ -6,13 +14,6 @@ use kimchi::{
         Keccak,
     },
     grid,
-};
-
-use super::{
-    column::KeccakColumn,
-    environment::KeccakEnv,
-    interpreter::{Absorb, KeccakInterpreter, KeccakStep, Sponge},
-    DIM, HASH_BYTELENGTH, QUARTERS, WORDS_IN_HASH,
 };
 
 pub(crate) fn pad_blocks<Fp: Field>(pad_bytelength: usize) -> Vec<Fp> {
@@ -79,6 +80,10 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
             KeccakStep::Sponge(typ) => self.run_sponge(typ),
             KeccakStep::Round(i) => self.run_round(i),
         }
+
+        // WRITE LOOKUPS
+        self.lookups(LookupMode::Write);
+
         self.update_step();
     }
 

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -2,10 +2,8 @@ use super::{
     column::KeccakColumn,
     environment::KeccakEnv,
     interpreter::{Absorb, KeccakInterpreter, KeccakStep, Sponge},
-    lookups::Lookups,
     DIM, HASH_BYTELENGTH, QUARTERS, WORDS_IN_HASH,
 };
-use crate::mips::interpreter::LookupMode;
 use ark_ff::Field;
 use kimchi::{
     circuits::polynomials::keccak::{
@@ -67,6 +65,8 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         while self.curr_step.is_some() {
             self.step();
         }
+
+        // TODO: create READ lookup tables
     }
 
     // FIXME: read preimage from memory and pad and expand
@@ -80,9 +80,6 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
             KeccakStep::Sponge(typ) => self.run_sponge(typ),
             KeccakStep::Round(i) => self.run_round(i),
         }
-
-        // WRITE LOOKUPS
-        self.lookups(LookupMode::Write);
 
         self.update_step();
     }

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -156,15 +156,6 @@ pub struct Lookup<Fp> {
 }
 
 impl<T: One> Lookup<T> {
-    pub fn new(mode: LookupMode, table_id: LookupTable, value: Vec<T>) -> Self {
-        Self {
-            mode,
-            magnitude: T::one(),
-            table_id,
-            value,
-        }
-    }
-
     pub fn read_if(if_is_true: T, table_id: LookupTable, value: Vec<T>) -> Self {
         Self {
             mode: LookupMode::Read,


### PR DESCRIPTION
This PR leverages the `LookupMode` enum to easily reuse the lookups code in the Keccak workflow for both witness and constraints stages (until this PR, the code was only reading lookups which were never written, so this PR fixes that pending issue).