### PR TITLE
[easy] Fix typo in PR 1826

### DIFF
--- a/optimism/src/lookup.rs
+++ b/optimism/src/lookup.rs
@@ -45,7 +45,7 @@ pub enum LookupTableIDs {
 #[derive(Clone, Debug)]
 pub struct Lookup<T> {
     pub mode: LookupMode,
-    /// The number of times that this lookup value should be added to / subtracted from the lookup accumulator.    pub magnitude_contribution: Fp,
+    /// The number of times that this lookup value should be added to / subtracted from the lookup accumulator.
     pub magnitude: T,
     pub table_id: LookupTableIDs,
     pub value: Vec<T>,

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -619,7 +619,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
             // The first 8 bytes of the read preimage are the preimage length, followed by the body
             // of the preimage
             if idx < LENGTH_SIZE {
-                self.write_column(Column::ScratchState(MIPS_READING_PREIMAGE_OFFSET), 1);
+                self.write_column(Column::ScratchState(MIPS_READING_PREIMAGE_OFFSET), 0);
                 let length_byte = u64::to_be_bytes(preimage_len as u64)[idx];
                 unsafe {
                     self.push_memory(&(*addr + i), length_byte as u64);
@@ -627,7 +627,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
                 }
             } else {
                 preimage_read_len += 1; // At most, it will be actual_read_len
-                self.write_column(Column::ScratchState(MIPS_READING_PREIMAGE_OFFSET), 0);
+                self.write_column(Column::ScratchState(MIPS_READING_PREIMAGE_OFFSET), 1);
                 // This should really be handled by the keccak oracle.
                 let preimage_byte = self.preimage.as_ref().unwrap()[idx - LENGTH_SIZE];
                 // Write the individual byte to the witness


### PR DESCRIPTION
I missed committing this change inside the commit fe1c5473cc420dccd3615614748e8670cbf39d06 of https://github.com/o1-labs/proof-systems/pull/1826

Basically without this, the behavior is the opposite -> sets to 1 when it is reading the bytelength, and to 0 when it reads the actual bytes of the preimage.