### PR TITLE
Add constraint count and degree in docs

### DIFF
--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -89,8 +89,8 @@ pub struct KeccakWitness<T> {
     pub hash_index: T,                        // Which hash this is inside the circuit
     pub step_index: T,                        // Which step this is inside the hash
     pub mode_flags: [T; MODE_FLAGS_COLS_LEN], // Round, Absorb, Squeeze
-    pub curr: [T; ZKVM_KECCAK_COLS_CURR],     // Curr[0..1965) + RC as quarters
-    pub next: [T; ZKVM_KECCAK_COLS_NEXT],     // Next[0..100)
+    pub curr: [T; ZKVM_KECCAK_COLS_CURR], // Contains 1969 witnesses used in the current step including Input and RoundConstants
+    pub next: [T; ZKVM_KECCAK_COLS_NEXT], // Contains the Output
 }
 
 impl<T: Clone> KeccakWitness<T> {


### PR DESCRIPTION
This PR improves the documentation of the `keccak/constraints.rs` module. In particular, it includes the constraint count for better traceability, including their degree.

Only 5 constraints have degree 3, so we shall expect that after quadricization is applied, we will need just a few more witness columns and constraints to make them degree 2.

Alternatively, we can intentionally shift the beginning of the sponge columns (since they have about 1k less used columns than the round), so that the `quotient_c` values are located in witness columns which would be set to zero regardless in sponge steps. That way, we could rephrase the constraint to be instead of `is_round * is_boolean (quotient_c)` to just `is_boolean(quotient_c)`. Opening issue to trace this optimization -> https://github.com/o1-labs/proof-systems/issues/1751