### PR TITLE
Alternative `is_round()` definition

### DIFF
--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -64,11 +64,10 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
                 self.constrain(Self::either_false(self.is_round(), self.is_root()));
                 // Absorb and Squeeze cannot happen at the same time
                 self.constrain(Self::either_false(self.is_absorb(), self.is_squeeze()));
-                // Only one of Round and Sponge can be zero
-                // This means either Sponge is true or Round is nonzero -> has an inverse
-                self.constrain(self.is_sponge() * self.round());
-                self.constrain(self.is_round() * Self::is_one(self.round() * self.inverse_round()));
-                // Trivially, is_sponge and is_round are mutually exclusive
+                // Round and Sponge cannot happen at the same time
+                self.constrain(Self::either_false(self.is_sponge(), self.is_round()));
+                // NOTE: is_sponge and is_round are no longer mutually exclusive because both
+                // can be zero at the same time (when MIPS instruction is running, so constraints work)
             }
         }
 

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -322,7 +322,7 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
     }
 
     fn is_round(&self) -> Self::Variable {
-        Self::not(self.is_sponge())
+        Self::is_nonzero(self.round(), self.inverse_round())
     }
 
     fn round(&self) -> Self::Variable {


### PR DESCRIPTION
Uses `is_nonzero()` helper.

This way, there are no conflicting definitions of `is_round()`, because it no longer is the negation of `is_sponge()` (to allow for both to be false at the same time, in case it is a MIPS instruction row).