### PR TITLE
Tests: ensure we use the affine coordinates

### DIFF
--- a/kimchi/src/tests/ec.rs
+++ b/kimchi/src/tests/ec.rs
@@ -68,7 +68,7 @@ fn ec_test() {
     };
 
     for &p in ps.iter().take(num_doubles) {
-        let p2 = p + p;
+        let p2: Other = p + p;
         let (x1, y1) = (p.x, p.y);
         let x1_squared = x1.square();
         // 2 * s * y1 = 3 * x1^2
@@ -96,7 +96,7 @@ fn ec_test() {
         let p = ps[i];
         let q = qs[i];
 
-        let pq = p + q;
+        let pq: Other = p + q;
         let (x1, y1) = (p.x, p.y);
         let (x2, y2) = (q.x, q.y);
         // (x2 - x1) * s = y2 - y1
@@ -120,9 +120,9 @@ fn ec_test() {
     }
 
     for &p in ps.iter().take(num_infs) {
-        let q = -p;
+        let q: Other = -p;
 
-        let p2 = p + p;
+        let p2: Other = p + p;
         let (x1, y1) = (p.x, p.y);
         let x1_squared = x1.square();
         // 2 * s * y1 = -3 * x1^2

--- a/kimchi/src/tests/endomul.rs
+++ b/kimchi/src/tests/endomul.rs
@@ -70,8 +70,9 @@ fn endomul_test() {
         // let g = Other::prime_subgroup_generator().into_projective();
         let acc0 = {
             let t = Other::new(endo_q * base.x, base.y, false);
-            let p = t + base;
-            let acc = p + p;
+            // Ensuring we use affine coordinates
+            let p: Other = t + base;
+            let acc: Other = p + p;
             (acc.x, acc.y)
         };
 


### PR DESCRIPTION
It is important to ensure we use the affine coordinates. The addition might not always be returning a point in the affine coordinates, and therefore accessing the individual curve coordinates might lead to undefined behavior, potentially critical bugs.

Actually, it is the case between arkworks 0.3.0 and arkworks 0.4.x.