### PR TITLE
Keccak doc: adding some comments in the constants file

### DIFF
--- a/kimchi/src/circuits/polynomials/keccak/constants.rs
+++ b/kimchi/src/circuits/polynomials/keccak/constants.rs
@@ -1,16 +1,36 @@
 /// Constants for each witness' index offsets and lengths
 
 // KECCAK PARAMETERS
+/// The dimension of the Keccak state
 pub const DIM: usize = 5;
+
+/// An element of the Keccak state is 64 bits. However, we split the state into
+/// quarters of 16 bits to represent XOR and AND using the finite field
+/// addition. See the Keccak RFC for more information.
 pub const QUARTERS: usize = 4;
+
 pub const SHIFTS: usize = 4;
+
+/// The number of rounds in the Keccak permutation
 pub const ROUNDS: usize = 24;
+
+/// The number of bytes that can be processed by the Keccak permutation. It is
+/// the rate of the sponge configuration.
 pub const RATE_IN_BYTES: usize = 1088 / 8;
+
+/// The number of bytes used as a capacity in the sponge.
 pub const CAPACITY_IN_BYTES: usize = 512 / 8;
+
+/// The number of columns the Keccak circuit uses.
 pub const KECCAK_COLS: usize = 1965;
+
+/// The number of field elements used to represent the whole Keccak state.
 pub const STATE_LEN: usize = QUARTERS * DIM * DIM;
+
 pub const SHIFTS_LEN: usize = SHIFTS * STATE_LEN;
+
 // ROUND INDICES
+
 pub const THETA_STATE_A_OFF: usize = 0;
 pub const THETA_STATE_A_LEN: usize = STATE_LEN;
 pub const THETA_SHIFTS_C_OFF: usize = THETA_STATE_A_LEN;


### PR DESCRIPTION
The goal of this small PR is to fill the content of the HTML page generated by

```
RUSTDOCFLAGS="--enable-index-page -Zunstable-options -D warnings" cargo +nightly doc --workspace --all-features --no-deps
```
that we can find published [here](https://o1-labs.github.io/proof-systems/rustdoc/kimchi/circuits/polynomials/keccak/constants/index.html).