### PR TITLE
Aggregate mode flags of `KeccakColumns` into an array

### DIFF
--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -15,6 +15,14 @@ use super::{ZKVM_KECCAK_COLS_CURR, ZKVM_KECCAK_COLS_NEXT};
 const ZKVM_KECCAK_COLS_LENGTH: usize =
     ZKVM_KECCAK_COLS_CURR + ZKVM_KECCAK_COLS_NEXT + QUARTERS + RATE_IN_BYTES + 14;
 
+const FLAG_ROUND_OFFSET: usize = 0;
+const FLAG_ABSORB_OFFSET: usize = 1;
+const FLAG_SQUEEZE_OFFSET: usize = 2;
+const FLAG_ROOT_OFFSET: usize = 3;
+const FLAG_PAD_OFFSET: usize = 4;
+const FLAG_LENGTH_OFFSET: usize = 5;
+const FLAG_TWO_TO_PAD_OFFSET: usize = 6;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum KeccakColumn {
     HashIndex,
@@ -26,7 +34,7 @@ pub enum KeccakColumn {
     FlagPad,                // Coeff Pad = 0 | 1
     FlagLength,             // Coeff Length 0 | 1 ..=136
     TwoToPad,               // 2^PadLength
-    FlagsBytes(usize),      // 136 boolean values
+    PadBytesFlags(usize),   // 136 boolean values
     PadSuffix(usize),       // 5 values with padding suffix
     RoundConstants(usize),  // Round constants
     Input(usize),           // Curr[0..100) either ThetaStateA or SpongeOldState
@@ -54,16 +62,10 @@ pub enum KeccakColumn {
 pub struct KeccakColumns<T> {
     pub hash_index: T,
     pub step_index: T,
-    pub flag_round: T,                    // Coeff Round = [0..24)
-    pub flag_absorb: T,                   // Coeff Absorb = 0 | 1
-    pub flag_squeeze: T,                  // Coeff Squeeze = 0 | 1
-    pub flag_root: T,                     // Coeff Root = 0 | 1
-    pub flag_pad: T,                      // Coeff Pad = 0 | 1
-    pub flag_length: T,                   // Coeff Length 0 | 1 ..=136
-    pub two_to_pad: T,                    // 2^PadLength
-    pub flags_bytes: [T; RATE_IN_BYTES],  // 136 boolean values
-    pub pad_suffix: [T; 5],               // 5 values with padding suffix
-    pub round_constants: [T; QUARTERS],   // Round constants
+    pub mode_flags: [T; 7], // Round, Absorb, Squeeze, Root, Pad, Length, TwoToPad
+    pub pad_bytes_flags: [T; RATE_IN_BYTES], // 136 boolean values -> sponge
+    pub pad_suffix: [T; 5], // 5 values with padding suffix -> sponge
+    pub round_constants: [T; QUARTERS], // Round constants -> round
     pub curr: [T; ZKVM_KECCAK_COLS_CURR], // Curr[0..1965)
     pub next: [T; ZKVM_KECCAK_COLS_NEXT], // Next[0..100)
 }
@@ -79,14 +81,8 @@ impl<T: Zero + One + Clone> Default for KeccakColumns<T> {
         KeccakColumns {
             hash_index: T::zero(),
             step_index: T::zero(),
-            flag_round: T::zero(),
-            flag_absorb: T::zero(),
-            flag_squeeze: T::zero(),
-            flag_root: T::zero(),
-            flag_pad: T::zero(),
-            flag_length: T::zero(),
-            two_to_pad: T::one(), // So that default 2^0 is in the table
-            flags_bytes: std::array::from_fn(|_| T::zero()),
+            mode_flags: std::array::from_fn(|_| T::zero()), // TwoToPad default zero lookup won't be triggered
+            pad_bytes_flags: std::array::from_fn(|_| T::zero()),
             pad_suffix: std::array::from_fn(|_| T::zero()),
             round_constants: std::array::from_fn(|_| T::zero()), // default zeros, but lookup only if is round
             curr: std::array::from_fn(|_| T::zero()),
@@ -102,14 +98,14 @@ impl<T: Clone> Index<KeccakColumn> for KeccakColumns<T> {
         match index {
             KeccakColumn::HashIndex => &self.hash_index,
             KeccakColumn::StepIndex => &self.step_index,
-            KeccakColumn::FlagRound => &self.flag_round,
-            KeccakColumn::FlagAbsorb => &self.flag_absorb,
-            KeccakColumn::FlagSqueeze => &self.flag_squeeze,
-            KeccakColumn::FlagRoot => &self.flag_root,
-            KeccakColumn::FlagPad => &self.flag_pad,
-            KeccakColumn::FlagLength => &self.flag_length,
-            KeccakColumn::TwoToPad => &self.two_to_pad,
-            KeccakColumn::FlagsBytes(idx) => &self.flags_bytes[idx],
+            KeccakColumn::FlagRound => &self.mode_flags[FLAG_ROUND_OFFSET],
+            KeccakColumn::FlagAbsorb => &self.mode_flags[FLAG_ABSORB_OFFSET],
+            KeccakColumn::FlagSqueeze => &self.mode_flags[FLAG_SQUEEZE_OFFSET],
+            KeccakColumn::FlagRoot => &self.mode_flags[FLAG_ROOT_OFFSET],
+            KeccakColumn::FlagPad => &self.mode_flags[FLAG_PAD_OFFSET],
+            KeccakColumn::FlagLength => &self.mode_flags[FLAG_LENGTH_OFFSET],
+            KeccakColumn::TwoToPad => &self.mode_flags[FLAG_TWO_TO_PAD_OFFSET],
+            KeccakColumn::PadBytesFlags(idx) => &self.pad_bytes_flags[idx],
             KeccakColumn::PadSuffix(idx) => &self.pad_suffix[idx],
             KeccakColumn::RoundConstants(idx) => &self.round_constants[idx],
             KeccakColumn::Input(idx) => &self.curr[idx],
@@ -140,14 +136,14 @@ impl<T: Clone> IndexMut<KeccakColumn> for KeccakColumns<T> {
         match index {
             KeccakColumn::HashIndex => &mut self.hash_index,
             KeccakColumn::StepIndex => &mut self.step_index,
-            KeccakColumn::FlagRound => &mut self.flag_round,
-            KeccakColumn::FlagAbsorb => &mut self.flag_absorb,
-            KeccakColumn::FlagSqueeze => &mut self.flag_squeeze,
-            KeccakColumn::FlagRoot => &mut self.flag_root,
-            KeccakColumn::FlagPad => &mut self.flag_pad,
-            KeccakColumn::FlagLength => &mut self.flag_length,
-            KeccakColumn::TwoToPad => &mut self.two_to_pad,
-            KeccakColumn::FlagsBytes(idx) => &mut self.flags_bytes[idx],
+            KeccakColumn::FlagRound => &mut self.mode_flags[FLAG_ROUND_OFFSET],
+            KeccakColumn::FlagAbsorb => &mut self.mode_flags[FLAG_ABSORB_OFFSET],
+            KeccakColumn::FlagSqueeze => &mut self.mode_flags[FLAG_SQUEEZE_OFFSET],
+            KeccakColumn::FlagRoot => &mut self.mode_flags[FLAG_ROOT_OFFSET],
+            KeccakColumn::FlagPad => &mut self.mode_flags[FLAG_PAD_OFFSET],
+            KeccakColumn::FlagLength => &mut self.mode_flags[FLAG_LENGTH_OFFSET],
+            KeccakColumn::TwoToPad => &mut self.mode_flags[FLAG_TWO_TO_PAD_OFFSET],
+            KeccakColumn::PadBytesFlags(idx) => &mut self.pad_bytes_flags[idx],
             KeccakColumn::PadSuffix(idx) => &mut self.pad_suffix[idx],
             KeccakColumn::RoundConstants(idx) => &mut self.round_constants[idx],
             KeccakColumn::Input(idx) => &mut self.curr[idx],
@@ -181,14 +177,8 @@ impl<F> IntoIterator for KeccakColumns<F> {
         let mut iter_contents = Vec::with_capacity(ZKVM_KECCAK_COLS_LENGTH);
         iter_contents.push(self.hash_index);
         iter_contents.push(self.step_index);
-        iter_contents.push(self.flag_round);
-        iter_contents.push(self.flag_absorb);
-        iter_contents.push(self.flag_squeeze);
-        iter_contents.push(self.flag_root);
-        iter_contents.push(self.flag_pad);
-        iter_contents.push(self.flag_length);
-        iter_contents.push(self.two_to_pad);
-        iter_contents.extend(self.flags_bytes);
+        iter_contents.extend(self.mode_flags);
+        iter_contents.extend(self.pad_bytes_flags);
         iter_contents.extend(self.pad_suffix);
         iter_contents.extend(self.round_constants);
         iter_contents.extend(self.curr);
@@ -208,14 +198,8 @@ where
         let mut iter_contents = Vec::with_capacity(ZKVM_KECCAK_COLS_LENGTH);
         iter_contents.push(self.hash_index);
         iter_contents.push(self.step_index);
-        iter_contents.push(self.flag_round);
-        iter_contents.push(self.flag_absorb);
-        iter_contents.push(self.flag_squeeze);
-        iter_contents.push(self.flag_root);
-        iter_contents.push(self.flag_pad);
-        iter_contents.push(self.flag_length);
-        iter_contents.push(self.two_to_pad);
-        iter_contents.extend(self.flags_bytes);
+        iter_contents.extend(self.mode_flags);
+        iter_contents.extend(self.pad_bytes_flags);
         iter_contents.extend(self.pad_suffix);
         iter_contents.extend(self.round_constants);
         iter_contents.extend(self.curr);
@@ -250,31 +234,23 @@ impl<G: Send + std::fmt::Debug> FromParallelIterator<G> for KeccakColumns<G> {
             .collect::<Vec<G>>()
             .try_into()
             .unwrap();
-        let flags_bytes = iter_contents
+        let pad_bytes_flags = iter_contents
             .drain(iter_contents.len() - RATE_IN_BYTES..)
             .collect::<Vec<G>>()
             .try_into()
             .unwrap();
-        let two_to_pad = iter_contents.pop().unwrap();
-        let flag_length = iter_contents.pop().unwrap();
-        let flag_pad = iter_contents.pop().unwrap();
-        let flag_root = iter_contents.pop().unwrap();
-        let flag_squeeze = iter_contents.pop().unwrap();
-        let flag_absorb = iter_contents.pop().unwrap();
-        let flag_round = iter_contents.pop().unwrap();
+        let mode_flags = iter_contents
+            .drain(iter_contents.len() - 7..)
+            .collect::<Vec<G>>()
+            .try_into()
+            .unwrap();
         let step_index = iter_contents.pop().unwrap();
         let hash_index = iter_contents.pop().unwrap();
         KeccakColumns {
             hash_index,
             step_index,
-            flag_round,
-            flag_absorb,
-            flag_squeeze,
-            flag_root,
-            flag_pad,
-            flag_length,
-            two_to_pad,
-            flags_bytes,
+            mode_flags,
+            pad_bytes_flags,
             pad_suffix,
             round_constants,
             curr,
@@ -294,14 +270,8 @@ where
         let mut iter_contents = Vec::with_capacity(ZKVM_KECCAK_COLS_LENGTH);
         iter_contents.push(&self.hash_index);
         iter_contents.push(&self.step_index);
-        iter_contents.push(&self.flag_round);
-        iter_contents.push(&self.flag_absorb);
-        iter_contents.push(&self.flag_squeeze);
-        iter_contents.push(&self.flag_root);
-        iter_contents.push(&self.flag_pad);
-        iter_contents.push(&self.flag_length);
-        iter_contents.push(&self.two_to_pad);
-        iter_contents.extend(&self.flags_bytes);
+        iter_contents.extend(&self.mode_flags);
+        iter_contents.extend(&self.pad_bytes_flags);
         iter_contents.extend(&self.pad_suffix);
         iter_contents.extend(&self.round_constants);
         iter_contents.extend(&self.curr);
@@ -321,14 +291,8 @@ where
         let mut iter_contents = Vec::with_capacity(ZKVM_KECCAK_COLS_LENGTH);
         iter_contents.push(&mut self.hash_index);
         iter_contents.push(&mut self.step_index);
-        iter_contents.push(&mut self.flag_round);
-        iter_contents.push(&mut self.flag_absorb);
-        iter_contents.push(&mut self.flag_squeeze);
-        iter_contents.push(&mut self.flag_root);
-        iter_contents.push(&mut self.flag_pad);
-        iter_contents.push(&mut self.flag_length);
-        iter_contents.push(&mut self.two_to_pad);
-        iter_contents.extend(&mut self.flags_bytes);
+        iter_contents.extend(&mut self.mode_flags);
+        iter_contents.extend(&mut self.pad_bytes_flags);
         iter_contents.extend(&mut self.pad_suffix);
         iter_contents.extend(&mut self.round_constants);
         iter_contents.extend(&mut self.curr);

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -58,8 +58,6 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
                 self.constrain(Self::is_boolean(self.is_squeeze()));
                 // Root is either true or false
                 self.constrain(Self::is_boolean(self.is_root()));
-                // Pad is either true or false
-                self.constrain(Self::is_boolean(self.is_pad()));
                 for i in 0..RATE_IN_BYTES {
                     // Bytes are either involved on padding or not
                     self.constrain(Self::is_boolean(self.in_padding(i)));

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -229,7 +229,7 @@ pub(crate) trait KeccakEnvironment {
 
     fn bytes_block(&self, idx: usize) -> Vec<Self::Variable>;
 
-    fn flags_bytes(&self) -> [Self::Variable; RATE_IN_BYTES];
+    fn pad_bytes_flags(&self) -> [Self::Variable; RATE_IN_BYTES];
     fn flags_block(&self, idx: usize) -> Vec<Self::Variable>;
 
     fn block_in_padding(&self, idx: usize) -> Self::Variable;
@@ -404,7 +404,7 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
     }
 
     fn in_padding(&self, idx: usize) -> Self::Variable {
-        self.variable(KeccakColumn::FlagsBytes(idx))
+        self.variable(KeccakColumn::PadBytesFlags(idx))
     }
 
     fn pad_suffix(&self, idx: usize) -> Self::Variable {
@@ -419,14 +419,14 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
         }
     }
 
-    fn flags_bytes(&self) -> [Self::Variable; RATE_IN_BYTES] {
-        array::from_fn(|idx| self.variable(KeccakColumn::FlagsBytes(idx)))
+    fn pad_bytes_flags(&self) -> [Self::Variable; RATE_IN_BYTES] {
+        array::from_fn(|idx| self.variable(KeccakColumn::PadBytesFlags(idx)))
     }
 
     fn flags_block(&self, idx: usize) -> Vec<Self::Variable> {
         match idx {
-            0 => self.flags_bytes()[0..12].to_vec(),
-            1..=4 => self.flags_bytes()[12 + (idx - 1) * 31..12 + idx * 31].to_vec(),
+            0 => self.pad_bytes_flags()[0..12].to_vec(),
+            1..=4 => self.pad_bytes_flags()[12 + (idx - 1) * 31..12 + idx * 31].to_vec(),
             _ => panic!("No more blocks of flags can be part of padding"),
         }
     }

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -219,7 +219,8 @@ pub(crate) trait KeccakEnvironment {
 
     fn round(&self) -> Self::Variable;
 
-    fn length(&self) -> Self::Variable;
+    fn pad_length(&self) -> Self::Variable;
+    fn inv_pad_length(&self) -> Self::Variable;
 
     fn two_to_pad(&self) -> Self::Variable;
 
@@ -384,7 +385,7 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
     }
 
     fn is_pad(&self) -> Self::Variable {
-        self.variable(KeccakColumn::FlagPad)
+        Self::is_nonzero(self.pad_length(), self.inv_pad_length())
     }
 
     fn is_round(&self) -> Self::Variable {
@@ -395,8 +396,11 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
         self.variable(KeccakColumn::FlagRound)
     }
 
-    fn length(&self) -> Self::Variable {
-        self.variable(KeccakColumn::FlagLength)
+    fn pad_length(&self) -> Self::Variable {
+        self.variable(KeccakColumn::PadLength)
+    }
+    fn inv_pad_length(&self) -> Self::Variable {
+        self.variable(KeccakColumn::InvPadLength)
     }
 
     fn two_to_pad(&self) -> Self::Variable {

--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -162,12 +162,11 @@ impl<Fp: Field> Lookups for KeccakEnv<Fp> {
         // PADDING LOOKUPS
         // Power of two corresponds to 2^pad_length
         // Pad suffixes correspond to 10*1 rule
-        // Note: When FlagLength=0, TwoToPad=1, and all PadSuffix=0
         self.add_lookup(Lookup::read_if(
-            self.is_sponge(),
+            self.is_pad(),
             LookupTable::PadLookup,
             vec![
-                self.length(),
+                self.pad_length(),
                 self.two_to_pad(),
                 self.pad_suffix(0),
                 self.pad_suffix(1),

--- a/optimism/src/keccak/proof.rs
+++ b/optimism/src/keccak/proof.rs
@@ -1,6 +1,6 @@
 use super::column::KeccakColumns;
 use crate::DOMAIN_SIZE;
-use ark_ff::{One, Zero};
+use ark_ff::Zero;
 use ark_poly::univariate::DensePolynomial;
 use ark_poly::{Evaluations, Polynomial, Radix2EvaluationDomain as D};
 use kimchi::groupmap::GroupMap;
@@ -31,14 +31,10 @@ impl<G: KimchiCurve> Default for KeccakProofInputs<G> {
             evaluations: KeccakColumns {
                 hash_index: (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect(),
                 step_index: (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect(),
-                flag_round: (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect(),
-                flag_absorb: (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect(),
-                flag_squeeze: (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect(),
-                flag_root: (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect(),
-                flag_pad: (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect(),
-                flag_length: (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect(),
-                two_to_pad: (0..DOMAIN_SIZE).map(|_| G::ScalarField::one()).collect(),
-                flags_bytes: std::array::from_fn(|_| {
+                mode_flags: std::array::from_fn(|_| {
+                    (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect()
+                }),
+                pad_bytes_flags: std::array::from_fn(|_| {
                     (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect()
                 }),
                 pad_suffix: std::array::from_fn(|_| {
@@ -141,14 +137,10 @@ where
         KeccakColumns {
             hash_index: eval_col(evaluations.hash_index),
             step_index: eval_col(evaluations.step_index),
-            flag_round: eval_col(evaluations.flag_round),
-            flag_absorb: eval_col(evaluations.flag_absorb),
-            flag_squeeze: eval_col(evaluations.flag_squeeze),
-            flag_root: eval_col(evaluations.flag_root),
-            flag_pad: eval_col(evaluations.flag_pad),
-            flag_length: eval_col(evaluations.flag_length),
-            two_to_pad: eval_col(evaluations.two_to_pad),
-            flags_bytes: eval_array_col(&evaluations.flags_bytes).try_into().unwrap(),
+            mode_flags: eval_array_col(&evaluations.mode_flags).try_into().unwrap(),
+            pad_bytes_flags: eval_array_col(&evaluations.pad_bytes_flags)
+                .try_into()
+                .unwrap(),
             pad_suffix: eval_array_col(&evaluations.pad_suffix).try_into().unwrap(),
             round_constants: eval_array_col(&evaluations.round_constants)
                 .try_into()
@@ -165,14 +157,8 @@ where
         KeccakColumns {
             hash_index: comm(&polys.hash_index),
             step_index: comm(&polys.step_index),
-            flag_round: comm(&polys.flag_round),
-            flag_absorb: comm(&polys.flag_absorb),
-            flag_squeeze: comm(&polys.flag_squeeze),
-            flag_root: comm(&polys.flag_root),
-            flag_pad: comm(&polys.flag_pad),
-            flag_length: comm(&polys.flag_length),
-            two_to_pad: comm(&polys.two_to_pad),
-            flags_bytes: comm_array(&polys.flags_bytes).try_into().unwrap(),
+            mode_flags: comm_array(&polys.mode_flags).try_into().unwrap(),
+            pad_bytes_flags: comm_array(&polys.pad_bytes_flags).try_into().unwrap(),
             pad_suffix: comm_array(&polys.pad_suffix).try_into().unwrap(),
             round_constants: comm_array(&polys.round_constants).try_into().unwrap(),
             curr: comm_array(&polys.curr).try_into().unwrap(),
@@ -199,14 +185,8 @@ where
         KeccakColumns {
             hash_index: comm(&polys.hash_index),
             step_index: comm(&polys.step_index),
-            flag_round: comm(&polys.flag_round),
-            flag_absorb: comm(&polys.flag_absorb),
-            flag_squeeze: comm(&polys.flag_squeeze),
-            flag_root: comm(&polys.flag_root),
-            flag_pad: comm(&polys.flag_pad),
-            flag_length: comm(&polys.flag_length),
-            two_to_pad: comm(&polys.two_to_pad),
-            flags_bytes: comm_array(&polys.flags_bytes).try_into().unwrap(),
+            mode_flags: comm_array(&polys.mode_flags).try_into().unwrap(),
+            pad_bytes_flags: comm_array(&polys.pad_bytes_flags).try_into().unwrap(),
             pad_suffix: comm_array(&polys.pad_suffix).try_into().unwrap(),
             round_constants: comm_array(&polys.round_constants).try_into().unwrap(),
             curr: comm_array(&polys.curr).try_into().unwrap(),
@@ -378,14 +358,10 @@ fn test_keccak_prover() {
             evaluations: KeccakColumns {
                 hash_index: (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>(),
                 step_index: (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>(),
-                flag_round: (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>(),
-                flag_absorb: (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>(),
-                flag_squeeze: (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>(),
-                flag_root: (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>(),
-                flag_pad: (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>(),
-                flag_length: (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>(),
-                two_to_pad: (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>(),
-                flags_bytes: std::array::from_fn(|_| {
+                mode_flags: std::array::from_fn(|_| {
+                    (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>()
+                }),
+                pad_bytes_flags: std::array::from_fn(|_| {
                     (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>()
                 }),
                 pad_suffix: std::array::from_fn(|_| {

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -69,8 +69,11 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
     }
 
     fn set_flag_pad(&mut self) {
-        self.write_column(KeccakColumn::FlagPad, 1);
-        self.write_column(KeccakColumn::FlagLength, self.pad_len);
+        self.write_column(KeccakColumn::PadLength, self.pad_len);
+        self.write_column_field(
+            KeccakColumn::InvPadLength,
+            Fp::inverse(&Fp::from(self.pad_len)).unwrap(),
+        );
         let pad_range = RATE_IN_BYTES - self.pad_len as usize..RATE_IN_BYTES;
         for i in pad_range {
             self.write_column(KeccakColumn::PadBytesFlags(i), 1);

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -73,7 +73,7 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         self.write_column(KeccakColumn::FlagLength, self.pad_len);
         let pad_range = RATE_IN_BYTES - self.pad_len as usize..RATE_IN_BYTES;
         for i in pad_range {
-            self.write_column(KeccakColumn::FlagsBytes(i), 1);
+            self.write_column(KeccakColumn::PadBytesFlags(i), 1);
         }
     }
 

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -110,14 +110,11 @@ pub fn main() -> ExitCode {
             // Resize without deallocating
             keccak_columns.hash_index.clear();
             keccak_columns.step_index.clear();
-            keccak_columns.flag_round.clear();
-            keccak_columns.flag_absorb.clear();
-            keccak_columns.flag_squeeze.clear();
-            keccak_columns.flag_root.clear();
-            keccak_columns.flag_pad.clear();
-            keccak_columns.flag_length.clear();
-            keccak_columns.two_to_pad.clear();
-            keccak_columns.flags_bytes.iter_mut().for_each(Vec::clear);
+            keccak_columns.mode_flags.iter_mut().for_each(Vec::clear);
+            keccak_columns
+                .pad_bytes_flags
+                .iter_mut()
+                .for_each(Vec::clear);
             keccak_columns.pad_suffix.iter_mut().for_each(Vec::clear);
             keccak_columns
                 .round_constants
@@ -131,14 +128,8 @@ pub fn main() -> ExitCode {
         KeccakColumns {
             hash_index: Vec::with_capacity(domain_size),
             step_index: Vec::with_capacity(domain_size),
-            flag_round: Vec::with_capacity(domain_size),
-            flag_absorb: Vec::with_capacity(domain_size),
-            flag_squeeze: Vec::with_capacity(domain_size),
-            flag_root: Vec::with_capacity(domain_size),
-            flag_pad: Vec::with_capacity(domain_size),
-            flag_length: Vec::with_capacity(domain_size),
-            two_to_pad: Vec::with_capacity(domain_size),
-            flags_bytes: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
+            mode_flags: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
+            pad_bytes_flags: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
             pad_suffix: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
             round_constants: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
             curr: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
@@ -162,33 +153,19 @@ pub fn main() -> ExitCode {
             keccak_current_pre_folding_witness
                 .step_index
                 .push(keccak_env.keccak_witness.step_index);
-            keccak_current_pre_folding_witness
-                .flag_round
-                .push(keccak_env.keccak_witness.flag_round);
-            keccak_current_pre_folding_witness
-                .flag_absorb
-                .push(keccak_env.keccak_witness.flag_absorb);
-            keccak_current_pre_folding_witness
-                .flag_squeeze
-                .push(keccak_env.keccak_witness.flag_squeeze);
-            keccak_current_pre_folding_witness
-                .flag_root
-                .push(keccak_env.keccak_witness.flag_root);
-            keccak_current_pre_folding_witness
-                .flag_pad
-                .push(keccak_env.keccak_witness.flag_pad);
-            keccak_current_pre_folding_witness
-                .flag_length
-                .push(keccak_env.keccak_witness.flag_length);
-            keccak_current_pre_folding_witness
-                .two_to_pad
-                .push(keccak_env.keccak_witness.two_to_pad);
             for (env_wit, pre_fold_wit) in keccak_env
                 .keccak_witness
-                .flags_bytes
+                .mode_flags
                 .iter()
-                .zip(keccak_current_pre_folding_witness.flags_bytes.iter_mut())
+                .zip(keccak_current_pre_folding_witness.mode_flags.iter_mut())
             {
+                pre_fold_wit.push(*env_wit);
+            }
+            for (env_wit, pre_fold_wit) in keccak_env.keccak_witness.pad_bytes_flags.iter().zip(
+                keccak_current_pre_folding_witness
+                    .pad_bytes_flags
+                    .iter_mut(),
+            ) {
                 pre_fold_wit.push(*env_wit);
             }
             for (env_wit, pre_fold_wit) in keccak_env


### PR DESCRIPTION
This PR reduces lines of code. 

It is part of https://github.com/o1-labs/proof-systems/issues/1709, as I am planning to aggregate them further when it comes to sponge-only columns, so they can take the space we already have between columns 800 and 1965 (so we don't always pay 200 extra columns for no reason).