### PR TITLE
[easy] Helper for `Byte` lookup table

### DIFF
--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -33,6 +33,9 @@ pub(crate) trait Lookups {
         dense: Self::Variable,
         sparse: Self::Variable,
     );
+
+    /// Adds a lookup to the Byte table
+    fn lookup_byte(&mut self, rw: LookupMode, flag: Self::Variable, value: Self::Variable);
 }
 
 impl<Fp: Field> Lookups for KeccakEnv<Fp> {
@@ -68,11 +71,7 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
             // BYTES LOOKUPS
             for i in 0..200 {
                 // Bytes are <2^8
-                self.add_lookup(Lookup {
-                    numerator: Signed::new(rw, None),
-                    table_id: LookupTable::ByteLookup,
-                    value: vec![self.sponge_bytes(i)],
-                })
+                self.lookup_byte(rw, self.is_sponge(), self.sponge_bytes(i));
             }
             // SHIFTS LOOKUPS
             for i in 100..SHIFTS_LEN {
@@ -199,6 +198,14 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
             numerator: Signed::new(rw, Some(flag)),
             table_id: LookupTable::ResetLookup,
             value: vec![dense, sparse],
+        });
+    }
+
+    fn lookup_byte(&mut self, rw: LookupMode, flag: Self::Variable, value: Self::Variable) {
+        self.add_lookup(Lookup {
+            numerator: Signed::new(rw, Some(flag)),
+            table_id: LookupTable::ByteLookup,
+            value: vec![value],
         });
     }
 }

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -165,8 +165,7 @@ pub enum LookupTable {
     RoundConstantsLookup,
     // All [0..136] values of possible padding lengths, the value 2^len, and the 5 corresponding pad suffixes with the 10*1 rule
     PadLookup,
-    // All values that can be stored in a byte
-    // TODO: model as RangeCheck16 for x and a scaled x' = x * 2^8
+    // All values that can be stored in a byte (amortized table, better than model as RangeCheck16 (x and scaled x)
     ByteLookup,
 }
 


### PR DESCRIPTION
This PR is the third one trying to simplify the `Lookup` trait for `KeccakEnv` by adding a helper to easily create lookups to the `Byte` lookup table. Not only does it clean up the interface, but it also allows for switch on/off functionality thanks to the flag argument of `Signed`.