### PR TITLE
Make contents of `KeccakColumns` arrays instead of vectors

### DIFF
--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -5,18 +5,17 @@ use kimchi::circuits::polynomials::keccak::constants::{
     CHI_SHIFTS_B_LEN, CHI_SHIFTS_B_OFF, CHI_SHIFTS_SUM_LEN, CHI_SHIFTS_SUM_OFF, PIRHO_DENSE_E_LEN,
     PIRHO_DENSE_E_OFF, PIRHO_DENSE_ROT_E_LEN, PIRHO_DENSE_ROT_E_OFF, PIRHO_EXPAND_ROT_E_LEN,
     PIRHO_EXPAND_ROT_E_OFF, PIRHO_QUOTIENT_E_LEN, PIRHO_QUOTIENT_E_OFF, PIRHO_REMAINDER_E_LEN,
-    PIRHO_REMAINDER_E_OFF, PIRHO_SHIFTS_E_LEN, PIRHO_SHIFTS_E_OFF, SPONGE_BYTES_OFF,
-    SPONGE_NEW_STATE_OFF, SPONGE_OLD_STATE_OFF, SPONGE_SHIFTS_OFF, STATE_LEN, THETA_DENSE_C_LEN,
-    THETA_DENSE_C_OFF, THETA_DENSE_ROT_C_LEN, THETA_DENSE_ROT_C_OFF, THETA_EXPAND_ROT_C_LEN,
-    THETA_EXPAND_ROT_C_OFF, THETA_QUOTIENT_C_LEN, THETA_QUOTIENT_C_OFF, THETA_REMAINDER_C_LEN,
-    THETA_REMAINDER_C_OFF, THETA_SHIFTS_C_LEN, THETA_SHIFTS_C_OFF, THETA_STATE_A_LEN,
-    THETA_STATE_A_OFF,
+    PIRHO_REMAINDER_E_OFF, PIRHO_SHIFTS_E_LEN, PIRHO_SHIFTS_E_OFF, QUARTERS, RATE_IN_BYTES,
+    SPONGE_BYTES_OFF, SPONGE_NEW_STATE_OFF, SPONGE_OLD_STATE_OFF, SPONGE_SHIFTS_OFF, STATE_LEN,
+    THETA_DENSE_C_LEN, THETA_DENSE_C_OFF, THETA_DENSE_ROT_C_LEN, THETA_DENSE_ROT_C_OFF,
+    THETA_EXPAND_ROT_C_LEN, THETA_EXPAND_ROT_C_OFF, THETA_QUOTIENT_C_LEN, THETA_QUOTIENT_C_OFF,
+    THETA_REMAINDER_C_LEN, THETA_REMAINDER_C_OFF, THETA_SHIFTS_C_LEN, THETA_SHIFTS_C_OFF,
+    THETA_STATE_A_LEN, THETA_STATE_A_OFF,
 };
-use serde::{Deserialize, Serialize};
 
 use super::{grid_index, ZKVM_KECCAK_COLS_CURR, ZKVM_KECCAK_COLS_NEXT};
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum KeccakColumn {
     HashIndex,
     StepIndex,
@@ -54,23 +53,23 @@ pub enum KeccakColumn {
     SpongeXorState(usize),                    // Absorb Next[0..100)
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct KeccakColumns<T> {
     hash_index: T,
     step_index: T,
-    flag_round: T,           // Coeff Round = 0 | 1 .. 24
-    flag_absorb: T,          // Coeff Absorb = 0 | 1
-    flag_squeeze: T,         // Coeff Squeeze = 0 | 1
-    flag_root: T,            // Coeff Root = 0 | 1
-    flag_pad: T,             // Coeff Pad = 0 | 1
-    flag_length: T,          // Coeff Length 0 | 1 .. 136
-    two_to_pad: T,           // 2^PadLength
-    inverse_round: T,        // Round^-1
-    flags_bytes: Vec<T>,     // 136 boolean values
-    pad_suffix: Vec<T>,      // 5 values with padding suffix
-    round_constants: Vec<T>, // Round constants
-    curr: Vec<T>,            // Curr[0..1965)
-    next: Vec<T>,            // Next[0..100)
+    flag_round: T,                    // Coeff Round = 0 | 1 .. 24
+    flag_absorb: T,                   // Coeff Absorb = 0 | 1
+    flag_squeeze: T,                  // Coeff Squeeze = 0 | 1
+    flag_root: T,                     // Coeff Root = 0 | 1
+    flag_pad: T,                      // Coeff Pad = 0 | 1
+    flag_length: T,                   // Coeff Length 0 | 1 .. 136
+    two_to_pad: T,                    // 2^PadLength
+    inverse_round: T,                 // Round^-1
+    flags_bytes: [T; RATE_IN_BYTES],  // 136 boolean values
+    pad_suffix: [T; 5],               // 5 values with padding suffix
+    round_constants: [T; QUARTERS],   // Round constants
+    curr: [T; ZKVM_KECCAK_COLS_CURR], // Curr[0..1965)
+    next: [T; ZKVM_KECCAK_COLS_NEXT], // Next[0..100)
 }
 
 impl<T: Clone> KeccakColumns<T> {
@@ -123,11 +122,11 @@ impl<T: Zero + One + Clone> Default for KeccakColumns<T> {
             flag_length: T::zero(),
             two_to_pad: T::one(), // So that default 2^0 is in the table
             inverse_round: T::zero(),
-            flags_bytes: vec![T::zero(); 136],
-            pad_suffix: vec![T::zero(); 5],
-            round_constants: vec![T::zero(); 4], // RC[0] is set to be all zeros
-            curr: vec![T::zero(); ZKVM_KECCAK_COLS_CURR],
-            next: vec![T::zero(); ZKVM_KECCAK_COLS_NEXT],
+            flags_bytes: std::array::from_fn(|_| T::zero()),
+            pad_suffix: std::array::from_fn(|_| T::zero()),
+            round_constants: std::array::from_fn(|_| T::zero()), // RC[0] is set to be all zeros
+            curr: std::array::from_fn(|_| T::zero()),
+            next: std::array::from_fn(|_| T::zero()),
         }
     }
 }


### PR DESCRIPTION
This is to replicate the behavior of `WitnessColumns` of MIPS for `KeccakColumns`, so the code containing the proof is closer to that of MIPS and it is easier to review.