### PR TITLE
[easy] Create `KeccakProof` struct

### DIFF
--- a/optimism/src/keccak/proof.rs
+++ b/optimism/src/keccak/proof.rs
@@ -1,6 +1,7 @@
 use super::column::KeccakColumns;
 use ark_ff::{One, Zero};
 use kimchi::curve::KimchiCurve;
+use poly_commitment::{OpenProof, PolyComm};
 
 #[derive(Debug)]
 pub struct KeccakProofInputs<G: KimchiCurve> {
@@ -39,4 +40,12 @@ impl<G: KimchiCurve> Default for KeccakProofInputs<G> {
             },
         }
     }
+}
+
+#[derive(Debug)]
+pub struct KeccakProof<G: KimchiCurve, OpeningProof: OpenProof<G>> {
+    _commitments: KeccakColumns<PolyComm<G>>,
+    _zeta_evaluations: KeccakColumns<G::ScalarField>,
+    _zeta_omega_evaluations: KeccakColumns<G::ScalarField>,
+    _opening_proof: OpeningProof,
 }


### PR DESCRIPTION
This PR creates the struct `KeccakProof`, replicating the struct `Proof` inside the mips module. 

Disclaimer: we can probably avoid code duplication by making the contents of `mips/proof.rs` more generic. But for now, let's create an independent one inside the keccak module, make sure it works, and refactor later. Created issue to track it https://github.com/o1-labs/proof-systems/issues/1705.