### PR TITLE
[easy] Implement default for `KeccakProofInputs`

### DIFF
--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -55,21 +55,21 @@ pub enum KeccakColumn {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct KeccakColumns<T> {
-    hash_index: T,
-    step_index: T,
-    flag_round: T,                    // Coeff Round = 0 | 1 .. 24
-    flag_absorb: T,                   // Coeff Absorb = 0 | 1
-    flag_squeeze: T,                  // Coeff Squeeze = 0 | 1
-    flag_root: T,                     // Coeff Root = 0 | 1
-    flag_pad: T,                      // Coeff Pad = 0 | 1
-    flag_length: T,                   // Coeff Length 0 | 1 .. 136
-    two_to_pad: T,                    // 2^PadLength
-    inverse_round: T,                 // Round^-1
-    flags_bytes: [T; RATE_IN_BYTES],  // 136 boolean values
-    pad_suffix: [T; 5],               // 5 values with padding suffix
-    round_constants: [T; QUARTERS],   // Round constants
-    curr: [T; ZKVM_KECCAK_COLS_CURR], // Curr[0..1965)
-    next: [T; ZKVM_KECCAK_COLS_NEXT], // Next[0..100)
+    pub(crate) hash_index: T,
+    pub(crate) step_index: T,
+    pub(crate) flag_round: T,                    // Coeff Round = 0 | 1 .. 24
+    pub(crate) flag_absorb: T,                   // Coeff Absorb = 0 | 1
+    pub(crate) flag_squeeze: T,                  // Coeff Squeeze = 0 | 1
+    pub(crate) flag_root: T,                     // Coeff Root = 0 | 1
+    pub(crate) flag_pad: T,                      // Coeff Pad = 0 | 1
+    pub(crate) flag_length: T,                   // Coeff Length 0 | 1 .. 136
+    pub(crate) two_to_pad: T,                    // 2^PadLength
+    pub(crate) inverse_round: T,                 // Round^-1
+    pub(crate) flags_bytes: [T; RATE_IN_BYTES],  // 136 boolean values
+    pub(crate) pad_suffix: [T; 5],               // 5 values with padding suffix
+    pub(crate) round_constants: [T; QUARTERS],   // Round constants
+    pub(crate) curr: [T; ZKVM_KECCAK_COLS_CURR], // Curr[0..1965)
+    pub(crate) next: [T; ZKVM_KECCAK_COLS_NEXT], // Next[0..100)
 }
 
 impl<T: Clone> KeccakColumns<T> {

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -10,6 +10,7 @@ pub mod constraints;
 pub mod environment;
 pub mod interpreter;
 pub mod lookups;
+pub mod proof;
 pub mod witness;
 
 pub(crate) const HASH_BITLENGTH: usize = 256;

--- a/optimism/src/keccak/proof.rs
+++ b/optimism/src/keccak/proof.rs
@@ -4,13 +4,13 @@ use kimchi::curve::KimchiCurve;
 
 #[derive(Debug)]
 pub struct KeccakProofInputs<G: KimchiCurve> {
-    evaluations: KeccakColumns<Vec<G::ScalarField>>,
+    _evaluations: KeccakColumns<Vec<G::ScalarField>>,
 }
 
 impl<G: KimchiCurve> Default for KeccakProofInputs<G> {
     fn default() -> Self {
         KeccakProofInputs {
-            evaluations: KeccakColumns {
+            _evaluations: KeccakColumns {
                 hash_index: (0..1 << 15).map(|_| G::ScalarField::zero()).collect(),
                 step_index: (0..1 << 15).map(|_| G::ScalarField::zero()).collect(),
                 flag_round: (0..1 << 15).map(|_| G::ScalarField::zero()).collect(),

--- a/optimism/src/keccak/proof.rs
+++ b/optimism/src/keccak/proof.rs
@@ -1,0 +1,42 @@
+use super::column::KeccakColumns;
+use ark_ff::{One, Zero};
+use kimchi::curve::KimchiCurve;
+
+#[derive(Debug)]
+pub struct KeccakProofInputs<G: KimchiCurve> {
+    evaluations: KeccakColumns<Vec<G::ScalarField>>,
+}
+
+impl<G: KimchiCurve> Default for KeccakProofInputs<G> {
+    fn default() -> Self {
+        KeccakProofInputs {
+            evaluations: KeccakColumns {
+                hash_index: (0..1 << 15).map(|_| G::ScalarField::zero()).collect(),
+                step_index: (0..1 << 15).map(|_| G::ScalarField::zero()).collect(),
+                flag_round: (0..1 << 15).map(|_| G::ScalarField::zero()).collect(),
+                flag_absorb: (0..1 << 15).map(|_| G::ScalarField::zero()).collect(),
+                flag_squeeze: (0..1 << 15).map(|_| G::ScalarField::zero()).collect(),
+                flag_root: (0..1 << 15).map(|_| G::ScalarField::zero()).collect(),
+                flag_pad: (0..1 << 15).map(|_| G::ScalarField::zero()).collect(),
+                flag_length: (0..1 << 15).map(|_| G::ScalarField::zero()).collect(),
+                two_to_pad: (0..1 << 15).map(|_| G::ScalarField::one()).collect(),
+                inverse_round: (0..1 << 15).map(|_| G::ScalarField::zero()).collect(),
+                flags_bytes: std::array::from_fn(|_| {
+                    (0..1 << 15).map(|_| G::ScalarField::zero()).collect()
+                }),
+                pad_suffix: std::array::from_fn(|_| {
+                    (0..1 << 15).map(|_| G::ScalarField::zero()).collect()
+                }),
+                round_constants: std::array::from_fn(|_| {
+                    (0..1 << 15).map(|_| G::ScalarField::zero()).collect()
+                }),
+                curr: std::array::from_fn(|_| {
+                    (0..1 << 15).map(|_| G::ScalarField::zero()).collect()
+                }),
+                next: std::array::from_fn(|_| {
+                    (0..1 << 15).map(|_| G::ScalarField::zero()).collect()
+                }),
+            },
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the Default trait for the struct `KeccakProofInputs` in a similar way as `ProofInputs` inside the mips module.