### PR TITLE
[easy but long] Improve documentation of environment and fix `from_shifts` function

### DIFF
--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -47,37 +47,37 @@ pub(crate) const PAD_SUFFIX_LEN: usize = 5; // The padding suffix of 1088 bits i
 /// (Sponge or Round) that is currently being executed.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum KeccakColumn {
-    HashIndex,              // Which hash this is inside the circuit
-    StepIndex,              // Which step this is inside the hash
-    FlagRound,              // Coeff Round = [0..24)
-    FlagAbsorb,             // Coeff Absorb = 0 | 1
-    FlagSqueeze,            // Coeff Squeeze = 0 | 1
-    FlagRoot,               // Coeff Root = 0 | 1
-    PadLength,              // Coeff Length 0 | 1 ..=136
-    InvPadLength,           // Inverse of PadLength when PadLength != 0
-    TwoToPad,               // 2^PadLength
-    PadBytesFlags(usize),   // 136 boolean values
-    PadSuffix(usize),       // 5 values with padding suffix
-    RoundConstants(usize),  // Round constants
-    Input(usize),           // Curr[0..100) either ThetaStateA or SpongeOldState
-    ThetaShiftsC(usize),    // Round Curr[100..180)
-    ThetaDenseC(usize),     // Round Curr[180..200)
-    ThetaQuotientC(usize),  // Round Curr[200..205)
+    HashIndex,    // Hash identifier to distinguish inside the syscalls communication channel
+    StepIndex,    // Hash step identifier to distinguish inside interstep communication
+    FlagRound,    // Coeff Round = [0..24)
+    FlagAbsorb,   // Coeff Absorb = 0 | 1
+    FlagSqueeze,  // Coeff Squeeze = 0 | 1
+    FlagRoot,     // Coeff Root = 0 | 1
+    PadLength,    // Coeff Length 0 | 1 ..=136
+    InvPadLength, // Inverse of PadLength when PadLength != 0
+    TwoToPad,     // 2^PadLength
+    PadBytesFlags(usize), // 136 boolean values
+    PadSuffix(usize), // 5 values with padding suffix
+    RoundConstants(usize), // Round constants
+    Input(usize), // Curr[0..100) either ThetaStateA or SpongeOldState
+    ThetaShiftsC(usize), // Round Curr[100..180)
+    ThetaDenseC(usize), // Round Curr[180..200)
+    ThetaQuotientC(usize), // Round Curr[200..205)
     ThetaRemainderC(usize), // Round Curr[205..225)
-    ThetaDenseRotC(usize),  // Round Curr[225..245)
+    ThetaDenseRotC(usize), // Round Curr[225..245)
     ThetaExpandRotC(usize), // Round Curr[245..265)
-    PiRhoShiftsE(usize),    // Round Curr[265..665)
-    PiRhoDenseE(usize),     // Round Curr[665..765)
-    PiRhoQuotientE(usize),  // Round Curr[765..865)
+    PiRhoShiftsE(usize), // Round Curr[265..665)
+    PiRhoDenseE(usize), // Round Curr[665..765)
+    PiRhoQuotientE(usize), // Round Curr[765..865)
     PiRhoRemainderE(usize), // Round Curr[865..965)
-    PiRhoDenseRotE(usize),  // Round Curr[965..1065)
+    PiRhoDenseRotE(usize), // Round Curr[965..1065)
     PiRhoExpandRotE(usize), // Round Curr[1065..1165)
-    ChiShiftsB(usize),      // Round Curr[1165..1565)
-    ChiShiftsSum(usize),    // Round Curr[1565..1965)
-    SpongeNewState(usize),  // Sponge Curr[100..200)
-    SpongeBytes(usize),     // Sponge Curr[200..400)
-    SpongeShifts(usize),    // Sponge Curr[400..800)
-    Output(usize),          // Next[0..100) either IotaStateG or SpongeXorState
+    ChiShiftsB(usize), // Round Curr[1165..1565)
+    ChiShiftsSum(usize), // Round Curr[1565..1965)
+    SpongeNewState(usize), // Sponge Curr[100..200)
+    SpongeBytes(usize), // Sponge Curr[200..400)
+    SpongeShifts(usize), // Sponge Curr[400..800)
+    Output(usize), // Next[0..100) either IotaStateG or SpongeXorState
 }
 
 /// The witness columns used by the Keccak circuit.

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -1,20 +1,25 @@
+/// This module contains the definition and implementation of the Keccak environment
+use crate::{
+    keccak::{
+        column::{KeccakColumn, KeccakWitness, PAD_BYTES_LEN, ROUND_COEFFS_LEN},
+        constraints::Constraints,
+        grid_index,
+        interpreter::{Absorb, KeccakStep, Sponge},
+        ArithOps, BoolOps, DIM, E, QUARTERS,
+    },
+    mips::interpreter::Lookup,
+};
+use ark_ff::{Field, One};
+use kimchi::{
+    auto_clone_array,
+    circuits::expr::ConstantTerm::Literal,
+    circuits::{expr::Operations, polynomials::keccak::constants::*, polynomials::keccak::Keccak},
+    grid,
+    o1_utils::Two,
+};
 use std::array;
 
