### PR TITLE
[easy] Helper to check if a witness is nonzero using inverses

### DIFF
--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -93,6 +93,10 @@ impl<Fp: Field> BoolOps for KeccakEnv<Fp> {
         x - Self::Variable::one()
     }
 
+    fn is_nonzero(x: Self::Variable, x_inv: Self::Variable) -> Self::Variable {
+        x * x_inv - Self::Variable::one()
+    }
+
     fn xor(x: Self::Variable, y: Self::Variable) -> Self::Variable {
         Self::is_one(x + y)
     }

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -46,6 +46,8 @@ pub(crate) trait BoolOps {
 
     fn is_one(x: Self::Variable) -> Self::Variable;
 
+    fn is_nonzero(x: Self::Variable, x_inv: Self::Variable) -> Self::Variable;
+
     fn xor(x: Self::Variable, y: Self::Variable) -> Self::Variable;
 
     fn or(x: Self::Variable, y: Self::Variable) -> Self::Variable;


### PR DESCRIPTION
It will be used for an alternative definition of `is_round()` for Keccak, but could be used elsewhere.