### PR TITLE
Make witness fields public

### DIFF
--- a/msm/src/proof.rs
+++ b/msm/src/proof.rs
@@ -84,8 +84,8 @@ where
 
 #[derive(Debug)]
 pub struct Witness<G: KimchiCurve> {
-    pub(crate) evaluations: WitnessColumns<Vec<G::ScalarField>>,
-    pub(crate) mvlookups: Vec<LookupWitness<G::ScalarField>>,
+    pub evaluations: WitnessColumns<Vec<G::ScalarField>>,
+    pub mvlookups: Vec<LookupWitness<G::ScalarField>>,
 }
 
 // This should be used only for testing purposes.


### PR DESCRIPTION
It is used later to build witness in the subdirectory serialization