-use super::{
-    column::{KeccakColumn, KeccakWitness, PAD_BYTES_LEN, ROUND_COEFFS_LEN},
-    constraints::Constraints,
-    grid_index,
-    interpreter::{Absorb, KeccakStep, Sponge},
-    ArithOps, BoolOps, DIM, E, QUARTERS,
-};
-use crate::mips::interpreter::Lookup;
-use ark_ff::{Field, One};
-use kimchi::circuits::{expr::Operations, polynomials::keccak::Keccak};
-use kimchi::{
-    auto_clone_array, circuits::expr::ConstantTerm::Literal,
-    circuits::polynomials::keccak::constants::*, grid, o1_utils::Two,
-};
-
+/// This struct contains all that needs to be kept track of during the execution of the Keccak step interpreter
 #[derive(Clone, Debug)]
 pub struct KeccakEnv<Fp> {
     /// Constraints that are added to the circuit
@@ -45,6 +50,7 @@ pub struct KeccakEnv<Fp> {
 }
 
 impl<Fp: Field> KeccakEnv<Fp> {
+    /// Starts a new Keccak environment for a given hash index and bytestring of preimage data
     pub fn new(hash_idx: u64, preimage: &[u8]) -> Self {
         let mut env = Self {
             constraints: vec![],
@@ -60,9 +66,10 @@ impl<Fp: Field> KeccakEnv<Fp> {
             pad_len: 0,
         };
 
-        // Store hash index
+        // Store hash index in the witness
         env.write_column(KeccakColumn::HashIndex, env.hash_idx);
 
+        // Update the number of blocks left to be absorbed depending on the length of the preimage
         env.blocks_left_to_absorb = Keccak::num_blocks(preimage.len()) as u64;
 
         // Configure first step depending on number of blocks remaining
@@ -73,10 +80,10 @@ impl<Fp: Field> KeccakEnv<Fp> {
         };
         env.step_idx = 0;
 
-        // Root state is zero
+        // Root state (all zeros) shall be used for the first step
         env.prev_block = vec![0u64; STATE_LEN];
 
-        // Pad preimage
+        // Pad preimage with the 10*1 padding rule
         env.padded = Keccak::pad(preimage);
         env.block_idx = 0;
         env.pad_len = (env.padded.len() - preimage.len()) as u64;
@@ -84,18 +91,22 @@ impl<Fp: Field> KeccakEnv<Fp> {
         env
     }
 
+    /// Writes an integer value to a column of the Keccak witness
     pub fn write_column(&mut self, column: KeccakColumn, value: u64) {
         self.keccak_witness[column] = Fp::from(value);
     }
 
+    /// Writes a field value to a column of the Keccak witness
     pub fn write_column_field(&mut self, column: KeccakColumn, value: Fp) {
         self.keccak_witness[column] = value;
     }
 
+    /// Nullifies the KeccakWitness of the environment by resetting it to default values
     pub fn null_state(&mut self) {
         self.keccak_witness = KeccakWitness::default();
     }
 
+    /// This function updates the next step of the environment depending on the current step
     pub fn update_step(&mut self) {
         match self.keccak_step {
             Some(step) => match step {
@@ -187,6 +198,7 @@ impl<Fp: Field> ArithOps for KeccakEnv<Fp> {
     }
 }
 
+/// This trait includes functionalities needed to obtain the variables of the Keccak circuit needed for constraints
 pub(crate) trait KeccakEnvironment {
     type Column;
     type Variable: std::ops::Mul<Self::Variable, Output = Self::Variable>
@@ -195,6 +207,16 @@ pub(crate) trait KeccakEnvironment {
         + Clone;
     type Fp: std::ops::Neg<Output = Self::Fp>;
 
+    /// This function returns the composed sparse variable from shifts of any correct length:
+    /// - When the length is 400, two index configurations are possible:
+    ///     - If `i` is `Some`, then this sole index could range between [0..400)
+    ///     - If `i` is `None`, then `y`, `x` and `q` must be `Some` and
+    ///         - `y` must range between [0..5)
+    ///         - `x` must range between [0..5)
+    ///         - `q` must range between [0..4)
+    /// - When the length is 80, both `i` and `y` should be `None`, and `x` and `q` must be `Some` with:
+    ///     - `x` must range between [0..5)
+    ///     - `q` must range between [0..4)
     fn from_shifts(
         shifts: &[Self::Variable],
         i: Option<usize>,
@@ -203,110 +225,181 @@ pub(crate) trait KeccakEnvironment {
         q: Option<usize>,
     ) -> Self::Variable;
 
+    /// This function returns the composed variable from dense quarters of any correct length:
+    /// - When `y` is `Some`, then the length must be 100 and:
+    ///     - `y` must range between [0..5)
+    ///     - `x` must range between [0..5)
+    /// - When `y` is `None`, then the length must be 20 and:
+    ///     - `x` must range between [0..5)
     fn from_quarters(quarters: &[Self::Variable], y: Option<usize>, x: usize) -> Self::Variable;
 
+    /// Returns a variable that encodes whether the current step is a sponge
     fn is_sponge(&self) -> Self::Variable;
-
+    /// Returns a variable that encodes whether the current step is an absorb sponge
     fn is_absorb(&self) -> Self::Variable;
-
+    /// Returns a variable that encodes whether the current step is a squeeze sponge
     fn is_squeeze(&self) -> Self::Variable;
-
+    /// Returns a variable that encodes whether the current step is the first absorb sponge
     fn is_root(&self) -> Self::Variable;
-
+    /// Returns a degree-2 variable that encodes whether the current step is the last absorb sponge
     fn is_pad(&self) -> Self::Variable;
 
+    /// Returns a variable that encodes whether the current step is a permutation round
     fn is_round(&self) -> Self::Variable;
-
+    /// Returns a variable that encodes the current round number [0..24)
     fn round(&self) -> Self::Variable;
 
+    /// Returns a variable that encodes the bytelength of the padding if any [0..136)
     fn pad_length(&self) -> Self::Variable;
-
+    /// Returns a variable that encodes the value 2^pad_length
     fn two_to_pad(&self) -> Self::Variable;
 
+    /// Returns a variable that encodes whether the `idx`-th byte of the new block is involved in the padding
     fn in_padding(&self, idx: usize) -> Self::Variable;
 
+    /// Returns a variable that encodes the `idx`-th chunk of the padding suffix
+    /// - if `idx` = 0, then the length is 12 bytes at most
+    /// - if `idx` = [1..5), then the length is 31 bytes at most
     fn pad_suffix(&self, idx: usize) -> Self::Variable;
 
+    /// Returns a variable that encodes the `idx`-th block of bytes of the new block
+    /// by composing the bytes variables, with `idx` in [0..5)
     fn bytes_block(&self, idx: usize) -> Vec<Self::Variable>;
 
+    /// Returns the 136 flags indicating which bytes of the new block are involved in the padding, as variables
     fn pad_bytes_flags(&self) -> [Self::Variable; PAD_BYTES_LEN];
+
+    /// Returns a vector of pad bytes flags as variables, with `idx` in [0..5)
+    /// - if `idx` = 0, then the length of the vector is at most 12
+    /// - if `idx` = [1..5), then the length of the vector is at most 31
     fn flags_block(&self, idx: usize) -> Vec<Self::Variable>;
 
+    /// This function returns a variable that is computed as the accumulated value of the
+    /// operation `byte * flag * 2^8` for each byte block and flag block of the new block.
+    /// This function will be used in constraints to determine whether the padding is located
+    /// at the end of the preimage data, as consecutive bits that are involved in the padding.
     fn block_in_padding(&self, idx: usize) -> Self::Variable;
 
+    /// Returns the 4 expanded quarters that encode the round constant, as variables
     fn round_constants(&self) -> [Self::Variable; ROUND_COEFFS_LEN];
 
+    /// Returns the `idx`-th old state expanded quarter, as a variable
     fn old_state(&self, idx: usize) -> Self::Variable;
 
+    /// Returns the `idx`-th new state expanded quarter, as a variable
     fn new_state(&self, idx: usize) -> Self::Variable;
 
+    /// Returns the output of an absorb sponge, which is the XOR of the old state and the new state
     fn xor_state(&self, idx: usize) -> Self::Variable;
 
+    /// Returns the last 32 terms that are added to the new block in an absorb sponge, as variables which should be zeros
     fn sponge_zeros(&self) -> [Self::Variable; SPONGE_ZEROS_LEN];
 
+    /// Returns the 400 terms that compose the shifts of the sponge, as variables
     fn vec_sponge_shifts(&self) -> [Self::Variable; SPONGE_SHIFTS_LEN];
+    /// Returns the `idx`-th term of the shifts of the sponge, as a variable
     fn sponge_shifts(&self, idx: usize) -> Self::Variable;
 
-    fn sponge_byte(&self, idx: usize) -> Self::Variable;
+    /// Returns the 200 bytes of the sponge, as variables
     fn sponge_bytes(&self) -> [Self::Variable; SPONGE_BYTES_LEN];
+    /// Returns the `idx`-th byte of the sponge, as a variable
+    fn sponge_byte(&self, idx: usize) -> Self::Variable;
 
+    /// Returns the (y,x,q)-th input of the theta algorithm, as a variable
     fn state_a(&self, y: usize, x: usize, q: usize) -> Self::Variable;
 
+    /// Returns the 80 variables corresponding to ThetaShiftsC
     fn vec_shifts_c(&self) -> [Self::Variable; THETA_SHIFTS_C_LEN];
+    /// Returns the (i,x,q)-th variable of ThetaShiftsC
     fn shifts_c(&self, i: usize, x: usize, q: usize) -> Self::Variable;
 
+    /// Returns the 20 variables corresponding to ThetaDenseC
     fn vec_dense_c(&self) -> [Self::Variable; THETA_DENSE_C_LEN];
+    /// Returns the (x,q)-th term of ThetaDenseC, as a variable
     fn dense_c(&self, x: usize, q: usize) -> Self::Variable;
 
+    /// Returns the 5 variables corresponding to ThetaQuotientC
     fn vec_quotient_c(&self) -> [Self::Variable; THETA_QUOTIENT_C_LEN];
+    /// Returns the (x)-th term of ThetaQuotientC, as a variable
     fn quotient_c(&self, x: usize) -> Self::Variable;
 
+    /// Returns the 20 variables corresponding to ThetaRemainderC
     fn vec_remainder_c(&self) -> [Self::Variable; THETA_REMAINDER_C_LEN];
+    /// Returns the (x,q)-th variable of ThetaRemainderC
     fn remainder_c(&self, x: usize, q: usize) -> Self::Variable;
 
+    /// Returns the 20 variables corresponding to ThetaDenseRotC
     fn vec_dense_rot_c(&self) -> [Self::Variable; THETA_DENSE_ROT_C_LEN];
+    /// Returns the (x,q)-th variable of ThetaDenseRotC
     fn dense_rot_c(&self, x: usize, q: usize) -> Self::Variable;
 
+    /// Returns the 20 variables corresponding to ThetaExpandRotC
     fn vec_expand_rot_c(&self) -> [Self::Variable; THETA_EXPAND_ROT_C_LEN];
+    /// Returns the (x,q)-th variable of ThetaExpandRotC
     fn expand_rot_c(&self, x: usize, q: usize) -> Self::Variable;
 
+    /// Returns the 400 variables corresponding to PiRhoShiftsE
     fn vec_shifts_e(&self) -> [Self::Variable; PIRHO_SHIFTS_E_LEN];
+    /// Returns the (i,y,x,q)-th variable of PiRhoShiftsE
     fn shifts_e(&self, i: usize, y: usize, x: usize, q: usize) -> Self::Variable;
 
+    /// Returns the 100 variables corresponding to PiRhoDenseE
     fn vec_dense_e(&self) -> [Self::Variable; PIRHO_DENSE_E_LEN];
+    /// Returns the (y,x,q)-th variable of PiRhoDenseE
     fn dense_e(&self, y: usize, x: usize, q: usize) -> Self::Variable;
 
+    /// Returns the 100 variables corresponding to PiRhoQuotientE
     fn vec_quotient_e(&self) -> [Self::Variable; PIRHO_QUOTIENT_E_LEN];
+    /// Returns the (y,x,q)-th variable of PiRhoQuotientE
     fn quotient_e(&self, y: usize, x: usize, q: usize) -> Self::Variable;
 
+    /// Returns the 100 variables corresponding to PiRhoRemainderE
     fn vec_remainder_e(&self) -> [Self::Variable; PIRHO_REMAINDER_E_LEN];
+    /// Returns the (y,x,q)-th variable of PiRhoRemainderE
     fn remainder_e(&self, y: usize, x: usize, q: usize) -> Self::Variable;
 
+    /// Returns the 100 variables corresponding to PiRhoDenseRotE
     fn vec_dense_rot_e(&self) -> [Self::Variable; PIRHO_DENSE_ROT_E_LEN];
+    /// Returns the (y,x,q)-th variable of PiRhoDenseRotE
     fn dense_rot_e(&self, y: usize, x: usize, q: usize) -> Self::Variable;
 
+    /// Returns the 100 variables corresponding to PiRhoExpandRotE
     fn vec_expand_rot_e(&self) -> [Self::Variable; PIRHO_EXPAND_ROT_E_LEN];
+    /// Returns the (y,x,q)-th variable of PiRhoExpandRotE
     fn expand_rot_e(&self, y: usize, x: usize, q: usize) -> Self::Variable;
 
+    /// Returns the 400 variables corresponding to ChiShiftsB
     fn vec_shifts_b(&self) -> [Self::Variable; CHI_SHIFTS_B_LEN];
+    /// Returns the (i,y,x,q)-th variable of ChiShiftsB
     fn shifts_b(&self, i: usize, y: usize, x: usize, q: usize) -> Self::Variable;
 
+    /// Returns the 400 variables corresponding to ChiShiftsSum
     fn vec_shifts_sum(&self) -> [Self::Variable; CHI_SHIFTS_SUM_LEN];
+    /// Returns the (i,y,x,q)-th variable of ChiShiftsSum
     fn shifts_sum(&self, i: usize, y: usize, x: usize, q: usize) -> Self::Variable;
 
+    /// Returns the `idx`-th output of a round step as a variable
     fn state_g(&self, idx: usize) -> Self::Variable;
 
-    /// Returns the hash index
+    /// Returns the hash index as a variable
     fn hash_index(&self) -> Self::Variable;
-    /// Returns the step index
+    /// Returns the step index as a variable
     fn step_index(&self) -> Self::Variable;
-    /// Returns the input variables
+
+    /// Returns the 100 step input variables, which correspond to the:
+    /// - State A when the current step is a permutation round
+    /// - Old state when the current step is a non-root sponge
     fn input(&self) -> [Self::Variable; STATE_LEN];
     /// Returns a slice of the input variables of the current step
+    /// including the current hash index and step index
     fn input_of_step(&self) -> Vec<Self::Variable>;
-    /// Returns the output variables
+
+    /// Returns the 100 step output variables, which correspond to the:
+    /// - State G when the current step is a permutation round
+    /// - Xor state when the current step is an absorb sponge
     fn output(&self) -> [Self::Variable; STATE_LEN];
     /// Returns a slice of the output variables of the current step (= input of next step)
+    /// including the current hash index and step index
     fn output_of_step(&self) -> Vec<Self::Variable>;
 }
 
@@ -338,8 +431,8 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
                         + Self::two_pow(3) * shifts(3, y.unwrap(), x.unwrap(), q.unwrap())
                 }
             }
-            100 => {
-                let shifts = grid!(100, shifts);
+            80 => {
+                let shifts = grid!(80, shifts);
                 shifts(0, x.unwrap(), q.unwrap())
                     + Self::two_pow(1) * shifts(1, x.unwrap(), q.unwrap())
                     + Self::two_pow(2) * shifts(2, x.unwrap(), q.unwrap())


### PR DESCRIPTION
This PR adds documentation comments inside the `keccak/environment.rs` file. 

As part of the documenting process, I realized that the `from_shifts` function was not behaving as expected. In the sense that it was giving support for shifts of length 100, which do not exist. Instead, I changed the match branch to be 80, which will fix it.

It also addresses this comment by Danny https://github.com/o1-labs/proof-systems/pull/1749#discussion_r1464876470