### PR TITLE
Fix location where channel lookups are executed

### DIFF
--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -103,6 +103,7 @@ impl<Fp: Field> KeccakLookups for KeccakEnv<Fp> {
     type Column = KeccakColumn;
     type Variable = E<Fp>;
 
+    // TODO: optimize this by using a single lookup reusing PadSuffix
     fn lookup_syscall_preimage(&mut self) {
         for i in 0..RATE_IN_BYTES {
             self.add_lookup(Lookup::read_if(

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -11,7 +11,6 @@ use crate::keccak::{
     environment::KeccakEnv,
     grid_index,
     interpreter::{Absorb, KeccakInterpreter, KeccakStep, Sponge},
-    lookups::KeccakLookups,
     DIM, HASH_BYTELENGTH, QUARTERS, WORDS_IN_HASH,
 };
 use ark_ff::Field;

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -63,10 +63,6 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         }
         self.write_column(KeccakColumn::StepIndex, self.step_idx);
 
-        // INTER-STEP CHANNEL
-        // Write outputs for next step if not a squeeze and read inputs of curr step if not a root
-        self.lookup_steps();
-
         self.update_step();
     }
 
@@ -140,9 +136,6 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         }
 
         // Rest is zero thanks to null_state
-
-        // COMMUNICATION CHANNEL: Write hash output
-        self.lookup_syscall_hash();
     }
 
     fn run_absorb(&mut self, absorb: Absorb) {
@@ -188,9 +181,6 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
             self.write_column(KeccakColumn::SpongeShifts(idx), *value);
         }
         // Rest is zero thanks to null_state
-
-        // COMMUNICATION CHANNEL: read bytes of current block
-        self.lookup_syscall_preimage();
 
         // Update environment
         self.prev_block = xor_state;

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -623,6 +623,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
                 KeccakEnv::<Fp>::new(self.hash_count, self.preimage.as_ref().unwrap());
 
             // COMMUNICATION CHANNEL: Write preimage bytes
+            // FIXME: this should be executed in the constraints side
             let preimage = self.preimage.as_ref().unwrap();
             for (i, byte) in preimage.iter().enumerate() {
                 keccak_env.add_lookup(Lookup::write_one(
@@ -636,6 +637,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
             }
 
             // COMMUNICATION CHANNEL: Read hash output
+            // FIXME: this should be executed in the constraints side
             match self.preimage_key {
                 Some(preimage_key) => {
                     let bytes31 = (1..32).fold(Fp::zero(), |acc, i| {


### PR DESCRIPTION
After a meeting with Matthew, he explained that the lookups should only be added from the constraints side of the interpreters, and not from the witness side.

This was the case for normal read-only lookups. But for read-write (communication channel) lookups, these were happening from the witness interpreter code, both on the Keccak and MIPS sides.

This PR easily fixes the rw lookups on the Keccak side, making use of the `write_if` and `read_if` interfaces, substituting the old `write_one` and `read_one`. That way, these will only be nonzero when the condition holds (for preimage, at every absorb; for hash, at squeeze steps). Similar with inter-step lookups.

Nonetheless, moving the MIPS side of the read/write lookups for the syscalls channel is still not addressed in this PR. I am still figuring out where in the code this could be done.