### PR TITLE
Communication channel of preimage bytes

### DIFF
--- a/kimchi/src/circuits/polynomials/keccak/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/keccak/circuitgates.rs
@@ -307,7 +307,7 @@ where
             // In squeeze, Check shifts correspond to the 256-bit prefix digest of the old state (current)
             constraints.push(squeeze() * (old_state(i) - from_shifts!(shifts, i)));
         }
-        for i in 0..136 {
+        for i in 0..RATE_IN_BYTES {
             // Check padding
             constraints.push(flags(i) * (pad(i) - bytes(i)));
         }

--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::mips::interpreter::{Lookup, LookupTable};
 use ark_ff::Field;
 use kimchi::circuits::polynomials::keccak::constants::{
-    DIM, QUARTERS, SHIFTS, SHIFTS_LEN, STATE_LEN,
+    DIM, QUARTERS, RATE_IN_BYTES, SHIFTS, SHIFTS_LEN, STATE_LEN,
 };
 
 pub(crate) trait Lookups {
@@ -21,6 +21,9 @@ pub(crate) trait Lookups {
 
     /// Adds all lookups of Self
     fn lookups(&mut self);
+
+    /// Reads Lookups containing the 136 bytes of the block of the preimage
+    fn lookup_syscall_preimage(&mut self);
 
     /// Writes a Lookup containing the 31byte output of the hash (excludes the MSB)
     fn lookup_syscall_hash(&mut self);
@@ -82,9 +85,18 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
             // IOTA LOOKUPS
             self.lookups_round_iota();
         }
+    }
 
-        // STEP (INPUT/OUTPUT) COMMUNICATION CHANNEL
-        // Must be done inside caller
+    fn lookup_syscall_preimage(&mut self) {
+        for i in 0..RATE_IN_BYTES {
+            self.add_lookup(Lookup::read_one(
+                LookupTable::SyscallLookup,
+                vec![
+                    Self::constant((self.block_idx * RATE_IN_BYTES + i) as u64),
+                    self.sponge_bytes(i),
+                ],
+            ));
+        }
     }
 
     fn lookup_syscall_hash(&mut self) {

--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -92,7 +92,8 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
             self.add_lookup(Lookup::read_one(
                 LookupTable::SyscallLookup,
                 vec![
-                    Self::constant((self.block_idx * RATE_IN_BYTES + i) as u64),
+                    self.hash_index(),
+                    Self::constant(self.block_idx * RATE_IN_BYTES as u64 + i as u64),
                     self.sponge_bytes(i),
                 ],
             ));
@@ -103,7 +104,10 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
         let bytes31 = (1..32).fold(Self::zero(), |acc, i| {
             acc * Self::two_pow(8) + self.sponge_bytes(i)
         });
-        self.add_lookup(Lookup::write_one(LookupTable::SyscallLookup, vec![bytes31]));
+        self.add_lookup(Lookup::write_one(
+            LookupTable::SyscallLookup,
+            vec![self.hash_index(), bytes31],
+        ));
     }
 
     fn lookup_steps(&mut self) {

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -70,7 +70,7 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
 
         // TODO: create READ lookup tables
 
-        // When finish, write hash to Syscall channel
+        // COMMUNICATION CHANNEL: Write hash output
         self.lookup_syscall_hash();
     }
 
@@ -211,6 +211,9 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
             self.write_column_field(KeccakColumn::PadSuffix(i), *value);
         }
         // Rest is zero thanks to null_state
+
+        // COMMUNICATION CHANNEL: read bytes of current block
+        self.lookup_syscall_preimage();
 
         // Update environment
         self.prev_block = xor_state;

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -59,6 +59,7 @@ pub struct Env<Fp> {
     pub scratch_state: [Fp; SCRATCH_SIZE],
     pub halt: bool,
     pub syscall_env: SyscallEnv,
+    pub hash_count: u64,
     pub preimage_oracle: PreImageOracle,
     pub preimage: Option<Vec<u8>>,
     pub preimage_bytes_read: Option<u64>,
@@ -620,7 +621,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         self.preimage_bytes_read = Some(self.preimage_bytes_read.unwrap() + actual_read_len);
         // If we've read the entire preimage, trigger Keccak workflow
         if self.preimage_bytes_read.unwrap() == preimage_len as u64 {
-            let mut keccak_env = KeccakEnv::<Fp>::default();
+            let mut keccak_env = KeccakEnv::<Fp>::new(self.hash_count);
             keccak_env.hash(self.preimage.as_ref().unwrap());
 
             // Write preimage bytes to the communication channel
@@ -629,6 +630,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
                 keccak_env.add_lookup(Lookup::write_one(
                     LookupTable::SyscallLookup,
                     vec![
+                        <KeccakEnv<Fp> as ArithOps>::constant(self.hash_count),
                         <KeccakEnv<Fp> as ArithOps>::constant(i as u64),
                         <KeccakEnv<Fp> as ArithOps>::constant(*byte as u64),
                     ],
@@ -642,14 +644,19 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
                     });
                     keccak_env.add_lookup(Lookup::read_one(
                         LookupTable::SyscallLookup,
-                        vec![<KeccakEnv<Fp> as ArithOps>::constant_field(bytes31)],
+                        vec![
+                            <KeccakEnv<Fp> as ArithOps>::constant(self.hash_count),
+                            <KeccakEnv<Fp> as ArithOps>::constant_field(bytes31),
+                        ],
                     ));
                 }
                 None => panic!("preimage_key should be set"),
             }
             self.keccak_env = Some(keccak_env);
         }
-
+        // Reset Keccak environment
+        self.preimage_bytes_read = Some(0);
+        self.hash_count += 1;
         actual_read_len
     }
 
@@ -757,6 +764,7 @@ impl<Fp: Field> Env<Fp> {
             scratch_state: fresh_scratch_state(),
             halt: state.exited,
             syscall_env,
+            hash_count: 0,
             preimage_oracle,
             preimage: state.preimage,
             preimage_bytes_read: Some(0),

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -622,6 +622,19 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         if self.preimage_bytes_read.unwrap() == preimage_len as u64 {
             let mut keccak_env = KeccakEnv::<Fp>::default();
             keccak_env.hash(self.preimage.as_ref().unwrap());
+
+            // Write preimage bytes to the communication channel
+            let preimage = self.preimage.as_ref().unwrap();
+            for (i, byte) in preimage.iter().enumerate() {
+                keccak_env.add_lookup(Lookup::write_one(
+                    LookupTable::SyscallLookup,
+                    vec![
+                        <KeccakEnv<Fp> as ArithOps>::constant(i as u64),
+                        <KeccakEnv<Fp> as ArithOps>::constant(*byte as u64),
+                    ],
+                ))
+            }
+
             match self.preimage_key {
                 Some(preimage_key) => {
                     let bytes31 = (1..32).fold(Fp::zero(), |acc, i| {


### PR DESCRIPTION
This PR adds lookups on the Keccak side and the MIPS side to communicate that the preimage data used.

We could have optimizations later (like blocks of bytes as used inside padding), but for now each byte is passed to the channel as a two-column value `[hash idx, byte idx, byte value]`.