### PR TITLE
Kimchi/verifier: stop relying on iterator on option

### DIFF
--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -214,7 +214,11 @@ where
         //~ 1. If using lookup, absorb the commitment to the aggregation lookup polynomial.
         if index.lookup_index.is_some() {
             // Should not fail, as the lookup index is present
-            let lookup_commits = self.commitments.lookup.as_ref()..ok_or(VerifyError::LookupCommitmentMissing)?;
+            let lookup_commits = self
+                .commitments
+                .lookup
+                .as_ref()
+                .ok_or(VerifyError::LookupCommitmentMissing)?;
             absorb_commitment(&mut fq_sponge, &lookup_commits.aggreg);
         }
 

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -212,9 +212,11 @@ where
         let gamma = fq_sponge.challenge();
 
         //~ 1. If using lookup, absorb the commitment to the aggregation lookup polynomial.
-        self.commitments.lookup.iter().for_each(|l| {
-            absorb_commitment(&mut fq_sponge, &l.aggreg);
-        });
+        if index.lookup_index.is_some() {
+            // Should not fail, as the lookup index is present
+            let lookup_commits = self.commitments.lookup.as_ref().unwrap();
+            absorb_commitment(&mut fq_sponge, &lookup_commits.aggreg);
+        }
 
         //~ 1. Absorb the commitment to the permutation trace with the Fq-Sponge.
         absorb_commitment(&mut fq_sponge, &self.commitments.z_comm);

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -214,7 +214,7 @@ where
         //~ 1. If using lookup, absorb the commitment to the aggregation lookup polynomial.
         if index.lookup_index.is_some() {
             // Should not fail, as the lookup index is present
-            let lookup_commits = self.commitments.lookup.as_ref().unwrap();
+            let lookup_commits = self.commitments.lookup.as_ref()..ok_or(VerifyError::LookupCommitmentMissing)?;
             absorb_commitment(&mut fq_sponge, &lookup_commits.aggreg);
         }
 


### PR DESCRIPTION
commitments.lookup is an option. By using iter followed by for_each, the reader might suppose it is a list.
IMO, it seems more readable to check if lookups are used, unwrap the lookup commitments, without verifying if an error is raised as it should never happened, and get the commitment to the lookup aggregator.