### PR TITLE
Reduce Keccak columns by 145

### DIFF
--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -34,6 +34,7 @@ const PAD_TWO_OFF: usize = 803;
 const PAD_BYTES_OFF: usize = 804;
 pub(crate) const PAD_BYTES_LEN: usize = RATE_IN_BYTES;
 const PAD_SUFFIX_OFF: usize = PAD_BYTES_OFF + RATE_IN_BYTES;
+pub(crate) const PAD_SUFFIX_LEN: usize = 5;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum KeccakColumn {

--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -2,7 +2,7 @@ use std::ops::{Index, IndexMut};
 
 use ark_ff::{One, Zero};
 use kimchi::circuits::polynomials::keccak::constants::{
-    CHI_SHIFTS_B_OFF, CHI_SHIFTS_SUM_OFF, PIRHO_DENSE_E_OFF, PIRHO_DENSE_ROT_E_OFF,
+    CHI_SHIFTS_B_OFF, CHI_SHIFTS_SUM_OFF, KECCAK_COLS, PIRHO_DENSE_E_OFF, PIRHO_DENSE_ROT_E_OFF,
     PIRHO_EXPAND_ROT_E_OFF, PIRHO_QUOTIENT_E_OFF, PIRHO_REMAINDER_E_OFF, PIRHO_SHIFTS_E_OFF,
     QUARTERS, RATE_IN_BYTES, SPONGE_BYTES_OFF, SPONGE_NEW_STATE_OFF, SPONGE_SHIFTS_OFF,
     THETA_DENSE_C_OFF, THETA_DENSE_ROT_C_OFF, THETA_EXPAND_ROT_C_OFF, THETA_QUOTIENT_C_OFF,
@@ -12,23 +12,28 @@ use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelIterator};
 
 use super::{ZKVM_KECCAK_COLS_CURR, ZKVM_KECCAK_COLS_NEXT};
 
-const MODE_FLAGS_COLS_LENGTH: usize = 7;
-const SUFFIX_COLS_LENGTH: usize = 5;
-const ZKVM_KECCAK_COLS_LENGTH: usize = ZKVM_KECCAK_COLS_CURR
-    + ZKVM_KECCAK_COLS_NEXT
-    + QUARTERS
-    + RATE_IN_BYTES
-    + SUFFIX_COLS_LENGTH
-    + MODE_FLAGS_COLS_LENGTH
-    + 2;
+const ZKVM_KECCAK_COLS_LENGTH: usize =
+    ZKVM_KECCAK_COLS_CURR + ZKVM_KECCAK_COLS_NEXT + MODE_FLAGS_COLS_LEN + 2;
 
-const FLAG_ROUND_OFFSET: usize = 0;
-const FLAG_ABSORB_OFFSET: usize = 1;
-const FLAG_SQUEEZE_OFFSET: usize = 2;
-const FLAG_ROOT_OFFSET: usize = 3;
-const FLAG_PAD_LENGTH_OFFSET: usize = 4;
-const FLAG_INV_PAD_LENGTH_OFFSET: usize = 5;
-const FLAG_TWO_TO_PAD_OFFSET: usize = 6;
+const MODE_FLAGS_COLS_LEN: usize = 3;
+
+const FLAG_ROUND_OFF: usize = 0;
+const FLAG_ABSORB_OFF: usize = 1;
+const FLAG_SQUEEZE_OFF: usize = 2;
+
+const ROUND_COEFFS_OFF: usize = KECCAK_COLS;
+pub(crate) const ROUND_COEFFS_LEN: usize = QUARTERS;
+
+// The following elements do not increase the total column count
+// because they only appear in sponge rows, which only have 800 curr columns used.
+const SPONGE_COEFFS_OFF: usize = 800;
+const FLAG_ROOT_OFF: usize = SPONGE_COEFFS_OFF;
+const PAD_LEN_OFF: usize = 801;
+const PAD_INV_OFF: usize = 802;
+const PAD_TWO_OFF: usize = 803;
+const PAD_BYTES_OFF: usize = 804;
+pub(crate) const PAD_BYTES_LEN: usize = RATE_IN_BYTES;
+const PAD_SUFFIX_OFF: usize = PAD_BYTES_OFF + RATE_IN_BYTES;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum KeccakColumn {
@@ -69,12 +74,9 @@ pub enum KeccakColumn {
 pub struct KeccakColumns<T> {
     pub hash_index: T,
     pub step_index: T,
-    pub mode_flags: [T; MODE_FLAGS_COLS_LENGTH], // Round, Absorb, Squeeze, Root, PadLength, InvPadLength, TwoToPad
-    pub pad_bytes_flags: [T; RATE_IN_BYTES],     // 136 boolean values -> sponge
-    pub pad_suffix: [T; SUFFIX_COLS_LENGTH],     // 5 values with padding suffix -> sponge
-    pub round_constants: [T; QUARTERS],          // Round constants -> round
-    pub curr: [T; ZKVM_KECCAK_COLS_CURR],        // Curr[0..1965)
-    pub next: [T; ZKVM_KECCAK_COLS_NEXT],        // Next[0..100)
+    pub mode_flags: [T; MODE_FLAGS_COLS_LEN], // Round, Absorb, Squeeze, Root, PadLength, InvPadLength, TwoToPad
+    pub curr: [T; ZKVM_KECCAK_COLS_CURR],     // Curr[0..1965) + RC as quarters
+    pub next: [T; ZKVM_KECCAK_COLS_NEXT],     // Next[0..100)
 }
 
 impl<T: Clone> KeccakColumns<T> {
@@ -89,10 +91,7 @@ impl<T: Zero + One + Clone> Default for KeccakColumns<T> {
             hash_index: T::zero(),
             step_index: T::zero(),
             mode_flags: std::array::from_fn(|_| T::zero()), // Defaults are zero, but lookups will not be triggered
-            pad_bytes_flags: std::array::from_fn(|_| T::zero()),
-            pad_suffix: std::array::from_fn(|_| T::zero()),
-            round_constants: std::array::from_fn(|_| T::zero()), // default zeros, but lookup only if is round
-            curr: std::array::from_fn(|_| T::zero()),
+            curr: std::array::from_fn(|_| T::zero()), // default zeros, but lookups will not be triggered always
             next: std::array::from_fn(|_| T::zero()),
         }
     }
@@ -105,16 +104,16 @@ impl<T: Clone> Index<KeccakColumn> for KeccakColumns<T> {
         match index {
             KeccakColumn::HashIndex => &self.hash_index,
             KeccakColumn::StepIndex => &self.step_index,
-            KeccakColumn::FlagRound => &self.mode_flags[FLAG_ROUND_OFFSET],
-            KeccakColumn::FlagAbsorb => &self.mode_flags[FLAG_ABSORB_OFFSET],
-            KeccakColumn::FlagSqueeze => &self.mode_flags[FLAG_SQUEEZE_OFFSET],
-            KeccakColumn::FlagRoot => &self.mode_flags[FLAG_ROOT_OFFSET],
-            KeccakColumn::PadLength => &self.mode_flags[FLAG_PAD_LENGTH_OFFSET],
-            KeccakColumn::InvPadLength => &self.mode_flags[FLAG_INV_PAD_LENGTH_OFFSET],
-            KeccakColumn::TwoToPad => &self.mode_flags[FLAG_TWO_TO_PAD_OFFSET],
-            KeccakColumn::PadBytesFlags(idx) => &self.pad_bytes_flags[idx],
-            KeccakColumn::PadSuffix(idx) => &self.pad_suffix[idx],
-            KeccakColumn::RoundConstants(idx) => &self.round_constants[idx],
+            KeccakColumn::FlagRound => &self.mode_flags[FLAG_ROUND_OFF],
+            KeccakColumn::FlagAbsorb => &self.mode_flags[FLAG_ABSORB_OFF],
+            KeccakColumn::FlagSqueeze => &self.mode_flags[FLAG_SQUEEZE_OFF],
+            KeccakColumn::FlagRoot => &self.curr[FLAG_ROOT_OFF],
+            KeccakColumn::PadLength => &self.curr[PAD_LEN_OFF],
+            KeccakColumn::InvPadLength => &self.curr[PAD_INV_OFF],
+            KeccakColumn::TwoToPad => &self.curr[PAD_TWO_OFF],
+            KeccakColumn::PadBytesFlags(idx) => &self.curr[PAD_BYTES_OFF + idx],
+            KeccakColumn::PadSuffix(idx) => &self.curr[PAD_SUFFIX_OFF + idx],
+            KeccakColumn::RoundConstants(idx) => &self.curr[ROUND_COEFFS_OFF + idx],
             KeccakColumn::Input(idx) => &self.curr[idx],
             KeccakColumn::ThetaShiftsC(idx) => &self.curr[THETA_SHIFTS_C_OFF + idx],
             KeccakColumn::ThetaDenseC(idx) => &self.curr[THETA_DENSE_C_OFF + idx],
@@ -143,16 +142,16 @@ impl<T: Clone> IndexMut<KeccakColumn> for KeccakColumns<T> {
         match index {
             KeccakColumn::HashIndex => &mut self.hash_index,
             KeccakColumn::StepIndex => &mut self.step_index,
-            KeccakColumn::FlagRound => &mut self.mode_flags[FLAG_ROUND_OFFSET],
-            KeccakColumn::FlagAbsorb => &mut self.mode_flags[FLAG_ABSORB_OFFSET],
-            KeccakColumn::FlagSqueeze => &mut self.mode_flags[FLAG_SQUEEZE_OFFSET],
-            KeccakColumn::FlagRoot => &mut self.mode_flags[FLAG_ROOT_OFFSET],
-            KeccakColumn::PadLength => &mut self.mode_flags[FLAG_PAD_LENGTH_OFFSET],
-            KeccakColumn::InvPadLength => &mut self.mode_flags[FLAG_INV_PAD_LENGTH_OFFSET],
-            KeccakColumn::TwoToPad => &mut self.mode_flags[FLAG_TWO_TO_PAD_OFFSET],
-            KeccakColumn::PadBytesFlags(idx) => &mut self.pad_bytes_flags[idx],
-            KeccakColumn::PadSuffix(idx) => &mut self.pad_suffix[idx],
-            KeccakColumn::RoundConstants(idx) => &mut self.round_constants[idx],
+            KeccakColumn::FlagRound => &mut self.mode_flags[FLAG_ROUND_OFF],
+            KeccakColumn::FlagAbsorb => &mut self.mode_flags[FLAG_ABSORB_OFF],
+            KeccakColumn::FlagSqueeze => &mut self.mode_flags[FLAG_SQUEEZE_OFF],
+            KeccakColumn::FlagRoot => &mut self.curr[FLAG_ROOT_OFF],
+            KeccakColumn::PadLength => &mut self.curr[PAD_LEN_OFF],
+            KeccakColumn::InvPadLength => &mut self.curr[PAD_INV_OFF],
+            KeccakColumn::TwoToPad => &mut self.curr[PAD_TWO_OFF],
+            KeccakColumn::PadBytesFlags(idx) => &mut self.curr[PAD_BYTES_OFF + idx],
+            KeccakColumn::PadSuffix(idx) => &mut self.curr[PAD_SUFFIX_OFF + idx],
+            KeccakColumn::RoundConstants(idx) => &mut self.curr[ROUND_COEFFS_OFF + idx],
             KeccakColumn::Input(idx) => &mut self.curr[idx],
             KeccakColumn::ThetaShiftsC(idx) => &mut self.curr[THETA_SHIFTS_C_OFF + idx],
             KeccakColumn::ThetaDenseC(idx) => &mut self.curr[THETA_DENSE_C_OFF + idx],
@@ -185,9 +184,6 @@ impl<F> IntoIterator for KeccakColumns<F> {
         iter_contents.push(self.hash_index);
         iter_contents.push(self.step_index);
         iter_contents.extend(self.mode_flags);
-        iter_contents.extend(self.pad_bytes_flags);
-        iter_contents.extend(self.pad_suffix);
-        iter_contents.extend(self.round_constants);
         iter_contents.extend(self.curr);
         iter_contents.extend(self.next);
         iter_contents.into_iter()
@@ -206,9 +202,6 @@ where
         iter_contents.push(self.hash_index);
         iter_contents.push(self.step_index);
         iter_contents.extend(self.mode_flags);
-        iter_contents.extend(self.pad_bytes_flags);
-        iter_contents.extend(self.pad_suffix);
-        iter_contents.extend(self.round_constants);
         iter_contents.extend(self.curr);
         iter_contents.extend(self.next);
         iter_contents.into_par_iter()
@@ -231,23 +224,8 @@ impl<G: Send + std::fmt::Debug> FromParallelIterator<G> for KeccakColumns<G> {
             .collect::<Vec<G>>()
             .try_into()
             .unwrap();
-        let round_constants = iter_contents
-            .drain(iter_contents.len() - QUARTERS..)
-            .collect::<Vec<G>>()
-            .try_into()
-            .unwrap();
-        let pad_suffix = iter_contents
-            .drain(iter_contents.len() - SUFFIX_COLS_LENGTH..)
-            .collect::<Vec<G>>()
-            .try_into()
-            .unwrap();
-        let pad_bytes_flags = iter_contents
-            .drain(iter_contents.len() - RATE_IN_BYTES..)
-            .collect::<Vec<G>>()
-            .try_into()
-            .unwrap();
         let mode_flags = iter_contents
-            .drain(iter_contents.len() - MODE_FLAGS_COLS_LENGTH..)
+            .drain(iter_contents.len() - MODE_FLAGS_COLS_LEN..)
             .collect::<Vec<G>>()
             .try_into()
             .unwrap();
@@ -257,9 +235,6 @@ impl<G: Send + std::fmt::Debug> FromParallelIterator<G> for KeccakColumns<G> {
             hash_index,
             step_index,
             mode_flags,
-            pad_bytes_flags,
-            pad_suffix,
-            round_constants,
             curr,
             next,
         }
@@ -278,9 +253,6 @@ where
         iter_contents.push(&self.hash_index);
         iter_contents.push(&self.step_index);
         iter_contents.extend(&self.mode_flags);
-        iter_contents.extend(&self.pad_bytes_flags);
-        iter_contents.extend(&self.pad_suffix);
-        iter_contents.extend(&self.round_constants);
         iter_contents.extend(&self.curr);
         iter_contents.extend(&self.next);
         iter_contents.into_par_iter()
@@ -299,9 +271,6 @@ where
         iter_contents.push(&mut self.hash_index);
         iter_contents.push(&mut self.step_index);
         iter_contents.extend(&mut self.mode_flags);
-        iter_contents.extend(&mut self.pad_bytes_flags);
-        iter_contents.extend(&mut self.pad_suffix);
-        iter_contents.extend(&mut self.round_constants);
         iter_contents.extend(&mut self.curr);
         iter_contents.extend(&mut self.next);
         iter_contents.into_par_iter()

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -14,6 +14,8 @@ use kimchi::circuits::{
     },
 };
 
+use super::column::PAD_SUFFIX_LEN;
+
 pub trait Constraints {
     type Column;
     type Variable: std::ops::Mul<Self::Variable, Output = Self::Variable>
@@ -127,7 +129,7 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
             });
             self.constrain(self.is_pad() * (self.two_to_pad() - Self::one() - pad_at_end));
             // Check that the padding value is correct
-            for i in 0..5 {
+            for i in 0..PAD_SUFFIX_LEN {
                 self.constrain(self.is_pad() * (self.block_in_padding(i) - self.pad_suffix(i)));
             }
         }

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -16,7 +16,7 @@ pub mod witness;
 pub(crate) const HASH_BITLENGTH: usize = 256;
 pub(crate) const HASH_BYTELENGTH: usize = HASH_BITLENGTH / 8;
 pub(crate) const WORD_LENGTH_IN_BITS: usize = 64;
-pub(crate) const ZKVM_KECCAK_COLS_CURR: usize = KECCAK_COLS;
+pub(crate) const ZKVM_KECCAK_COLS_CURR: usize = KECCAK_COLS + QUARTERS;
 pub(crate) const ZKVM_KECCAK_COLS_NEXT: usize = STATE_LEN;
 pub(crate) const WORDS_IN_HASH: usize = HASH_BITLENGTH / WORD_LENGTH_IN_BITS;
 

--- a/optimism/src/keccak/proof.rs
+++ b/optimism/src/keccak/proof.rs
@@ -34,15 +34,6 @@ impl<G: KimchiCurve> Default for KeccakProofInputs<G> {
                 mode_flags: std::array::from_fn(|_| {
                     (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect()
                 }),
-                pad_bytes_flags: std::array::from_fn(|_| {
-                    (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect()
-                }),
-                pad_suffix: std::array::from_fn(|_| {
-                    (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect()
-                }),
-                round_constants: std::array::from_fn(|_| {
-                    (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect()
-                }),
                 curr: std::array::from_fn(|_| {
                     (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect()
                 }),
@@ -138,13 +129,6 @@ where
             hash_index: eval_col(evaluations.hash_index),
             step_index: eval_col(evaluations.step_index),
             mode_flags: eval_array_col(&evaluations.mode_flags).try_into().unwrap(),
-            pad_bytes_flags: eval_array_col(&evaluations.pad_bytes_flags)
-                .try_into()
-                .unwrap(),
-            pad_suffix: eval_array_col(&evaluations.pad_suffix).try_into().unwrap(),
-            round_constants: eval_array_col(&evaluations.round_constants)
-                .try_into()
-                .unwrap(),
             curr: eval_array_col(&evaluations.curr).try_into().unwrap(),
             next: eval_array_col(&evaluations.next).try_into().unwrap(),
         }
@@ -158,9 +142,6 @@ where
             hash_index: comm(&polys.hash_index),
             step_index: comm(&polys.step_index),
             mode_flags: comm_array(&polys.mode_flags).try_into().unwrap(),
-            pad_bytes_flags: comm_array(&polys.pad_bytes_flags).try_into().unwrap(),
-            pad_suffix: comm_array(&polys.pad_suffix).try_into().unwrap(),
-            round_constants: comm_array(&polys.round_constants).try_into().unwrap(),
             curr: comm_array(&polys.curr).try_into().unwrap(),
             next: comm_array(&polys.next).try_into().unwrap(),
         }
@@ -186,9 +167,6 @@ where
             hash_index: comm(&polys.hash_index),
             step_index: comm(&polys.step_index),
             mode_flags: comm_array(&polys.mode_flags).try_into().unwrap(),
-            pad_bytes_flags: comm_array(&polys.pad_bytes_flags).try_into().unwrap(),
-            pad_suffix: comm_array(&polys.pad_suffix).try_into().unwrap(),
-            round_constants: comm_array(&polys.round_constants).try_into().unwrap(),
             curr: comm_array(&polys.curr).try_into().unwrap(),
             next: comm_array(&polys.next).try_into().unwrap(),
         }
@@ -359,15 +337,6 @@ fn test_keccak_prover() {
                 hash_index: (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>(),
                 step_index: (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>(),
                 mode_flags: std::array::from_fn(|_| {
-                    (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>()
-                }),
-                pad_bytes_flags: std::array::from_fn(|_| {
-                    (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>()
-                }),
-                pad_suffix: std::array::from_fn(|_| {
-                    (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>()
-                }),
-                round_constants: std::array::from_fn(|_| {
                     (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>()
                 }),
                 curr: std::array::from_fn(|_| {

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -111,15 +111,6 @@ pub fn main() -> ExitCode {
             keccak_columns.hash_index.clear();
             keccak_columns.step_index.clear();
             keccak_columns.mode_flags.iter_mut().for_each(Vec::clear);
-            keccak_columns
-                .pad_bytes_flags
-                .iter_mut()
-                .for_each(Vec::clear);
-            keccak_columns.pad_suffix.iter_mut().for_each(Vec::clear);
-            keccak_columns
-                .round_constants
-                .iter_mut()
-                .for_each(Vec::clear);
             keccak_columns.curr.iter_mut().for_each(Vec::clear);
             keccak_columns.next.iter_mut().for_each(Vec::clear);
         };
@@ -129,9 +120,6 @@ pub fn main() -> ExitCode {
             hash_index: Vec::with_capacity(domain_size),
             step_index: Vec::with_capacity(domain_size),
             mode_flags: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
-            pad_bytes_flags: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
-            pad_suffix: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
-            round_constants: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
             curr: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
             next: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
         };
@@ -159,28 +147,6 @@ pub fn main() -> ExitCode {
                 .iter()
                 .zip(keccak_current_pre_folding_witness.mode_flags.iter_mut())
             {
-                pre_fold_wit.push(*env_wit);
-            }
-            for (env_wit, pre_fold_wit) in keccak_env.keccak_witness.pad_bytes_flags.iter().zip(
-                keccak_current_pre_folding_witness
-                    .pad_bytes_flags
-                    .iter_mut(),
-            ) {
-                pre_fold_wit.push(*env_wit);
-            }
-            for (env_wit, pre_fold_wit) in keccak_env
-                .keccak_witness
-                .pad_suffix
-                .iter()
-                .zip(keccak_current_pre_folding_witness.pad_suffix.iter_mut())
-            {
-                pre_fold_wit.push(*env_wit);
-            }
-            for (env_wit, pre_fold_wit) in keccak_env.keccak_witness.round_constants.iter().zip(
-                keccak_current_pre_folding_witness
-                    .round_constants
-                    .iter_mut(),
-            ) {
                 pre_fold_wit.push(*env_wit);
             }
             for (env_wit, pre_fold_wit) in keccak_env


### PR DESCRIPTION
Closes https://github.com/o1-labs/proof-systems/issues/1709.

This PR leverages the fact that plenty of columns are only accessed during sponge rows, which only use 800 of the 1965 available `curr` columns. Storing those coefficients in `curr` saves us 145 columns (meaning additional field elements in the witness) whose consumed space is redundant otherwise.

As a side effect, this reduces the lines of code needed in the proof of Keccak.