### PR TITLE
Fix conditionals used in constraints and lookups of Keccak

### DIFF
--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -80,15 +80,16 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
             // - 1 of degree 2
             {
                 // Squeeze and Root are not both true
-                self.constrain(Self::either_false(self.is_squeeze(), self.is_root()));
+                self.constrain(Self::either_zero(self.is_squeeze(), self.is_root()));
                 // Squeeze and Pad are not both true
-                self.constrain(Self::either_false(self.is_squeeze(), self.is_pad()));
+                self.constrain(Self::either_zero(self.is_squeeze(), self.is_pad()));
                 // Round and Pad are not both true
-                self.constrain(Self::either_false(self.is_round(), self.is_pad()));
+                self.constrain(Self::either_zero(self.is_round(), self.is_pad()));
                 // Round and Root are not both true
-                self.constrain(Self::either_false(self.is_round(), self.is_root()));
-                // Absorb and Squeeze cannot happen at the same time
-                self.constrain(Self::either_false(self.is_absorb(), self.is_squeeze()));
+                self.constrain(Self::either_zero(self.is_round(), self.is_root()));
+                // Absorb and Squeeze cannot happen at the same time.
+                // Equivalent to is_boolean(is_sponge())
+                self.constrain(Self::either_zero(self.is_absorb(), self.is_squeeze()));
                 // Trivially, is_sponge and is_round are mutually exclusive
             }
         }

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -162,7 +162,7 @@ impl<Fp: Field> BoolOps for KeccakEnv<Fp> {
     }
 
     fn xor(x: Self::Variable, y: Self::Variable) -> Self::Variable {
-        x + y
+        x.clone() + y.clone() - Self::constant(2) * x * y
     }
 
     fn or(x: Self::Variable, y: Self::Variable) -> Self::Variable {

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -154,22 +154,22 @@ impl<Fp: Field> BoolOps for KeccakEnv<Fp> {
     }
 
     fn is_one(x: Self::Variable) -> Self::Variable {
-        x - Self::Variable::one()
+        Self::not(x)
     }
 
     fn is_nonzero(x: Self::Variable, x_inv: Self::Variable) -> Self::Variable {
-        x * x_inv - Self::Variable::one()
+        Self::is_one(x * x_inv)
     }
 
     fn xor(x: Self::Variable, y: Self::Variable) -> Self::Variable {
-        Self::is_one(x + y)
+        x + y
     }
 
     fn or(x: Self::Variable, y: Self::Variable) -> Self::Variable {
         x.clone() + y.clone() - x * y
     }
 
-    fn either_false(x: Self::Variable, y: Self::Variable) -> Self::Variable {
+    fn either_zero(x: Self::Variable, y: Self::Variable) -> Self::Variable {
         x * y
     }
 }
@@ -233,18 +233,18 @@ pub(crate) trait KeccakEnvironment {
     ///     - `x` must range between [0..5)
     fn from_quarters(quarters: &[Self::Variable], y: Option<usize>, x: usize) -> Self::Variable;
 
-    /// Returns a variable that encodes whether the current step is a sponge
+    /// Returns a variable that encodes whether the current step is a sponge (1 = yes)
     fn is_sponge(&self) -> Self::Variable;
-    /// Returns a variable that encodes whether the current step is an absorb sponge
+    /// Returns a variable that encodes whether the current step is an absorb sponge (1 = yes)
     fn is_absorb(&self) -> Self::Variable;
-    /// Returns a variable that encodes whether the current step is a squeeze sponge
+    /// Returns a variable that encodes whether the current step is a squeeze sponge (1 = yes)
     fn is_squeeze(&self) -> Self::Variable;
-    /// Returns a variable that encodes whether the current step is the first absorb sponge
+    /// Returns a variable that encodes whether the current step is the first absorb sponge (1 = yes)
     fn is_root(&self) -> Self::Variable;
-    /// Returns a degree-2 variable that encodes whether the current step is the last absorb sponge
+    /// Returns a degree-2 variable that encodes whether the current step is the last absorb sponge (1 = yes)
     fn is_pad(&self) -> Self::Variable;
 
-    /// Returns a variable that encodes whether the current step is a permutation round
+    /// Returns a variable that encodes whether the current step is a permutation round (1 = yes)
     fn is_round(&self) -> Self::Variable;
     /// Returns a variable that encodes the current round number [0..24)
     fn round(&self) -> Self::Variable;
@@ -254,7 +254,7 @@ pub(crate) trait KeccakEnvironment {
     /// Returns a variable that encodes the value 2^pad_length
     fn two_to_pad(&self) -> Self::Variable;
 
-    /// Returns a variable that encodes whether the `idx`-th byte of the new block is involved in the padding
+    /// Returns a variable that encodes whether the `idx`-th byte of the new block is involved in the padding (1 = yes)
     fn in_padding(&self, idx: usize) -> Self::Variable;
 
     /// Returns a variable that encodes the `idx`-th chunk of the padding suffix
@@ -477,7 +477,10 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
     }
 
     fn is_pad(&self) -> Self::Variable {
-        Self::is_nonzero(self.pad_length(), self.variable(KeccakColumn::InvPadLength))
+        Self::not(Self::is_nonzero(
+            self.pad_length(),
+            self.variable(KeccakColumn::InvPadLength),
+        ))
     }
 
     fn is_round(&self) -> Self::Variable {

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -49,29 +49,29 @@ pub(crate) trait BoolOps {
         + Clone;
     type Fp: std::ops::Neg<Output = Self::Fp>;
 
-    /// Degree-2 variable encoding whether the input is a boolean value
+    /// Degree-2 variable encoding whether the input is a boolean value (0 = yes)
     fn is_boolean(x: Self::Variable) -> Self::Variable;
 
     /// Degree-1 variable encoding the negation of the input
     /// Note: it only works as expected if the input is a boolean value
     fn not(x: Self::Variable) -> Self::Variable;
 
-    /// Degree-1 variable encoding whether the input is the value one
+    /// Degree-1 variable encoding whether the input is the value one (0 = yes)
     fn is_one(x: Self::Variable) -> Self::Variable;
 
-    /// Degree-2 variable encoding whether the first input is nonzero.
+    /// Degree-2 variable encoding whether the first input is nonzero (0 = yes).
     /// It requires the second input to be the multiplicative inverse of the first.
     /// Note: if the first input is zero, there is no multiplicative inverse.
     fn is_nonzero(x: Self::Variable, x_inv: Self::Variable) -> Self::Variable;
 
-    /// Degree-1 variable encoding the XOR of two variables which should be boolean
+    /// Degree-1 variable encoding the XOR of two variables which should be boolean (1 = true)
     fn xor(x: Self::Variable, y: Self::Variable) -> Self::Variable;
 
-    /// Degree-1 variable encoding the OR of two variables, which should be boolean
+    /// Degree-1 variable encoding the OR of two variables, which should be boolean (1 = true)
     fn or(x: Self::Variable, y: Self::Variable) -> Self::Variable;
 
-    /// Degree-2 variable encoding whether at least one of the two inputs is zero
-    fn either_false(x: Self::Variable, y: Self::Variable) -> Self::Variable;
+    /// Degree-2 variable encoding whether at least one of the two inputs is zero (0 = yes)
+    fn either_zero(x: Self::Variable, y: Self::Variable) -> Self::Variable;
 }
 
 /// This trait defines common arithmetic operations used in the Keccak circuit

--- a/optimism/src/lookup.rs
+++ b/optimism/src/lookup.rs
@@ -72,6 +72,7 @@ impl<Fp: std::fmt::Display + Field> std::fmt::Display for Lookup<Fp> {
 }
 
 impl<T: One> Lookup<T> {
+    /// Reads one value when `if_is_true` is 1.
     pub fn read_if(if_is_true: T, table_id: LookupTables, value: Vec<T>) -> Self {
         Self {
             mode: LookupMode::Read,
@@ -81,6 +82,7 @@ impl<T: One> Lookup<T> {
         }
     }
 
+    /// Writes one value when `if_is_true` is 1.
     pub fn write_if(if_is_true: T, table_id: LookupTables, value: Vec<T>) -> Self {
         Self {
             mode: LookupMode::Write,
@@ -90,6 +92,7 @@ impl<T: One> Lookup<T> {
         }
     }
 
+    /// Reads one value from a table.
     pub fn read_one(table_id: LookupTables, value: Vec<T>) -> Self {
         Self {
             mode: LookupMode::Read,
@@ -99,6 +102,7 @@ impl<T: One> Lookup<T> {
         }
     }
 
+    /// Writes one value to a table.
     pub fn write_one(table_id: LookupTables, value: Vec<T>) -> Self {
         Self {
             mode: LookupMode::Write,

--- a/optimism/src/lookup.rs
+++ b/optimism/src/lookup.rs
@@ -44,15 +44,15 @@ pub enum LookupTables {
 }
 
 #[derive(Clone, Debug)]
-pub struct Lookup<Fp> {
+pub struct Lookup<T> {
     pub mode: LookupMode,
     /// The number of times that this lookup value should be added to / subtracted from the lookup accumulator.    pub magnitude_contribution: Fp,
-    pub magnitude: Fp,
+    pub magnitude: T,
     pub table_id: LookupTables,
-    pub value: Vec<Fp>,
+    pub value: Vec<T>,
 }
 
-impl<Fp: std::fmt::Display + Field> std::fmt::Display for Lookup<Fp> {
+impl<F: std::fmt::Display + Field> std::fmt::Display for Lookup<F> {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let numerator = match self.mode {
             LookupMode::Read => self.magnitude,


### PR DESCRIPTION
I realized there was a notation incoherence between the `if` conditionals inside the Lookup trait (when `if_is_true` is 1, it is supposed to insert the lookup, nothing otherwise), and the `is_` conditionals in constraints, where sometimes a `0` was being seen as a `true`, given that this is what makes the constraints satisfiable. 

I unified the notation in this PR, and clarified what is the meaning of each variable in the doc comments.