### PR TITLE
MSM: Merge existing feature work on SRS and constraints

### DIFF
--- a/msm/src/columns.rs
+++ b/msm/src/columns.rs
@@ -1,5 +1,36 @@
+use crate::LIMBS_NUM;
+
+// @volhovm: maybe this needs to be a trait
 /// Describe a generic indexed variable X_{i}.
-#[derive(Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum Column {
     X(usize),
+}
+
+/// A datatype expressing a generalized column, but with potentially
+/// more convenient interface than a bare column.
+pub trait ColumnIndexer {
+    fn ix_to_column(self) -> Column;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+/// Column indexer for MSM columns
+pub enum MSMColumnIndexer {
+    A(usize),
+    B(usize),
+    C(usize),
+}
+
+impl ColumnIndexer for MSMColumnIndexer {
+    fn ix_to_column(self) -> Column {
+        let to_column_inner = |offset, i| {
+            assert!(i < LIMBS_NUM);
+            Column::X(LIMBS_NUM * offset + i)
+        };
+        match self {
+            MSMColumnIndexer::A(i) => to_column_inner(0, i),
+            MSMColumnIndexer::B(i) => to_column_inner(1, i),
+            MSMColumnIndexer::C(i) => to_column_inner(2, i),
+        }
+    }
 }

--- a/msm/src/constraint.rs
+++ b/msm/src/constraint.rs
@@ -1,6 +1,11 @@
-use kimchi::circuits::expr::{ConstantExpr, Expr};
+use ark_ff::Field;
+
+use kimchi::circuits::expr::{ConstantExpr, Expr, ExprInner, Variable};
+use kimchi::circuits::gate::CurrOrNext;
 
 use crate::columns::Column;
+use crate::columns::{ColumnIndexer, MSMColumnIndexer};
+use crate::{Fp, LIMBS_NUM};
 
 /// Used to represent constraints as multi variate polynomials. The variables
 /// are over the columns.
@@ -37,3 +42,41 @@ use crate::columns::Column;
 /// A list of such constraints is used to represent the entire circuit and will
 /// be used to build the quotient polynomial.
 pub type MSMExpr<F> = Expr<ConstantExpr<F>, Column>;
+
+#[allow(dead_code)]
+pub struct BuilderEnv<F: Field> {
+    // TODO something like a running list of constraints
+    pub(crate) constraints: Vec<MSMExpr<F>>,
+    // TODO An accumulated elliptic curve sum for the sub-MSM algorithm
+    pub(crate) accumulated_result: F,
+}
+
+pub fn make_msm_constraint() -> MSMExpr<Fp> {
+    let mut limb_constraints: Vec<_> = vec![];
+
+    for i in 0..LIMBS_NUM {
+        let a_i = MSMExpr::Atom(ExprInner::<
+            kimchi::circuits::expr::Operations<kimchi::circuits::expr::ConstantExprInner<Fp>>,
+            Column,
+        >::Cell(Variable {
+            col: MSMColumnIndexer::A(i).ix_to_column(),
+            row: CurrOrNext::Curr,
+        }));
+        let b_i = MSMExpr::Atom(ExprInner::Cell(Variable {
+            col: MSMColumnIndexer::B(i).ix_to_column(),
+            row: CurrOrNext::Curr,
+        }));
+        let c_i = MSMExpr::Atom(ExprInner::Cell(Variable {
+            col: MSMColumnIndexer::C(i).ix_to_column(),
+            row: CurrOrNext::Curr,
+        }));
+        let limb_constraint = a_i + b_i - c_i;
+        limb_constraints.push(limb_constraint);
+    }
+
+    let combined_constraint =
+        Expr::combine_constraints(0..(limb_constraints.len() as u32), limb_constraints);
+
+    println!("{:?}", combined_constraint);
+    combined_constraint
+}

--- a/msm/src/constraint.rs
+++ b/msm/src/constraint.rs
@@ -12,21 +12,21 @@ use crate::columns::Column;
 /// use kimchi::circuits::expr::{ConstantExprInner, ExprInner, Operations, Variable};
 /// use kimchi::circuits::gate::CurrOrNext;
 /// use kimchi_msm::columns::Column;
-/// use kimchi_msm::constraint::E;
+/// use kimchi_msm::constraint::MSMExpr;
 /// pub type Fp = ark_bn254::Fr;
-/// let x1 = E::<Fp>::Atom(
+/// let x1 = MSMExpr::<Fp>::Atom(
 ///     ExprInner::<Operations<ConstantExprInner<Fp>>, Column>::Cell(Variable {
 ///         col: Column::X(1),
 ///         row: CurrOrNext::Curr,
 ///     }),
 /// );
-/// let x2 = E::<Fp>::Atom(
+/// let x2 = MSMExpr::<Fp>::Atom(
 ///     ExprInner::<Operations<ConstantExprInner<Fp>>, Column>::Cell(Variable {
 ///         col: Column::X(1),
 ///         row: CurrOrNext::Curr,
 ///     }),
 /// );
-/// let x3 = E::<Fp>::Atom(
+/// let x3 = MSMExpr::<Fp>::Atom(
 ///     ExprInner::<Operations<ConstantExprInner<Fp>>, Column>::Cell(Variable {
 ///         col: Column::X(1),
 ///         row: CurrOrNext::Curr,
@@ -36,4 +36,4 @@ use crate::columns::Column;
 /// ```
 /// A list of such constraints is used to represent the entire circuit and will
 /// be used to build the quotient polynomial.
-pub type E<F> = Expr<ConstantExpr<F>, Column>;
+pub type MSMExpr<F> = Expr<ConstantExpr<F>, Column>;

--- a/msm/src/lib.rs
+++ b/msm/src/lib.rs
@@ -6,6 +6,7 @@ use poly_commitment::pairing_proof::PairingProof;
 
 pub mod columns;
 pub mod constraint;
+pub mod precomputed_srs;
 pub mod proof;
 pub mod prover;
 pub mod verifier;

--- a/msm/src/lib.rs
+++ b/msm/src/lib.rs
@@ -10,12 +10,27 @@ pub mod proof;
 pub mod prover;
 pub mod verifier;
 
+/// Domain size for the MSM project, equal to the BN254 SRS size.
 pub const DOMAIN_SIZE: usize = 1 << 15;
 
-pub type BN254 = ark_ec::bn::Bn<ark_bn254::Parameters>;
+// @volhovm: maybe move these to the FF circuits module later.
+/// Bitsize of the foreign field limb representation.
+pub const LIMB_BITSIZE: usize = 16;
 
-/// The native field we are working with
+/// Number of limbs representing one foreign field element (either
+/// [`Ff1`] or [`Ff2`]).
+pub const LIMBS_NUM: usize = 16;
+
+pub type BN254 = ark_ec::bn::Bn<ark_bn254::Parameters>;
+pub type BN254G1Affine = <BN254 as ark_ec::PairingEngine>::G1Affine;
+pub type BN254G2Affine = <BN254 as ark_ec::PairingEngine>::G2Affine;
+
+/// The native field we are working with.
 pub type Fp = ark_bn254::Fr;
+
+/// The foreign field we are emulating (one of the two)
+pub type Ff1 = mina_curves::pasta::Fp;
+pub type Ff2 = mina_curves::pasta::Fq;
 
 pub type SpongeParams = PlonkSpongeConstantsKimchi;
 pub type BaseSponge = DefaultFqSponge<ark_bn254::g1::Parameters, SpongeParams>;

--- a/msm/src/main.rs
+++ b/msm/src/main.rs
@@ -1,6 +1,6 @@
 use kimchi::circuits::domains::EvaluationDomains;
 
-use ark_ff::UniformRand;
+use kimchi_msm::precomputed_srs::get_bn254_srs;
 use kimchi_msm::proof::Witness;
 use kimchi_msm::prover::prove;
 use kimchi_msm::verifier::verify;
@@ -13,11 +13,7 @@ pub fn main() {
     println!("Creating the domain and SRS");
     let domain = EvaluationDomains::<Fp>::create(DOMAIN_SIZE).unwrap();
 
-    // Trusted setup toxic waste
-    let x = Fp::rand(&mut rand::rngs::OsRng);
-
-    let mut srs: PairingSRS<BN254> = PairingSRS::create(x, domain.d1.size as usize);
-    srs.full_srs.add_lagrange_basis(domain.d1);
+    let srs: PairingSRS<BN254> = get_bn254_srs(domain);
 
     let witness = Witness::random(domain);
 

--- a/msm/src/main.rs
+++ b/msm/src/main.rs
@@ -1,13 +1,32 @@
-use kimchi::circuits::domains::EvaluationDomains;
+use ark_ff::UniformRand;
+use rand::thread_rng;
 
+use kimchi::circuits::domains::EvaluationDomains;
+use poly_commitment::pairing_proof::PairingSRS;
+
+use kimchi_msm::constraint::BuilderEnv;
 use kimchi_msm::precomputed_srs::get_bn254_srs;
-use kimchi_msm::proof::Witness;
 use kimchi_msm::prover::prove;
 use kimchi_msm::verifier::verify;
-use kimchi_msm::BN254;
-use kimchi_msm::DOMAIN_SIZE;
-use kimchi_msm::{BaseSponge, Fp, OpeningProof, ScalarSponge};
-use poly_commitment::pairing_proof::PairingSRS;
+use kimchi_msm::{
+    BN254G1Affine, BaseSponge, Ff1, Fp, OpeningProof, ScalarSponge, BN254, DOMAIN_SIZE,
+};
+
+pub fn generate_random_msm_witness() -> BuilderEnv<BN254G1Affine> {
+    let mut env = BuilderEnv::<BN254G1Affine>::empty();
+    let mut rng = thread_rng();
+
+    let row_num = 5;
+    assert!(row_num < DOMAIN_SIZE);
+
+    for _row_i in 0..row_num {
+        let a: Ff1 = Ff1::rand(&mut rng);
+        let b: Ff1 = Ff1::rand(&mut rng);
+        env.add_test_addition(a, b);
+    }
+
+    env
+}
 
 pub fn main() {
     println!("Creating the domain and SRS");
@@ -15,7 +34,8 @@ pub fn main() {
 
     let srs: PairingSRS<BN254> = get_bn254_srs(domain);
 
-    let witness = Witness::random(domain);
+    let env = generate_random_msm_witness();
+    let witness = env.get_witness();
 
     println!("Generating the proof");
     let proof = prove::<_, OpeningProof, BaseSponge, ScalarSponge>(domain, &srs, witness);

--- a/msm/src/precomputed_srs.rs
+++ b/msm/src/precomputed_srs.rs
@@ -1,0 +1,121 @@
+//! Clone of kimchi/precomputed_srs.rs but for MSM project with BN254
+
+use std::path::PathBuf;
+use std::{fs::File, io::BufReader};
+
+use ark_ff::UniformRand;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Write};
+
+use kimchi::circuits::domains::EvaluationDomains;
+use poly_commitment::pairing_proof::PairingSRS;
+
+use crate::{BN254G2Affine, Fp, BN254, DOMAIN_SIZE};
+
+/// The path of the serialized BN254 SRS.
+pub fn get_bn254_srs_path() -> PathBuf {
+    let base_path = env!("CARGO_MANIFEST_DIR");
+    if base_path.is_empty() {
+        println!("WARNING: BN254 precomputation: CARGO_MANIFEST_DIR is absent in release mode, can't determine orking directory. Turn off --release");
+    }
+    let res = PathBuf::from(base_path).join("./msm_srs/msm_bn254.srs");
+    println!("BN254 SRS path: {:?}", res);
+    res
+}
+
+/// Tries to read the SRS from disk, otherwise panics.
+pub fn read_bn254_srs_from_disk() -> PairingSRS<BN254> {
+    let srs_path = get_bn254_srs_path();
+    let file =
+        File::open(srs_path.clone()).unwrap_or_else(|_| panic!("missing SRS file: {srs_path:?}"));
+    let reader = BufReader::new(file);
+    rmp_serde::from_read(reader).unwrap()
+}
+
+// @volhovm: Serialization of G2Affine points is broken somewhere deep
+// underneath. This test works for most types including G1Affine, but
+// it fails for G2 while reading with 'value: InvalidData'.
+// Try to find a "mode" setting -- maybe serialization is optimised, while deserialization is not. Serialize_with_mode
+pub fn test_serialization() {
+    let path = PathBuf::from("./test_file.srs");
+
+    let file1 = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(path.clone())
+        .expect("failed to open SRS file");
+    let x = Fp::rand(&mut rand::rngs::OsRng);
+    let srs: PairingSRS<BN254> = PairingSRS::create(x, DOMAIN_SIZE);
+
+    // minimal example: a single G2 point
+    let actual: BN254G2Affine = srs.verifier_srs.h;
+    let _ = actual.serialize(file1);
+
+    let file2 = File::open(path.clone()).unwrap_or_else(|_| panic!("File absent"));
+    let reader = BufReader::new(file2);
+    let expected: BN254G2Affine = CanonicalDeserialize::deserialize(reader).unwrap();
+
+    assert!(expected == actual, "test_serialization() failed");
+    println!("test_serialization() success");
+}
+
+/// Creates a BN254 SRS. If the `overwrite_srs` flag is on, or
+/// `SRS_OVERWRITE` env variable is ON, also writes it into the file.
+pub fn create_and_store_srs(
+    overwrite_srs: bool,
+    domain: EvaluationDomains<Fp>,
+) -> PairingSRS<BN254> {
+    // Trusted setup toxic waste
+    let x = Fp::rand(&mut rand::rngs::OsRng);
+
+    let mut srs: PairingSRS<BN254> = PairingSRS::create(x, DOMAIN_SIZE);
+    srs.full_srs.add_lagrange_basis(domain.d1);
+
+    // overwrite SRS if the env var is set
+    let srs_path = get_bn254_srs_path();
+    if overwrite_srs || std::env::var("SRS_OVERWRITE").is_ok() {
+        println!("Writing the SRS");
+        // Create parent directories
+        std::fs::create_dir_all(srs_path.parent().unwrap()).unwrap();
+        // Open/create the file
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(srs_path)
+            .expect("failed to open SRS file");
+
+        let srs_bytes = rmp_serde::to_vec(&srs).unwrap();
+        file.write_all(&srs_bytes).expect("failed to write file");
+        file.flush().expect("failed to flush file");
+    }
+
+    println!("Reading the SRS from the disk to double check");
+    // get SRS from disk
+    let srs_on_disk = read_bn254_srs_from_disk();
+
+    // check that it matches what we just generated
+    // *TODO*!!! Equality must be defined
+    assert_eq!(srs, srs_on_disk);
+
+    srs
+}
+
+/// Obtains an SRS for a specific curve from disk, or generates it if absent.
+pub fn get_bn254_srs(domain: EvaluationDomains<Fp>) -> PairingSRS<BN254> {
+    // Temporarily just generate it from scratch since SRS serialization is broken. See test_serialization.
+    let trapdoor = Fp::rand(&mut rand::rngs::OsRng);
+    let mut srs = PairingSRS::create(trapdoor, DOMAIN_SIZE);
+    srs.full_srs.add_lagrange_basis(domain.d1);
+    srs
+
+    //let srs_path = get_bn254_srs_path();
+    //match File::open(srs_path.clone()) {
+    //    Ok(file) => {
+    //        let reader = BufReader::new(file);
+    //        rmp_serde::from_read(reader).unwrap()
+    //    }
+    //    Err(_) => {
+    //        println!("missing SRS file: {srs_path:?}. Will create a new SRS...");
+    //        create_and_store_srs(true, domain)
+    //    }
+    //}
+}

--- a/poly-commitment/src/pairing_proof.rs
+++ b/poly-commitment/src/pairing_proof.rs
@@ -43,7 +43,7 @@ impl<Pair: PairingEngine> Clone for PairingProof<Pair> {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct PairingSRS<Pair: PairingEngine> {
     pub full_srs: SRS<Pair::G1Affine>,
     pub verifier_srs: SRS<Pair::G2Affine>,


### PR DESCRIPTION
Review by commit. 

Contains some basic stuff (constants, circuits, generating simple expression/witness) that was written 1.5 weeks ago, but somewhat adjusted to the new datatypes now in `master`. E.g. I generalized a few things/added some traits as we discussed we want this project to be slightly more generic.

The main intention of the PR is to discard the `dw-mv/large-msm` branch which contained some useful stuff (hopefully all/mostly ported now), but is otherwise unsynchronized with `master`.

*Not an intention*: to make any actual final decisions on traits/structs and architecture in general.