### PR TITLE
Remove spew to stdout

### DIFF
--- a/kimchi/Cargo.toml
+++ b/kimchi/Cargo.toml
@@ -25,6 +25,7 @@ num-derive.workspace = true
 num-integer.workspace = true
 num-traits.workspace = true
 itertools.workspace = true
+log.workspace = true
 rand = { workspace = true, features = ["std_rng"] }
 rand_core.workspace = true
 rayon.workspace = true

--- a/kimchi/src/circuits/polynomials/turshi.rs
+++ b/kimchi/src/circuits/polynomials/turshi.rs
@@ -92,6 +92,7 @@ use crate::{
     proof::ProofEvaluations,
 };
 use ark_ff::{FftField, Field, PrimeField, SquareRootField};
+use log::error;
 use rand::{prelude::StdRng, SeedableRng};
 use std::array;
 use std::marker::PhantomData;
@@ -247,7 +248,7 @@ impl<F: PrimeField + SquareRootField> CircuitGate<F> {
                 }
             }
             Err(x) => {
-                println!("{x:?}");
+                error!("{x:?}");
                 Err(format!("Failed to evaluate {:?} constraint", self.typ))
             }
         }

--- a/kimchi/src/snarky/api.rs
+++ b/kimchi/src/snarky/api.rs
@@ -18,6 +18,7 @@ use crate::{
 
 use ark_ec::AffineCurve;
 use ark_ff::PrimeField;
+use log::debug;
 use poly_commitment::{commitment::CommitmentCurve, OpenProof, SRS};
 
 use super::{errors::SnarkyResult, runner::RunState, snarky_type::SnarkyType};
@@ -132,11 +133,10 @@ where
         let public_output =
             Circuit::PublicOutput::value_of_field_elements(public_output_values, aux);
 
-        witness.debug();
-
         // verify the witness
         // TODO: return error instead of panicking
         if debug {
+            witness.debug();
             self.index
                 .verify(&witness.0, &public_input_and_output)
                 .unwrap();
@@ -318,7 +318,7 @@ pub trait SnarkyCircuit: Sized {
         srs.add_lagrange_basis(cs.domain.d1);
         let srs = std::sync::Arc::new(srs);
 
-        println!("using an SRS of size {}", srs.size());
+        debug!("using an SRS of size {}", srs.size());
 
         // create indexes
         let endo_q = <<Self as SnarkyCircuit>::Curve as KimchiCurve>::other_curve_endo();


### PR DESCRIPTION
Move a few `println!()` statements to `log::{error, debug}` so consumers can control what gets emitted to stdout.