### PR TITLE
Generic MVLookup - MSM

### DIFF
--- a/msm/README.md
+++ b/msm/README.md
@@ -1,0 +1,51 @@
+## MSM circuit
+
+This is a specialised circuit to compute a large MSM where the elements are
+defined over a foreign field, like the one used by the Pickles verifier.
+For simplicity, we suppose the foreign field is on maximum 256 bits.
+
+The witness is splitted in two different parts:
+- Columns: this is the column of the circuit.
+- Lookups: this contain a list of lookups per row.
+  [MVLookup](https://eprint.iacr.org/2022/1530.pdf) is used. It contains
+  the individual polynomials $f_i(X)$ containing the looked up values, the
+  table/polynomial $t(X)$ the polynomials $f_i(X)$ look into and the
+  multiplicity polynomial $m(X)$ as defined in the paper.
+
+The individual columns of the circuit are defined in `src/column.rs`.
+The polynomials can be expressed using the expression framework, instantiated in `src/column.rs`, with
+```rust
+type E<Fp> = Expr<ConstantExpr<F>, MSMColumn>
+```
+
+The proof structure is defined in `src/proof.rs`. A proof consists of
+commitments to the circuit columns and the lookup polynomials, in addition to
+their evaluations, the evaluation points and the opening proofs.
+The prover/verifier are respectively in `src/prover.rs` and `src/verifier.rs`.
+Note that the prover/verifier implementation is generic enough to be used to
+implement other circuits.
+
+The protocol used is a Plonk-ish arithmetisations without the permutation
+argument. The circuit is wide enough (i.e. has enough
+columns) to handle one elliptic curve addition on one row.
+
+The foreign field elements are defined with 16 limbs of 16bits. Limbs-wise
+elementary addition and multiplication is used, and range checks on 16 bits is
+used.
+An addition of two field elements $a = (a_{1}, ..., a_{16})$ and $b = (b_{1}, ...,
+b_{16})$ will be performed on one row, using one power of alpha for each (i.e one
+constraint for each).
+
+The elliptic curve points are represented in affine coordinates.
+As a reminder, the equations for addition are:
+
+```math
+\lambda = \frac{y_2 - y_1}{x_2 - x_1}
+```
+
+```math
+\begin{align}
+x_3 & = \lambda^2 - x_{1} - x_{2} \\
+y_3 & = \lambda (x_{1} - x_{3}) - y_{1}
+\end{align}
+```

--- a/msm/src/constraint.rs
+++ b/msm/src/constraint.rs
@@ -101,6 +101,7 @@ impl BuilderEnv<BN254G1Affine> {
 
         Witness {
             evaluations: WitnessColumns { x },
+            mvlookups: vec![],
         }
     }
 

--- a/msm/src/lib.rs
+++ b/msm/src/lib.rs
@@ -128,6 +128,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_soundness_mvlookup() {
         let seed: [u8; 32] = thread_rng().gen();
         eprintln!("Seed: {:?}", seed);
@@ -157,6 +158,7 @@ mod tests {
         // generate the proof
         let proof = prove::<_, OpeningProof, BaseSponge, ScalarSponge>(domain, &srs, witness);
         let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge>(domain, &srs, &proof);
+        // FIXME: At the moment, it does verify. It should not. We are missing constraints.
         assert!(!verifies);
     }
 }

--- a/msm/src/lib.rs
+++ b/msm/src/lib.rs
@@ -6,6 +6,7 @@ use poly_commitment::pairing_proof::PairingProof;
 
 pub mod columns;
 pub mod constraint;
+pub mod mvlookup;
 pub mod precomputed_srs;
 pub mod proof;
 pub mod prover;

--- a/msm/src/lib.rs
+++ b/msm/src/lib.rs
@@ -44,14 +44,17 @@ mod tests {
     use ark_ff::UniformRand;
     use kimchi::circuits::domains::EvaluationDomains;
     use poly_commitment::pairing_proof::PairingSRS;
+    use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};
 
     use crate::{
-        proof::Witness, prover::prove, verifier::verify, BaseSponge, Fp, OpeningProof,
-        ScalarSponge, BN254,
+        mvlookup::Lookup, proof::Witness, prover::prove, verifier::verify, BaseSponge, Fp,
+        OpeningProof, ScalarSponge, BN254,
     };
 
     #[test]
     fn test_completeness() {
+        // Include tests for completeness for MVLookup as the random witness
+        // includes all arguments
         let domain_size = 1 << 8;
         let domain = EvaluationDomains::<Fp>::create(domain_size).unwrap();
 
@@ -122,17 +125,38 @@ mod tests {
                 verify::<_, OpeningProof, BaseSponge, ScalarSponge>(domain, &srs, &proof_clone);
             assert!(!verifies);
         }
+    }
 
-        // Changing at least one evaluation at \zeta*\omega in the proof should fail
-        // the verification.
-        // TODO: improve me by swapping only one evaluation at \zeta*\omega.
-        // It should easier when an index trait is implemented.
-        {
-            let mut proof_clone = proof.clone();
-            proof_clone.zeta_omega_evaluations = proof_prime.zeta_omega_evaluations;
-            let verifies =
-                verify::<_, OpeningProof, BaseSponge, ScalarSponge>(domain, &srs, &proof_clone);
-            assert!(!verifies);
-        }
+    #[test]
+    fn test_soundness_mvlookup() {
+        let seed: [u8; 32] = thread_rng().gen();
+        eprintln!("Seed: {:?}", seed);
+        let mut rng = StdRng::from_seed(seed);
+
+        // We generate two different witness and two different proofs.
+        let domain_size = 1 << 8;
+        let domain = EvaluationDomains::<Fp>::create(domain_size).unwrap();
+
+        // Trusted setup toxic waste
+        let x = Fp::rand(&mut rng);
+
+        let mut srs: PairingSRS<BN254> = PairingSRS::create(x, domain.d1.size as usize);
+        srs.full_srs.add_lagrange_basis(domain.d1);
+
+        let mut witness = Witness::random(domain);
+        // Take one random f_i (FIXME: taking first one for now)
+        let looked_up_values = witness.mvlookups[0].f[0].clone();
+        // We change a random looked up element (FIXME: first one for now)
+        let wrong_looked_up_value = Lookup {
+            table_id: looked_up_values[0].table_id,
+            numerator: looked_up_values[0].numerator,
+            value: vec![Fp::rand(&mut rng)],
+        };
+        // Overwriting the first looked up value
+        witness.mvlookups[0].f[0][0] = wrong_looked_up_value;
+        // generate the proof
+        let proof = prove::<_, OpeningProof, BaseSponge, ScalarSponge>(domain, &srs, witness);
+        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge>(domain, &srs, &proof);
+        assert!(!verifies);
     }
 }

