### PR TITLE
Add docs to interpreter and change location where `PadSuffix` columns were assigned

### DIFF
--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -1,5 +1,5 @@
-/// This module defines the custom columns used in the Keccak witness, which
-/// are aliases for the actual Keccak witness columns also defined here.
+//! This module defines the custom columns used in the Keccak witness, which
+//! are aliases for the actual Keccak witness columns also defined here.
 use super::{ZKVM_KECCAK_COLS_CURR, ZKVM_KECCAK_COLS_NEXT};
 use ark_ff::{One, Zero};
 use kimchi::circuits::polynomials::keccak::constants::{

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -1,4 +1,4 @@
-/// This module contains the constraints for one Keccak step.
+//! This module contains the constraints for one Keccak step.
 use crate::keccak::{
     column::{KeccakColumn, PAD_SUFFIX_LEN},
     environment::{KeccakEnv, KeccakEnvironment},

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -1,4 +1,4 @@
-/// This module contains the definition and implementation of the Keccak environment
+//! This module contains the definition and implementation of the Keccak environment
 use crate::{
     keccak::{
         column::{KeccakColumn, KeccakWitness, PAD_BYTES_LEN, ROUND_COEFFS_LEN},

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -1,3 +1,5 @@
+//! This module defines the Keccak interpreter in charge of triggering the Keccak workflow
+
 /// Variants of Keccak steps available for the interpreter
 #[derive(Clone, Debug, PartialEq, Copy)]
 pub enum KeccakStep {
@@ -15,13 +17,13 @@ pub enum Sponge {
 /// Order of absorb steps in the computation depending on the number of blocks to absorb
 #[derive(Clone, Debug, PartialEq, Copy)]
 pub enum Absorb {
-    First,
-    Middle,
-    Last,
-    FirstAndLast,
+    First,        // Also known as the root absorb
+    Middle,       // Any other absorb
+    Last,         // Also known as the padding absorb
+    FirstAndLast, // In case there is only one block to absorb (preimage data is less than 136 bytes)
 }
 
-/// Interpreter for the Keccak hash function
+/// Interpreter for the Keccak hash function in charge of instantiating the Keccak environment.
 pub trait KeccakInterpreter {
     type Position;
 
@@ -31,19 +33,39 @@ pub trait KeccakInterpreter {
         + std::ops::Mul<Self::Variable, Output = Self::Variable>
         + std::fmt::Debug;
 
+    /// Entrypoint for the interpreter. It executes one step of the Keccak circuit (one row),
+    /// and updates the environment accordingly (including the witness and inter-step lookups).
+    /// When it finishes, it updates the value of the current step, so that the next call to
+    /// the `step()` function executes the next step.
     fn step(&mut self);
 
+    /// Updates the witness corresponding to the `FlagRound` column with a value in [0..24)
     fn set_flag_round(&mut self, round: u64);
+    /// Sets the witness corresponding to the `FlagSqueeze` column to 1
+    fn set_flag_squeeze(&mut self);
+    /// Sets the witness corresponding to the `FlagAbsorb` column to 1 and
+    /// updates and any other sponge flag depending on the kind of absorb step (root, padding, both).
     fn set_flag_absorb(&mut self, absorb: Absorb);
+    /// Sets the witness corresponding to the `FlagRoot` column to 1
     fn set_flag_root(&mut self);
+    /// Sets the witness corresponding to the `FlagPad` column to 1, and updates the remaining columns
+    /// related to padding flags such as `PadLength`, `InvPadLength`, `TwoToPad`, `PadBytesFlags`, and `PadSuffix`.
     fn set_flag_pad(&mut self);
 
+    /// Assigns the witness values needed in a sponge step (absorb or squeeze)
     fn run_sponge(&mut self, sponge: Sponge);
+    /// Assigns the witness values needed in an absorb step (root, padding, or middle)
     fn run_absorb(&mut self, absorb: Absorb);
+    /// Assigns the witness values needed in a squeeze step
     fn run_squeeze(&mut self);
+    /// Assigns the witness values needed in the round step for the given round index
     fn run_round(&mut self, round: u64);
+    /// Assigns the witness values needed in the theta algorithm
     fn run_theta(&mut self, state_a: &[u64]) -> Vec<u64>;
+    /// Assigns the witness values needed in the pirho algorithm
     fn run_pirho(&mut self, state_e: &[u64]) -> Vec<u64>;
+    /// Assigns the witness values needed in the chi algorithm
     fn run_chi(&mut self, state_b: &[u64]) -> Vec<u64>;
+    /// Assigns the witness values needed in the iota algorithm
     fn run_iota(&mut self, state_f: &[u64], round: usize) -> Vec<u64>;
 }

--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -1,4 +1,4 @@
-/// This module includes the lookups of the Keccak circuit
+//! This module includes the lookups of the Keccak circuit
 use crate::{
     keccak::{
         column::KeccakColumn,


### PR DESCRIPTION
While adding doc comments to the `keccak/interpreter.rs` file, I realized that the `PadSuffix` columns of the witness were being assigned in every absorb sponge, even when they are only used in padding absorbs. This is not really a bug, given that constraints and lookups would still hold. But I thought it made more sense to do it only in padding rows.