### PR TITLE
Stop ignoring doc warnings

### DIFF
--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build Rust Documentation
         run: |
           eval $(opam env)
-          RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --all --no-deps
+          RUSTDOCFLAGS="--enable-index-page -Zunstable-options -D warnings" cargo doc --all --no-deps
 
       - name: Build the mdbook
         run: |

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build Rust Documentation
         run: |
           eval $(opam env)
-          RUSTDOCFLAGS="--enable-index-page -Zunstable-options -D warnings" cargo doc --workspace --no-deps
+          RUSTDOCFLAGS="--enable-index-page -Zunstable-options -D warnings" cargo doc --workspace --all-features --no-deps
 
       - name: Build the mdbook
         run: |

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build Rust Documentation
         run: |
           eval $(opam env)
-          RUSTDOCFLAGS="--enable-index-page -Zunstable-options -D warnings" cargo doc --all --no-deps
+          RUSTDOCFLAGS="--enable-index-page -Zunstable-options -D warnings" cargo doc --workspace --no-deps
 
       - name: Build the mdbook
         run: |

--- a/internal-tracing/src/lib.rs
+++ b/internal-tracing/src/lib.rs
@@ -1,9 +1,5 @@
 use std::time::SystemTime;
 
-mod internal_tracing {
-    pub use crate::*;
-}
-
 #[cfg(feature = "enabled")]
 pub use serde_json::{json, to_writer as json_to_writer, Value as JsonValue};
 

--- a/kimchi/snarky-deriver/src/lib.rs
+++ b/kimchi/snarky-deriver/src/lib.rs
@@ -17,7 +17,7 @@ use syn::{
 };
 
 /// The [SnarkyType] derive macro.
-/// It generates implementations of [`kimchi::snarky::SnarkyType`],
+/// It generates implementations of \[`kimchi::snarky::SnarkyType`\],
 /// as long as your structure's fields implement that type as well.
 /// It works very similarly to [`serde`].
 ///

