### PR TITLE
Use 0.38.0 instead of the latest release 0.39.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,8 @@ jobs:
 
       - name: Install markdownlint
         run: |
-          npm install -g markdownlint-cli
+          # FIXME: 0.39.0 makes the CI fail
+          npm install -g markdownlint-cli@0.38.0
 
       #
       # Doc & Spec


### PR DESCRIPTION
0.39.0 has been released during the night CET. It makes the CI unhappy.