### PR TITLE
Starting Kimchi MSM circuit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,6 +1257,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "kimchi_msm"
+version = "0.1.0"
+dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "groupmap",
+ "kimchi",
+ "mina-curves",
+ "mina-poseidon",
+ "num-bigint",
+ "o1-utils",
+ "poly-commitment",
+ "rand",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
 name = "kimchi_optimism"
 version = "0.1.0"
 dependencies = [
@@ -1435,6 +1458,7 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-std",
+ "num-bigint",
  "rand",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "hasher",
     "kimchi",
     "kimchi/snarky-deriver/",
+    "msm",
     "optimism",
     "poseidon",
     "poseidon/export_test_vectors",

--- a/msm/Cargo.toml
+++ b/msm/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "kimchi_msm"
+version = "0.1.0"
+description = "Large MSM circuit"
+repository = "https://github.com/o1-labs/proof-systems"
+homepage = "https://o1-labs.github.io/proof-systems/"
+documentation = "https://o1-labs.github.io/proof-systems/rustdoc/"
+readme = "README.md"
+edition = "2021"
+license = "Apache-2.0"
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "main"
+path = "src/main.rs"
+
+
+[dependencies]
+ark-bn254 = { version = "0.3.0" }
+ark-serialize = "0.3.0"
+o1-utils = { path = "../utils" }
+kimchi = { path = "../kimchi", version = "0.1.0", features = [ "bn254" ] }
+poly-commitment = { path = "../poly-commitment", version = "0.1.0" }
+groupmap = { path = "../groupmap", version = "0.1.0" }
+mina-curves = { path = "../curves", version = "0.1.0" }
+mina-poseidon = { path = "../poseidon", version = "0.1.0" }
+num-bigint = { version = "0.4.3", features = ["rand"] }
+rmp-serde = "1.1.1"
+serde_json = "1.0.91"
+serde = "1.0.130"
+serde_with = "1.10.0"
+ark-poly = { version = "0.3.0", features = [ "parallel" ] }
+ark-ff = { version = "0.3.0", features = [ "parallel" ] }
+ark-ec = { version = "0.3.0", features = [ "parallel" ] }
+rand = "0.8.5"

--- a/msm/src/columns.rs
+++ b/msm/src/columns.rs
@@ -1,0 +1,5 @@
+/// Describe a generic indexed variable X_{i}.
+#[derive(Clone, Copy, Debug)]
+pub enum Column {
+    X(usize),
+}

--- a/msm/src/lib.rs
+++ b/msm/src/lib.rs
@@ -1,0 +1,22 @@
+use mina_poseidon::{
+    constants::PlonkSpongeConstantsKimchi,
+    sponge::{DefaultFqSponge, DefaultFrSponge},
+};
+use poly_commitment::pairing_proof::PairingProof;
+
+pub mod columns;
+pub mod proof;
+pub mod prover;
+pub mod verifier;
+
+pub const DOMAIN_SIZE: usize = 1 << 15;
+
+pub type BN254 = ark_ec::bn::Bn<ark_bn254::Parameters>;
+
+/// The native field we are working with
+pub type Fp = ark_bn254::Fr;
+
+pub type SpongeParams = PlonkSpongeConstantsKimchi;
+pub type BaseSponge = DefaultFqSponge<ark_bn254::g1::Parameters, SpongeParams>;
+pub type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
+pub type OpeningProof = PairingProof<BN254>;

--- a/msm/src/main.rs
+++ b/msm/src/main.rs
@@ -1,0 +1,30 @@
+use kimchi::circuits::domains::EvaluationDomains;
+
+use ark_ff::UniformRand;
+use kimchi_msm::proof::Witness;
+use kimchi_msm::prover::prove;
+use kimchi_msm::verifier::verify;
+use kimchi_msm::BN254;
+use kimchi_msm::DOMAIN_SIZE;
+use kimchi_msm::{BaseSponge, Fp, OpeningProof, ScalarSponge};
+use poly_commitment::pairing_proof::PairingSRS;
+
+pub fn main() {
+    println!("Creating the domain and SRS");
+    let domain = EvaluationDomains::<Fp>::create(DOMAIN_SIZE).unwrap();
+
+    // Trusted setup toxic waste
+    let x = Fp::rand(&mut rand::rngs::OsRng);
+
+    let mut srs: PairingSRS<BN254> = PairingSRS::create(x, DOMAIN_SIZE);
+    srs.full_srs.add_lagrange_basis(domain.d1);
+
+    let witness = Witness::random();
+
+    println!("Generating the proof");
+    let proof = prove::<_, OpeningProof, BaseSponge, ScalarSponge>(domain, &srs, witness);
+
+    println!("Verifying the proof");
+    let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge>(domain, &srs, &proof);
+    println!("Proof verification result: {verifies}")
+}

--- a/msm/src/proof.rs
+++ b/msm/src/proof.rs
@@ -1,0 +1,47 @@
+use ark_ff::UniformRand;
+use kimchi::curve::KimchiCurve;
+use poly_commitment::{commitment::PolyComm, OpenProof};
+use rand::{prelude::*, thread_rng};
+
+use crate::DOMAIN_SIZE;
+
+/// List all columns of the circuit.
+/// It is parametrized by a type `T` which can be either:
+/// - `Vec<G::ScalarField>` for the evaluations
+/// - `PolyComm<G>` for the commitments
+#[derive(Debug)]
+pub struct WitnessColumns<T> {
+    pub x: Vec<T>,
+}
+
+#[derive(Debug)]
+pub struct Witness<G: KimchiCurve> {
+    pub(crate) evaluations: WitnessColumns<Vec<G::ScalarField>>,
+}
+
+#[allow(dead_code)]
+impl<G: KimchiCurve> Witness<G> {
+    pub fn random() -> Self {
+        let mut rng = thread_rng();
+        let random_n = rng.gen_range(1..1000);
+        Witness {
+            evaluations: WitnessColumns {
+                x: (0..random_n)
+                    .map(|_| {
+                        (0..DOMAIN_SIZE)
+                            .map(|_| G::ScalarField::rand(&mut rng))
+                            .collect::<Vec<_>>()
+                    })
+                    .collect::<Vec<_>>(),
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Proof<G: KimchiCurve, OpeningProof: OpenProof<G>> {
+    pub(crate) commitments: WitnessColumns<PolyComm<G>>,
+    pub(crate) zeta_evaluations: WitnessColumns<G::ScalarField>,
+    pub(crate) zeta_omega_evaluations: WitnessColumns<G::ScalarField>,
+    pub(crate) opening_proof: OpeningProof,
+}

--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -1,0 +1,129 @@
+use ark_ff::Zero;
+use ark_poly::{univariate::DensePolynomial, Evaluations, Polynomial, Radix2EvaluationDomain as D};
+use kimchi::circuits::domains::EvaluationDomains;
+use kimchi::plonk_sponge::FrSponge;
+use kimchi::{curve::KimchiCurve, groupmap::GroupMap};
+use mina_poseidon::sponge::ScalarChallenge;
+use mina_poseidon::FqSponge;
+use poly_commitment::{
+    commitment::{absorb_commitment, PolyComm},
+    evaluation_proof::DensePolynomialOrEvaluations,
+    OpenProof, SRS as _,
+};
+
+use crate::proof::{Proof, Witness, WitnessColumns};
+
+pub fn prove<
+    G: KimchiCurve,
+    OpeningProof: OpenProof<G>,
+    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
+    EFrSponge: FrSponge<G::ScalarField>,
+>(
+    domain: EvaluationDomains<G::ScalarField>,
+    srs: &OpeningProof::SRS,
+    inputs: Witness<G>,
+) -> Proof<G, OpeningProof>
+where
+    OpeningProof::SRS: Sync,
+{
+    let Witness { evaluations } = inputs;
+    // TODO: generalize this by using a trait on the column type
+    let polys = {
+        let WitnessColumns { x } = evaluations;
+        let eval_col = |evals: Vec<G::ScalarField>| {
+            Evaluations::<G::ScalarField, D<G::ScalarField>>::from_vec_and_domain(evals, domain.d1)
+                .interpolate()
+        };
+        let x = x.into_iter().map(eval_col).collect::<Vec<_>>();
+        WitnessColumns { x }
+    };
+
+    let commitments = {
+        let WitnessColumns { x } = &polys;
+        let comm = |poly: &DensePolynomial<G::ScalarField>| srs.commit_non_hiding(poly, 1, None);
+        let x = x.iter().map(comm).collect::<Vec<_>>();
+        WitnessColumns { x }
+    };
+
+    let mut fq_sponge = EFqSponge::new(G::other_curve_sponge_params());
+    for comm in commitments.x.iter() {
+        absorb_commitment(&mut fq_sponge, comm)
+    }
+
+    // TODO: add quotient polynomial (based on constraints and expresion framework)
+
+    // We start the evaluations.
+    let zeta_chal = ScalarChallenge(fq_sponge.challenge());
+    let (_, endo_r) = G::endos();
+    let zeta = zeta_chal.to_field(endo_r);
+    let omega = domain.d1.group_gen;
+    let zeta_omega = zeta * omega;
+
+    // Evaluate the polynomials at zeta and zeta * omega -- Columns
+    let (zeta_evaluations, zeta_omega_evaluations) = {
+        let evals = |point| {
+            let WitnessColumns { x } = &polys;
+            let comm = |poly: &DensePolynomial<G::ScalarField>| poly.evaluate(point);
+            let x = x.iter().map(comm).collect::<Vec<_>>();
+            WitnessColumns { x }
+        };
+        (evals(&zeta), evals(&zeta_omega))
+    };
+    // -- Start opening proof - Preparing the Rust structures
+    let group_map = G::Map::setup();
+
+    // Gathering all polynomials to use in the opening proof
+    let polynomials: Vec<DensePolynomial<_>> = polys.x.into_iter().collect();
+
+    let polynomials: Vec<_> = polynomials
+        .iter()
+        .map(|poly| {
+            (
+                DensePolynomialOrEvaluations::DensePolynomial(poly),
+                None,
+                PolyComm {
+                    unshifted: vec![G::ScalarField::zero()],
+                    shifted: None,
+                },
+            )
+        })
+        .collect();
+
+    // Fiat Shamir - absorbing evaluations
+    let fq_sponge_before_evaluations = fq_sponge.clone();
+    let mut fr_sponge = EFrSponge::new(G::sponge_params());
+    fr_sponge.absorb(&fq_sponge.digest());
+
+    for (zeta_eval, zeta_omega_eval) in zeta_evaluations
+        .x
+        .iter()
+        .zip(zeta_omega_evaluations.x.iter())
+    {
+        fr_sponge.absorb(zeta_eval);
+        fr_sponge.absorb(zeta_omega_eval);
+    }
+
+    let v_chal = fr_sponge.challenge();
+    let v = v_chal.to_field(endo_r);
+    let u_chal = fr_sponge.challenge();
+    let u = u_chal.to_field(endo_r);
+
+    let opening_proof = OpenProof::open::<_, _, D<G::ScalarField>>(
+        srs,
+        &group_map,
+        polynomials.as_slice(),
+        &[zeta, zeta_omega],
+        v,
+        u,
+        fq_sponge_before_evaluations,
+        &mut rand::rngs::OsRng,
+    );
+    // -- End opening proof - Preparing the structures
+
+    Proof {
+        commitments,
+        zeta_evaluations,
+        zeta_omega_evaluations,
+        opening_proof,
+    }
+}

--- a/msm/src/verifier.rs
+++ b/msm/src/verifier.rs
@@ -1,0 +1,105 @@
+use kimchi::circuits::domains::EvaluationDomains;
+use kimchi::plonk_sponge::FrSponge;
+use kimchi::{curve::KimchiCurve, groupmap::GroupMap};
+use mina_poseidon::sponge::ScalarChallenge;
+use mina_poseidon::FqSponge;
+use poly_commitment::{
+    commitment::{absorb_commitment, combined_inner_product, BatchEvaluationProof, Evaluation},
+    OpenProof,
+};
+use rand::thread_rng;
+
+use crate::DOMAIN_SIZE;
+
+use crate::proof::Proof;
+
+pub fn verify<
+    G: KimchiCurve,
+    OpeningProof: OpenProof<G>,
+    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
+    EFrSponge: FrSponge<G::ScalarField>,
+>(
+    domain: EvaluationDomains<G::ScalarField>,
+    srs: &OpeningProof::SRS,
+    proof: &Proof<G, OpeningProof>,
+) -> bool {
+    let Proof {
+        commitments,
+        zeta_evaluations,
+        zeta_omega_evaluations,
+        opening_proof,
+    } = proof;
+
+    // -- Absorbing the commitments
+    let mut fq_sponge = EFqSponge::new(G::other_curve_sponge_params());
+    for comm in commitments.x.iter() {
+        absorb_commitment(&mut fq_sponge, comm)
+    }
+    // -- Finish absorbing the commitments
+
+    // -- Preparing for opening proof verification
+    let zeta_chal = ScalarChallenge(fq_sponge.challenge());
+    let (_, endo_r) = G::endos();
+    let zeta: G::ScalarField = zeta_chal.to_field(endo_r);
+    let omega = domain.d1.group_gen;
+    let zeta_omega = zeta * omega;
+
+    let fq_sponge_before_evaluations = fq_sponge.clone();
+    let mut fr_sponge = EFrSponge::new(G::sponge_params());
+    fr_sponge.absorb(&fq_sponge.digest());
+
+    let es: Vec<_> = zeta_evaluations
+        .x
+        .iter()
+        .zip(zeta_omega_evaluations.x.iter())
+        .map(|(zeta, zeta_omega)| (vec![vec![*zeta], vec![*zeta_omega]], None))
+        .collect();
+
+    let evaluations: Vec<_> = commitments
+        .x
+        .iter()
+        .zip(
+            zeta_evaluations
+                .x
+                .iter()
+                .zip(zeta_omega_evaluations.x.iter()),
+        )
+        .map(|(commitment, (zeta_eval, zeta_omega_eval))| Evaluation {
+            commitment: commitment.clone(),
+            evaluations: vec![vec![*zeta_eval], vec![*zeta_omega_eval]],
+            degree_bound: None,
+        })
+        .collect();
+
+    // -- Absorb all evaluations
+    for (zeta_eval, zeta_omega_eval) in zeta_evaluations
+        .x
+        .iter()
+        .zip(zeta_omega_evaluations.x.iter())
+    {
+        fr_sponge.absorb(zeta_eval);
+        fr_sponge.absorb(zeta_omega_eval);
+    }
+    // -- End absorb all evaluations
+
+    let v_chal = fr_sponge.challenge();
+    let v = v_chal.to_field(endo_r);
+    let u_chal = fr_sponge.challenge();
+    let u = u_chal.to_field(endo_r);
+
+    let combined_inner_product =
+        combined_inner_product(&[zeta, zeta_omega], &v, &u, es.as_slice(), DOMAIN_SIZE);
+
+    let batch = BatchEvaluationProof {
+        sponge: fq_sponge_before_evaluations,
+        evaluations,
+        evaluation_points: vec![zeta, zeta_omega],
+        polyscale: v,
+        evalscale: u,
+        opening: opening_proof,
+        combined_inner_product,
+    };
+
+    let group_map = G::Map::setup();
+    OpeningProof::verify(srs, &group_map, &mut [batch], &mut thread_rng())
+}


### PR DESCRIPTION
This commit sets the basic structure for the Kimchi MSM circuit which aims to be a circuit allowing to prove a large MSM with group elements formed from a foreign field.

It defines a generic prover and verifier over a indexed number of columns called X_i, and using KZG over the curve BN254.
In following PRs, the prover and verifier will use iterators to absorb commitments and evaluate points.
Also, MVLookup will be integrated.

Run `cargo run --bin main --release` to verify the verifier accepts a random proof.