--- a/kimchi/snarky-deriver/src/lib.rs
+++ b/kimchi/snarky-deriver/src/lib.rs
@@ -19,7 +19,7 @@ use syn::{
 /// The [SnarkyType] derive macro.
 /// It generates implementations of \[`kimchi::snarky::SnarkyType`\],
 /// as long as your structure's fields implement that type as well.
-/// It works very similarly to [`serde`].
+/// It works very similarly to \[`serde`\].
 ///
 /// For example:
 ///
@@ -30,10 +30,11 @@ use syn::{
 /// }
 /// ```
 ///
-/// You can specify your snarky type implementation to only apply to a single field (e.g. `Fp`),
-/// or to apply to a field that has a different name than `F`:
+/// You can specify your snarky type implementation to only apply to a single
+/// field (e.g. `Fp`), or to apply to a field that has a different name than
+/// `F`:
 ///
-/// ```ignore
+/// ```text
 /// #[derive(kimchi::SnarkyType)]
 /// #[snarky(field = "G::ScalarField")]
 /// struct MyType<G> where G: KimchiCurve {
@@ -41,7 +42,7 @@ use syn::{
 ///
 /// You can skip a field in the serializer:
 ///
-/// ```ignore
+/// ```text
 /// #[derive(kimchi::SnarkyType)]
 /// struct MyType<F> where F: PrimeField {
 ///  #[snarky(skip)]
@@ -51,7 +52,7 @@ use syn::{
 /// Finally, you can specify a custom check function,
 /// as well as a custom auxiliary function and type:
 ///
-/// ```ignore
+/// ```text
 /// #[derive(kimchi::SnarkyType)]
 /// #[snarky(check_fn = "my_check_fn")]
 /// #[snarky(auxiliary_fn = "my_auxiliary_fn")]
@@ -62,13 +63,13 @@ use syn::{
 /// By default, a tuple will be use to represent the out-of-circuit type.
 /// You can specify it yourself by using the `value` helper attribute:
 ///
-/// ```ignore
+/// ```text
 /// #[derive(kimchi::SnarkyType)]
 /// #[snarky(value = "MyOutOfCircuitType")]
 /// struct MyType<F> where F: PrimeField {
 /// ```
 ///
-/// and implement the [`CircuitAndValue`] trait on your [`SnarkyType`].
+/// and implement the \[`CircuitAndValue`\] trait on your \[`SnarkyType`\].
 ///
 #[proc_macro_derive(SnarkyType, attributes(snarky))]
 pub fn derive_snarky_type(item: TokenStream) -> TokenStream {

--- a/kimchi/src/circuits/polynomials/keccak/mod.rs
+++ b/kimchi/src/circuits/polynomials/keccak/mod.rs
@@ -38,7 +38,7 @@ macro_rules! grid {
 /// | 2     | 62 |  6 | 43 | 15 | 61 |
 /// | 3     | 28 | 55 | 25 | 21 | 56 |
 /// | 4     | 27 | 20 | 39 |  8 | 14 |
-/// Note that the order of the indexing is [y][x] to match the encoding of the witness algorithm
+/// Note that the order of the indexing is `[y][x]` to match the encoding of the witness algorithm
 pub const OFF: [[u64; DIM]; DIM] = [
     [0, 1, 62, 28, 27],
     [36, 44, 6, 55, 20],

--- a/kimchi/src/snarky/cvar.rs
+++ b/kimchi/src/snarky/cvar.rs
@@ -263,7 +263,7 @@ where
     /// This is because the exact same reduction that will eventually happen on each clone
     /// will end up creating the same set of constraints multiple times in the circuit.
     ///
-    /// It is useful to call [`seal`] on a variable that represents a long computation
+    /// It is useful to call on a variable that represents a long computation
     /// that hasn't been constrained yet (e.g. by an assert call, or a call to a custom gate),
     /// before using it further in the circuit.
     pub fn seal(&self, state: &mut RunState<F>, loc: Cow<'static, str>) -> SnarkyResult<Self> {

--- a/kimchi/src/snarky/runner.rs
+++ b/kimchi/src/snarky/runner.rs
@@ -36,7 +36,7 @@ where
     }
 }
 
-/// An enum that wraps either a [BasicSnarkyConstraint] or a [KimchiConstraintSystem].
+/// An enum that wraps either a [`BasicSnarkyConstraint`] or a \[`KimchiConstraintSystem`\].
 // TODO: we should get rid of this once basic constraint system is gone
 #[derive(Debug)]
 pub enum Constraint<F: PrimeField> {
@@ -158,9 +158,10 @@ impl<F> RunState<F>
 where
     F: PrimeField,
 {
-    /// Creates a new [Self] based on the size of the public input,
+    /// Creates a new [`Self`] based on the size of the public input,
     /// and the size of the public output.
-    /// If [with_system] is set it will create a [SnarkyConstraintSystem] in order to compile a new circuit.
+    /// If `with_system` is set it will create a [SnarkyConstraintSystem] in
+    /// order to compile a new circuit.
     pub fn new<Curve: KimchiCurve<ScalarField = F>>(
         public_input_size: usize,
         public_output_size: usize,
@@ -367,7 +368,7 @@ where
         self.add_constraint(Constraint::BasicSnarkyConstraint(constraint), label, loc)
     }
 
-    /// Adds a list of [AnnotatedConstraint]s to the circuit.
+    /// Adds a list of [`Constraint`] to the circuit.
     // TODO: clean up all these add constraints functions
     // TODO: do I really need to pass a vec?
     pub fn add_constraint(

--- a/kimchi/src/snarky/snarky_type.rs
+++ b/kimchi/src/snarky/snarky_type.rs
@@ -1,10 +1,12 @@
-//! The [SnarkyType] trait is a useful trait that allows us to define our own snarky variables on top of [FieldVar].
-//! Without it, we'd be limited to using the [FieldVar] type directly, handling and returning arrays of [FieldVar]s all the time.
-//! So this is useful for the same reason that programming languages allow users to define their own types,
-//! instead of relying only on `usize`.
+//! The [SnarkyType] trait is a useful trait that allows us to define our own
+//! snarky variables on top of [FieldVar].
+//! Without it, we'd be limited to using the [FieldVar] type directly, handling
+//! and returning arrays of [FieldVar]s all the time.
+//! So this is useful for the same reason that programming languages allow users
+//! to define their own types, instead of relying only on `usize`.
 //!
-//! To define your own snarky type, implement the [SnarkyType] trait.
-//! A good example is the [Boolean] type.
+//! To define your own snarky type, implement the `SnarkyType` trait.
+//! A good example is the `Boolean` type.
 
 use super::{
     cvar::FieldVar,

--- a/kimchi/src/snarky/union_find.rs
+++ b/kimchi/src/snarky/union_find.rs
@@ -60,8 +60,9 @@ where
     }
 
     /// Union the subsets to which x and y belong.
-    /// If it returns Some<u32>, it is the tag for unified subset.
-    /// If it returns None, at least one of x and y is not in the disjoint-set.
+    /// If it returns `Some<u32>`, it is the tag for unified subset.
+    /// If it returns `None`, at least one of x and y is not in the
+    /// disjoint-set.
     pub fn union(&mut self, x: T, y: T) -> Option<usize> {
         let (x_root, y_root) = match (self.find(x), self.find(y)) {
             (Some(x), Some(y)) => (x, y),


### PR DESCRIPTION
This PR makes the CI stops ignoring the warnings while building the doc. It also includes multiple fixes, mostly the ones introduced by the recent integration of `snarky`.