### PR TITLE
Communication channel of preimage key

### DIFF
--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -91,7 +91,10 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
         let bytes31 = (1..32).fold(Self::zero(), |acc, i| {
             acc * Self::two_pow(8) + self.sponge_bytes(i)
         });
-        self.add_lookup(Lookup::write_one(LookupTable::SyscallLookup, vec![bytes31]));
+        self.add_lookup(Lookup::write_one(
+            LookupTable::SyscallLookup,
+            vec![self.hash_counter(), bytes31],
+        ));
     }
 
     fn lookup_steps(&mut self) {

--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -22,6 +22,9 @@ pub(crate) trait Lookups {
     /// Adds all lookups of Self
     fn lookups(&mut self);
 
+    /// Writes a Lookup containing the 31byte output of the hash (excludes the MSB)
+    fn lookup_syscall_hash(&mut self);
+
     /// Reads a Lookup containing the input of a step
     /// and writes a Lookup containing the output of the next step
     fn lookup_steps(&mut self);
@@ -82,6 +85,13 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
 
         // STEP (INPUT/OUTPUT) COMMUNICATION CHANNEL
         // Must be done inside caller
+    }
+
+    fn lookup_syscall_hash(&mut self) {
+        let bytes31 = (1..32).fold(Self::zero(), |acc, i| {
+            acc * Self::two_pow(8) + self.sponge_bytes(i)
+        });
+        self.add_lookup(Lookup::write_one(LookupTable::SyscallLookup, vec![bytes31]));
     }
 
     fn lookup_steps(&mut self) {

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -43,6 +43,9 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
     type Variable = Fp;
 
     fn hash(&mut self, preimage: &[u8]) {
+        // Store hash index
+        self.write_column(KeccakColumn::HashCounter, self.hash_idx);
+
         // FIXME Read preimage for each block
 
         self.blocks_left_to_absorb = Keccak::num_blocks(preimage.len()) as u64;

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -69,7 +69,9 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         }
 
         // TODO: create READ lookup tables
-        // TODO: When finish, write hash to Syscall channel using `output_of_step()` on Squeeze step
+
+        // When finish, write hash to Syscall channel
+        self.lookup_syscall_hash();
     }
 
     // FIXME: read preimage from memory and pad and expand

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -145,6 +145,8 @@ pub enum LookupTable {
     ByteLookup,
     // Input/Output of Keccak steps
     KeccakStepLookup,
+    // Syscalls communication channel
+    SyscallLookup,
 }
 
 #[derive(Clone, Debug)]

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -1,5 +1,8 @@
 use crate::cannon::{Page, State};
 use crate::keccak::interpreter::KeccakInterpreter;
+use crate::keccak::lookups::Lookups;
+use crate::keccak::ArithOps;
+use crate::mips::interpreter::{Lookup, LookupTable};
 use crate::{
     cannon::{
         Hint, Meta, Start, StepFrequency, VmConfiguration, PAGE_ADDRESS_MASK, PAGE_ADDRESS_SIZE,
@@ -18,6 +21,7 @@ use crate::{
 };
 use ark_ff::Field;
 use core::panic;
+use kimchi::o1_utils::Two;
 use log::{debug, info};
 use std::array;
 use std::fs::File;
@@ -58,6 +62,7 @@ pub struct Env<Fp> {
     pub preimage_oracle: PreImageOracle,
     pub preimage: Option<Vec<u8>>,
     pub preimage_bytes_read: Option<u64>,
+    pub preimage_key: Option<[u8; 32]>,
     pub keccak_env: Option<KeccakEnv<Fp>>,
 }
 
@@ -573,6 +578,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
             }
             let preimage = self.preimage_oracle.get_preimage(preimage_key).get();
             self.preimage = Some(preimage);
+            self.preimage_key = Some(preimage_key);
         }
 
         const LENGTH_SIZE: usize = 8;
@@ -616,6 +622,18 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         if self.preimage_bytes_read.unwrap() == preimage_len as u64 {
             let mut keccak_env = KeccakEnv::<Fp>::default();
             keccak_env.hash(self.preimage.as_ref().unwrap());
+            match self.preimage_key {
+                Some(preimage_key) => {
+                    let bytes31 = (1..32).fold(Fp::zero(), |acc, i| {
+                        acc * Fp::two_pow(8) + Fp::from(preimage_key[i])
+                    });
+                    keccak_env.add_lookup(Lookup::read_one(
+                        LookupTable::SyscallLookup,
+                        vec![<KeccakEnv<Fp> as ArithOps>::constant_field(bytes31)],
+                    ));
+                }
+                None => panic!("preimage_key should be set"),
+            }
             self.keccak_env = Some(keccak_env);
         }
 
@@ -729,6 +747,7 @@ impl<Fp: Field> Env<Fp> {
             preimage_oracle,
             preimage: state.preimage,
             preimage_bytes_read: Some(0),
+            preimage_key: None,
             keccak_env: None,
         }
     }

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -630,7 +630,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
                     });
                     keccak_env.add_lookup(Lookup::read_one(
                         LookupTable::SyscallLookup,
-                        vec![<KeccakEnv<Fp> as ArithOps>::constant_field(bytes31)],
+                        vec![
+                            <KeccakEnv<Fp> as ArithOps>::constant(self.hash_count),
+                            <KeccakEnv<Fp> as ArithOps>::constant_field(bytes31),
+                        ],
                     ));
                 }
                 None => panic!("preimage_key should be set"),


### PR DESCRIPTION
This PR adds lookups on the Keccak side and the MIPS side to communicate that the preimage key corresponds to the claimed hash. 

Here, because only 31 bytes are needed (the MSB of the hash is dropped to store the identifier 0x02 in most cases), these 248 bits can be stored as a single field element in the table. A leading value encoding the hash index is included.

A similar approach shall be followed for the preimage data, except that here they will be stored as bytes (https://github.com/o1-labs/proof-systems/pull/1688).