### PR TITLE
Kimchi MSM: use domain variable instead of crate var DOMAIN_SIZE

### DIFF
--- a/msm/src/main.rs
+++ b/msm/src/main.rs
@@ -16,10 +16,10 @@ pub fn main() {
     // Trusted setup toxic waste
     let x = Fp::rand(&mut rand::rngs::OsRng);
 
-    let mut srs: PairingSRS<BN254> = PairingSRS::create(x, DOMAIN_SIZE);
+    let mut srs: PairingSRS<BN254> = PairingSRS::create(x, domain.d1.size as usize);
     srs.full_srs.add_lagrange_basis(domain.d1);
 
-    let witness = Witness::random();
+    let witness = Witness::random(domain);
 
     println!("Generating the proof");
     let proof = prove::<_, OpeningProof, BaseSponge, ScalarSponge>(domain, &srs, witness);

--- a/msm/src/proof.rs
+++ b/msm/src/proof.rs
@@ -1,9 +1,7 @@
 use ark_ff::UniformRand;
-use kimchi::curve::KimchiCurve;
+use kimchi::{circuits::domains::EvaluationDomains, curve::KimchiCurve};
 use poly_commitment::{commitment::PolyComm, OpenProof};
 use rand::{prelude::*, thread_rng};
-
-use crate::DOMAIN_SIZE;
 
 /// List all columns of the circuit.
 /// It is parametrized by a type `T` which can be either:
@@ -21,14 +19,14 @@ pub struct Witness<G: KimchiCurve> {
 
 #[allow(dead_code)]
 impl<G: KimchiCurve> Witness<G> {
-    pub fn random() -> Self {
+    pub fn random(domain: EvaluationDomains<G::ScalarField>) -> Self {
         let mut rng = thread_rng();
         let random_n = rng.gen_range(1..1000);
         Witness {
             evaluations: WitnessColumns {
                 x: (0..random_n)
                     .map(|_| {
-                        (0..DOMAIN_SIZE)
+                        (0..domain.d1.size as usize)
                             .map(|_| G::ScalarField::rand(&mut rng))
                             .collect::<Vec<_>>()
                     })

--- a/msm/src/verifier.rs
+++ b/msm/src/verifier.rs
@@ -9,8 +9,6 @@ use poly_commitment::{
 };
 use rand::thread_rng;
 
-use crate::DOMAIN_SIZE;
-
 use crate::proof::Proof;
 
 pub fn verify<
@@ -87,8 +85,13 @@ pub fn verify<
     let u_chal = fr_sponge.challenge();
     let u = u_chal.to_field(endo_r);
 
-    let combined_inner_product =
-        combined_inner_product(&[zeta, zeta_omega], &v, &u, es.as_slice(), DOMAIN_SIZE);
+    let combined_inner_product = combined_inner_product(
+        &[zeta, zeta_omega],
+        &v,
+        &u,
+        es.as_slice(),
+        domain.d1.size as usize,
+    );
 
     let batch = BatchEvaluationProof {
         sponge: fq_sponge_before_evaluations,


### PR DESCRIPTION
It makes the code more generic, and DOMAIN_SIZE is only used once to instantiate a domain variable. The domain variable is used everywhere else.