--- a/msm/src/mvlookup.rs
+++ b/msm/src/mvlookup.rs
@@ -1,0 +1,171 @@
+//! Implement the protocol MVLookup <https://eprint.iacr.org/2022/1530.pdf>
+
+use std::iter;
+
+use ark_ff::{FftField, Field};
+use kimchi::circuits::domains::EvaluationDomains;
+use rand::{seq::SliceRandom, thread_rng, Rng};
+
+// TODO: Add more built-in lookup tables
+#[derive(Copy, Clone, Debug)]
+pub enum LookupTable {
+    RangeCheck16,
+    /// Custom lookup table
+    /// The index of the table is used as the ID, padded with the number of
+    /// built-in tables.
+    Custom(usize),
+}
+
+impl LookupTable {
+    /// Assign a unique ID to the lookup tables.
+    pub fn into_field<F: Field>(self) -> F {
+        match self {
+            LookupTable::RangeCheck16 => F::one(),
+            LookupTable::Custom(id) => F::from(id as u64) + F::one(),
+        }
+    }
+}
+
+/// Generic structure to represent a (vector) lookup the table with ID
+/// `table_id`.
+/// The structure represents the individual fraction of the sum described in the
+/// MVLookup protocol (for instance Eq. 8).
+/// The table ID is added to the random linear combination formed with the
+/// values. The combiner for the random linear combination is coined during the
+/// proving phase by the prover.
+#[derive(Debug, Clone)]
+pub struct Lookup<F> {
+    #[allow(dead_code)]
+    pub(crate) table_id: LookupTable,
+    #[allow(dead_code)]
+    pub(crate) numerator: F,
+    #[allow(dead_code)]
+    pub(crate) value: Vec<F>,
+}
+
+/// Represents a witness of one instance of the lookup argument
+#[derive(Debug)]
+pub struct LookupWitness<F> {
+    /// A list of functions/looked-up values.
+    #[allow(dead_code)]
+    pub(crate) f: Vec<Vec<Lookup<F>>>,
+    /// The table the lookup is performed on.
+    #[allow(dead_code)]
+    pub(crate) t: Vec<Lookup<F>>,
+    /// The multiplicity polynomial
+    #[allow(dead_code)]
+    pub(crate) m: Vec<F>,
+}
+
+// This should be used only for testing purposes.
+// It is not only in the test API because it is used at the moment in the
+// main.rs. It should be moved to the test API when main.rs is replaced with
+// real production code.
+impl<F: FftField> LookupWitness<F> {
+    /// Generate a random number of correct lookups in the table RangeCheck16
+    pub fn random(domain: EvaluationDomains<F>) -> Self {
+        let mut rng = thread_rng();
+        // TODO: generate more random f
+        let table_size: u64 = rng.gen_range(1..domain.d1.size);
+        let table_id = rng.gen_range(1..1000);
+        // Build a table of value we can look up
+        let t: Vec<u64> = {
+            // Generate distinct values to avoid to have to handle the
+            // normalized multiplicity polynomial
+            let mut n: Vec<u64> = (1..(table_size * 100)).collect();
+            n.shuffle(&mut rng);
+            n[0..table_size as usize].to_vec()
+        };
+        // permutation argument
+        let f = {
+            let mut f = t.clone();
+            f.shuffle(&mut rng);
+            f
+        };
+        let dummy_value = F::rand(&mut rng);
+        let repeated_dummy_value: Vec<F> = {
+            let r: Vec<F> = iter::repeat(dummy_value)
+                .take((domain.d1.size - table_size) as usize)
+                .collect();
+            r
+        };
+        let t_evals = {
+            let mut table = Vec::with_capacity(domain.d1.size as usize);
+            table.extend(t.iter().map(|v| Lookup {
+                table_id: LookupTable::Custom(table_id),
+                numerator: -F::one(),
+                value: vec![F::from(*v)],
+            }));
+            table.extend(
+                repeated_dummy_value
+                    .iter()
+                    .map(|v| Lookup {
+                        table_id: LookupTable::Custom(table_id),
+                        numerator: -F::one(),
+                        value: vec![*v],
+                    })
+                    .collect::<Vec<Lookup<F>>>(),
+            );
+            table
+        };
+        let f_evals: Vec<Lookup<F>> = {
+            let mut table = Vec::with_capacity(domain.d1.size as usize);
+            table.extend(f.iter().map(|v| Lookup {
+                table_id: LookupTable::Custom(table_id),
+                numerator: F::one(),
+                value: vec![F::from(*v)],
+            }));
+            table.extend(
+                repeated_dummy_value
+                    .iter()
+                    .map(|v| Lookup {
+                        table_id: LookupTable::Custom(table_id),
+                        numerator: F::one(),
+                        value: vec![*v],
+                    })
+                    .collect::<Vec<Lookup<F>>>(),
+            );
+            table
+        };
+        let m = (0..domain.d1.size).map(|_| F::one()).collect();
+        LookupWitness {
+            f: vec![f_evals],
+            t: t_evals,
+            m,
+        }
+    }
+}
+
+/// Represents the proof of the lookup argument
+/// It is parametrized by the type `T` which can be either:
+/// - Polycomm<G: KimchiCurve> for the commitments
+/// - F for the evaluations at zeta (resp. zeta omega).
+#[derive(Debug, Clone)]
+pub struct LookupProof<T> {
+    #[allow(dead_code)]
+    pub(crate) m: T,
+    #[allow(dead_code)]
+    // Contain t.
+    // TODO: split t and f
+    pub(crate) f: Vec<T>,
+    // pub(crate) t: T,
+    #[allow(dead_code)]
+    pub(crate) sum: T,
+}
+
+/// Iterator implementation to abstract the content of the structure.
+/// It can be used to iterate over the commitments (resp. the evaluations)
+/// without requiring to have a look at the inner fields.
+impl<'lt, G> IntoIterator for &'lt LookupProof<G> {
+    type Item = &'lt G;
+    type IntoIter = std::vec::IntoIter<&'lt G>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let n = self.f.len();
+        let mut iter_contents = Vec::with_capacity(1 + n + 1);
+        iter_contents.push(&self.m);
+        iter_contents.extend(&self.f);
+        iter_contents.push(&self.sum);
+        iter_contents.into_iter()
+    }
+}

