### PR TITLE
Preliminary work for zkVM lookups

### DIFF
--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -1,9 +1,11 @@
 //! This module contains the constraints for one Keccak step.
-use crate::keccak::{
-    column::{KeccakColumn, PAD_SUFFIX_LEN},
-    environment::{KeccakEnv, KeccakEnvironment},
-    lookups::Lookups,
-    {ArithOps, BoolOps, E, WORDS_IN_HASH},
+use crate::{
+    keccak::{
+        column::{KeccakColumn, PAD_SUFFIX_LEN},
+        environment::{KeccakEnv, KeccakEnvironment},
+        {ArithOps, BoolOps, E, WORDS_IN_HASH},
+    },
+    lookup::Lookups,
 };
 use ark_ff::Field;
 use kimchi::circuits::{

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -7,7 +7,7 @@ use crate::{
         interpreter::{Absorb, KeccakStep, Sponge},
         ArithOps, BoolOps, DIM, E, QUARTERS,
     },
-    mips::interpreter::Lookup,
+    lookup::Lookup,
 };
 use ark_ff::{Field, One};
 use kimchi::{

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -6,12 +6,12 @@
 ///
 /// For a pseudo code implementation of Keccap-f, see
 /// https://keccak.team/keccak_specs_summary.html
-use super::{
+use crate::keccak::{
     column::KeccakColumn,
     environment::KeccakEnv,
     grid_index,
     interpreter::{Absorb, KeccakInterpreter, KeccakStep, Sponge},
-    lookups::Lookups,
+    lookups::KeccakLookups,
     DIM, HASH_BYTELENGTH, QUARTERS, WORDS_IN_HASH,
 };
 use ark_ff::Field;

--- a/optimism/src/lib.rs
+++ b/optimism/src/lib.rs
@@ -11,6 +11,9 @@ pub mod cannon_cli;
 /// Implementation of Keccak used by the zkVM.
 pub mod keccak;
 
+/// The lookup argument.
+pub mod lookup;
+
 /// MIPS interpreter.
 pub mod mips;
 

--- a/optimism/src/lookup.rs
+++ b/optimism/src/lookup.rs
@@ -1,0 +1,97 @@
+use ark_ff::One;
+
+#[derive(Copy, Clone, Debug)]
+pub enum Sign {
+    Pos,
+    Neg,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum LookupMode {
+    Read,
+    Write,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum LookupTable {
+    MemoryLookup,
+    RegisterLookup,
+    // Single-column table of 2^16 entries with the sparse representation of all values
+    SparseLookup,
+    // Single-column table of all values in the range [0, 2^16)
+    RangeCheck16Lookup,
+    // Dual-column table of all values in the range [0, 2^16) and their sparse representation
+    ResetLookup,
+    // 24-row table with all possible values for round and their round constant in expanded form
+    RoundConstantsLookup,
+    // All [0..136] values of possible padding lengths, the value 2^len, and the 5 corresponding pad suffixes with the 10*1 rule
+    PadLookup,
+    // All values that can be stored in a byte (amortized table, better than model as RangeCheck16 (x and scaled x)
+    ByteLookup,
+    // Input/Output of Keccak steps
+    KeccakStepLookup,
+    // Syscalls communication channel
+    SyscallLookup,
+}
+
+#[derive(Clone, Debug)]
+pub struct Lookup<Fp> {
+    pub mode: LookupMode,
+    /// The number of times that this lookup value should be added to / subtracted from the lookup accumulator.    pub magnitude_contribution: Fp,
+    pub magnitude: Fp,
+    pub table_id: LookupTable,
+    pub value: Vec<Fp>,
+}
+
+impl<T: One> Lookup<T> {
+    pub fn read_if(if_is_true: T, table_id: LookupTable, value: Vec<T>) -> Self {
+        Self {
+            mode: LookupMode::Read,
+            magnitude: if_is_true,
+            table_id,
+            value,
+        }
+    }
+
+    pub fn write_if(if_is_true: T, table_id: LookupTable, value: Vec<T>) -> Self {
+        Self {
+            mode: LookupMode::Write,
+            magnitude: if_is_true,
+            table_id,
+            value,
+        }
+    }
+
+    pub fn read_one(table_id: LookupTable, value: Vec<T>) -> Self {
+        Self {
+            mode: LookupMode::Read,
+            magnitude: T::one(),
+            table_id,
+            value,
+        }
+    }
+
+    pub fn write_one(table_id: LookupTable, value: Vec<T>) -> Self {
+        Self {
+            mode: LookupMode::Write,
+            magnitude: T::one(),
+            table_id,
+            value,
+        }
+    }
+}
+
+/// This trait adds basic methods to deal with lookups inside an environment
+pub trait Lookups {
+    type Column;
+    type Variable: std::ops::Mul<Self::Variable, Output = Self::Variable>
+        + std::ops::Add<Self::Variable, Output = Self::Variable>
+        + std::ops::Sub<Self::Variable, Output = Self::Variable>
+        + Clone;
+
+    /// Adds a given Lookup to the environment
+    fn add_lookup(&mut self, lookup: Lookup<Self::Variable>);
+
+    /// Adds all lookups of Self to the environment
+    fn lookups(&mut self);
+}

--- a/optimism/src/lookup.rs
+++ b/optimism/src/lookup.rs
@@ -55,7 +55,7 @@ impl<Fp: std::fmt::Display + Field> std::fmt::Display for Lookup<Fp> {
             numerator, self.table_id
         )?;
         for value in self.value.iter() {
-            write!(formatter, "\t{}\n", value)?;
+            writeln!(formatter, "\t{}", value)?;
         }
         write!(formatter, "]")?;
         Ok(())

--- a/optimism/src/lookup.rs
+++ b/optimism/src/lookup.rs
@@ -1,4 +1,4 @@
-use ark_ff::One;
+use ark_ff::{Field, One};
 
 #[derive(Copy, Clone, Debug)]
 pub enum Sign {
@@ -41,6 +41,25 @@ pub struct Lookup<Fp> {
     pub magnitude: Fp,
     pub table_id: LookupTable,
     pub value: Vec<Fp>,
+}
+
+impl<Fp: std::fmt::Display + Field> std::fmt::Display for Lookup<Fp> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let numerator = match self.mode {
+            LookupMode::Read => self.magnitude,
+            LookupMode::Write => -self.magnitude,
+        };
+        write!(
+            formatter,
+            "numerator: {}\ntable_id: {:?}\nvalue:\n[\n",
+            numerator, self.table_id
+        )?;
+        for value in self.value.iter() {
+            write!(formatter, "\t{}\n", value)?;
+        }
+        write!(formatter, "]")?;
+        Ok(())
+    }
 }
 
 impl<T: One> Lookup<T> {

--- a/optimism/src/mips/constraints.rs
+++ b/optimism/src/mips/constraints.rs
@@ -1,6 +1,6 @@
 use crate::{
     lookup::Lookup,
-    mips::{column::Column as MIPSColumn, interpreter::InterpreterEnv},
+    mips::{column::Column as MIPSColumn, interpreter::InterpreterEnv, E},
 };
 use ark_ff::Field;
 use kimchi::circuits::{
@@ -10,7 +10,8 @@ use kimchi::circuits::{
 
 pub struct Env<Fp> {
     pub scratch_state_idx: usize,
-    pub constraints: Vec<Expr<ConstantExpr<Fp>, MIPSColumn>>,
+    pub constraints: Vec<E<Fp>>,
+    pub lookups: Vec<Lookup<E<Fp>>>,
 }
 
 impl<Fp: Field> InterpreterEnv for Env<Fp> {
@@ -40,8 +41,8 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         // No-op, witness only
     }
 
-    fn add_lookup(&mut self, _lookup: Lookup<Self::Variable>) {
-        // FIXME: Track the lookup values in the environment.
+    fn add_lookup(&mut self, lookup: Lookup<Self::Variable>) {
+        self.lookups.push(lookup);
     }
 
     fn instruction_counter(&self) -> Self::Variable {

--- a/optimism/src/mips/constraints.rs
+++ b/optimism/src/mips/constraints.rs
@@ -1,6 +1,6 @@
-use crate::mips::{
-    column::Column as MIPSColumn,
-    interpreter::{self, InterpreterEnv},
+use crate::{
+    lookup::Lookup,
+    mips::{column::Column as MIPSColumn, interpreter::InterpreterEnv},
 };
 use ark_ff::Field;
 use kimchi::circuits::{
@@ -40,7 +40,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         // No-op, witness only
     }
 
-    fn add_lookup(&mut self, _lookup: interpreter::Lookup<Self::Variable>) {
+    fn add_lookup(&mut self, _lookup: Lookup<Self::Variable>) {
         // FIXME: Track the lookup values in the environment.
     }
 

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -1,5 +1,6 @@
 use crate::{
     cannon::PAGE_ADDRESS_SIZE,
+    lookup::{Lookup, LookupTable},
     mips::registers::{
         REGISTER_CURRENT_IP, REGISTER_HEAP_POINTER, REGISTER_HI, REGISTER_LO, REGISTER_NEXT_IP,
         REGISTER_PREIMAGE_KEY_END, REGISTER_PREIMAGE_OFFSET,
@@ -112,87 +113,6 @@ pub enum ITypeInstruction {
     Store32Conditional,           // sc
     StoreWordLeft,                // swl
     StoreWordRight,               // swr
-}
-
-#[derive(Copy, Clone, Debug)]
-pub enum Sign {
-    Pos,
-    Neg,
-}
-
-#[derive(Copy, Clone, Debug)]
-pub enum LookupMode {
-    Read,
-    Write,
-}
-
-#[derive(Copy, Clone, Debug)]
-pub enum LookupTable {
-    MemoryLookup,
-    RegisterLookup,
-    // Single-column table of 2^16 entries with the sparse representation of all values
-    SparseLookup,
-    // Single-column table of all values in the range [0, 2^16)
-    RangeCheck16Lookup,
-    // Dual-column table of all values in the range [0, 2^16) and their sparse representation
-    ResetLookup,
-    // 24-row table with all possible values for round and their round constant in expanded form
-    RoundConstantsLookup,
-    // All [0..136] values of possible padding lengths, the value 2^len, and the 5 corresponding pad suffixes with the 10*1 rule
-    PadLookup,
-    // All values that can be stored in a byte (amortized table, better than model as RangeCheck16 (x and scaled x)
-    ByteLookup,
-    // Input/Output of Keccak steps
-    KeccakStepLookup,
-    // Syscalls communication channel
-    SyscallLookup,
-}
-
-#[derive(Clone, Debug)]
-pub struct Lookup<Fp> {
-    pub mode: LookupMode,
-    /// The number of times that this lookup value should be added to / subtracted from the lookup accumulator.    pub magnitude_contribution: Fp,
-    pub magnitude: Fp,
-    pub table_id: LookupTable,
-    pub value: Vec<Fp>,
-}
-
-impl<T: One> Lookup<T> {
-    pub fn read_if(if_is_true: T, table_id: LookupTable, value: Vec<T>) -> Self {
-        Self {
-            mode: LookupMode::Read,
-            magnitude: if_is_true,
-            table_id,
-            value,
-        }
-    }
-
-    pub fn write_if(if_is_true: T, table_id: LookupTable, value: Vec<T>) -> Self {
-        Self {
-            mode: LookupMode::Write,
-            magnitude: if_is_true,
-            table_id,
-            value,
-        }
-    }
-
-    pub fn read_one(table_id: LookupTable, value: Vec<T>) -> Self {
-        Self {
-            mode: LookupMode::Read,
-            magnitude: T::one(),
-            table_id,
-            value,
-        }
-    }
-
-    pub fn write_one(table_id: LookupTable, value: Vec<T>) -> Self {
-        Self {
-            mode: LookupMode::Write,
-            magnitude: T::one(),
-            table_id,
-            value,
-        }
-    }
 }
 
 pub trait InterpreterEnv {

--- a/optimism/src/mips/mod.rs
+++ b/optimism/src/mips/mod.rs
@@ -1,6 +1,12 @@
+use kimchi::circuits::expr::{ConstantExpr, Expr};
+
+use self::column::Column as MIPSColumn;
+
 pub mod column;
 pub mod constraints;
 pub mod interpreter;
 pub mod proof;
 pub mod registers;
 pub mod witness;
+
+pub(crate) type E<F> = Expr<ConstantExpr<F>, MIPSColumn>;

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -1,13 +1,10 @@
-use crate::cannon::{Page, State};
-use crate::keccak::lookups::Lookups;
-use crate::keccak::ArithOps;
-use crate::mips::interpreter::{Lookup, LookupTable};
 use crate::{
     cannon::{
-        Hint, Meta, Start, StepFrequency, VmConfiguration, PAGE_ADDRESS_MASK, PAGE_ADDRESS_SIZE,
-        PAGE_SIZE,
+        Hint, Meta, Page, Start, State, StepFrequency, VmConfiguration, PAGE_ADDRESS_MASK,
+        PAGE_ADDRESS_SIZE, PAGE_SIZE,
     },
-    keccak::environment::KeccakEnv,
+    keccak::{environment::KeccakEnv, ArithOps},
+    lookup::{Lookup, LookupTable, Lookups},
     mips::{
         column::Column,
         interpreter::{
@@ -135,7 +132,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         }
     }
 
-    fn add_lookup(&mut self, _lookup: interpreter::Lookup<Self::Variable>) {
+    fn add_lookup(&mut self, _lookup: Lookup<Self::Variable>) {
         // FIXME: Track the lookup values in the environment.
     }
 

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -16,16 +16,13 @@ use crate::{
 };
 use ark_ff::Field;
 use core::panic;
-use kimchi::{
-    circuits::expr::{ConstantTerm::Literal, Operations},
-    o1_utils::Two,
-};
+use kimchi::o1_utils::Two;
 use log::{debug, info};
-use std::array;
-use std::fs::File;
-use std::io::{BufWriter, Write};
-
-use super::E;
+use std::{
+    array,
+    fs::File,
+    io::{BufWriter, Write},
+};
 
 pub const NUM_GLOBAL_LOOKUP_TERMS: usize = 1;
 pub const NUM_DECODING_LOOKUP_TERMS: usize = 2;
@@ -48,7 +45,6 @@ impl SyscallEnv {
 }
 
 pub struct Env<Fp> {
-    pub lookups: Vec<Lookup<E<Fp>>>,
     pub instruction_counter: u64,
     pub memory: Vec<(u32, Vec<u8>)>,
     pub last_memory_accesses: [usize; 3],
@@ -138,17 +134,8 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         }
     }
 
-    fn add_lookup(&mut self, lookup: Lookup<Self::Variable>) {
-        self.lookups.push(Lookup {
-            mode: lookup.mode,
-            magnitude: E::<Fp>::constant(Operations::from(Literal(Fp::from(lookup.magnitude)))),
-            table_id: lookup.table_id,
-            value: lookup
-                .value
-                .into_iter()
-                .map(|x| E::<Fp>::constant(Operations::from(Literal(Fp::from(x)))))
-                .collect::<Vec<_>>(),
-        });
+    fn add_lookup(&mut self, _lookup: Lookup<Self::Variable>) {
+        // No-op, constraints only
     }
 
     fn instruction_counter(&self) -> Self::Variable {
@@ -765,7 +752,6 @@ impl<Fp: Field> Env<Fp> {
         };
 
         Env {
-            lookups: Vec::new(),
             instruction_counter: state.step,
             memory: initial_memory.clone(),
             last_memory_accesses: [0usize; 3],


### PR DESCRIPTION
This PR is mainly a code reorganization of lookup-related code that was already present in other parts of the zkvm code, and aggregate it into one lookup module instead.

Apart from that, it lays the foundations to start keeping track of lookups on the mips side as well (they were only being saved in keccak so far). ~This will be subject to changes, as we decide when and how these lookups should be added -> should this happen in the interpreter/witness side or constraints? Also, there's the question of whether lookups should be a Vec<Lookup<E<Fp>>> (meaning of variables), or directly Vec<Lookup<Fp>>.~

~As a reference for the upcoming PRs, I will be using this draft PR as a baseline, as it contained some code for lookups that was removed from the current demo -> https://github.dev/o1-labs/proof-systems/pull/1332~

After talking to Matthew in a meeting, I could confirm that keeping track of the lookups should happen at the constraints side, not the witness side. Also, confirmed that the content in the lookups should be `E<Fp>` and not just `Fp`. 