### PR TITLE
[berkeley] Fix CI, and stop `time` crate from periodically breaking CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,10 +51,7 @@ jobs:
       #
 
       - name: Install cargo-spec for specifications
-        uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-spec
-          version: 0.4.1
+        run: cargo install --locked --version 0.4.1 cargo-spec
 
       - name: Build the kimchi specification
         run: |

--- a/book/Cargo.toml
+++ b/book/Cargo.toml
@@ -11,3 +11,5 @@ license = "Apache-2.0"
 
 [build-dependencies]
 cargo-spec = { version = "0.5.0" }
+time = { version = "~0.3.23" } # This crate is a known bad-actor for breaking rust version support.
+plist = { version = "~1.5.0" } # This crate improperly constrains its bad-actor dependency (`time`).


### PR DESCRIPTION
The maintainer of the `time` crate is a known bad-actor for bumping `rust-version` in a way that will automatically break CI pipelines.

See https://github.com/time-rs/time/issues/575 and the discussion linked from there for more.