### PR TITLE
Fix CI: Make cargo doc warnings critical

### DIFF
--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -1,9 +1,12 @@
 name: Deploy Specifications & Docs to GitHub Pages
 
 on:
-  push:
-    branches:
-      - "*"
+  # Only trigger this job when PR is merged into master:
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request_target-workflow-when-a-pull-request-merges
+  pull_request_target:
+    branches: [master]
+    types:
+      - closed
 
 env:
   OCAML_VERSION: "4.14.0"
@@ -14,6 +17,7 @@ env:
 jobs:
   release:
     name: GitHub Pages
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -1,12 +1,8 @@
 name: Deploy Specifications & Docs to GitHub Pages
 
 on:
-  # Only trigger this job when PR is merged into master:
-  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request_target-workflow-when-a-pull-request-merges
-  pull_request_target:
+  push:
     branches: [master]
-    types:
-      - closed
 
 env:
   OCAML_VERSION: "4.14.0"
@@ -17,7 +13,6 @@ env:
 jobs:
   release:
     name: GitHub Pages
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -2,7 +2,7 @@ name: Deploy Specifications & Docs to GitHub Pages
 
 on:
   push:
-    branches: [master]
+    branches: ["master"]
 
 env:
   OCAML_VERSION: "4.14.0"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
         ocaml_version: ["4.14"]
 
     runs-on: ubuntu-latest
-    name: Basic checks and tests for (rust = ${{ matrix.rust_toolchain_version }}; ocaml = ${{ matrix.ocaml_version }})
+    name: Run some basic checks and tests
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,13 +65,13 @@ jobs:
 
       - name: Build the kimchi specification
         run: |
-          cd book/specifications
-          cd kimchi && make build
+          cd book/specifications/kimchi
+          make build
 
       - name: Build the polynomial commitment specification
         run: |
-          cd book/specifications
-          cd poly-commitment && make build
+          cd book/specifications/poly-commitment
+          make build
 
       - name: Check that up-to-date specification is checked in
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,9 +1,7 @@
 name: CI
 
 on:
-  push:
   pull_request:
-    types: [opened, reopened]
 
 env:
   # https://doc.rust-lang.org/cargo/reference/profiles.html#release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
         ocaml_version: ["4.14"]
 
     runs-on: ubuntu-latest
-    name: Run some basic checks and tests
+    name: Basic checks and tests
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4.1.1
@@ -75,6 +75,11 @@ jobs:
       - name: Check that up-to-date specification is checked in
         run: |
           git diff --exit-code ":(exclude)rust-toolchain"
+
+      - name: Build cargo docs
+        run: |
+          eval $(opam env)
+          RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps
 
       #
       # Coding guidelines

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
         ocaml_version: ["4.14"]
 
     runs-on: ubuntu-latest
-    name: Basic checks and tests
+    name: Basic checks and tests for (rust = ${{ matrix.rust_toolchain_version }}; ocaml = ${{ matrix.ocaml_version }})
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+    types: [opened, reopened]
 
 env:
   # https://doc.rust-lang.org/cargo/reference/profiles.html#release

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -448,14 +448,14 @@ pub fn to_group<G: CommitmentCurve>(m: &G::Map, t: <G as AffineCurve>::BaseField
 /// potential segments (if a polynomial was split in several parts).
 ///
 /// Elements in `evaluation_points` are several discrete points on which
-/// we evaluate polynomials, e.g. [zeta,zeta*w]. See `PointEvaluations`.
+/// we evaluate polynomials, e.g. `[zeta,zeta*w]`. See `PointEvaluations`.
 ///
 /// Note that if one of the polynomial comes specified with a degree
 /// bound, the evaluation for the last segment is potentially shifted
 /// to meet the proof.
 ///
 /// Returns
-///    res = \sum_{k=1}^{|polys|} \sum_{i=1}^{|segments[k]|} polyscale^{k*n+i} ( \sum_j polys[k][j][i] * evalscale^j )
+///    `res = \sum_{k=1}^{|polys|} \sum_{i=1}^{|segments[k]|} polyscale^{k*n+i} ( \sum_j polys[k][j][i] * evalscale^j )`
 #[allow(clippy::type_complexity)]
 pub fn combined_inner_product<F: PrimeField>(
     evaluation_points: &[F],

--- a/poseidon/src/sponge.rs
+++ b/poseidon/src/sponge.rs
@@ -3,8 +3,8 @@ use crate::poseidon::{ArithmeticSponge, ArithmeticSpongeParams, Sponge};
 use ark_ec::{short_weierstrass_jacobian::GroupAffine, SWModelParameters};
 use ark_ff::{BigInteger, Field, FpParameters, One, PrimeField, Zero};
 
-/// Abstracts a sponge operating on a base field [`Fq`] of the curve
-/// [`G`]. The parameter [`Fr`] is modelling the scalar field of the
+/// Abstracts a sponge operating on a base field `Fq` of the curve
+/// `G`. The parameter `Fr` is modelling the scalar field of the
 /// curve.
 pub trait FqSponge<Fq: Field, G, Fr> {
     /// Creates a new sponge.
@@ -14,10 +14,10 @@ pub trait FqSponge<Fq: Field, G, Fr> {
     /// straightforward and calls the underlying sponge directly.
     fn absorb_fq(&mut self, x: &[Fq]);
 
-    /// Absorbs a base field point, that is a pair of [`Fq`] elements.
+    /// Absorbs a base field point, that is a pair of `Fq` elements.
     fn absorb_g(&mut self, g: &[G]);
 
-    /// Absorbs an element of the scalar field [`Fr`] --- it is done
+    /// Absorbs an element of the scalar field `Fr` --- it is done
     /// by converting the element to the base field first.
     fn absorb_fr(&mut self, x: &[Fr]);
 


### PR DESCRIPTION
Recent changes to GH page deployment made doc warnings critical, but this was not caught in CI. This PR adds the missing CI warning and fixes some newly introduced doc warnings.