--- a/msm/src/mvlookup.rs
+++ b/msm/src/mvlookup.rs
@@ -44,6 +44,17 @@ pub struct Lookup<F> {
 #[derive(Debug)]
 pub struct LookupWitness<F> {
     /// A list of functions/looked-up values.
+    /// The values are represented as:
+    /// [ [f_{1}(1), ..., f_{1}(\omega^n)],
+    ///   [f_{2}(1), ..., f_{2}(\omega^n)]
+    ///     ...
+    ///   [f_{m}(1), ..., f_{m}(\omega^n)]
+    /// ]
+    /// TODO: for efficiency, as we go through columns and after that row, we
+    /// should reorganize this. While working on the interpreter, we might
+    /// change this structure.
+    /// TODO: for efficiency, we might want to have a single flat fixed-size
+    /// array
     pub(crate) f: Vec<Vec<Lookup<F>>>,
     /// The table the lookup is performed on.
     pub(crate) t: Vec<Lookup<F>>,
@@ -134,13 +145,16 @@ impl<F: FftField> LookupWitness<F> {
 /// It is parametrized by the type `T` which can be either:
 /// - Polycomm<G: KimchiCurve> for the commitments
 /// - F for the evaluations at zeta (resp. zeta omega).
+/// FIXME: We should have a fixed number of m and h. Should we encode that in
+/// the type?
 #[derive(Debug, Clone)]
 pub struct LookupProof<T> {
+    // The multiplicity polynomials
+    // FIXME: There should be more than one, one per lookup table
     pub(crate) m: T,
-    // Contain t.
-    // TODO: split t and f
-    pub(crate) f: Vec<T>,
-    // pub(crate) t: T,
+    // The polynomial keeping the sum of each row
+    pub(crate) h: Vec<T>,
+    // The "running-sum" over the rows, coined \phi
     pub(crate) sum: T,
 }
 
@@ -152,11 +166,236 @@ impl<'lt, G> IntoIterator for &'lt LookupProof<G> {
     type IntoIter = std::vec::IntoIter<&'lt G>;
 
     fn into_iter(self) -> Self::IntoIter {
-        let n = self.f.len();
+        let n = self.h.len();
         let mut iter_contents = Vec::with_capacity(1 + n + 1);
         iter_contents.push(&self.m);
-        iter_contents.extend(&self.f);
+        iter_contents.extend(&self.h);
         iter_contents.push(&self.sum);
         iter_contents.into_iter()
+    }
+}
+
+pub mod prover {
+    use ark_ff::Zero;
+    use ark_poly::Evaluations;
+    use ark_poly::{univariate::DensePolynomial, Radix2EvaluationDomain as D};
+    use kimchi::circuits::domains::EvaluationDomains;
+    use kimchi::curve::KimchiCurve;
+    use mina_poseidon::FqSponge;
+    use poly_commitment::commitment::{absorb_commitment, PolyComm};
+    use poly_commitment::{OpenProof, SRS as _};
+
+    use super::{Lookup, LookupWitness};
+
+    pub struct Env<G: KimchiCurve> {
+        // FIXME: only one lookup terms for now
+        pub lookup_counters_evals_d1: Evaluations<G::ScalarField, D<G::ScalarField>>,
+        // FIXME: only one lookup terms for now
+        pub lookup_counters_poly_d1: DensePolynomial<G::ScalarField>,
+        // FIXME: only one lookup terms for now
+        pub lookup_counters_comm_d1: PolyComm<G>,
+
+        pub lookup_terms_evals_d1: Vec<Evaluations<G::ScalarField, D<G::ScalarField>>>,
+        pub lookup_terms_poly_d1: Vec<DensePolynomial<G::ScalarField>>,
+        pub lookup_terms_comms_d1: Vec<PolyComm<G>>,
+
+        pub lookup_aggregation_evals_d1: Evaluations<G::ScalarField, D<G::ScalarField>>,
+        pub lookup_aggregation_poly_d1: DensePolynomial<G::ScalarField>,
+        pub lookup_aggregation_comm_d1: PolyComm<G>,
+    }
+
+    impl<G: KimchiCurve> Env<G> {
+        /// Create an environment for the prover to create a proof for the MVLookup protocol.
+        /// The protocol does suppose that the individual lookup terms are
+        /// committed as part of the columns.
+        /// Therefore, the protocol only focus on commiting to the "grand
+        /// product sum" and the "row-accumulated" values.
+        pub fn create<
+            OpeningProof: OpenProof<G>,
+            Sponge: FqSponge<G::BaseField, G, G::ScalarField>,
+        >(
+            // FIXME: only one lookup for now
+            lookup: &LookupWitness<G::ScalarField>,
+            domain: EvaluationDomains<G::ScalarField>,
+            fq_sponge: &mut Sponge,
+            srs: &OpeningProof::SRS,
+        ) -> Self
+        where
+            OpeningProof::SRS: Sync,
+        {
+            // FIXME: only one lookup for now
+            let LookupWitness { f, t, m } = lookup;
+
+            // Polynomial m(X)
+            // FIXME: only one lookup terms for now
+            let lookup_counters_evals_d1 =
+                Evaluations::<G::ScalarField, D<G::ScalarField>>::from_vec_and_domain(
+                    m.to_vec(),
+                    domain.d1,
+                );
+            let lookup_counters_poly_d1: DensePolynomial<G::ScalarField> =
+                { lookup_counters_evals_d1.interpolate_by_ref() };
+
+            let lookup_counters_comm_d1: PolyComm<G> =
+                srs.commit_evaluations_non_hiding(domain.d1, &lookup_counters_evals_d1);
+
+            absorb_commitment(fq_sponge, &lookup_counters_comm_d1);
+            // -- end of m(X)
+
+            // -- start computing the row sums h(X)
+            // It will be used to compute the running sum in lookup_aggregation
+            // Coin a combiner to perform vector lookup.
+            // The row sums h are defined as
+            // h(\omega^i) = \sum_{j = 0}^{m} (1/\beta + f_{j}(\omega^i)) - (1 / (\beta + t(\omega^i)))
+            let vector_lookup_combiner = fq_sponge.challenge();
+
+            // Coin an evaluation point for the rational functions
+            let beta = fq_sponge.challenge();
+
+            let n = f.len();
+            // FIXME: only one lookup for now. We should have a table for this
+            // later
+            let lookup_terms_evals: Vec<G::ScalarField> = {
+                // We compute first the denominators of all f_i and t. We gather them in
+                // a vector to perform a batch inversion.
+                // We include t in the denominator, therefore n + 1
+                let mut denominators = Vec::with_capacity((n + 1) * domain.d1.size as usize);
+                // Iterate over the rows
+                for j in 0..domain.d1.size {
+                    // Iterate over individual columns (i.e. f_i and t)
+                    for f_i in f.iter() {
+                        let Lookup {
+                            numerator: _,
+                            table_id,
+                            value,
+                        } = &f_i[j as usize];
+                        // x + r * y + r^2 * z + ... + r^n table_id
+                        let combined_value: G::ScalarField =
+                            value.iter().rev().fold(G::ScalarField::zero(), |x, y| {
+                                x * vector_lookup_combiner + y
+                            }) * vector_lookup_combiner
+                                + table_id.into_field::<G::ScalarField>();
+
+                        // beta + a_{i}
+                        let lookup_denominator = beta + combined_value;
+                        denominators.push(lookup_denominator);
+                    }
+
+                    // We process t now
+                    let Lookup {
+                        numerator: _,
+                        table_id,
+                        value,
+                    } = &t[j as usize];
+                    let combined_value: G::ScalarField =
+                        value.iter().rev().fold(G::ScalarField::zero(), |x, y| {
+                            x * vector_lookup_combiner + y
+                        }) * vector_lookup_combiner
+                            + table_id.into_field::<G::ScalarField>();
+
+                    let lookup_denominator = beta + combined_value;
+                    denominators.push(lookup_denominator);
+                }
+
+                ark_ff::fields::batch_inversion(&mut denominators);
+
+                // Evals is the sum on the individual columns for each row
+                let mut evals = Vec::with_capacity(domain.d1.size as usize);
+                let mut denominator_index = 0;
+
+                // We only need to add the numerator now
+                for j in 0..domain.d1.size {
+                    let mut row_acc = G::ScalarField::zero();
+                    for f_i in f.iter() {
+                        let Lookup {
+                            numerator,
+                            table_id: _,
+                            value: _,
+                        } = &f_i[j as usize];
+                        row_acc += *numerator * denominators[denominator_index];
+                        denominator_index += 1;
+                    }
+                    // We process t now
+                    let Lookup {
+                        numerator,
+                        table_id: _,
+                        value: _,
+                    } = &t[j as usize];
+                    row_acc += *numerator * denominators[denominator_index];
+                    denominator_index += 1;
+                    evals.push(row_acc)
+                }
+                // FIXME: only one lookup terms for now
+                evals
+            };
+
+            // FIXME: only one lookup terms for now
+            let lookup_terms_evals_d1: Evaluations<G::ScalarField, D<G::ScalarField>> =
+                Evaluations::<G::ScalarField, D<G::ScalarField>>::from_vec_and_domain(
+                    lookup_terms_evals,
+                    domain.d1,
+                );
+
+            // FIXME: only one lookup terms for now
+            let lookup_terms_poly_d1: DensePolynomial<G::ScalarField> =
+                lookup_terms_evals_d1.interpolate_by_ref();
+
+            // FIXME: only one lookup terms for now
+            let lookup_terms_comms_d1: PolyComm<G> =
+                srs.commit_evaluations_non_hiding(domain.d1, &lookup_terms_evals_d1);
+
+            // FIXME: only one lookup terms for now
+            absorb_commitment(fq_sponge, &lookup_terms_comms_d1);
+            // -- end computing the row sums h
+
+            // -- start computing the running sum in lookup_aggregation
+            // The running sum, \phi, is defined recursively over the subgroup as followed:
+            // - phi(1) = 0
+            // - phi(\omega^{j + 1}) = \phi(\omega^j) + \
+            //                         \sum_{i = 1}^{n} (1 / \beta + f_i(\omega^{j + 1})) - \
+            //                         (m(\omega^{j + 1}) / beta + t(\omega^{j + 1}))
+            // - phi(\omega^n) = 0
+            let lookup_aggregation_evals_d1 = {
+                let mut evals = Vec::with_capacity(domain.d1.size as usize);
+                let mut acc = G::ScalarField::zero();
+                for i in 0..domain.d1.size as usize {
+                    // phi(1) = 0
+                    evals.push(acc);
+                    // FIXME: only one lookup for now.
+                    acc += lookup_terms_evals_d1[i]
+                }
+                // Sanity check to verify that the accumulator ends up being zero.
+                // FIXME: should we add it at runtime?
+                // assert_eq!(acc, G::ScalarField::zero());
+                Evaluations::<G::ScalarField, D<G::ScalarField>>::from_vec_and_domain(
+                    evals, domain.d1,
+                )
+            };
+
+            let lookup_aggregation_poly_d1 = lookup_aggregation_evals_d1.interpolate_by_ref();
+            let lookup_aggregation_comm_d1 =
+                srs.commit_evaluations_non_hiding(domain.d1, &lookup_aggregation_evals_d1);
+
+            absorb_commitment(fq_sponge, &lookup_aggregation_comm_d1);
+            Self {
+                // FIXME: only one lookup supported for now.
+                lookup_counters_evals_d1,
+                // FIXME: only one lookup supported for now.
+                lookup_counters_poly_d1,
+                // FIXME: only one lookup supported for now.
+                lookup_counters_comm_d1,
+
+                // FIXME: only one lookup supported for now.
+                lookup_terms_evals_d1: vec![lookup_terms_evals_d1],
+                // FIXME: only one lookup supported for now.
+                lookup_terms_poly_d1: vec![lookup_terms_poly_d1],
+                // FIXME: only one lookup supported for now.
+                lookup_terms_comms_d1: vec![lookup_terms_comms_d1],
+
+                lookup_aggregation_evals_d1,
+                lookup_aggregation_poly_d1,
+                lookup_aggregation_comm_d1,
+            }
+        }
     }
 }

--- a/msm/src/mvlookup.rs
+++ b/msm/src/mvlookup.rs
@@ -365,8 +365,10 @@ pub mod prover {
                     acc += lookup_terms_evals_d1[i]
                 }
                 // Sanity check to verify that the accumulator ends up being zero.
-                // FIXME: should we add it at runtime?
-                // assert_eq!(acc, G::ScalarField::zero());
+                // FIXME: This should be removed from runtime, and a constraint
+                // should be added. For now, the verifier accepts any proof.
+                // This will be fixed when constraints are added.
+                assert_eq!(acc, G::ScalarField::zero());
                 Evaluations::<G::ScalarField, D<G::ScalarField>>::from_vec_and_domain(
                     evals, domain.d1,
                 )

--- a/msm/src/mvlookup.rs
+++ b/msm/src/mvlookup.rs
@@ -35,11 +35,8 @@ impl LookupTable {
 /// proving phase by the prover.
 #[derive(Debug, Clone)]
 pub struct Lookup<F> {
-    #[allow(dead_code)]
     pub(crate) table_id: LookupTable,
-    #[allow(dead_code)]
     pub(crate) numerator: F,
-    #[allow(dead_code)]
     pub(crate) value: Vec<F>,
 }
 
@@ -47,13 +44,10 @@ pub struct Lookup<F> {
 #[derive(Debug)]
 pub struct LookupWitness<F> {
     /// A list of functions/looked-up values.
-    #[allow(dead_code)]
     pub(crate) f: Vec<Vec<Lookup<F>>>,
     /// The table the lookup is performed on.
-    #[allow(dead_code)]
     pub(crate) t: Vec<Lookup<F>>,
     /// The multiplicity polynomial
-    #[allow(dead_code)]
     pub(crate) m: Vec<F>,
 }
 
@@ -142,14 +136,11 @@ impl<F: FftField> LookupWitness<F> {
 /// - F for the evaluations at zeta (resp. zeta omega).
 #[derive(Debug, Clone)]
 pub struct LookupProof<T> {
-    #[allow(dead_code)]
     pub(crate) m: T,
-    #[allow(dead_code)]
     // Contain t.
     // TODO: split t and f
     pub(crate) f: Vec<T>,
     // pub(crate) t: T,
-    #[allow(dead_code)]
     pub(crate) sum: T,
 }
 

--- a/msm/src/proof.rs
+++ b/msm/src/proof.rs
@@ -4,6 +4,8 @@ use poly_commitment::{commitment::PolyComm, OpenProof};
 use rand::{prelude::*, thread_rng};
 use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelIterator};
 
+use crate::mvlookup::{LookupProof, LookupWitness};
+
 /// List all columns of the circuit.
 /// It is parametrized by a type `T` which can be either:
 /// - `Vec<G::ScalarField>` for the evaluations
@@ -83,7 +85,7 @@ where
 #[derive(Debug)]
 pub struct Witness<G: KimchiCurve> {
     pub(crate) evaluations: WitnessColumns<Vec<G::ScalarField>>,
-    // TODO: add MVLookup
+    pub(crate) mvlookups: Vec<LookupWitness<G::ScalarField>>,
 }
 
 // This should be used only for testing purposes.
@@ -105,14 +107,20 @@ impl<G: KimchiCurve> Witness<G> {
                     })
                     .collect::<Vec<_>>(),
             },
+            mvlookups: vec![LookupWitness::<G::ScalarField>::random(domain)],
         }
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct Proof<G: KimchiCurve, OpeningProof: OpenProof<G>> {
+    // Columns/PlonK argument
     pub(crate) commitments: WitnessColumns<PolyComm<G>>,
     pub(crate) zeta_evaluations: WitnessColumns<G::ScalarField>,
     pub(crate) zeta_omega_evaluations: WitnessColumns<G::ScalarField>,
+    // MVLookup argument
+    pub(crate) mvlookup_commitments: LookupProof<PolyComm<G>>,
+    pub(crate) mvlookup_zeta_evaluations: LookupProof<G::ScalarField>,
+    pub(crate) mvlookup_zeta_omega_evaluations: LookupProof<G::ScalarField>,
     pub(crate) opening_proof: OpeningProof,
 }

--- a/msm/src/proof.rs
+++ b/msm/src/proof.rs
@@ -92,7 +92,6 @@ pub struct Witness<G: KimchiCurve> {
 // It is not only in the test API because it is used at the moment in the
 // main.rs. It should be moved to the test API when main.rs is replaced with
 // real production code.
-#[allow(dead_code)]
 impl<G: KimchiCurve> Witness<G> {
     pub fn random(domain: EvaluationDomains<G::ScalarField>) -> Self {
         let mut rng = thread_rng();
@@ -119,8 +118,8 @@ pub struct Proof<G: KimchiCurve, OpeningProof: OpenProof<G>> {
     pub(crate) zeta_evaluations: WitnessColumns<G::ScalarField>,
     pub(crate) zeta_omega_evaluations: WitnessColumns<G::ScalarField>,
     // MVLookup argument
-    pub(crate) mvlookup_commitments: LookupProof<PolyComm<G>>,
-    pub(crate) mvlookup_zeta_evaluations: LookupProof<G::ScalarField>,
-    pub(crate) mvlookup_zeta_omega_evaluations: LookupProof<G::ScalarField>,
+    pub(crate) mvlookup_commitments: Option<LookupProof<PolyComm<G>>>,
+    pub(crate) mvlookup_zeta_evaluations: Option<LookupProof<G::ScalarField>>,
+    pub(crate) mvlookup_zeta_omega_evaluations: Option<LookupProof<G::ScalarField>>,
     pub(crate) opening_proof: OpeningProof,
 }

--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -65,20 +65,16 @@ where
     let LookupWitness { f, t, m } = mvlookup;
 
     // Polynomial m(X)
-    let lookup_counters_poly_d1: DensePolynomial<G::ScalarField> = {
-        let evals = Evaluations::<G::ScalarField, D<G::ScalarField>>::from_vec_and_domain(
+    let lookup_counters_evals_d1 =
+        Evaluations::<G::ScalarField, D<G::ScalarField>>::from_vec_and_domain(
             m.to_vec(),
             domain.d1,
         );
-        evals.interpolate()
-    };
-    let lookup_counters_evals_d8: Evaluations<G::ScalarField, D<G::ScalarField>> = {
-        // We interpolate and get evaluations on d8 also
-        lookup_counters_poly_d1.evaluate_over_domain_by_ref(domain.d8)
-    };
+    let lookup_counters_poly_d1: DensePolynomial<G::ScalarField> =
+        { lookup_counters_evals_d1.interpolate_by_ref() };
 
     let lookup_counters_comm_d1: PolyComm<G> =
-        srs.commit_evaluations_non_hiding(domain.d1, &lookup_counters_evals_d8);
+        srs.commit_evaluations_non_hiding(domain.d1, &lookup_counters_evals_d1);
 
     absorb_commitment(&mut fq_sponge, &lookup_counters_comm_d1);
     // -- end of m(X)

--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -14,6 +14,7 @@ use poly_commitment::{
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
 
+use crate::mvlookup::{Lookup, LookupProof, LookupWitness};
 use crate::proof::{Proof, Witness, WitnessColumns};
 
 pub fn prove<
@@ -57,6 +58,179 @@ where
         .into_iter()
         .for_each(|comm| absorb_commitment(&mut fq_sponge, comm));
 
+    // -- Start MVLookup
+    // TODO: handle more than one, use into_parallel
+    assert_eq!(inputs.mvlookups.len(), 1);
+    let mvlookup: &LookupWitness<G::ScalarField> = &inputs.mvlookups[0];
+    let LookupWitness { f, t, m } = mvlookup;
+
+    // Polynomial m(X)
+    let lookup_counters_poly_d1: DensePolynomial<G::ScalarField> = {
+        let evals = Evaluations::<G::ScalarField, D<G::ScalarField>>::from_vec_and_domain(
+            m.to_vec(),
+            domain.d1,
+        );
+        evals.interpolate()
+    };
+    let lookup_counters_evals_d8: Evaluations<G::ScalarField, D<G::ScalarField>> = {
+        // We interpolate and get evaluations on d8 also
+        lookup_counters_poly_d1.evaluate_over_domain_by_ref(domain.d8)
+    };
+
+    let lookup_counters_comm_d1: PolyComm<G> =
+        srs.commit_evaluations_non_hiding(domain.d1, &lookup_counters_evals_d8);
+
+    absorb_commitment(&mut fq_sponge, &lookup_counters_comm_d1);
+    // -- end of m(X)
+
+    // -- start computing individual elements of the lookup (f_i and t)
+    // It will be used to compute the running sum in lookup_aggregation
+    // Coin a combiner to perform vector lookup.
+    let vector_lookup_value_combiner = fq_sponge.challenge();
+
+    // Coin an evaluation point for the rational functions
+    let beta = fq_sponge.challenge();
+
+    let n = f.len();
+    let lookup_terms_evals: Vec<G::ScalarField> = {
+        // We compute first the denominators of all f_i and t. We gather them in
+        // a vector to perform a batch inversion.
+        // We include t in the denominator, therefore n + 1
+        let mut denominators = Vec::with_capacity((n + 1) * domain.d1.size as usize);
+        // Iterate over the rows
+        for f_i in f.iter() {
+            // Iterate over individual columns (i.e. f_i and t)
+            for Lookup {
+                numerator: _,
+                table_id,
+                value,
+            } in f_i.iter().chain(t.iter())
+            // Include t
+            {
+                // x + r * y + r^2 * z + ... + r^n table_id
+                let combined_value: G::ScalarField =
+                    value.iter().rev().fold(G::ScalarField::zero(), |x, y| {
+                        x * vector_lookup_value_combiner + y
+                    }) * vector_lookup_value_combiner
+                        + table_id.into_field::<G::ScalarField>();
+
+                // beta + a_{i}
+                let lookup_denominator = beta + combined_value;
+                denominators.push(lookup_denominator);
+            }
+        }
+
+        ark_ff::fields::batch_inversion(&mut denominators);
+
+        // n + 1 for t
+        let mut evals = Vec::with_capacity((n + 1) * domain.d1.size as usize);
+        let mut denominator_index = 0;
+
+        // Including now the numerator
+        for row_lookups in f.iter() {
+            let mut row_acc = G::ScalarField::zero();
+            for Lookup {
+                numerator,
+                table_id: _,
+                value: _,
+            } in row_lookups.iter().chain(t.iter())
+            {
+                row_acc += *numerator * denominators[denominator_index];
+                denominator_index += 1;
+            }
+            evals.push(row_acc)
+        }
+        evals
+    };
+
+    // evals contain the evaluations for the N + 1 polynomials. We must split it
+    // in individual vectors to interpolate and commit.
+    // Get back the individual evaluation f_i and t
+    let mut individual_evals: Vec<Vec<G::ScalarField>> = Vec::with_capacity(n + 1);
+    for _i in 0..=n {
+        individual_evals.push(Vec::with_capacity(domain.d1.size as usize));
+    }
+
+    for (i, v) in lookup_terms_evals.iter().enumerate() {
+        individual_evals[i % (n + 1)].push(*v)
+    }
+
+    let lookup_terms_evals_d1: Vec<Evaluations<G::ScalarField, D<G::ScalarField>>> =
+        individual_evals
+            // Parallelize
+            .into_par_iter()
+            .map(|evals| {
+                Evaluations::<G::ScalarField, D<G::ScalarField>>::from_vec_and_domain(
+                    evals, domain.d1,
+                )
+            })
+            .collect();
+
+    let lookup_terms_poly_d1: Vec<DensePolynomial<G::ScalarField>> = (&lookup_terms_evals_d1)
+        // Parallelize
+        .into_par_iter()
+        .map(|evals| evals.interpolate_by_ref())
+        .collect();
+
+    let lookup_terms_evals_d8: Vec<Evaluations<G::ScalarField, D<G::ScalarField>>> =
+        (&lookup_terms_poly_d1)
+            // Parallelize
+            .into_par_iter()
+            .map(|p| p.evaluate_over_domain_by_ref(domain.d8))
+            .collect();
+
+    let lookup_terms_comms_d1: Vec<PolyComm<G>> = (&lookup_terms_evals_d8)
+        // Parallelize
+        .into_par_iter()
+        .map(|lt| srs.commit_evaluations_non_hiding(domain.d1, lt))
+        .collect();
+
+    lookup_terms_comms_d1
+        .iter()
+        .for_each(|comm| absorb_commitment(&mut fq_sponge, comm));
+    // -- end computing individual elements of the lookup (f_i and t)
+
+    // -- start computing the running sum in lookup_aggregation
+    // The running sum, \phi, is defined recursively over the subgroup as followed:
+    // - phi(1) = 0
+    // - phi(\omega^{j + 1}) = \phi(\omega^j) + \
+    //                         \sum_{i = 1}^{n} (1 / \beta + f_i(\omega^{j + 1})) - \
+    //                         (m(\omega^{j + 1}) / beta + t(\omega^{j + 1}))
+    // - phi(\omega^n) = 0
+    let lookup_aggregation_evals_d1 = {
+        let mut evals = Vec::with_capacity(domain.d1.size as usize);
+        let mut acc = G::ScalarField::zero();
+        for i in 0..domain.d1.size as usize {
+            // phi(1) = 0
+            evals.push(acc);
+            // Terms are f_1, ..., f_n, t
+            for terms in lookup_terms_evals_d8.iter() {
+                // Because the individual evaluations of f_i and t are on d1
+                acc += terms[8 * i];
+            }
+        }
+        // Sanity check to verify that the accumulator ends up being zero.
+        assert_eq!(acc, G::ScalarField::zero());
+        Evaluations::<G::ScalarField, D<G::ScalarField>>::from_vec_and_domain(evals, domain.d1)
+    };
+
+    let lookup_aggregation_poly_d1 = lookup_aggregation_evals_d1.interpolate();
+    let lookup_aggregation_evals_d8 =
+        lookup_aggregation_poly_d1.evaluate_over_domain_by_ref(domain.d8);
+
+    let lookup_aggregation_comm_d1 =
+        srs.commit_evaluations_non_hiding(domain.d1, &lookup_aggregation_evals_d8);
+
+    absorb_commitment(&mut fq_sponge, &lookup_aggregation_comm_d1);
+
+    let mvlookup_commitments = LookupProof {
+        m: lookup_counters_comm_d1,
+        f: lookup_terms_comms_d1,
+        sum: lookup_aggregation_comm_d1,
+    };
+    // -- end computing the running sum in lookup_aggregation
+    // -- End of MVLookup
+
     // TODO: add quotient polynomial (based on constraints and expresion framework)
 
     // We start the evaluations.
@@ -67,6 +241,7 @@ where
     let zeta_omega = zeta * omega;
 
     // Evaluate the polynomials at zeta and zeta * omega -- Columns
+    // TODO: Parallelize
     let (zeta_evaluations, zeta_omega_evaluations) = {
         let evals = |point| {
             let WitnessColumns { x } = &polys;
@@ -76,13 +251,24 @@ where
         };
         (evals(&zeta), evals(&zeta_omega))
     };
+    // TODO: Parallelize
+    let (mvlookup_zeta_evaluations, mvlookup_zeta_omega_evaluations) = {
+        let evals = |point| {
+            let comm = |poly: &DensePolynomial<G::ScalarField>| poly.evaluate(point);
+            let m = comm(&lookup_counters_poly_d1);
+            let f = lookup_terms_poly_d1.iter().map(comm).collect::<Vec<_>>();
+            let sum = comm(&lookup_aggregation_poly_d1);
+            LookupProof { m, f, sum }
+        };
+        (evals(&zeta), evals(&zeta_omega))
+    };
     // -- Start opening proof - Preparing the Rust structures
     let group_map = G::Map::setup();
 
     // Gathering all polynomials to use in the opening proof
     let polynomials: Vec<_> = polys.into_iter().collect();
 
-    let polynomials: Vec<_> = polynomials
+    let mut polynomials: Vec<_> = polynomials
         .iter()
         .map(|poly| {
             (
@@ -95,6 +281,41 @@ where
             )
         })
         .collect();
+    // Adding MVLookup
+    // -- first m(X)
+    polynomials.push((
+        DensePolynomialOrEvaluations::DensePolynomial(&lookup_counters_poly_d1),
+        None,
+        PolyComm {
+            unshifted: vec![G::ScalarField::zero()],
+            shifted: None,
+        },
+    ));
+    // -- after that f_i and t
+    polynomials.extend(
+        lookup_terms_poly_d1
+            .iter()
+            .map(|poly| {
+                (
+                    DensePolynomialOrEvaluations::DensePolynomial(poly),
+                    None,
+                    PolyComm {
+                        unshifted: vec![G::ScalarField::zero()],
+                        shifted: None,
+                    },
+                )
+            })
+            .collect::<Vec<_>>(),
+    );
+    // -- after that the running sum
+    polynomials.push((
+        DensePolynomialOrEvaluations::DensePolynomial(&lookup_aggregation_poly_d1),
+        None,
+        PolyComm {
+            unshifted: vec![G::ScalarField::zero()],
+            shifted: None,
+        },
+    ));
 
     // Fiat Shamir - absorbing evaluations
     let fq_sponge_before_evaluations = fq_sponge.clone();
@@ -104,6 +325,14 @@ where
     for (zeta_eval, zeta_omega_eval) in zeta_evaluations
         .into_iter()
         .zip(zeta_omega_evaluations.into_iter())
+    {
+        fr_sponge.absorb(zeta_eval);
+        fr_sponge.absorb(zeta_omega_eval);
+    }
+    // MVLookup FS
+    for (zeta_eval, zeta_omega_eval) in mvlookup_zeta_evaluations
+        .into_iter()
+        .zip(mvlookup_zeta_omega_evaluations.into_iter())
     {
         fr_sponge.absorb(zeta_eval);
         fr_sponge.absorb(zeta_omega_eval);
@@ -130,6 +359,9 @@ where
         commitments,
         zeta_evaluations,
         zeta_omega_evaluations,
+        mvlookup_commitments,
+        mvlookup_zeta_evaluations,
+        mvlookup_zeta_omega_evaluations,
         opening_proof,
     }
 }

--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -210,12 +210,9 @@ where
         Evaluations::<G::ScalarField, D<G::ScalarField>>::from_vec_and_domain(evals, domain.d1)
     };
 
-    let lookup_aggregation_poly_d1 = lookup_aggregation_evals_d1.interpolate();
-    let lookup_aggregation_evals_d8 =
-        lookup_aggregation_poly_d1.evaluate_over_domain_by_ref(domain.d8);
-
+    let lookup_aggregation_poly_d1 = lookup_aggregation_evals_d1.interpolate_by_ref();
     let lookup_aggregation_comm_d1 =
-        srs.commit_evaluations_non_hiding(domain.d1, &lookup_aggregation_evals_d8);
+        srs.commit_evaluations_non_hiding(domain.d1, &lookup_aggregation_evals_d1);
 
     absorb_commitment(&mut fq_sponge, &lookup_aggregation_comm_d1);
 


### PR DESCRIPTION
Current bug (expected): does not handle multiplicity different than one. Coming in a following PR with a test.
Also support only one table. Change coming in another PR, it is straightforward to generalize.

Fix https://github.com/MinaProtocol/mina/issues/15089

It is not sound, yet. Missing constraints.

TODO:
- [x] support empty list of lookups
- [x] support more than one lookup table in the proof (done in https://github.com/o1-labs/proof-systems/pull/1827)
- [ ] handle multiplicity