### PR TITLE
Book: Fix Kimchi syntax regarding u/v + cosmetics

### DIFF
--- a/book/src/kimchi/final_check.md
+++ b/book/src/kimchi/final_check.md
@@ -15,14 +15,14 @@ What is it missing in the permutation part? Let's look more closely. This is wha
 
 $$
 \begin{align}
--1 \cdot z(\zeta \omega) \cdot zkpm(\zeta) \cdot \alpha^{PERM0} \cdot \\
-                (w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma) \cdot \\
-                (w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma) \cdot \\
-                (w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma) \cdot \\
-                (w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma) \cdot \\
-                (w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma) \cdot \\
-                (w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma) \cdot \\
-                \beta \cdot \sigma[6](x)
+-1\, \cdot\, &z(\zeta \omega) \cdot \mathsf{zkpm}(\zeta) \cdot \alpha^{\mathsf{PERM0}} \\
+     \cdot\, &(w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma) \\
+     \cdot\, &(w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma) \\
+     \cdot\, &(w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma) \\
+     \cdot\, &(w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma) \\
+     \cdot\, &(w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma) \\
+     \cdot\, &(w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma) \\
+     \cdot\, &\beta \cdot \sigma[6](x)
 \end{align}
 $$
 
@@ -30,70 +30,72 @@ In comparison, here is the list of the stuff we needed to have:
 
 1. the two sides of the coin:
     $$\begin{align}
-        & z(\zeta) \cdot zkpm(\zeta) \cdot \alpha^{PERM0} \cdot \\
-        & (w[0](\zeta) + \beta \cdot \text{shift}[0] \zeta + \gamma) \cdot \\
-        & (w[1](\zeta) + \beta \cdot \text{shift}[1] \zeta + \gamma) \cdot \\
-        & (w[2](\zeta) + \beta \cdot \text{shift}[2] \zeta + \gamma) \cdot \\
-        & (w[3](\zeta) + \beta \cdot \text{shift}[3] \zeta + \gamma) \cdot \\
-        & (w[4](\zeta) + \beta \cdot \text{shift}[4] \zeta + \gamma) \cdot \\
-        & (w[5](\zeta) + \beta \cdot \text{shift}[5] \zeta + \gamma) \cdot \\
-        & (w[6](\zeta) + \beta \cdot \text{shift}[6] \zeta + \gamma)
+         z(\zeta)\, \cdot\, &\mathsf{zkpm}(\zeta) \cdot \alpha^{\mathsf{PERM0}} \\
+                    \cdot\, &(w[0](\zeta) + \beta \cdot \mathsf{shift}[0](\zeta) + \gamma) \\
+                    \cdot\, &(w[1](\zeta) + \beta \cdot \mathsf{shift}[1](\zeta) + \gamma) \\
+                    \cdot\, &(w[2](\zeta) + \beta \cdot \mathsf{shift}[2](\zeta) + \gamma) \\
+                    \cdot\, &(w[3](\zeta) + \beta \cdot \mathsf{shift}[3](\zeta) + \gamma) \\
+                    \cdot\, &(w[4](\zeta) + \beta \cdot \mathsf{shift}[4](\zeta) + \gamma) \\
+                    \cdot\, &(w[5](\zeta) + \beta \cdot \mathsf{shift}[5](\zeta) + \gamma) \\
+                    \cdot\, &(w[6](\zeta) + \beta \cdot \mathsf{shift}[6](\zeta) + \gamma)
     \end{align}$$
-    with $\text{shift}[0] = 1$
+    with $\mathsf{shift}[0] = 1$
 2. and
     $$\begin{align}
-    & -1 \cdot z(\zeta \omega) \cdot zkpm(\zeta) \cdot \alpha^{PERM0} \cdot \\
-    & (w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma) \cdot \\
-    & (w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma) \cdot \\
-    & (w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma) \cdot \\
-    & (w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma) \cdot \\
-    & (w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma) \cdot \\
-    & (w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma) \cdot \\
-    & (w[6](\zeta) + \beta \cdot \sigma[6](\zeta) + \gamma) \cdot
+    -1\, \cdot\, &z(\zeta \omega) \cdot \mathsf{zkpm}(\zeta) \cdot \alpha^{\mathsf{PERM0}} \\
+         \cdot\, &(w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma) \\
+         \cdot\, &(w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma) \\
+         \cdot\, &(w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma) \\
+         \cdot\, &(w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma) \\
+         \cdot\, &(w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma) \\
+         \cdot\, &(w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma) \\
+         \cdot\, &(w[6](\zeta) + \beta \cdot \sigma[6](\zeta) + \gamma)
     \end{align}$$
 3. the initialization:
-    $$(z(\zeta) - 1) L_1(\zeta) \alpha^{PERM1}$$
+    $$(z(\zeta) - 1) \cdot L_1(\zeta) \cdot \alpha^{\mathsf{PERM1}}$$
 4. and the end of the accumulator:
-    $$(z(\zeta) - 1) L_{n-k}(\zeta) \alpha^{PERM2}$$
+    $$(z(\zeta) - 1) \cdot L_{n-k}(\zeta) \cdot \alpha^{\mathsf{PERM2}}$$
 
 You can read more about why it looks like that in [this post](https://minaprotocol.com/blog/a-more-efficient-approach-to-zero-knowledge-for-plonk).
 
 We can see clearly that the permutation stuff we have in f is clearly lacking. It's just the subtraction part (equation 2), and even that is missing some terms. It is missing exactly this:
 
-$$\begin{align}
-    & -1 \cdot z(\zeta \omega) \cdot zkpm(\zeta) \cdot \alpha^{PERM0} \cdot \\
-    & (w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma) \cdot \\
-    & (w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma) \cdot \\
-    & (w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma) \cdot \\
-    & (w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma) \cdot \\
-    & (w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma) \cdot \\
-    & (w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma) \cdot \\
-    & (w[6](\zeta) + \gamma)
-    \end{align}$$
+$$
+\begin{align}
+    -1\ \cdot\, &z(\zeta \omega) \cdot \mathsf{zkpm}(\zeta) \cdot \alpha^{\mathsf{PERM0}}  \\
+        \cdot\, &(w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma)  \\
+        \cdot\, &(w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma)  \\
+        \cdot\, &(w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma)  \\
+        \cdot\, &(w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma)  \\
+        \cdot\, &(w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma)  \\
+        \cdot\, &(w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma)  \\
+        \cdot\, &(w[6](\zeta) + \gamma)
+\end{align}
+$$
 
 So at the end, when we have to check for the identity $f(\zeta) = Z_H(\zeta) t(\zeta)$ we'll actually have to check something like this (I colored the missing parts on the left hand side of the equation):
 
 $$
 \begin{align}
-& f(\zeta) + \color{darkgreen}{pub(\zeta)} + \\
-& \color{darkred}{z(\zeta) \cdot zkpm(\zeta) \cdot \alpha^{PERM0} \cdot} \\
-& \color{darkred}{(w[0](\zeta) + \beta \zeta + \gamma) \cdot} \\
-& \color{darkred}{(w[1](\zeta) + \beta \cdot \text{shift}[0] \zeta + \gamma) \cdot} \\
-& \color{darkred}{(w[2](\zeta) + \beta \cdot \text{shift}[1] \zeta + \gamma) \cdot} \\
-& \color{darkred}{(w[3](\zeta) + \beta \cdot \text{shift}[2] \zeta + \gamma) \cdot} \\
-& \color{darkred}{(w[4](\zeta) + \beta \cdot \text{shift}[3] \zeta + \gamma) \cdot} \\
-& \color{darkred}{(w[5](\zeta) + \beta \cdot \text{shift}[4] \zeta + \gamma) \cdot} \\
-& \color{darkred}{(w[6](\zeta) + \beta \cdot \text{shift}[5] \zeta + \gamma) +} \\
-& \color{blue}{- z(\zeta \omega) \cdot zkpm(\zeta) \cdot \alpha^{PERM0} \cdot} \\
-& \color{blue}{(w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma) \cdot} \\
-& \color{blue}{(w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma) \cdot} \\
-& \color{blue}{(w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma) \cdot} \\
-& \color{blue}{(w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma) \cdot} \\
-& \color{blue}{(w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma) \cdot} \\
-& \color{blue}{(w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma) \cdot} \\
-& \color{blue}{(w[6](\zeta) + \gamma) +} \\
-& \color{purple}{(z(\zeta) - 1) L_1(\zeta) \alpha^{PERM1} +} \\
-& \color{darkblue}{(z(\zeta) - 1) L_{n-k}(\zeta) \alpha^{PERM2}} \\
+f(\zeta) &+ \color{darkgreen}{\mathsf{pub}(\zeta)} \\
+& \color{darkred}{+ z(\zeta) \cdot \mathsf{zkpm}(\zeta) \cdot \alpha^{\mathsf{PERM0}}} \\
+& \qquad \color{darkred}{\cdot (w[0](\zeta) + \beta \zeta + \gamma)} \\
+& \qquad \color{darkred}{\cdot (w[1](\zeta) + \beta \cdot \mathsf{shift}[0](\zeta) + \gamma)} \\
+& \qquad \color{darkred}{\cdot (w[2](\zeta) + \beta \cdot \mathsf{shift}[1](\zeta) + \gamma)} \\
+& \qquad \color{darkred}{\cdot (w[3](\zeta) + \beta \cdot \mathsf{shift}[2](\zeta) + \gamma)} \\
+& \qquad \color{darkred}{\cdot (w[4](\zeta) + \beta \cdot \mathsf{shift}[3](\zeta) + \gamma)} \\
+& \qquad \color{darkred}{\cdot (w[5](\zeta) + \beta \cdot \mathsf{shift}[4](\zeta) + \gamma)} \\
+& \qquad \color{darkred}{\cdot (w[6](\zeta) + \beta \cdot \mathsf{shift}[5](\zeta) + \gamma)} \\
+& \color{blue}{- z(\zeta \omega) \cdot \mathsf{zkpm}(\zeta) \cdot \alpha^{\mathsf{PERM0}} \cdot} \\
+& \qquad \color{blue}{\cdot (w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma) \cdot} \\
+& \qquad \color{blue}{\cdot (w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma) \cdot} \\
+& \qquad \color{blue}{\cdot (w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma) \cdot} \\
+& \qquad \color{blue}{\cdot (w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma) \cdot} \\
+& \qquad \color{blue}{\cdot (w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma) \cdot} \\
+& \qquad \color{blue}{\cdot (w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma) \cdot} \\
+& \qquad \color{blue}{\cdot (w[6](\zeta) + \gamma)} \\
+& \color{purple}{+ (z(\zeta) - 1) \cdot L_1(\zeta) \cdot \alpha^{\mathsf{PERM1}}} \\
+& \color{darkblue}{+ (z(\zeta) - 1) \cdot L_{n-k}(\zeta) \cdot \alpha^{\mathsf{PERM2}}} \\
 & = t(\zeta)(\zeta^n - 1)
 \end{align}
 $$
@@ -103,26 +105,26 @@ I highlight what changes in each steps. First, we just move things around:
 
 $$
 \begin{align}
-& f(\zeta) + pub(\zeta) + \\
-& z(\zeta) \cdot zkpm(\zeta) \cdot \alpha^{PERM0} \cdot \\
-& (w[0](\zeta) + \beta \cdot \text{shift}[0] \zeta + \gamma) \cdot \\
-& (w[1](\zeta) + \beta \cdot \text{shift}[1] \zeta + \gamma) \cdot \\
-& (w[2](\zeta) + \beta \cdot \text{shift}[2] \zeta + \gamma) \cdot \\
-& (w[3](\zeta) + \beta \cdot \text{shift}[3] \zeta + \gamma) \cdot \\
-& (w[4](\zeta) + \beta \cdot \text{shift}[4] \zeta + \gamma) \cdot \\
-& (w[5](\zeta) + \beta \cdot \text{shift}[5] \zeta + \gamma) \cdot \\
-& (w[6](\zeta) + \beta \cdot \text{shift}[6] \zeta + \gamma) + \\
-& - z(\zeta \omega) \cdot zkpm(\zeta) \cdot \alpha^{PERM0} \cdot \\
-& (w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma) \cdot \\
-& (w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma) \cdot \\
-& (w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma) \cdot \\
-& (w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma) \cdot \\
-& (w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma) \cdot \\
-& (w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma) \cdot \\
-& (w[6](\zeta) + \gamma) + \\
-& \color{darkred}{- t(\zeta)(\zeta^n - 1)} \\
-& = \color{darkred}{(1 - z(\zeta)) L_1(\zeta) \alpha^{PERM1} +} \\
-& \color{darkred}{(1 - z(\zeta)) L_{n-k}(\zeta) \alpha^{PERM2}} \\
+f(\zeta) &+ \mathsf{pub}(\zeta) \\
+ &+ z(\zeta) \cdot \mathsf{zkpm}(\zeta) \cdot \alpha^{\mathsf{PERM0}} \\
+& \qquad \cdot (w[0](\zeta) + \beta \cdot \mathsf{shift}[0] \zeta + \gamma)  \\
+& \qquad \cdot (w[1](\zeta) + \beta \cdot \mathsf{shift}[1] \zeta + \gamma)  \\
+& \qquad \cdot (w[2](\zeta) + \beta \cdot \mathsf{shift}[2] \zeta + \gamma)  \\
+& \qquad \cdot (w[3](\zeta) + \beta \cdot \mathsf{shift}[3] \zeta + \gamma)  \\
+& \qquad \cdot (w[4](\zeta) + \beta \cdot \mathsf{shift}[4] \zeta + \gamma)  \\
+& \qquad \cdot (w[5](\zeta) + \beta \cdot \mathsf{shift}[5] \zeta + \gamma)  \\
+& \qquad \cdot (w[6](\zeta) + \beta \cdot \mathsf{shift}[6] \zeta + \gamma) \\
+ &- z(\zeta \omega) \cdot \mathsf{zkpm}(\zeta) \cdot \alpha^{\mathsf{PERM0}} \cdot \\
+& \qquad \cdot (w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma) \\
+& \qquad \cdot (w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma) \\
+& \qquad \cdot (w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma) \\
+& \qquad \cdot (w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma) \\
+& \qquad \cdot (w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma) \\
+& \qquad \cdot (w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma) \\
+& \qquad \cdot (w[6](\zeta) + \gamma) \\
+&\color{darkred}{- t(\zeta)(\zeta^n - 1)} \\
+ &= \color{darkred}{(1 - z(\zeta)) L_1(\zeta) \alpha^{\mathsf{PERM1}}} \\
+ & \qquad \color{darkred}{+ (1 - z(\zeta)) L_{n-k}(\zeta) \alpha^{\mathsf{PERM2}}} \\
 \end{align}
 $$
 
@@ -130,25 +132,25 @@ here are the actual lagrange basis calculated with the [formula here](../plonk/l
 
 $$
 \begin{align}
-& f(\zeta) + pub(\zeta) + \\
-& z(\zeta) \cdot zkpm(\zeta) \cdot \alpha^{PERM0} \cdot \\
-& (w[0](\zeta) + \beta \cdot \text{shift}[0] \zeta + \gamma) \cdot \\
-& (w[1](\zeta) + \beta \cdot \text{shift}[1] \zeta + \gamma) \cdot \\
-& (w[2](\zeta) + \beta \cdot \text{shift}[2] \zeta + \gamma) \cdot \\
-& (w[3](\zeta) + \beta \cdot \text{shift}[3] \zeta + \gamma) \cdot \\
-& (w[4](\zeta) + \beta \cdot \text{shift}[4] \zeta + \gamma) \cdot \\
-& (w[5](\zeta) + \beta \cdot \text{shift}[5] \zeta + \gamma) \cdot \\
-& (w[6](\zeta) + \beta \cdot \text{shift}[6] \zeta + \gamma) + \\
-& - z(\zeta \omega) \cdot zkpm(\zeta) \cdot \alpha^{PERM0} \cdot \\
-& (w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma) \cdot \\
-& (w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma) \cdot \\
-& (w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma) \cdot \\
-& (w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma) \cdot \\
-& (w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma) \cdot \\
-& (w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma) \cdot \\
-& (w[6](\zeta) + \gamma) + \\
-& - t(\zeta)(\zeta^n - 1) \\
-& = \color{darkred}{(1 - z(\zeta))[\frac{(\zeta^n - 1)}{n(\zeta - 1)} \alpha^{PERM1} + \frac{\omega^{n-k}(\zeta^n - 1)}{n(\zeta - \omega^{n-k})} \alpha^{PERM2}]}
+f(\zeta) + &\mathsf{pub}(\zeta) \\
++ & z(\zeta) \cdot \mathsf{zkpm}(\zeta) \cdot \alpha^{\mathsf{PERM0}} \\
+& \quad \cdot (w[0](\zeta) + \beta \cdot \mathsf{shift}[0] \zeta + \gamma) \\
+& \quad \cdot (w[1](\zeta) + \beta \cdot \mathsf{shift}[1] \zeta + \gamma) \\
+& \quad \cdot (w[2](\zeta) + \beta \cdot \mathsf{shift}[2] \zeta + \gamma) \\
+& \quad \cdot (w[3](\zeta) + \beta \cdot \mathsf{shift}[3] \zeta + \gamma) \\
+& \quad \cdot (w[4](\zeta) + \beta \cdot \mathsf{shift}[4] \zeta + \gamma) \\
+& \quad \cdot (w[5](\zeta) + \beta \cdot \mathsf{shift}[5] \zeta + \gamma) \\
+& \quad \cdot (w[6](\zeta) + \beta \cdot \mathsf{shift}[6] \zeta + \gamma) + \\
+- & z(\zeta \omega) \cdot \mathsf{zkpm}(\zeta) \cdot \alpha^{\mathsf{PERM0}} \\
+& \quad \cdot (w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma) \\
+& \quad \cdot (w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma) \\
+& \quad \cdot (w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma) \\
+& \quad \cdot (w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma) \\
+& \quad \cdot (w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma) \\
+& \quad \cdot (w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma) \\
+& \quad \cdot (w[6](\zeta) + \gamma) + \\
+- & t(\zeta)(\zeta^n - 1) \\
+= & \color{darkred}{(1 - z(\zeta))[\frac{(\zeta^n - 1)}{n(\zeta - 1)} \alpha^{\mathsf{PERM1}} + \frac{\omega^{n-k}(\zeta^n - 1)}{n(\zeta - \omega^{n-k})} \alpha^{\mathsf{PERM2}}]}
 \end{align}
 $$
 
@@ -157,37 +159,37 @@ finally we extract some terms from the lagrange basis:
 $$
 \begin{align}
 & \color{darkred}{[} \\
-& \; f(\zeta) + pub(\zeta) + \\
-& \; z(\zeta) \cdot zkpm(\zeta) \cdot \alpha^{PERM0} \cdot \\
-& \; (w[0](\zeta) + \beta \cdot \text{shift}[0] \zeta + \gamma) \cdot \\
-& \; (w[1](\zeta) + \beta \cdot \text{shift}[1] \zeta + \gamma) \cdot \\
-& \; (w[2](\zeta) + \beta \cdot \text{shift}[2] \zeta + \gamma) \cdot \\
-& \; (w[3](\zeta) + \beta \cdot \text{shift}[3] \zeta + \gamma) \cdot \\
-& \; (w[4](\zeta) + \beta \cdot \text{shift}[4] \zeta + \gamma) \cdot \\
-& \; (w[5](\zeta) + \beta \cdot \text{shift}[5] \zeta + \gamma) \cdot \\
-& \; (w[6](\zeta) + \beta \cdot \text{shift}[6] \zeta + \gamma) + \\
-& \; - z(\zeta \omega) \cdot zkpm(\zeta) \cdot \alpha^{PERM0} \cdot \\
-& \; (w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma) \cdot \\
-& \; (w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma) \cdot \\
-& \; (w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma) \cdot \\
-& \; (w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma) \cdot \\
-& \; (w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma) \cdot \\
-& \; (w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma) \cdot \\
-& \; (w[6](\zeta) + \gamma) + \\
-& \; - t(\zeta)(\zeta^n - 1) \\
+&  f(\zeta) + \mathsf{pub}(\zeta) \\
+&  + z(\zeta) \cdot \mathsf{zkpm}(\zeta) \cdot \alpha^{\mathsf{PERM0}}  \\
+&  \qquad \cdot (w[0](\zeta) + \beta \cdot \mathsf{shift}[0] \zeta + \gamma) \\
+&  \qquad \cdot (w[1](\zeta) + \beta \cdot \mathsf{shift}[1] \zeta + \gamma) \\
+&  \qquad \cdot (w[2](\zeta) + \beta \cdot \mathsf{shift}[2] \zeta + \gamma) \\
+&  \qquad \cdot (w[3](\zeta) + \beta \cdot \mathsf{shift}[3] \zeta + \gamma) \\
+&  \qquad \cdot (w[4](\zeta) + \beta \cdot \mathsf{shift}[4] \zeta + \gamma) \\
+&  \qquad \cdot (w[5](\zeta) + \beta \cdot \mathsf{shift}[5] \zeta + \gamma) \\
+&  \qquad \cdot (w[6](\zeta) + \beta \cdot \mathsf{shift}[6] \zeta + \gamma) + \\
+&  - z(\zeta \omega) \cdot \mathsf{zkpm}(\zeta) \cdot \alpha^{\mathsf{PERM0}} \\
+&  \qquad \cdot (w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma) \\
+&  \qquad \cdot (w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma) \\
+&  \qquad \cdot (w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma) \\
+&  \qquad \cdot (w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma) \\
+&  \qquad \cdot (w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma) \\
+&  \qquad \cdot (w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma) \\
+&  \qquad \cdot (w[6](\zeta) + \gamma) \\
+&  - t(\zeta)(\zeta^n - 1) \\
 & \color{darkred}{] \cdot (\zeta - 1)(\zeta - \omega^{n-k})} & \\
-& = \color{darkred}{(1 - z(\zeta))[\frac{(\zeta^n - 1)(\zeta - \omega^{n-k})}{n} \alpha^{PERM1} + \frac{\omega^{n-k}(\zeta^n - 1)(\zeta - 1)}{n} \alpha^{PERM2}]}
+& = \color{darkred}{(1 - z(\zeta))\Bigg[\frac{(\zeta^n - 1)(\zeta - \omega^{n-k})}{n} \alpha^{\mathsf{PERM1}} + \frac{\omega^{n-k}(\zeta^n - 1)(\zeta - 1)}{n} \alpha^{\mathsf{PERM2}}\Bigg]}
 \end{align}
 $$
 
-with $\alpha^{PERM0} = \alpha^{17}, \alpha^{PERM1} = \alpha^{18}, \alpha^{PERM2} = \alpha^{19}$
+with $\alpha^{\mathsf{PERM0}} = \alpha^{17}, \alpha^{\mathsf{PERM1}} = \alpha^{18}, \alpha^{\mathsf{PERM2}} = \alpha^{19}$
 
 Why do we do things this way? Most likely to reduce
 
 Also, about the code:
 
-* the division by $n$ in the $\alpha^{PERM1}$ and the $\alpha^{PERM2}$ terms is missing (why?)
-* the multiplication by $w^{n-k}$ in the $\alpha^{PERM2}$ term is missing (why?)
+* the division by $n$ in the $\alpha^{\mathsf{PERM1}}$ and the $\alpha^{\mathsf{PERM2}}$ terms is missing (why?)
+* the multiplication by $w^{n-k}$ in the $\alpha^{\mathsf{PERM2}}$ term is missing (why?)
 
 As these terms are constants, and do not prevent the division by $Z_H$ to form $t$, $t$ also omits them. In other word, they cancel one another.
 
@@ -211,29 +213,25 @@ t += &bnd;
 // t is evaluated at zeta and sent...
 ```
 
-Notice that **`bnd` is not divided by the vanishing polynomial**. Also what's `perm`? Let's answer the latter:
+Notice that **`bnd` is not divided by the vanishing polynomial**. Also what's `perm`? Let's answer the latter TESTREMOVEME:
 
 $$
 \begin{align}
-perm(x) = & \\
-    & a^{PERM0} \cdot zkpl(x) \cdot [ \\
-    & \;\;   z(x) \cdot \\
-    & \;\;   (w[0](x) + \gamma + x \cdot \beta \cdot \text{shift}[0]) \cdot \\
-    & \;\;   (w[1](x) + \gamma + x \cdot \beta \cdot \text{shift}[1]) \cdot \cdots \\
-    & \;   - \\
-    & \;\;   z(x \cdot w) \cdot \\
-    & \;\;   (w[0](x) + \gamma + \sigma[0] \cdot \beta) \cdot \\
-    & \;\;   (w[1](x) + \gamma + \sigma[1] \cdot \beta) \cdot ... \\
+\mathsf{perm}(x) =\ & a^{\mathsf{PERM0}} \cdot \mathsf{zkpl}(x) \cdot [ \\
+    & z(x) \cdot (w[0](x) + \gamma + x \cdot \beta \cdot \mathsf{shift}[0])  \\
+    & \qquad \cdot (w[1](x) + \gamma + x \cdot \beta \cdot \mathsf{shift}[1]) \cdot \ldots \\
+  - &z(x \cdot w) \cdot (w[0](x) + \gamma + \sigma[0] \cdot \beta) \\
+    & \qquad \quad \ \ \cdot (w[1](x) + \gamma + \sigma[1] \cdot \beta) \cdot \ldots \\
     &]
 \end{align}
 $$
 
 and `bnd` is:
 
-$$bnd(x) =
-    a^{PERM1} \cdot \frac{z(x) - 1}{x - 1}
+$$\mathsf{bnd}(x) =
+    a^{\mathsf{PERM1}} \cdot \frac{z(x) - 1}{x - 1}
     +
-    a^{PERM2} \cdot \frac{z(x) - 1}{x - sid[n-k]}
+    a^{\mathsf{PERM2}} \cdot \frac{z(x) - 1}{x - \mathsf{sid}[n-k]}
 $$
 
 you can see that some terms are missing in `bnd`, specifically the numerator $x^n - 1$. Well, it would have been cancelled by the division by the vanishing polynomial, and this is the reason why we didn't divide that term by $Z_H(x) = x^n - 1$.

--- a/book/src/kimchi/maller_15.md
+++ b/book/src/kimchi/maller_15.md
@@ -17,10 +17,10 @@ $$
 They could do this like so:
 
 $$
-com(L) = com(f) - Z_H(\zeta) \cdot com(t)
+\mathsf{com}(L) = \mathsf{com}(f) - Z_H(\zeta) \cdot \mathsf{com}(t)
 $$
 
-Since they already know $f$, they can produce $com(f)$, the only thing they need is $com(t)$. So the protocol looks like that:
+Since they already know $f$, they can produce $\mathsf{com}(f)$, the only thing they need is $\mathsf{com}(t)$. So the protocol looks like that:
 
 ![maller 15 1](../img/maller_15_1.png)
 
@@ -39,7 +39,7 @@ In the rest of this document, we review the details and considerations needed to
 
 ## How to deal with a chunked $t$?
 
-There's one challenge that prevents us from directly using this approach: $com(t)$ is typically sent and received in several commitments (called chunks or segments throughout the codebase). As $t$ is the largest polynomial, usually exceeding the size of the SRS (which is by default set to be the size of the domain).
+There's one challenge that prevents us from directly using this approach: $\mathsf{com}(t)$ is typically sent and received in several commitments (called chunks or segments throughout the codebase). As $t$ is the largest polynomial, usually exceeding the size of the SRS (which is by default set to be the size of the domain).
 
 ### The verifier side
 
@@ -53,13 +53,13 @@ where every $L_i$ is of degree $n-1$ at most.
 Then we have that
 
 $$
-com(L) = com(L_0) + com(x^n \cdot L_1) + com(x^{2n} \cdot L_2) + \cdots
+\mathsf{com}(L) = \mathsf{com}(L_0) + \mathsf{com}(x^n \cdot L_1) + \mathsf{com}(x^{2n} \cdot L_2) + \cdots
 $$
 
 Which the verifier can't produce because of the powers of $x^n$, but we can linearize it as we already know which $x$ we're going to evaluate that polynomial with:
 
 $$
-com(\tilde L) = com(L_0) + \zeta^n \cdot com(L_1) + \zeta^{2n} \cdot com(L_2) + \cdots
+\mathsf{com}(\tilde L) = \mathsf{com}(L_0) + \zeta^n \cdot \mathsf{com}(L_1) + \zeta^{2n} \cdot \mathsf{com}(L_2) + \cdots
 $$
 
 ### The prover side
@@ -83,9 +83,9 @@ $$
 To compute it, there are two rules to follow:
 
 * when two commitment are **added** together, their associated blinding factors get added as well:
-    $$com(a) + com(b) \implies r_a + r_b$$
+    $$\mathsf{com}(a) + \mathsf{com}(b) \implies r_a + r_b$$
 * when **scaling** a commitment, its blinding factor gets scalled too:
-    $$n \cdot com(a) \implies n \cdot r_a$$
+    $$n \cdot \mathsf{com}(a) \implies n \cdot r_a$$
 
 As such, if we know $r_f$ and $r_t$, we can compute:
 
@@ -97,7 +97,7 @@ The prover knows the blinding factor of the commitment to $t$, as they committed
 
 1. **The commitments we sent them**. In the linearization process, the verifier actually gets rid of most prover commitments, except for the commitment to the last sigma commitment $S_{\sigma6}$. (TODO: link to the relevant part in the spec) As this commitment is public, it is not blinded.
 2. **The public commitments**. Think commitment to selector polynomials or the public input polynomial. These commitments are not blinded, and thus do not impact the calculation of the blinding factor.
-3. **The evaluations we sent them**. Instead of using commitments to the wires when recreating $f$, the verifier uses the (verified) evaluations of these in $\zeta$. If we scale our commitment $com(z)$ with any of these scalars, we will have to do the same with $r_z$.
+3. **The evaluations we sent them**. Instead of using commitments to the wires when recreating $f$, the verifier uses the (verified) evaluations of these in $\zeta$. If we scale our commitment $\mathsf{com}(z)$ with any of these scalars, we will have to do the same with $r_z$.
 
 Thus, the blinding factor of $\tilde L$ is  $(\zeta^n-1) \cdot r_{\tilde t}$.
 
@@ -109,24 +109,24 @@ It should be equal to the following:
 $$
 \begin{align}
 & \tilde f(\zeta) - \tilde t(\zeta)(\zeta^n - 1) = \\
-& \frac{1 - z(\zeta)}{(\zeta - 1)(\zeta - \omega^{n-k})}\left[ \frac{(\zeta^n - 1)(\zeta - \omega^{n-k})}{n} \alpha^{PERM1} + \frac{\omega^{n-k}(\zeta^n - 1)(\zeta - 1)}{n} \alpha^{PERM2} \right] \\
-& - pub(\zeta) \\
-& \; - z(\zeta) \cdot zkpm(\zeta) \cdot \alpha^{PERM0} \cdot \\
-& \; (w[0](\zeta) + \beta \cdot \text{shift}[0] \zeta + \gamma) \cdot \\
-& \; (w[1](\zeta) + \beta \cdot \text{shift}[1] \zeta + \gamma) \cdot \\
-& \; (w[2](\zeta) + \beta \cdot \text{shift}[2] \zeta + \gamma) \cdot \\
-& \; (w[3](\zeta) + \beta \cdot \text{shift}[3] \zeta + \gamma) \cdot \\
-& \; (w[4](\zeta) + \beta \cdot \text{shift}[4] \zeta + \gamma) \cdot \\
-& \; (w[5](\zeta) + \beta \cdot \text{shift}[5] \zeta + \gamma) \cdot \\
-& \; (w[6](\zeta) + \beta \cdot \text{shift}[6] \zeta + \gamma) + \\
-& \; + z(\zeta \omega) \cdot zkpm(\zeta) \cdot \alpha^{PERM0} \cdot \\
-& \; (w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma) \cdot \\
-& \; (w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma) \cdot \\
-& \; (w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma) \cdot \\
-& \; (w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma) \cdot \\
-& \; (w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma) \cdot \\
-& \; (w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma) \cdot \\
-& \; (w[6](\zeta) + \gamma) + \\
+& \frac{1 - z(\zeta)}{(\zeta - 1)(\zeta - \omega^{n-k})}\left[ \frac{(\zeta^n - 1)(\zeta - \omega^{n-k})}{n} \alpha^{\mathsf{PERM1}} + \frac{\omega^{n-k}(\zeta^n - 1)(\zeta - 1)}{n} \alpha^{\mathsf{PERM2}} \right] \\
+& - \mathsf{pub}(\zeta) \\
+& \; - z(\zeta) \cdot \mathsf{zkpm}(\zeta) \cdot \alpha^{\mathsf{PERM0}} \\
+& \; \qquad \qquad \cdot (w[0](\zeta) + \beta \cdot \mathsf{shift}[0] \zeta + \gamma)  \\
+& \; \qquad \qquad \cdot (w[1](\zeta) + \beta \cdot \mathsf{shift}[1] \zeta + \gamma)  \\
+& \; \qquad \qquad \cdot (w[2](\zeta) + \beta \cdot \mathsf{shift}[2] \zeta + \gamma)  \\
+& \; \qquad \qquad \cdot (w[3](\zeta) + \beta \cdot \mathsf{shift}[3] \zeta + \gamma)  \\
+& \; \qquad \qquad \cdot (w[4](\zeta) + \beta \cdot \mathsf{shift}[4] \zeta + \gamma)  \\
+& \; \qquad \qquad \cdot (w[5](\zeta) + \beta \cdot \mathsf{shift}[5] \zeta + \gamma)  \\
+& \; \qquad \qquad \cdot (w[6](\zeta) + \beta \cdot \mathsf{shift}[6] \zeta + \gamma)  \\
+& \; + z(\zeta \omega) \cdot \mathsf{zkpm}(\zeta) \cdot \alpha^{\mathsf{PERM0}}  \\
+& \; \qquad \qquad \cdot (w[0](\zeta) + \beta \cdot \sigma[0](\zeta) + \gamma)  \\
+& \; \qquad \qquad \cdot (w[1](\zeta) + \beta \cdot \sigma[1](\zeta) + \gamma)  \\
+& \; \qquad \qquad \cdot (w[2](\zeta) + \beta \cdot \sigma[2](\zeta) + \gamma)  \\
+& \; \qquad \qquad \cdot (w[3](\zeta) + \beta \cdot \sigma[3](\zeta) + \gamma)  \\
+& \; \qquad \qquad \cdot (w[4](\zeta) + \beta \cdot \sigma[4](\zeta) + \gamma)  \\
+& \; \qquad \qquad \cdot (w[5](\zeta) + \beta \cdot \sigma[5](\zeta) + \gamma)  \\
+& \; \qquad \qquad \cdot (w[6](\zeta) + \gamma) +
 \end{align}
 $$
 
@@ -146,25 +146,25 @@ Now here's how we need to modify the current protocol:
 3. The prover must create a linearized polynomial $\tilde L$ by creating a linearized polynomial $\tilde f$ and a linearized polynomial $\tilde t$ and computing:
     $$\tilde L = \tilde f + (\zeta^n-1) \cdot \tilde t$$
 4. While the verifier can compute the evaluation of $\tilde L(\zeta)$ by themselves, they don't know the evaluation of $\tilde L(\zeta \omega)$, so the prover needs to send that.
-5. The verifier must recreate $com(\tilde L)$, the commitment to $\tilde L$, themselves so that they can verify the evaluation proofs of both $\tilde L(\zeta)$ and $\tilde L(\zeta\omega)$.
+5. The verifier must recreate $\mathsf{com}(\tilde L)$, the commitment to $\tilde L$, themselves so that they can verify the evaluation proofs of both $\tilde L(\zeta)$ and $\tilde L(\zeta\omega)$.
 6. The evaluation of $\tilde L(\zeta \omega)$ must be absorbed in both sponges (Fq and Fr).
 
 ![maller 15 2](../img/maller_15_2.png)
 <!--
 ```sequence
-Prover->Verifier: com(t) (several of them)
+Prover->Verifier: \mathsf{com}(t) (several of them)
 Note right of Verifier: generates random point zeta
 Verifier->Prover: zeta
 Prover->Verifier: L_bar(zeta * omega) = y
 Prover->Verifier: proof that L_bar(zeta) = 0
 Prover->Verifier: proof that L_bar(zeta * omega) = y
-Note right of Verifier: produces com(L_bar)
+Note right of Verifier: produces \mathsf{com}(L_bar)
 Note right of Verifier: verifies the evaluation proof \n to check that L_bar(zeta) = 0
 ```
 -->
 
 The proposal is implemented in [#150](https://github.com/o1-labs/proof-systems/pull/150) with the following details:
 
-* the $\tilde L$ polynomial is called $ft$.
-* the evaluation of $\tilde L(\zeta)$ is called $ft_eval0$.
-* the evaluation $\tilde L(\zeta\omega)$ is called $ft_eval1$
+* the $\tilde L$ polynomial is called `ft`.
+* the evaluation of $\tilde L(\zeta)$ is called `ft_eval0`.
+* the evaluation $\tilde L(\zeta\omega)$ is called `ft_eval1`.

--- a/book/src/pickles/accumulation.md
+++ b/book/src/pickles/accumulation.md
@@ -729,15 +729,16 @@ Let $\mathcal{C} \subseteq \FF$ be the challenge space (128-bit GLV decomposed c
 1. Checking $\relation_{\mathsf{Acc}, \vec{G}}$ and polynomial relations (from PlonK) to $\relation_{\mathsf{PCS},d}$ (the dotted arrows):
     1. Sample $\chaleval \sample \mathcal{C}$ (evaluation point) using the Poseidon sponge.
     1. Read claimed evaluations at $\chaleval$ and $\omega \chaleval$ (`PointEvaluations`).
-    1. Sample $\chalu \sample \mathcal{C}$ (commitment combination challenge, `polyscale`) using the Poseidon sponge.
-    1. Sample $\chalv \sample \mathcal{C}$ (evaluation combination challenge, `evalscale`) using the Poseidon sponge.
-    1. Compute $C \in \GG$ with $\chalu$ from:
+    1. Sample $\chalv \sample \mathcal{C}$ (commitment combination challenge, `polyscale`) using the Poseidon sponge.
+    1. Sample $\chalu \sample \mathcal{C}$ (evaluation combination challenge, `evalscale`) using the Poseidon sponge.
+        - The $(\chalv, \chalu)$ notation is consistent with the Plonk paper where $\chalv$ recombines commitments and $\chalu$ recombines evaluations
+    1. Compute $C \in \GG$ with $\chalv$ from:
         - $\accCom^{(1)}, \ldots, \accCom^{(n)}$ (`RecursionChallenge.comm` $\in \GG$)
         - Polynomial commitments from PlonK (`ProverCommitments`)
-    1. Compute $\openy_{\chaleval}$ (part of `combined_inner_product`) with $\chalu$ from:
+    1. Compute $\openy_{\chaleval}$ (part of `combined_inner_product`) with $\chalv$ from:
         - The evaluations of $h^{(1)}(\chaleval), \ldots, h^{(n)}(\chaleval)$
         - Polynomial openings from PlonK (`ProofEvaluations`) at $\chaleval$
-    1. Compute $\openy_{\chaleval\omega}$ (part of `combined_inner_product`) with $\chalu$ from:
+    1. Compute $\openy_{\chaleval\omega}$ (part of `combined_inner_product`) with $\chalv$ from:
         - The evaluations of $h^{(1)}(\chaleval\omega), \ldots, h^{(n)}(\chaleval\omega)$
         - Polynomial openings from PlonK (`ProofEvaluations`) at $\chaleval \cdot \omega$
 
@@ -750,13 +751,13 @@ Let $\mathcal{C} \subseteq \FF$ be the challenge space (128-bit GLV decomposed c
             (\comm, \chaleval\omega, \openy_{\chaleval\omega}) &\in \langPCS{\degree}
             \end{align}
             $$
-        These are combined using a random linear combination with $\chalv$ in the inner product argument
+        These are combined using a random linear combination with $\chalu$ in the inner product argument
         (see [Different functionalities](/plonk/inner_product_api.html) for details).
         </details>
 
 1. Checking $\relation_{\mathsf{PCS}, d} \to \relation_{\mathsf{IPA},\ell}$.
     1. Sample $\genOpen \sample \GG$ using the Poseidon sponge: hash to curve.
-    1. Compute $\openy \gets \openy_{\chaleval} + \chalv \cdot \openy_{\chaleval\omega}$.
+    1. Compute $\openy \gets \openy_{\chaleval} + \chalu \cdot \openy_{\chaleval\omega}$.
     1. Update $\comm' \gets \comm + [\openy] \cdot \genOpen$.
 1. Checking $\relation_{\mathsf{IPA}, \ell} \to \relation_{\mathsf{IPA},1}$: <br>
    Check the correctness of the folding argument, for every $i = 1, \ldots, k$:
@@ -770,10 +771,10 @@ Let $\mathcal{C} \subseteq \FF$ be the challenge space (128-bit GLV decomposed c
 1. Checking $\relation_{\mathsf{IPA},1} \to \relation_{\mathsf{Acc}, \vec{G}}$
     1. Receive $c$ form the prover.
     1. Define $\hpoly$ from $\vec{\chalfold}$ (folding challenges, computed above).
-    1. Compute $\openy' \gets c \cdot (\hpoly(\chaleval) + \chalv \cdot \hpoly(\chaleval \omega))$, this works since:
+    1. Compute $\openy' \gets c \cdot (\hpoly(\chaleval) + \chalu \cdot \hpoly(\chaleval \omega))$, this works since:
        $$
        \openx^{(\rounds)} =
-       \openx^{(\rounds)}_{\chaleval} + \chalv \cdot \openx^{(\rounds)}_{\chaleval\omega}
+       \openx^{(\rounds)}_{\chaleval} + \chalu \cdot \openx^{(\rounds)}_{\chaleval\omega}
        $$
        See [Different functionalities](/plonk/inner_product_api.html) for more details or
        [the relevant code](https://github.com/o1-labs/proof-systems/blob/76c678d3db9878730f8a4eead65d1e038a509916/poly-commitment/src/commitment.rs#L785).


### PR DESCRIPTION
This PR primarily (commit #1) fixes the notation regarding `(v,u)` -- the polynomial combiner and the evaluation combiner. The code used them consistently with the plonk paper (`v` is `polyscale` and `u` is `evalscale`), however in the book they were swapped. This PR makes them all consistent across our code and documentation by fixing the book mistake.

The other two commits are purely cosmetic -- they fix some absent parentheses, add some `\cdot` for readability, and align long equations so they more clearly separate the terms in big sums/products.