### PR TITLE
Fix: `prev_block` was not being updated with value of `state_g` in-between rounds

### DIFF
--- a/kimchi/src/circuits/polynomials/keccak/witness.rs
+++ b/kimchi/src/circuits/polynomials/keccak/witness.rs
@@ -369,8 +369,8 @@ impl Iota {
         Self { state_g, rc }
     }
 
-    pub fn state_g(&self, i: usize) -> u64 {
-        self.state_g[i]
+    pub fn state_g(&self) -> Vec<u64> {
+        self.state_g.clone()
     }
 
     pub fn rc(&self, i: usize) -> u64 {

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -48,5 +48,5 @@ pub trait KeccakInterpreter {
     fn run_theta(&mut self, state_a: &[u64]) -> Vec<u64>;
     fn run_pirho(&mut self, state_e: &[u64]) -> Vec<u64>;
     fn run_chi(&mut self, state_b: &[u64]) -> Vec<u64>;
-    fn run_iota(&mut self, state_f: &[u64], round: usize);
+    fn run_iota(&mut self, state_f: &[u64], round: usize) -> Vec<u64>;
 }

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -308,8 +308,8 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         let state_g = iota.state_g();
 
         // Update columns
-        for i in 0..STATE_LEN {
-            self.write_column(KeccakColumn::IotaStateG(i), state_g[i]);
+        for (i, g) in state_g.iter().enumerate() {
+            self.write_column(KeccakColumn::IotaStateG(i), *g);
         }
         for i in 0..QUARTERS {
             self.write_column(KeccakColumn::RoundConstants(i), iota.rc(i));

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -212,9 +212,10 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         let state_e = self.run_theta(&state_a);
         let state_b = self.run_pirho(&state_e);
         let state_f = self.run_chi(&state_b);
-        self.run_iota(&state_f, round as usize);
+        let state_g = self.run_iota(&state_f, round as usize);
 
-        // Compute witness values
+        // Update block for next step with the output of the round
+        self.prev_block = state_g;
     }
 
     fn run_theta(&mut self, state_a: &[u64]) -> Vec<u64> {
@@ -302,15 +303,18 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         chi.state_f()
     }
 
-    fn run_iota(&mut self, state_f: &[u64], round: usize) {
+    fn run_iota(&mut self, state_f: &[u64], round: usize) -> Vec<u64> {
         let iota = Iota::create(state_f, round);
+        let state_g = iota.state_g();
 
         // Update columns
         for i in 0..STATE_LEN {
-            self.write_column(KeccakColumn::IotaStateG(i), iota.state_g(i));
+            self.write_column(KeccakColumn::IotaStateG(i), state_g[i]);
         }
         for i in 0..QUARTERS {
             self.write_column(KeccakColumn::RoundConstants(i), iota.rc(i));
         }
+
+        state_g
     }
 }


### PR DESCRIPTION
This PR includes a missing update that was not being performed inside the interpreter when running rounds. In particular, the output `state_g` was not being stored inside `self.prev_block`, so subsequent rounds could be loading old states instead.

For the rest (sponges), I have checked that the `prev_block` was being updated accordingly, this seems to be the only place where this was missing.

I realized about this issue when going through Misha's related comment in [this PR](https://github.com/o1-labs/proof-systems/pull/1637), asking about constraints between consecutive steps.