### PR TITLE
Split hash function into individual steps inside the main loop

### DIFF
--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -21,7 +21,7 @@ pub struct KeccakEnv<Fp> {
     /// The full state of the Keccak gate (witness)
     pub(crate) keccak_state: KeccakColumns<E<Fp>>,
     /// What step of the hash is being executed (or None, if just ended)
-    pub(crate) keccak_step: Option<KeccakStep>,
+    pub keccak_step: Option<KeccakStep>,
 
     /// Hash index in the circuit
     pub(crate) hash_idx: u64,
@@ -68,6 +68,7 @@ impl<Fp: Field> KeccakEnv<Fp> {
     pub fn null_state(&mut self) {
         self.keccak_state = KeccakColumns::default();
     }
+
     pub fn update_step(&mut self) {
         match self.keccak_step {
             Some(step) => match step {

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -31,9 +31,6 @@ pub trait KeccakInterpreter {
         + std::ops::Mul<Self::Variable, Output = Self::Variable>
         + std::fmt::Debug;
 
-    // FIXME: read preimage from memory
-    fn hash(&mut self, preimage: &[u8]);
-
     fn step(&mut self);
 
     fn set_flag_round(&mut self, round: u64);

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -8,7 +8,7 @@ use super::{
 use ark_ff::Field;
 use kimchi::{
     circuits::polynomials::keccak::{
-        constants::{CAPACITY_IN_BYTES, RATE_IN_BYTES, ROUNDS},
+        constants::{CAPACITY_IN_BYTES, RATE_IN_BYTES, ROUNDS, SHIFTS},
         witness::{Chi, Iota, PiRho, Theta},
         Keccak,
     },
@@ -266,7 +266,7 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         let chi = Chi::create(state_b);
 
         // Write Chi-related columns
-        for i in 0..DIM {
+        for i in 0..SHIFTS {
             for y in 0..DIM {
                 for x in 0..DIM {
                     for q in 0..QUARTERS {

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -42,47 +42,10 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
 
     type Variable = Fp;
 
-    fn hash(&mut self, preimage: &[u8]) {
-        // Store hash index
-        self.write_column(KeccakColumn::HashIndex, self.hash_idx);
-
-        // FIXME Read preimage for each block
-
-        self.blocks_left_to_absorb = Keccak::num_blocks(preimage.len()) as u64;
-
-        // Configure first step depending on number of blocks remaining
-        self.keccak_step = if self.blocks_left_to_absorb == 1 {
-            Some(KeccakStep::Sponge(Sponge::Absorb(Absorb::FirstAndLast)))
-        } else {
-            Some(KeccakStep::Sponge(Sponge::Absorb(Absorb::First)))
-        };
-        self.step_idx = 0;
-
-        // Root state is zero
-        self.prev_block = vec![0u64; STATE_LEN];
-
-        // Pad preimage
-        self.padded = Keccak::pad(preimage);
-        self.block_idx = 0;
-        self.pad_len = (self.padded.len() - preimage.len()) as u64;
-
-        // Run all steps of hash
-        while self.keccak_step.is_some() {
-            self.step();
-        }
-
-        // TODO: create READ lookup tables
-
-        // COMMUNICATION CHANNEL: Write hash output
-        self.lookup_syscall_hash();
-    }
-
     // FIXME: read preimage from memory and pad and expand
     fn step(&mut self) {
         // Reset columns to zeros to avoid conflicts between steps
         self.null_state();
-
-        // FIXME sparse notation
 
         match self.keccak_step.unwrap() {
             KeccakStep::Sponge(typ) => self.run_sponge(typ),
@@ -164,7 +127,8 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
 
         // Rest is zero thanks to null_state
 
-        // TODO: more updates to the env?
+        // COMMUNICATION CHANNEL: Write hash output
+        self.lookup_syscall_hash();
     }
 
     fn run_absorb(&mut self, absorb: Absorb) {

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -8,7 +8,7 @@ use super::{
 use ark_ff::Field;
 use kimchi::{
     circuits::polynomials::keccak::{
-        constants::{CAPACITY_IN_BYTES, RATE_IN_BYTES, ROUNDS, STATE_LEN},
+        constants::{CAPACITY_IN_BYTES, RATE_IN_BYTES, ROUNDS},
         witness::{Chi, Iota, PiRho, Theta},
         Keccak,
     },

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -102,9 +102,10 @@ pub fn main() -> ExitCode {
                 keccak_env.step();
             }
 
-            // TODO: update the witness with the Keccak step columns
+            // TODO: update the witness with the Keccak step columns before resetting the environment
+            // TODO: create READ lookup tables
 
-            // When the Keccak interpreter is done, we can reset the environment
+            // When the Keccak interpreter is finished, we can reset the environment
             env.keccak_env = None;
         }
 

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -2,6 +2,7 @@ use ark_ec::bn::Bn;
 use kimchi_optimism::{
     cannon::{self, Meta, Start, State},
     cannon_cli,
+    keccak::interpreter::KeccakInterpreter,
     mips::{proof, witness},
     preimage_oracle::PreImageOracle,
 };
@@ -94,6 +95,19 @@ pub fn main() -> ExitCode {
 
     while !env.halt {
         env.step(&configuration, &meta, &start);
+
+        if let Some(ref mut keccak_env) = env.keccak_env {
+            // Run all steps of hash
+            while keccak_env.keccak_step.is_some() {
+                keccak_env.step();
+            }
+
+            // TODO: update the witness with the Keccak step columns
+
+            // When the Keccak interpreter is done, we can reset the environment
+            env.keccak_env = None;
+        }
+
         for (scratch, scratch_pre_folding_witness) in env
             .scratch_state
             .iter()

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -1,5 +1,4 @@
 use crate::cannon::{Page, State};
-use crate::keccak::interpreter::KeccakInterpreter;
 use crate::keccak::lookups::Lookups;
 use crate::keccak::ArithOps;
 use crate::mips::interpreter::{Lookup, LookupTable};

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -624,7 +624,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
             let mut keccak_env = KeccakEnv::<Fp>::new(self.hash_count);
             keccak_env.hash(self.preimage.as_ref().unwrap());
 
-            // Write preimage bytes to the communication channel
+            // COMMUNICATION CHANNEL: Write preimage bytes
             let preimage = self.preimage.as_ref().unwrap();
             for (i, byte) in preimage.iter().enumerate() {
                 keccak_env.add_lookup(Lookup::write_one(
@@ -637,6 +637,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
                 ))
             }
 
+            // COMMUNICATION CHANNEL: Read hash output
             match self.preimage_key {
                 Some(preimage_key) => {
                     let bytes31 = (1..32).fold(Fp::zero(), |acc, i| {

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -621,8 +621,8 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         self.preimage_bytes_read = Some(self.preimage_bytes_read.unwrap() + actual_read_len);
         // If we've read the entire preimage, trigger Keccak workflow
         if self.preimage_bytes_read.unwrap() == preimage_len as u64 {
-            let mut keccak_env = KeccakEnv::<Fp>::new(self.hash_count);
-            keccak_env.hash(self.preimage.as_ref().unwrap());
+            let mut keccak_env =
+                KeccakEnv::<Fp>::new(self.hash_count, self.preimage.as_ref().unwrap());
 
             // COMMUNICATION CHANNEL: Write preimage bytes
             let preimage = self.preimage.as_ref().unwrap();
@@ -655,8 +655,8 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
             }
             self.keccak_env = Some(keccak_env);
         }
-        // Reset Keccak environment
-        self.preimage_bytes_read = Some(0);
+        // Reset environment
+        self.preimage_bytes_read = None;
         self.hash_count += 1;
         actual_read_len
     }

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -653,12 +653,13 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
                 None => panic!("preimage_key should be set"),
             }
             self.keccak_env = Some(keccak_env);
+
+            // Reset environment
+            self.preimage_bytes_read = None;
+            self.preimage = None;
+            self.preimage_key = None;
+            self.hash_count += 1;
         }
-        // Reset environment
-        self.preimage_bytes_read = None;
-        self.preimage = None;
-        self.preimage_key = None;
-        self.hash_count += 1;
 
         actual_read_len
     }

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -655,8 +655,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
             self.keccak_env = Some(keccak_env);
 
             // Reset environment
-            self.preimage_bytes_read = None;
-            self.preimage = None;
+            self.preimage_bytes_read = Some(0);
             self.preimage_key = None;
             self.hash_count += 1;
         }

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -657,7 +657,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         }
         // Reset environment
         self.preimage_bytes_read = None;
+        self.preimage = None;
+        self.preimage_key = None;
         self.hash_count += 1;
+
         actual_read_len
     }
 


### PR DESCRIPTION
This PR partially addresses issue https://github.com/o1-labs/proof-systems/issues/1695. 

Before this PR, the syscalls used to run the hash for the whole preimage in one go. But this approach overwrites individual Keccak steps witness data after every step update. Conversely, this PR solves that problem essentially thanks to moving parts of existing code around, so that the loop inside the old `hash()` function is executed as a sub-loop inside the halting condition loop inside `main.rs`. That way, a subsequent PR will be able to propagate the witness of each individual step, populating the folded instance for Keccak. In addition, now the function `request_preimage_write()` will only create an "empty" but non-`None` instance of `KeccakEnv` using as input the hash index and the preimage data. The fact that now `env.keccak_env.is_some()` will be used inside the loop to trigger subsequent Keccak steps (meaning, the `KeccakEnv::new()` function now returns a `KeccakEnv` containing the initialized values that used to be performed at the beginning of the old `hash()` function before the while loop). 