### PR TITLE
Trigger hash of `KeccakInterpreter` from Syscall

### DIFF
--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -18,6 +18,7 @@ use super::{grid_index, ZKVM_KECCAK_COLS_CURR, ZKVM_KECCAK_COLS_NEXT};
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum KeccakColumn {
+    HashCounter,
     StepCounter,
     FlagRound,                                // Coeff Round = 0 | 1 .. 24
     FlagAbsorb,                               // Coeff Absorb = 0 | 1
@@ -55,6 +56,7 @@ pub enum KeccakColumn {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct KeccakColumns<T> {
+    pub hash_counter: T,
     pub step_counter: T,
     pub flag_round: T,           // Coeff Round = 0 | 1 .. 24
     pub flag_absorb: T,          // Coeff Absorb = 0 | 1
@@ -102,6 +104,7 @@ impl<T: Clone> KeccakColumns<T> {
 impl<T: Zero + One + Clone> Default for KeccakColumns<T> {
     fn default() -> Self {
         KeccakColumns {
+            hash_counter: T::zero(),
             step_counter: T::zero(),
             flag_round: T::zero(),
             flag_absorb: T::zero(),
@@ -125,6 +128,7 @@ impl<T: Clone> Index<KeccakColumn> for KeccakColumns<T> {
 
     fn index(&self, index: KeccakColumn) -> &Self::Output {
         match index {
+            KeccakColumn::HashCounter => &self.hash_counter,
             KeccakColumn::StepCounter => &self.step_counter,
             KeccakColumn::FlagRound => &self.flag_round,
             KeccakColumn::FlagAbsorb => &self.flag_absorb,
@@ -195,6 +199,7 @@ impl<T: Clone> Index<KeccakColumn> for KeccakColumns<T> {
 impl<T: Clone> IndexMut<KeccakColumn> for KeccakColumns<T> {
     fn index_mut(&mut self, index: KeccakColumn) -> &mut Self::Output {
         match index {
+            KeccakColumn::HashCounter => &mut self.hash_counter,
             KeccakColumn::StepCounter => &mut self.step_counter,
             KeccakColumn::FlagRound => &mut self.flag_round,
             KeccakColumn::FlagAbsorb => &mut self.flag_absorb,

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -33,6 +33,22 @@ pub struct KeccakEnv<Fp> {
     pub(crate) curr_step: Option<KeccakStep>,
 }
 
+impl<Fp: Field> Default for KeccakEnv<Fp> {
+    fn default() -> Self {
+        Self {
+            constraints: vec![],
+            lookups: vec![],
+            prev_block: vec![],
+            padded: vec![],
+            block_idx: 0,
+            keccak_state: KeccakColumns::default(),
+            pad_len: 0,
+            blocks_left_to_absorb: 0,
+            curr_step: None,
+        }
+    }
+}
+
 impl<Fp: Field> KeccakEnv<Fp> {
     pub fn write_column(&mut self, column: KeccakColumn, value: u64) {
         self.keccak_state[column] = Self::constant(value);

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -21,8 +21,10 @@ pub struct KeccakEnv<Fp> {
     pub(crate) prev_block: Vec<u64>,
     /// Padded preimage data
     pub(crate) padded: Vec<u8>,
+    /// Hash index in the circuit
+    pub(crate) _hash_idx: u64,
     /// Current block of preimage data
-    pub(crate) block_idx: usize,
+    pub(crate) block_idx: u64,
     /// The full state of the Keccak gate (witness)
     pub(crate) keccak_state: KeccakColumns<E<Fp>>,
     /// Byte-length of the 10*1 pad (<=136)
@@ -35,13 +37,14 @@ pub struct KeccakEnv<Fp> {
     pub(crate) step_counter: u64,
 }
 
-impl<Fp: Field> Default for KeccakEnv<Fp> {
-    fn default() -> Self {
+impl<Fp: Field> KeccakEnv<Fp> {
+    pub fn new(hash_idx: u64) -> Self {
         Self {
             constraints: vec![],
             lookups: vec![],
             prev_block: vec![],
             padded: vec![],
+            _hash_idx: hash_idx,
             block_idx: 0,
             keccak_state: KeccakColumns::default(),
             pad_len: 0,
@@ -50,9 +53,7 @@ impl<Fp: Field> Default for KeccakEnv<Fp> {
             step_counter: 0,
         }
     }
-}
 
-impl<Fp: Field> KeccakEnv<Fp> {
     pub fn write_column(&mut self, column: KeccakColumn, value: u64) {
         self.keccak_state[column] = Self::constant(value);
     }

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -46,7 +46,8 @@ impl<Fp: Field> Default for KeccakEnv<Fp> {
             keccak_state: KeccakColumns::default(),
             pad_len: 0,
             blocks_left_to_absorb: 0,
-            curr_step: None,
+            keccak_step: None,
+            step_counter: 0,
         }
     }
 }

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -32,7 +32,7 @@ pub trait KeccakInterpreter {
         + std::fmt::Debug;
 
     // FIXME: read preimage from memory
-    fn hash(&mut self, preimage: Vec<u8>);
+    fn hash(&mut self, preimage: &[u8]);
 
     fn step(&mut self);
 

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -41,7 +41,7 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
 
     type Variable = Fp;
 
-    fn hash(&mut self, preimage: Vec<u8>) {
+    fn hash(&mut self, preimage: &[u8]) {
         // FIXME Read preimage
 
         self.blocks_left_to_absorb = Keccak::num_blocks(preimage.len()) as u64;
@@ -57,7 +57,7 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         self.prev_block = vec![0u64; STATE_LEN];
 
         // Pad preimage
-        self.padded = Keccak::pad(&preimage);
+        self.padded = Keccak::pad(preimage);
         self.block_idx = 0;
         self.pad_len = (self.padded.len() - preimage.len()) as u64;
 

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -166,7 +166,7 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         self.set_flag_absorb(absorb);
 
         // Compute witness values
-        let ini_idx = self.block_idx * RATE_IN_BYTES;
+        let ini_idx = RATE_IN_BYTES * self.block_idx as usize;
         let mut block = self.padded[ini_idx..ini_idx + RATE_IN_BYTES].to_vec();
 
         // Pad with zeros

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -55,6 +55,7 @@ pub struct Env<Fp> {
     pub scratch_state: [Fp; SCRATCH_SIZE],
     pub halt: bool,
     pub syscall_env: SyscallEnv,
+    pub hash_count: u64,
     pub preimage_oracle: PreImageOracle,
     pub preimage: Option<Vec<u8>>,
     pub preimage_bytes_read: Option<u64>,
@@ -614,11 +615,13 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         self.preimage_bytes_read = Some(self.preimage_bytes_read.unwrap() + actual_read_len);
         // If we've read the entire preimage, trigger Keccak workflow
         if self.preimage_bytes_read.unwrap() == preimage_len as u64 {
-            let mut keccak_env = KeccakEnv::<Fp>::default();
+            let mut keccak_env = KeccakEnv::<Fp>::new(self.hash_count);
             keccak_env.hash(self.preimage.as_ref().unwrap());
             self.keccak_env = Some(keccak_env);
         }
-
+        // Reset Keccak environment
+        self.preimage_bytes_read = Some(0);
+        self.hash_count += 1;
         actual_read_len
     }
 
@@ -726,6 +729,7 @@ impl<Fp: Field> Env<Fp> {
             scratch_state: fresh_scratch_state(),
             halt: state.exited,
             syscall_env,
+            hash_count: 0,
             preimage_oracle,
             preimage: state.preimage,
             preimage_bytes_read: Some(0),


### PR DESCRIPTION
This PR executes the hash of the `KeccakInterpreter` inside `request_preimage_write()`, which is called from the `interpret_rtype()` function, when the instruction is a `SyscallReadPreimage`. 

The idea here is to add a counter of the number of bytes of the preimage read so far inside the MIPS `Env`. When this value reaches the total length of the preimage, it's time to call the hash inside the interpreter of Keccak. This creates a new `KeccakEnv`, which triggers the witness creation code.

Some things remain to be done:
- Lookups between MIPS and Keccak (hash [here](https://github.com/o1-labs/proof-systems/pull/1687) and preimage [here](https://github.com/o1-labs/proof-systems/pull/1688))
> How and where to trigger Keccak constraints?
> - TBD when constraints of MIPS are also integrated with folding.

> NOTE: Right now I am doubting if defining the witness columns of Keccak as `keccak_state: KeccakColumns<E<Fp>>` is sufficient or not. In the sense that this keeps track of _one row_, but it is not a vector for all the steps. I wonder how this is handled in the MIPS side, and whether the same could be applied in Keccak. Specially considering what Matthew pointed out [here](https://github.com/o1-labs/proof-systems/pull/1681#pullrequestreview-1811231174) about rows not intermingling. 
> - After talking to Matthew, I will adapt the `KeccakInterpreter` trait so that each `request_preimage_write` calls single `step()` instead of the full `hash()`. The loop inside `hash()` checking if there are any other steps to run should be moved to a sub-loop inside the `main.rs` halt loop instead.