### PR TITLE
Constrain input and output between consecutive Keccak steps

### DIFF
--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -18,6 +18,7 @@ use super::{grid_index, ZKVM_KECCAK_COLS_CURR, ZKVM_KECCAK_COLS_NEXT};
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum KeccakColumn {
+    StepCounter,
     FlagRound,                                // Coeff Round = 0 | 1 .. 24
     FlagAbsorb,                               // Coeff Absorb = 0 | 1
     FlagSqueeze,                              // Coeff Squeeze = 0 | 1
@@ -54,6 +55,7 @@ pub enum KeccakColumn {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct KeccakColumns<T> {
+    pub step_counter: T,
     pub flag_round: T,           // Coeff Round = 0 | 1 .. 24
     pub flag_absorb: T,          // Coeff Absorb = 0 | 1
     pub flag_squeeze: T,         // Coeff Squeeze = 0 | 1
@@ -93,6 +95,7 @@ impl<T: Clone> KeccakColumns<T> {
 impl<T: Zero + One + Clone> Default for KeccakColumns<T> {
     fn default() -> Self {
         KeccakColumns {
+            step_counter: T::zero(),
             flag_round: T::zero(),
             flag_absorb: T::zero(),
             flag_squeeze: T::zero(),
@@ -115,6 +118,7 @@ impl<T: Clone> Index<KeccakColumn> for KeccakColumns<T> {
 
     fn index(&self, index: KeccakColumn) -> &Self::Output {
         match index {
+            KeccakColumn::StepCounter => &self.step_counter,
             KeccakColumn::FlagRound => &self.flag_round,
             KeccakColumn::FlagAbsorb => &self.flag_absorb,
             KeccakColumn::FlagSqueeze => &self.flag_squeeze,
@@ -184,6 +188,7 @@ impl<T: Clone> Index<KeccakColumn> for KeccakColumns<T> {
 impl<T: Clone> IndexMut<KeccakColumn> for KeccakColumns<T> {
     fn index_mut(&mut self, index: KeccakColumn) -> &mut Self::Output {
         match index {
+            KeccakColumn::StepCounter => &mut self.step_counter,
             KeccakColumn::FlagRound => &mut self.flag_round,
             KeccakColumn::FlagAbsorb => &mut self.flag_absorb,
             KeccakColumn::FlagSqueeze => &mut self.flag_squeeze,

--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -6,7 +6,7 @@ use kimchi::circuits::polynomials::keccak::constants::{
     PIRHO_DENSE_E_OFF, PIRHO_DENSE_ROT_E_LEN, PIRHO_DENSE_ROT_E_OFF, PIRHO_EXPAND_ROT_E_LEN,
     PIRHO_EXPAND_ROT_E_OFF, PIRHO_QUOTIENT_E_LEN, PIRHO_QUOTIENT_E_OFF, PIRHO_REMAINDER_E_LEN,
     PIRHO_REMAINDER_E_OFF, PIRHO_SHIFTS_E_LEN, PIRHO_SHIFTS_E_OFF, SPONGE_BYTES_OFF,
-    SPONGE_NEW_STATE_OFF, SPONGE_OLD_STATE_OFF, SPONGE_SHIFTS_OFF, THETA_DENSE_C_LEN,
+    SPONGE_NEW_STATE_OFF, SPONGE_OLD_STATE_OFF, SPONGE_SHIFTS_OFF, STATE_LEN, THETA_DENSE_C_LEN,
     THETA_DENSE_C_OFF, THETA_DENSE_ROT_C_LEN, THETA_DENSE_ROT_C_OFF, THETA_EXPAND_ROT_C_LEN,
     THETA_EXPAND_ROT_C_OFF, THETA_QUOTIENT_C_LEN, THETA_QUOTIENT_C_OFF, THETA_REMAINDER_C_LEN,
     THETA_REMAINDER_C_OFF, THETA_SHIFTS_C_LEN, THETA_SHIFTS_C_OFF, THETA_STATE_A_LEN,
@@ -89,6 +89,13 @@ impl<T: Clone> KeccakColumns<T> {
 
     pub fn chunk(&self, offset: usize, length: usize) -> &[T] {
         &self.curr[offset..offset + length]
+    }
+
+    pub(crate) fn curr_state(&self) -> &[T] {
+        &self.curr[0..STATE_LEN]
+    }
+    pub(crate) fn next_state(&self) -> &[T] {
+        &self.next
     }
 }
 

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -33,6 +33,10 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
     }
 
     fn constraints(&mut self) {
+        // INTER-STEP CHANNEL
+        // Read input of current step if not a root
+        self.lookup_input_of_step();
+
         // CORRECTNESS OF FLAGS
         {
             // TODO: remove redundancy if any

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -33,10 +33,6 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
     }
 
     fn constraints(&mut self) {
-        // INTER-STEP CHANNEL
-        // Read input of current step if not a root
-        self.lookup_input_of_step();
-
         // CORRECTNESS OF FLAGS
         {
             // TODO: remove redundancy if any

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -247,6 +247,8 @@ pub(crate) trait KeccakEnvironment {
 
     fn state_g(&self, q: usize) -> Self::Variable;
 
+    /// Returns the step counter
+    fn step_counter(&self) -> Self::Variable;
     /// Returns a slice of the input variables of the current step
     fn input_of_step(&self) -> Vec<Self::Variable>;
     /// Returns a slice of the output variables of the current step (= input of next step)
@@ -553,13 +555,19 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
         self.keccak_state[KeccakColumn::IotaStateG(q)].clone()
     }
 
+    fn step_counter(&self) -> Self::Variable {
+        self.keccak_state[KeccakColumn::StepCounter].clone()
+    }
+
     fn input_of_step(&self) -> Vec<Self::Variable> {
-        let (i, _curr_step) = self.curr_step;
-        [&[Self::constant(i)], self.keccak_state.curr_state()].concat()
+        [&[self.step_counter()], self.keccak_state.curr_state()].concat()
     }
 
     fn output_of_step(&self) -> Vec<Self::Variable> {
-        let (i, _curr_step) = self.curr_step;
-        [&[Self::constant(i + 1)], self.keccak_state.next_state()].concat()
+        [
+            &[self.step_counter() + Self::one()],
+            self.keccak_state.next_state(),
+        ]
+        .concat()
     }
 }

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -30,7 +30,7 @@ pub struct KeccakEnv<Fp> {
     /// How many blocks are left to absrob (including current absorb)
     pub(crate) blocks_left_to_absorb: u64,
     /// What step of the hash is being executed (or None, if just ended)
-    pub(crate) curr_step: Option<KeccakStep>,
+    pub(crate) curr_step: Option<(u64, KeccakStep)>,
 }
 
 impl<Fp: Field> KeccakEnv<Fp> {
@@ -47,25 +47,29 @@ impl<Fp: Field> KeccakEnv<Fp> {
     }
     pub fn update_step(&mut self) {
         match self.curr_step {
-            Some(step) => match step {
+            Some((i, step)) => match step {
                 KeccakStep::Sponge(sponge) => match sponge {
-                    Sponge::Absorb(_) => self.curr_step = Some(KeccakStep::Round(1)),
+                    Sponge::Absorb(_) => self.curr_step = Some((i + 1, KeccakStep::Round(1))),
                     Sponge::Squeeze => self.curr_step = None,
                 },
                 KeccakStep::Round(round) => {
                     if round < ROUNDS as u64 {
-                        self.curr_step = Some(KeccakStep::Round(round + 1));
+                        self.curr_step = Some((i + 1, KeccakStep::Round(round + 1)));
                     } else {
                         self.blocks_left_to_absorb -= 1;
                         match self.blocks_left_to_absorb {
-                            0 => self.curr_step = Some(KeccakStep::Sponge(Sponge::Squeeze)),
+                            0 => {
+                                self.curr_step = Some((i + 1, KeccakStep::Sponge(Sponge::Squeeze)))
+                            }
                             1 => {
                                 self.curr_step =
-                                    Some(KeccakStep::Sponge(Sponge::Absorb(Absorb::Last)))
+                                    Some((i + 1, KeccakStep::Sponge(Sponge::Absorb(Absorb::Last))))
                             }
                             _ => {
-                                self.curr_step =
-                                    Some(KeccakStep::Sponge(Sponge::Absorb(Absorb::Middle)))
+                                self.curr_step = Some((
+                                    i + 1,
+                                    KeccakStep::Sponge(Sponge::Absorb(Absorb::Middle)),
+                                ))
                             }
                         }
                     }

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -246,6 +246,11 @@ pub(crate) trait KeccakEnvironment {
     fn shifts_sum(&self, i: usize, y: usize, x: usize, q: usize) -> Self::Variable;
 
     fn state_g(&self, q: usize) -> Self::Variable;
+
+    /// Returns a slice of the input variables of the current step
+    fn input_of_step(&self) -> Vec<Self::Variable>;
+    /// Returns a slice of the output variables of the current step (= input of next step)
+    fn output_of_step(&self) -> Vec<Self::Variable>;
 }
 
 impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
@@ -546,5 +551,15 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
 
     fn state_g(&self, q: usize) -> Self::Variable {
         self.keccak_state[KeccakColumn::IotaStateG(q)].clone()
+    }
+
+    fn input_of_step(&self) -> Vec<Self::Variable> {
+        let (i, _curr_step) = self.curr_step;
+        [&[Self::constant(i)], self.keccak_state.curr_state()].concat()
+    }
+
+    fn output_of_step(&self) -> Vec<Self::Variable> {
+        let (i, _curr_step) = self.curr_step;
+        [&[Self::constant(i + 1)], self.keccak_state.next_state()].concat()
     }
 }

--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -22,11 +22,9 @@ pub(crate) trait Lookups {
     /// Adds all lookups of Self
     fn lookups(&mut self);
 
-    /// Reads a lookup containing the input of a step
-    fn lookup_input_of_step(&mut self);
-
-    /// Writes a lookup containing the output of a step
-    fn lookup_output_of_step(&mut self);
+    /// Reads a Lookup containing the input of a step
+    /// and writes a Lookup containing the output of the next step
+    fn lookup_steps(&mut self);
 
     /// Adds a lookup to the RangeCheck16 table
     fn lookup_rc16(&mut self, flag: Self::Variable, value: Self::Variable);
@@ -86,17 +84,14 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
         // Must be done inside caller
     }
 
-    fn lookup_input_of_step(&mut self) {
-        // Output of previous step is input of current step
+    fn lookup_steps(&mut self) {
+        // (if not a root) Output of previous step is input of current step
         self.add_lookup(Lookup::read_if(
             Self::not(self.is_root()),
             LookupTable::KeccakStepLookup,
             self.input_of_step(),
         ));
-    }
-
-    fn lookup_output_of_step(&mut self) {
-        // Input for next step is output of current step
+        // (if not a squeeze) Input for next step is output of current step
         self.add_lookup(Lookup::write_if(
             Self::not(self.is_squeeze()),
             LookupTable::KeccakStepLookup,

--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -1,7 +1,7 @@
 use super::{
     column::KeccakColumn,
     environment::{KeccakEnv, KeccakEnvironment},
-    ArithOps, BoolOps, E,
+    ArithOps, E,
 };
 use crate::mips::interpreter::{Lookup, LookupTable};
 use ark_ff::Field;
@@ -79,14 +79,12 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
         // STEP (INPUT/OUTPUT) COMMUNICATION CHANNEL
         {
             // Output of previous step is input of current step
-            self.add_lookup(Lookup::new(
-                rw,
+            self.add_lookup(Lookup::read_one(
                 LookupTable::KeccakStepLookup,
                 self.input_of_step(),
             ));
             // Input for next step is output of current step
-            self.add_lookup(Lookup::new(
-                rw,
+            self.add_lookup(Lookup::read_one(
                 LookupTable::KeccakStepLookup,
                 self.output_of_step(),
             ));

--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -1,7 +1,7 @@
 use super::{
     column::KeccakColumn,
     environment::{KeccakEnv, KeccakEnvironment},
-    ArithOps, E,
+    ArithOps, BoolOps, E,
 };
 use crate::mips::interpreter::{Lookup, LookupTable};
 use ark_ff::Field;
@@ -74,6 +74,17 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
             self.lookups_round_chi();
             // IOTA LOOKUPS
             self.lookups_round_iota();
+        }
+
+        // STEP (INPUT/OUTPUT) COMMUNICATION CHANNEL
+        {
+            // Output of previous step is input of current step
+            self.add_lookup(Lookup::new(
+                rw,
+                LookupTable::KeccakStepLookup,
+                self.input_of_step(),
+            ));
+            // Input for next step
         }
     }
 

--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -84,7 +84,12 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
                 LookupTable::KeccakStepLookup,
                 self.input_of_step(),
             ));
-            // Input for next step
+            // Input for next step is output of current step
+            self.add_lookup(Lookup::new(
+                rw,
+                LookupTable::KeccakStepLookup,
+                self.output_of_step(),
+            ));
         }
     }
 

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -48,9 +48,9 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
 
         // Configure first step depending on number of blocks remaining
         self.curr_step = if self.blocks_left_to_absorb == 1 {
-            Some(KeccakStep::Sponge(Sponge::Absorb(Absorb::FirstAndLast)))
+            Some((0, KeccakStep::Sponge(Sponge::Absorb(Absorb::FirstAndLast))))
         } else {
-            Some(KeccakStep::Sponge(Sponge::Absorb(Absorb::First)))
+            Some((0, KeccakStep::Sponge(Sponge::Absorb(Absorb::First))))
         };
 
         // Root state is zero
@@ -77,8 +77,8 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         // FIXME sparse notation
 
         match self.curr_step.unwrap() {
-            KeccakStep::Sponge(typ) => self.run_sponge(typ),
-            KeccakStep::Round(i) => self.run_round(i),
+            (_, KeccakStep::Sponge(typ)) => self.run_sponge(typ),
+            (_, KeccakStep::Round(i)) => self.run_round(i),
         }
 
         self.update_step();

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -89,8 +89,8 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         self.write_column(KeccakColumn::StepCounter, i);
 
         // INTER-STEP CHANNEL
-        // Write outputs for next step if not a squeeze
-        self.lookup_output_of_step();
+        // Write outputs for next step if not a squeeze and read inputs of curr step if not a root
+        self.lookup_steps();
 
         self.update_step();
     }

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -2,6 +2,7 @@ use super::{
     column::KeccakColumn,
     environment::KeccakEnv,
     interpreter::{Absorb, KeccakInterpreter, KeccakStep, Sponge},
+    lookups::Lookups,
     DIM, HASH_BYTELENGTH, QUARTERS, WORDS_IN_HASH,
 };
 use ark_ff::Field;
@@ -42,7 +43,7 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
     type Variable = Fp;
 
     fn hash(&mut self, preimage: Vec<u8>) {
-        // FIXME Read preimage for each block
+        // TODO: Read preimage for each block
 
         self.blocks_left_to_absorb = Keccak::num_blocks(preimage.len()) as u64;
 
@@ -70,7 +71,7 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         }
 
         // TODO: create READ lookup tables
-        // FIXME: When done, write hash to Syscall channel using `output_of_step()`
+        // TODO: When finish, write hash to Syscall channel using `output_of_step()` on Squeeze step
     }
 
     // FIXME: read preimage from memory and pad and expand
@@ -86,6 +87,10 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
             KeccakStep::Round(i) => self.run_round(i),
         }
         self.write_column(KeccakColumn::StepCounter, i);
+
+        // INTER-STEP CHANNEL
+        // Write outputs for next step if not a squeeze
+        self.lookup_output_of_step();
 
         self.update_step();
     }

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -42,7 +42,7 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
     type Variable = Fp;
 
     fn hash(&mut self, preimage: Vec<u8>) {
-        // FIXME Read preimage
+        // FIXME Read preimage for each block
 
         self.blocks_left_to_absorb = Keccak::num_blocks(preimage.len()) as u64;
 
@@ -70,6 +70,7 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         }
 
         // TODO: create READ lookup tables
+        // FIXME: When done, write hash to Syscall channel using `output_of_step()`
     }
 
     // FIXME: read preimage from memory and pad and expand

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -143,6 +143,8 @@ pub enum LookupTable {
     PadLookup,
     // All values that can be stored in a byte (amortized table, better than model as RangeCheck16 (x and scaled x)
     ByteLookup,
+    // Input/Output of Keccak steps
+    KeccakStepLookup,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This PR uses memory-styled lookups to constrain information in-between consecutive Keccak steps. Meaning, that the output of the i-th step is the input of the (i+1)-th step. Although steps consecution was already handled within a `KeccakEnv` instance and the input/output witness was code was done, it was not constrained anywhere else. This PR fixes that.

In the code there's 2 TODO's accounting for the final output of the hash and the inputs for it. This should be done in a similar fashion to encode the communication channel between the syscalls and keccak.

Closes https://github.com/o1-labs/proof-systems/pull/1676