### PR TITLE
Remove `inverse_round` and alternate definition of `is_round()`

### DIFF
--- a/kimchi/src/circuits/polynomials/keccak/gadget.rs
+++ b/kimchi/src/circuits/polynomials/keccak/gadget.rs
@@ -38,8 +38,7 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
                 pad,
                 extra_bytes,
             ));
-            // Start by 1 to avoid the dummy entry
-            for round in 1..=ROUNDS {
+            for round in 0..ROUNDS {
                 gates.push(Self::create_keccak_round(new_row + gates.len(), round));
             }
         }

--- a/kimchi/src/circuits/polynomials/keccak/mod.rs
+++ b/kimchi/src/circuits/polynomials/keccak/mod.rs
@@ -47,9 +47,8 @@ pub const OFF: [[u64; DIM]; DIM] = [
     [18, 2, 61, 56, 14],
 ];
 
-/// Contains the 24 round constants for Keccak and an initial dummy entry
-pub const RC: [u64; ROUNDS + 1] = [
-    0x0000000000000000,
+/// Contains the 24 round constants for Keccak
+pub const RC: [u64; ROUNDS] = [
     0x0000000000000001,
     0x0000000000008082,
     0x800000000000808a,

--- a/kimchi/src/circuits/polynomials/keccak/witness.rs
+++ b/kimchi/src/circuits/polynomials/keccak/witness.rs
@@ -430,8 +430,7 @@ pub fn extend_keccak_witness<F: PrimeField>(witness: &mut [Vec<F>; KECCAK_COLS],
 
         let mut ini_state = xor_state.clone();
 
-        // Start by 1 to avoid dummy entry
-        for round in 1..=ROUNDS {
+        for round in 0..ROUNDS {
             // Theta
             let theta = Theta::create(&ini_state);
 

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -77,10 +77,6 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
                 self.constrain(Self::either_false(self.is_round(), self.is_root()));
                 // Absorb and Squeeze cannot happen at the same time
                 self.constrain(Self::either_false(self.is_absorb(), self.is_squeeze()));
-                // Only one of Round and Sponge can be zero
-                // This means either Sponge is true or Round is nonzero -> has an inverse
-                self.constrain(self.is_sponge() * self.round());
-                self.constrain(self.is_round() * Self::is_one(self.round() * self.inverse_round()));
                 // Trivially, is_sponge and is_round are mutually exclusive
             }
         }

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -100,12 +100,12 @@ impl<Fp: Field> KeccakEnv<Fp> {
         match self.keccak_step {
             Some(step) => match step {
                 KeccakStep::Sponge(sponge) => match sponge {
-                    Sponge::Absorb(_) => self.keccak_step = Some(KeccakStep::Round(1)),
+                    Sponge::Absorb(_) => self.keccak_step = Some(KeccakStep::Round(0)),
 
                     Sponge::Squeeze => self.keccak_step = None,
                 },
                 KeccakStep::Round(round) => {
-                    if round < ROUNDS as u64 {
+                    if round < ROUNDS as u64 - 1 {
                         self.keccak_step = Some(KeccakStep::Round(round + 1));
                     } else {
                         self.blocks_left_to_absorb -= 1;
@@ -218,8 +218,6 @@ pub(crate) trait KeccakEnvironment {
     fn is_round(&self) -> Self::Variable;
 
     fn round(&self) -> Self::Variable;
-
-    fn inverse_round(&self) -> Self::Variable;
 
     fn length(&self) -> Self::Variable;
 
@@ -395,10 +393,6 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
 
     fn round(&self) -> Self::Variable {
         self.variable(KeccakColumn::FlagRound)
-    }
-
-    fn inverse_round(&self) -> Self::Variable {
-        self.variable(KeccakColumn::InverseRound)
     }
 
     fn length(&self) -> Self::Variable {

--- a/optimism/src/keccak/proof.rs
+++ b/optimism/src/keccak/proof.rs
@@ -38,7 +38,6 @@ impl<G: KimchiCurve> Default for KeccakProofInputs<G> {
                 flag_pad: (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect(),
                 flag_length: (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect(),
                 two_to_pad: (0..DOMAIN_SIZE).map(|_| G::ScalarField::one()).collect(),
-                inverse_round: (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect(),
                 flags_bytes: std::array::from_fn(|_| {
                     (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect()
                 }),
@@ -149,7 +148,6 @@ where
             flag_pad: eval_col(evaluations.flag_pad),
             flag_length: eval_col(evaluations.flag_length),
             two_to_pad: eval_col(evaluations.two_to_pad),
-            inverse_round: eval_col(evaluations.inverse_round),
             flags_bytes: eval_array_col(&evaluations.flags_bytes).try_into().unwrap(),
             pad_suffix: eval_array_col(&evaluations.pad_suffix).try_into().unwrap(),
             round_constants: eval_array_col(&evaluations.round_constants)
@@ -174,7 +172,6 @@ where
             flag_pad: comm(&polys.flag_pad),
             flag_length: comm(&polys.flag_length),
             two_to_pad: comm(&polys.two_to_pad),
-            inverse_round: comm(&polys.inverse_round),
             flags_bytes: comm_array(&polys.flags_bytes).try_into().unwrap(),
             pad_suffix: comm_array(&polys.pad_suffix).try_into().unwrap(),
             round_constants: comm_array(&polys.round_constants).try_into().unwrap(),
@@ -209,7 +206,6 @@ where
             flag_pad: comm(&polys.flag_pad),
             flag_length: comm(&polys.flag_length),
             two_to_pad: comm(&polys.two_to_pad),
-            inverse_round: comm(&polys.inverse_round),
             flags_bytes: comm_array(&polys.flags_bytes).try_into().unwrap(),
             pad_suffix: comm_array(&polys.pad_suffix).try_into().unwrap(),
             round_constants: comm_array(&polys.round_constants).try_into().unwrap(),
@@ -389,7 +385,6 @@ fn test_keccak_prover() {
                 flag_pad: (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>(),
                 flag_length: (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>(),
                 two_to_pad: (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>(),
-                inverse_round: (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>(),
                 flags_bytes: std::array::from_fn(|_| {
                     (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>()
                 }),

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -91,15 +91,8 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
     }
 
     fn set_flag_round(&mut self, round: u64) {
-        assert!(round <= ROUNDS as u64);
-        // Values between 0 (dummy, for sponges) and 24
+        assert!(round < ROUNDS as u64);
         self.write_column(KeccakColumn::FlagRound, round);
-        if round != 0 {
-            self.write_column_field(
-                KeccakColumn::InverseRound,
-                Fp::from(round).inverse().unwrap(),
-            );
-        }
     }
 
     fn run_sponge(&mut self, sponge: Sponge) {

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -117,7 +117,6 @@ pub fn main() -> ExitCode {
             keccak_columns.flag_pad.clear();
             keccak_columns.flag_length.clear();
             keccak_columns.two_to_pad.clear();
-            keccak_columns.inverse_round.clear();
             keccak_columns.flags_bytes.iter_mut().for_each(Vec::clear);
             keccak_columns.pad_suffix.iter_mut().for_each(Vec::clear);
             keccak_columns
@@ -139,7 +138,6 @@ pub fn main() -> ExitCode {
             flag_pad: Vec::with_capacity(domain_size),
             flag_length: Vec::with_capacity(domain_size),
             two_to_pad: Vec::with_capacity(domain_size),
-            inverse_round: Vec::with_capacity(domain_size),
             flags_bytes: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
             pad_suffix: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
             round_constants: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
@@ -185,9 +183,6 @@ pub fn main() -> ExitCode {
             keccak_current_pre_folding_witness
                 .two_to_pad
                 .push(keccak_env.keccak_witness.two_to_pad);
-            keccak_current_pre_folding_witness
-                .inverse_round
-                .push(keccak_env.keccak_witness.inverse_round);
             for (env_wit, pre_fold_wit) in keccak_env
                 .keccak_witness
                 .flags_bytes


### PR DESCRIPTION
Partially addresses https://github.com/o1-labs/proof-systems/issues/1709 and related to the old https://github.com/o1-labs/proof-systems/pull/1667 that was closed to address each issue independently.

After Matthew's input [here](https://github.com/o1-labs/proof-systems/pull/1681#pullrequestreview-1811231174), we now know that MIPS and Keccak columns won't intermingle because we will be having two different instances (one for each). This means that we don't need to consider the case that a row is not a sponge nor a round, but an instruction. Consequently, we can be fine with a _negated_ definition of `is_round()` as `not(is_sponge())`, reducing by one not only the columns (because we no longer need `inverse_round` to check that the round number is nonzero) but it also removes one constraint. It removes the dummy entry of the round constants table, as the 0 entry now corresponds to the first keccak round (as it used to be before https://github.com/o1-labs/proof-systems/pull/1596)

This simplifies the code and reduces some code duplications in the main. 