### PR TITLE
RAMLookups initial interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,6 +1451,7 @@ dependencies = [
  "groupmap",
  "hex",
  "kimchi",
+ "kimchi_msm",
  "libc",
  "libflate",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ groupmap = { path = "./groupmap", version = "0.1.0" }
 internal-tracing = { path = "./internal-tracing", version = "0.1.0" }
 kimchi = { path = "./kimchi", version = "0.1.0", features = ["bn254"] }
 kimchi-visu = { path = "./tools/kimchi-visu", version = "0.1.0" }
+kimchi-msm = { path = "./msm", version = "0.1.0" }
 mina-curves = { path = "./curves", version = "0.1.0" }
 mina-hasher = { path = "./hasher", version = "0.1.0" }
 mina-poseidon = { path = "./poseidon", version = "0.1.0" }

--- a/msm/src/lib.rs
+++ b/msm/src/lib.rs
@@ -5,7 +5,7 @@ use mina_poseidon::{
 use poly_commitment::pairing_proof::PairingProof;
 
 pub use mvlookup::{
-    Lookup as MVLookup, LookupProof as MVLookupProof, LookupTableID as MVLookupTableID,
+    Lookup as MVLookup, LookupProof as MVLookupProof, LookupTable as MVLookupTable, LookupTableID,
     LookupWitness as MVLookupWitness,
 };
 

--- a/msm/src/mvlookup.rs
+++ b/msm/src/mvlookup.rs
@@ -16,6 +16,22 @@ pub struct Lookup<F, ID: LookupTableID + Send + Sync + Copy> {
     pub(crate) value: Vec<F>,
 }
 
+/// Basic trait for MVLookups
+impl<F, ID> Lookup<F, ID>
+where
+    F: Clone,
+    ID: LookupTableID + Send + Sync + Copy,
+{
+    /// Creates a new MVLookup
+    pub fn new(table_id: ID, numerator: F, value: &[F]) -> Self {
+        Self {
+            table_id,
+            numerator,
+            value: value.to_vec(),
+        }
+    }
+}
+
 /// Trait for lookup table variants
 pub trait LookupTableID {
     /// Assign a unique ID to the lookup tables.

--- a/msm/src/mvlookup.rs
+++ b/msm/src/mvlookup.rs
@@ -38,6 +38,17 @@ pub trait LookupTableID {
     fn into_field<F: Field>(self) -> F;
 }
 
+/// A table of values that can be used for a lookup, along with the ID for the table.
+#[derive(Debug, Clone)]
+pub struct LookupTable<F, ID: LookupTableID + Send + Sync + Copy> {
+    /// Table ID corresponding to this table
+    #[allow(dead_code)]
+    pub table_id: ID,
+    /// Vector of values inside each entry of the table
+    #[allow(dead_code)]
+    pub entries: Vec<Vec<F>>,
+}
+
 /// Represents a witness of one instance of the lookup argument
 #[derive(Debug)]
 pub struct LookupWitness<F, ID: LookupTableID + Send + Sync + Copy> {

--- a/optimism/Cargo.toml
+++ b/optimism/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/test_preimage_read.rs"
 [dependencies]
 ark-bn254.workspace = true
 kimchi = { workspace = true, features = [ "bn254" ] }
+kimchi_msm = { path = "../msm", version = "0.1.0" }
 poly-commitment.workspace = true
 groupmap.workspace = true
 mina-curves.workspace = true

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -5,7 +5,7 @@ use crate::{
         environment::{KeccakEnv, KeccakEnvironment},
         KeccakColumn, {ArithOps, BoolOps, E, WORDS_IN_HASH},
     },
-    lookup::Lookups,
+    ramlookup::Lookups,
 };
 use ark_ff::Field;
 use kimchi::circuits::{

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -5,7 +5,7 @@ use crate::{
         environment::{KeccakEnv, KeccakEnvironment},
         KeccakColumn, {ArithOps, BoolOps, E, WORDS_IN_HASH},
     },
-    ramlookup::Lookups,
+    lookups::Lookups,
 };
 use ark_ff::Field;
 use kimchi::circuits::{

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -7,7 +7,7 @@ use crate::{
         interpreter::{Absorb, KeccakStep, Sponge},
         ArithOps, BoolOps, KeccakColumn, DIM, E, QUARTERS,
     },
-    lookup::Lookup,
+    ramlookup::RAMLookup,
 };
 use ark_ff::{Field, One};
 use kimchi::{
@@ -25,7 +25,7 @@ pub struct KeccakEnv<Fp> {
     /// Constraints that are added to the circuit
     pub(crate) constraints: Vec<E<Fp>>,
     /// Values that are looked up in the circuit
-    pub(crate) lookups: Vec<Lookup<E<Fp>>>,
+    pub(crate) lookups: Vec<RAMLookup<E<Fp>>>,
 
     /// The full state of the Keccak gate (witness)
     pub keccak_witness: KeccakWitness<Fp>,

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -7,7 +7,8 @@ use crate::{
         interpreter::{Absorb, KeccakStep, Sponge},
         ArithOps, BoolOps, KeccakColumn, DIM, E, QUARTERS,
     },
-    ramlookup::RAMLookup,
+    lookups::VMLookupTableIDs,
+    ramlookup::Lookup,
 };
 use ark_ff::{Field, One};
 use kimchi::{
@@ -25,7 +26,7 @@ pub struct KeccakEnv<Fp> {
     /// Constraints that are added to the circuit
     pub(crate) constraints: Vec<E<Fp>>,
     /// Values that are looked up in the circuit
-    pub(crate) lookups: Vec<RAMLookup<E<Fp>>>,
+    pub(crate) lookups: Vec<Lookup<E<Fp>, VMLookupTableIDs>>,
 
     /// The full state of the Keccak gate (witness)
     pub keccak_witness: KeccakWitness<Fp>,

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -7,8 +7,7 @@ use crate::{
         interpreter::{Absorb, KeccakStep, Sponge},
         ArithOps, BoolOps, KeccakColumn, DIM, E, QUARTERS,
     },
-    lookups::VMLookupTableIDs,
-    ramlookup::Lookup,
+    lookups::Lookup,
 };
 use ark_ff::{Field, One};
 use kimchi::{
@@ -26,7 +25,7 @@ pub struct KeccakEnv<Fp> {
     /// Constraints that are added to the circuit
     pub(crate) constraints: Vec<E<Fp>>,
     /// Values that are looked up in the circuit
-    pub(crate) lookups: Vec<Lookup<E<Fp>, VMLookupTableIDs>>,
+    pub(crate) lookups: Vec<Lookup<E<Fp>>>,
 
     /// The full state of the Keccak gate (witness)
     pub keccak_witness: KeccakWitness<Fp>,

--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -4,7 +4,7 @@ use crate::{
         environment::{KeccakEnv, KeccakEnvironment},
         ArithOps, BoolOps, KeccakColumn, E,
     },
-    lookups::{Lookups, VMLookupTableIDs},
+    lookups::{Lookups, VMLookup, VMLookupTableIDs},
     ramlookup::Lookup,
 };
 use ark_ff::Field;
@@ -15,9 +15,8 @@ use kimchi::circuits::polynomials::keccak::constants::{
 impl<Fp: Field> Lookups for KeccakEnv<Fp> {
     type Column = KeccakColumn;
     type Variable = E<Fp>;
-    type Table = VMLookupTableIDs;
 
-    fn add_lookup(&mut self, lookup: Lookup<Self::Variable, Self::Table>) {
+    fn add_lookup(&mut self, lookup: VMLookup<Self::Variable>) {
         self.lookups.push(lookup);
     }
 

--- a/optimism/src/lib.rs
+++ b/optimism/src/lib.rs
@@ -11,9 +11,6 @@ pub mod cannon_cli;
 /// Implementation of Keccak used by the zkVM.
 pub mod keccak;
 
-/// The lookup argument.
-pub mod lookup;
-
 /// MIPS interpreter.
 pub mod mips;
 
@@ -22,6 +19,9 @@ pub mod preimage_oracle;
 
 /// Proof system of the zkVM.
 pub mod proof;
+
+/// The RAM lookup argument.
+pub mod ramlookup;
 
 /// Generic definition of a zkvm witness.
 pub mod witness;

--- a/optimism/src/lib.rs
+++ b/optimism/src/lib.rs
@@ -11,6 +11,9 @@ pub mod cannon_cli;
 /// Implementation of Keccak used by the zkVM.
 pub mod keccak;
 
+/// Instantiation of the lookups for the VM project.
+pub mod lookups;
+
 /// MIPS interpreter.
 pub mod mips;
 
@@ -25,3 +28,5 @@ pub mod ramlookup;
 
 /// Generic definition of a zkvm witness.
 pub mod witness;
+
+pub use ramlookup::{Lookup as RAMLookup, LookupMode as RAMLookupMode};

--- a/optimism/src/lib.rs
+++ b/optimism/src/lib.rs
@@ -29,4 +29,4 @@ pub mod ramlookup;
 /// Generic definition of a zkvm witness.
 pub mod witness;
 
-pub use ramlookup::{Lookup as RAMLookup, LookupMode as RAMLookupMode};
+pub use ramlookup::{LookupMode as RAMLookupMode, RAMLookup};

--- a/optimism/src/lookups.rs
+++ b/optimism/src/lookups.rs
@@ -45,8 +45,10 @@ impl LookupTableID for LookupTableIDs {
     }
 }
 
+/// The lookups struct based on RAMLookups for the VM table IDs
 pub(crate) type Lookup<F> = RAMLookup<F, LookupTableIDs>;
 
+/// The lookup table struct based on MVLookupTable for the VM table IDs
 pub(crate) type LookupTable<F> = MVLookupTable<F, LookupTableIDs>;
 
 /// This trait adds basic methods to deal with lookups inside an environment

--- a/optimism/src/lookups.rs
+++ b/optimism/src/lookups.rs
@@ -59,10 +59,9 @@ pub(crate) trait Lookups {
         + std::ops::Sub<Self::Variable, Output = Self::Variable>
         + std::ops::Neg<Output = Self::Variable>
         + Clone;
-    type Table: MVLookupTableID + Send + Sync + Copy;
 
     /// Adds a given Lookup to the environment
-    fn add_lookup(&mut self, lookup: Lookup<Self::Variable, Self::Table>);
+    fn add_lookup(&mut self, lookup: VMLookup<Self::Variable>);
 
     /// Adds all lookups of Self to the environment
     fn lookups(&mut self);

--- a/optimism/src/lookups.rs
+++ b/optimism/src/lookups.rs
@@ -1,0 +1,157 @@
+//! Instantiation of the lookups for the VM project.
+
+use crate::{
+    keccak::witness::pad_blocks,
+    ramlookup::{Lookup, LookupTable},
+};
+use ark_ff::Field;
+use kimchi::{
+    circuits::polynomials::keccak::{
+        constants::{RATE_IN_BYTES, ROUNDS},
+        Keccak, RC,
+    },
+    o1_utils::Two,
+};
+use kimchi_msm::MVLookupTableID;
+
+pub(crate) const TWO_TO_16_UPPERBOUND: u32 = 1 << 16;
+
+#[derive(Copy, Clone, Debug)]
+pub enum VMLookupTableIDs {
+    // RAM Tables
+    MemoryLookup = 0,
+    RegisterLookup = 1,
+    /// Syscalls communication channel
+    SyscallLookup = 2,
+    /// Input/Output of Keccak steps
+    KeccakStepLookup = 3,
+
+    // Read Tables
+    /// Single-column table of all values in the range [0, 2^16)
+    RangeCheck16Lookup = 4,
+    /// Single-column table of 2^16 entries with the sparse representation of all values
+    SparseLookup = 5,
+    /// Dual-column table of all values in the range [0, 2^16) and their sparse representation
+    ResetLookup = 6,
+    /// 24-row table with all possible values for round and their round constant in expanded form (in big endian)
+    RoundConstantsLookup = 7,
+    /// All [1..136] values of possible padding lengths, the value 2^len, and the 5 corresponding pad suffixes with the 10*1 rule
+    PadLookup = 8,
+    /// All values that can be stored in a byte (amortized table, better than model as RangeCheck16 (x and scaled x)
+    ByteLookup = 9,
+}
+
+impl MVLookupTableID for VMLookupTableIDs {
+    fn into_field<F: Field>(self) -> F {
+        F::from(self as u32)
+    }
+}
+
+pub(crate) type VMLookup<F> = Lookup<F, VMLookupTableIDs>;
+
+pub(crate) type VMLookupTable<F> = LookupTable<F, VMLookupTableIDs>;
+
+/// This trait adds basic methods to deal with lookups inside an environment
+pub(crate) trait Lookups {
+    type Column;
+    type Variable: std::ops::Mul<Self::Variable, Output = Self::Variable>
+        + std::ops::Add<Self::Variable, Output = Self::Variable>
+        + std::ops::Sub<Self::Variable, Output = Self::Variable>
+        + std::ops::Neg<Output = Self::Variable>
+        + Clone;
+    type Table: MVLookupTableID + Send + Sync + Copy;
+
+    /// Adds a given Lookup to the environment
+    fn add_lookup(&mut self, lookup: Lookup<Self::Variable, Self::Table>);
+
+    /// Adds all lookups of Self to the environment
+    fn lookups(&mut self);
+}
+
+impl<F: Field> VMLookupTable<F> {
+    #[allow(dead_code)]
+    fn table_range_check_16() -> Self {
+        Self {
+            table_id: VMLookupTableIDs::RangeCheck16Lookup,
+            entries: (0..TWO_TO_16_UPPERBOUND)
+                .map(|i| vec![F::from(i)])
+                .collect(),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn table_sparse() -> Self {
+        Self {
+            table_id: VMLookupTableIDs::SparseLookup,
+            entries: (0..TWO_TO_16_UPPERBOUND)
+                .map(|i| {
+                    vec![F::from(
+                        u64::from_str_radix(&format!("{:b}", i), 16).unwrap(),
+                    )]
+                })
+                .collect(),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn table_reset() -> Self {
+        Self {
+            table_id: VMLookupTableIDs::ResetLookup,
+            entries: (0..TWO_TO_16_UPPERBOUND)
+                .map(|i| {
+                    vec![
+                        F::from(i),
+                        F::from(u64::from_str_radix(&format!("{:b}", i), 16).unwrap()),
+                    ]
+                })
+                .collect(),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn table_round_constants() -> Self {
+        Self {
+            table_id: VMLookupTableIDs::RoundConstantsLookup,
+            entries: (0..=ROUNDS)
+                .map(|i| {
+                    vec![
+                        F::from(i as u32),
+                        F::from(Keccak::sparse(RC[i])[3]),
+                        F::from(Keccak::sparse(RC[i])[2]),
+                        F::from(Keccak::sparse(RC[i])[1]),
+                        F::from(Keccak::sparse(RC[i])[0]),
+                    ]
+                })
+                .collect(),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn table_pad() -> Self {
+        Self {
+            table_id: VMLookupTableIDs::PadLookup,
+            entries: (1..=RATE_IN_BYTES)
+                .map(|i| {
+                    let suffix = pad_blocks(i);
+                    vec![
+                        F::from(i as u64),
+                        F::two_pow(i as u64),
+                        suffix[0],
+                        suffix[1],
+                        suffix[2],
+                        suffix[3],
+                        suffix[4],
+                    ]
+                })
+                .collect(),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn table_byte() -> Self {
+        Self {
+            table_id: VMLookupTableIDs::ByteLookup,
+            entries: (0..(1 << 8) as u32).map(|i| vec![F::from(i)]).collect(),
+        }
+    }
+}

--- a/optimism/src/mips/constraints.rs
+++ b/optimism/src/mips/constraints.rs
@@ -1,4 +1,6 @@
 use crate::{
+    cannon::VmConfiguration,
+    lookups::VMLookupTableIDs,
     mips::{
         column::{
             Column, MIPS_BYTES_READ_OFFSET, MIPS_CHUNK_BYTES_LENGTH, MIPS_HASH_COUNTER_OFFSET,
@@ -9,7 +11,7 @@ use crate::{
         registers::{REGISTER_PREIMAGE_KEY_START, REGISTER_PREIMAGE_OFFSET},
         E,
     },
-    ramlookup::{LookupTableIDs, RAMLookup},
+    ramlookup::Lookup,
 };
 use ark_ff::Field;
 use kimchi::circuits::{
@@ -24,7 +26,7 @@ pub struct Env<Fp> {
     /// A list of constraints, which are multi-variate polynomials over a field,
     /// represented using the expression framework of `kimchi`.
     pub constraints: Vec<E<Fp>>,
-    pub lookups: Vec<RAMLookup<E<Fp>>>,
+    pub lookups: Vec<Lookup<E<Fp>, VMLookupTableIDs>>,
 }
 
 impl<Fp: Field> InterpreterEnv for Env<Fp> {
@@ -64,7 +66,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         // No-op, witness only
     }
 
-    fn add_lookup(&mut self, lookup: RAMLookup<Self::Variable>) {
+    fn add_lookup(&mut self, lookup: Lookup<Self::Variable, VMLookupTableIDs>) {
         self.lookups.push(lookup);
     }
 
@@ -600,9 +602,9 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
 
         // COMMUNICATION CHANNEL: Write preimage chunk (1, 2, 3, or 4 bytes)
         for i in 0..MIPS_CHUNK_BYTES_LENGTH {
-            self.add_lookup(RAMLookup::write_if(
+            self.add_lookup(Lookup::write_if(
                 reading_preimage.clone() * has_n_bytes[i].clone(),
-                LookupTableIDs::SyscallLookup,
+                VMLookupTableIDs::SyscallLookup,
                 vec![
                     hash_counter.clone(),
                     byte_counter.clone() + Expr::from(i as u64),
@@ -627,9 +629,9 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
             row: CurrOrNext::Curr,
         }));
         let end_of_preimage = is_syscall * reading_preimage * preimage_left;
-        self.add_lookup(RAMLookup::read_if(
+        self.add_lookup(Lookup::read_if(
             end_of_preimage,
-            LookupTableIDs::SyscallLookup,
+            VMLookupTableIDs::SyscallLookup,
             vec![hash_counter, preimage_key],
         ));
 

--- a/optimism/src/mips/constraints.rs
+++ b/optimism/src/mips/constraints.rs
@@ -1,5 +1,4 @@
 use crate::{
-    cannon::VmConfiguration,
     lookups::VMLookupTableIDs,
     mips::{
         column::{

--- a/optimism/src/mips/constraints.rs
+++ b/optimism/src/mips/constraints.rs
@@ -1,5 +1,4 @@
 use crate::{
-    lookup::{Lookup, LookupTableIDs},
     mips::{
         column::{
             Column, MIPS_BYTES_READ_OFFSET, MIPS_CHUNK_BYTES_LENGTH, MIPS_HASH_COUNTER_OFFSET,
@@ -10,6 +9,7 @@ use crate::{
         registers::{REGISTER_PREIMAGE_KEY_START, REGISTER_PREIMAGE_OFFSET},
         E,
     },
+    ramlookup::{LookupTableIDs, RAMLookup},
 };
 use ark_ff::Field;
 use kimchi::circuits::{
@@ -24,7 +24,7 @@ pub struct Env<Fp> {
     /// A list of constraints, which are multi-variate polynomials over a field,
     /// represented using the expression framework of `kimchi`.
     pub constraints: Vec<E<Fp>>,
-    pub lookups: Vec<Lookup<E<Fp>>>,
+    pub lookups: Vec<RAMLookup<E<Fp>>>,
 }
 
 impl<Fp: Field> InterpreterEnv for Env<Fp> {
@@ -64,7 +64,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         // No-op, witness only
     }
 
-    fn add_lookup(&mut self, lookup: Lookup<Self::Variable>) {
+    fn add_lookup(&mut self, lookup: RAMLookup<Self::Variable>) {
         self.lookups.push(lookup);
     }
 
@@ -600,7 +600,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
 
         // COMMUNICATION CHANNEL: Write preimage chunk (1, 2, 3, or 4 bytes)
         for i in 0..MIPS_CHUNK_BYTES_LENGTH {
-            self.add_lookup(Lookup::write_if(
+            self.add_lookup(RAMLookup::write_if(
                 reading_preimage.clone() * has_n_bytes[i].clone(),
                 LookupTableIDs::SyscallLookup,
                 vec![
@@ -627,7 +627,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
             row: CurrOrNext::Curr,
         }));
         let end_of_preimage = is_syscall * reading_preimage * preimage_left;
-        self.add_lookup(Lookup::read_if(
+        self.add_lookup(RAMLookup::read_if(
             end_of_preimage,
             LookupTableIDs::SyscallLookup,
             vec![hash_counter, preimage_key],

--- a/optimism/src/mips/constraints.rs
+++ b/optimism/src/mips/constraints.rs
@@ -1,5 +1,5 @@
 use crate::{
-    lookups::VMLookupTableIDs,
+    lookups::{Lookup, LookupTableIDs},
     mips::{
         column::{
             Column, MIPS_BYTES_READ_OFFSET, MIPS_CHUNK_BYTES_LENGTH, MIPS_HASH_COUNTER_OFFSET,
@@ -10,7 +10,6 @@ use crate::{
         registers::{REGISTER_PREIMAGE_KEY_START, REGISTER_PREIMAGE_OFFSET},
         E,
     },
-    ramlookup::Lookup,
 };
 use ark_ff::Field;
 use kimchi::circuits::{
@@ -25,7 +24,7 @@ pub struct Env<Fp> {
     /// A list of constraints, which are multi-variate polynomials over a field,
     /// represented using the expression framework of `kimchi`.
     pub constraints: Vec<E<Fp>>,
-    pub lookups: Vec<Lookup<E<Fp>, VMLookupTableIDs>>,
+    pub lookups: Vec<Lookup<E<Fp>>>,
 }
 
 impl<Fp: Field> InterpreterEnv for Env<Fp> {
@@ -65,7 +64,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         // No-op, witness only
     }
 
-    fn add_lookup(&mut self, lookup: Lookup<Self::Variable, VMLookupTableIDs>) {
+    fn add_lookup(&mut self, lookup: Lookup<Self::Variable>) {
         self.lookups.push(lookup);
     }
 
@@ -603,7 +602,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         for i in 0..MIPS_CHUNK_BYTES_LENGTH {
             self.add_lookup(Lookup::write_if(
                 reading_preimage.clone() * has_n_bytes[i].clone(),
-                VMLookupTableIDs::SyscallLookup,
+                LookupTableIDs::SyscallLookup,
                 vec![
                     hash_counter.clone(),
                     byte_counter.clone() + Expr::from(i as u64),
@@ -630,7 +629,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         let end_of_preimage = is_syscall * reading_preimage * preimage_left;
         self.add_lookup(Lookup::read_if(
             end_of_preimage,
-            VMLookupTableIDs::SyscallLookup,
+            LookupTableIDs::SyscallLookup,
             vec![hash_counter, preimage_key],
         ));
 

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -1,11 +1,10 @@
 use crate::{
     cannon::PAGE_ADDRESS_SIZE,
-    lookups::VMLookupTableIDs,
+    lookups::{Lookup, LookupTableIDs},
     mips::registers::{
         REGISTER_CURRENT_IP, REGISTER_HEAP_POINTER, REGISTER_HI, REGISTER_LO, REGISTER_NEXT_IP,
         REGISTER_PREIMAGE_KEY_END, REGISTER_PREIMAGE_OFFSET,
     },
-    ramlookup::Lookup,
 };
 use ark_ff::{One, Zero};
 use strum_macros::{EnumCount, EnumIter};
@@ -169,7 +168,7 @@ pub trait InterpreterEnv {
         self.add_constraint(x.clone() * x.clone() - x);
     }
 
-    fn add_lookup(&mut self, lookup: Lookup<Self::Variable, VMLookupTableIDs>);
+    fn add_lookup(&mut self, lookup: Lookup<Self::Variable>);
 
     fn instruction_counter(&self) -> Self::Variable;
 
@@ -279,12 +278,12 @@ pub trait InterpreterEnv {
         unsafe { self.push_register_access_if(idx, new_accessed.clone(), if_is_true) };
         self.add_lookup(Lookup::write_if(
             if_is_true.clone(),
-            VMLookupTableIDs::RegisterLookup,
+            LookupTableIDs::RegisterLookup,
             vec![idx.clone(), last_accessed, old_value.clone()],
         ));
         self.add_lookup(Lookup::read_if(
             if_is_true.clone(),
-            VMLookupTableIDs::RegisterLookup,
+            LookupTableIDs::RegisterLookup,
             vec![idx.clone(), new_accessed, new_value.clone()],
         ));
         self.range_check64(&elapsed_time);
@@ -413,11 +412,11 @@ pub trait InterpreterEnv {
         };
         unsafe { self.push_memory_access(addr, new_accessed.clone()) };
         self.add_lookup(Lookup::write_one(
-            VMLookupTableIDs::MemoryLookup,
+            LookupTableIDs::MemoryLookup,
             vec![addr.clone(), last_accessed, old_value.clone()],
         ));
         self.add_lookup(Lookup::read_one(
-            VMLookupTableIDs::MemoryLookup,
+            LookupTableIDs::MemoryLookup,
             vec![addr.clone(), new_accessed, new_value.clone()],
         ));
         self.range_check64(&elapsed_time);
@@ -461,7 +460,7 @@ pub trait InterpreterEnv {
             self.push_register(&idx, ip.clone());
         }
         self.add_lookup(Lookup::read_one(
-            VMLookupTableIDs::RegisterLookup,
+            LookupTableIDs::RegisterLookup,
             vec![idx, new_accessed, ip],
         ));
     }
@@ -473,7 +472,7 @@ pub trait InterpreterEnv {
             unsafe { self.fetch_register(&idx, value_location) }
         };
         self.add_lookup(Lookup::write_one(
-            VMLookupTableIDs::RegisterLookup,
+            LookupTableIDs::RegisterLookup,
             vec![idx, self.instruction_counter(), ip.clone()],
         ));
         ip
@@ -489,7 +488,7 @@ pub trait InterpreterEnv {
             self.push_register(&idx, ip.clone());
         }
         self.add_lookup(Lookup::read_one(
-            VMLookupTableIDs::RegisterLookup,
+            LookupTableIDs::RegisterLookup,
             vec![idx, new_accessed, ip],
         ));
     }
@@ -501,7 +500,7 @@ pub trait InterpreterEnv {
             unsafe { self.fetch_register(&idx, value_location) }
         };
         self.add_lookup(Lookup::write_one(
-            VMLookupTableIDs::RegisterLookup,
+            LookupTableIDs::RegisterLookup,
             vec![idx, self.instruction_counter(), ip.clone()],
         ));
         ip

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -1,10 +1,10 @@
 use crate::{
     cannon::PAGE_ADDRESS_SIZE,
-    lookup::{Lookup, LookupTableIDs},
     mips::registers::{
         REGISTER_CURRENT_IP, REGISTER_HEAP_POINTER, REGISTER_HI, REGISTER_LO, REGISTER_NEXT_IP,
         REGISTER_PREIMAGE_KEY_END, REGISTER_PREIMAGE_OFFSET,
     },
+    ramlookup::{LookupTableIDs, RAMLookup},
 };
 use ark_ff::One;
 use strum_macros::{EnumCount, EnumIter};
@@ -167,7 +167,7 @@ pub trait InterpreterEnv {
         self.add_constraint(x.clone() * x.clone() - x);
     }
 
-    fn add_lookup(&mut self, lookup: Lookup<Self::Variable>);
+    fn add_lookup(&mut self, lookup: RAMLookup<Self::Variable>);
 
     fn instruction_counter(&self) -> Self::Variable;
 
@@ -275,12 +275,12 @@ pub trait InterpreterEnv {
             instruction_counter + Self::constant(1)
         };
         unsafe { self.push_register_access_if(idx, new_accessed.clone(), if_is_true) };
-        self.add_lookup(Lookup::write_if(
+        self.add_lookup(RAMLookup::write_if(
             if_is_true.clone(),
             LookupTableIDs::RegisterLookup,
             vec![idx.clone(), last_accessed, old_value.clone()],
         ));
-        self.add_lookup(Lookup::read_if(
+        self.add_lookup(RAMLookup::read_if(
             if_is_true.clone(),
             LookupTableIDs::RegisterLookup,
             vec![idx.clone(), new_accessed, new_value.clone()],
@@ -410,11 +410,11 @@ pub trait InterpreterEnv {
             instruction_counter + Self::constant(1)
         };
         unsafe { self.push_memory_access(addr, new_accessed.clone()) };
-        self.add_lookup(Lookup::write_one(
+        self.add_lookup(RAMLookup::write_one(
             LookupTableIDs::MemoryLookup,
             vec![addr.clone(), last_accessed, old_value.clone()],
         ));
-        self.add_lookup(Lookup::read_one(
+        self.add_lookup(RAMLookup::read_one(
             LookupTableIDs::MemoryLookup,
             vec![addr.clone(), new_accessed, new_value.clone()],
         ));
@@ -458,7 +458,7 @@ pub trait InterpreterEnv {
         unsafe {
             self.push_register(&idx, ip.clone());
         }
-        self.add_lookup(Lookup::read_one(
+        self.add_lookup(RAMLookup::read_one(
             LookupTableIDs::RegisterLookup,
             vec![idx, new_accessed, ip],
         ));
@@ -470,7 +470,7 @@ pub trait InterpreterEnv {
             let value_location = self.alloc_scratch();
             unsafe { self.fetch_register(&idx, value_location) }
         };
-        self.add_lookup(Lookup::write_one(
+        self.add_lookup(RAMLookup::write_one(
             LookupTableIDs::RegisterLookup,
             vec![idx, self.instruction_counter(), ip.clone()],
         ));
@@ -486,7 +486,7 @@ pub trait InterpreterEnv {
         unsafe {
             self.push_register(&idx, ip.clone());
         }
-        self.add_lookup(Lookup::read_one(
+        self.add_lookup(RAMLookup::read_one(
             LookupTableIDs::RegisterLookup,
             vec![idx, new_accessed, ip],
         ));
@@ -498,7 +498,7 @@ pub trait InterpreterEnv {
             let value_location = self.alloc_scratch();
             unsafe { self.fetch_register(&idx, value_location) }
         };
-        self.add_lookup(Lookup::write_one(
+        self.add_lookup(RAMLookup::write_one(
             LookupTableIDs::RegisterLookup,
             vec![idx, self.instruction_counter(), ip.clone()],
         ));

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -4,7 +4,6 @@ use crate::{
         PAGE_ADDRESS_SIZE, PAGE_SIZE,
     },
     keccak::environment::KeccakEnv,
-    lookup::Lookup,
     mips::{
         column::{
             Column, MIPS_BYTES_READ_OFFSET, MIPS_CHUNK_BYTES_LENGTH, MIPS_HASH_COUNTER_OFFSET,
@@ -17,6 +16,7 @@ use crate::{
         registers::Registers,
     },
     preimage_oracle::PreImageOracle,
+    ramlookup::RAMLookup,
 };
 use ark_ff::Field;
 use core::panic;
@@ -144,7 +144,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         }
     }
 
-    fn add_lookup(&mut self, _lookup: Lookup<Self::Variable>) {
+    fn add_lookup(&mut self, _lookup: RAMLookup<Self::Variable>) {
         // No-op, constraints only
     }
 

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -4,7 +4,7 @@ use crate::{
         PAGE_ADDRESS_SIZE, PAGE_SIZE,
     },
     keccak::environment::KeccakEnv,
-    lookups::VMLookupTableIDs,
+    lookups::Lookup,
     mips::{
         column::{
             Column, MIPS_BYTES_READ_OFFSET, MIPS_CHUNK_BYTES_LENGTH, MIPS_HASH_COUNTER_OFFSET,
@@ -17,7 +17,6 @@ use crate::{
         registers::Registers,
     },
     preimage_oracle::PreImageOracle,
-    ramlookup::Lookup,
 };
 use ark_ff::Field;
 use core::panic;
@@ -145,7 +144,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         }
     }
 
-    fn add_lookup(&mut self, _lookup: Lookup<Self::Variable, VMLookupTableIDs>) {
+    fn add_lookup(&mut self, _lookup: Lookup<Self::Variable>) {
         // No-op, constraints only
     }
 

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -4,6 +4,7 @@ use crate::{
         PAGE_ADDRESS_SIZE, PAGE_SIZE,
     },
     keccak::environment::KeccakEnv,
+    lookups::VMLookupTableIDs,
     mips::{
         column::{
             Column, MIPS_BYTES_READ_OFFSET, MIPS_CHUNK_BYTES_LENGTH, MIPS_HASH_COUNTER_OFFSET,
@@ -16,7 +17,7 @@ use crate::{
         registers::Registers,
     },
     preimage_oracle::PreImageOracle,
-    ramlookup::RAMLookup,
+    ramlookup::Lookup,
 };
 use ark_ff::Field;
 use core::panic;
@@ -144,7 +145,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         }
     }
 
-    fn add_lookup(&mut self, _lookup: RAMLookup<Self::Variable>) {
+    fn add_lookup(&mut self, _lookup: Lookup<Self::Variable, VMLookupTableIDs>) {
         // No-op, constraints only
     }
 

--- a/optimism/src/ramlookup.rs
+++ b/optimism/src/ramlookup.rs
@@ -1,15 +1,5 @@
-use ark_ff::{Field, One};
-use kimchi::{
-    circuits::polynomials::keccak::{
-        constants::{RATE_IN_BYTES, ROUNDS},
-        Keccak, RC,
-    },
-    o1_utils::Two,
-};
-
-use crate::keccak::witness::pad_blocks;
-
-pub(crate) const TWO_TO_16_UPPERBOUND: u32 = 1 << 16;
+use ark_ff::{Field, One, Zero};
+use kimchi_msm::MVLookupTableID;
 
 #[derive(Copy, Clone, Debug)]
 pub enum LookupMode {
@@ -17,62 +7,33 @@ pub enum LookupMode {
     Write,
 }
 
-#[derive(Copy, Clone, Debug)]
-pub enum LookupTableIDs {
-    // RAM Tables
-    MemoryLookup = 0,
-    RegisterLookup = 1,
-    /// Syscalls communication channel
-    SyscallLookup = 2,
-    /// Input/Output of Keccak steps
-    KeccakStepLookup = 3,
-
-    // Read Tables
-    /// Single-column table of all values in the range [0, 2^16)
-    RangeCheck16Lookup = 4,
-    /// Single-column table of 2^16 entries with the sparse representation of all values
-    SparseLookup = 5,
-    /// Dual-column table of all values in the range [0, 2^16) and their sparse representation
-    ResetLookup = 6,
-    /// 24-row table with all possible values for round and their round constant in expanded form (in big endian)
-    RoundConstantsLookup = 7,
-    /// All [1..136] values of possible padding lengths, the value 2^len, and the 5 corresponding pad suffixes with the 10*1 rule
-    PadLookup = 8,
-    /// All values that can be stored in a byte (amortized table, better than model as RangeCheck16 (x and scaled x)
-    ByteLookup = 9,
-}
-
 #[derive(Clone, Debug)]
-pub struct RAMLookup<T> {
+pub struct Lookup<T, ID: MVLookupTableID + Send + Sync + Copy> {
     pub mode: LookupMode,
     /// The number of times that this lookup value should be added to / subtracted from the lookup accumulator.
     pub magnitude: T,
-    pub table_id: LookupTableIDs,
+    pub table_id: ID,
     pub value: Vec<T>,
 }
 
-impl<F: std::fmt::Display + Field> std::fmt::Display for RAMLookup<F> {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let numerator = match self.mode {
-            LookupMode::Read => self.magnitude,
-            LookupMode::Write => -self.magnitude,
-        };
-        write!(
-            formatter,
-            "numerator: {}\ntable_id: {:?}\nvalue:\n[\n",
-            numerator, self.table_id
-        )?;
-        for value in self.value.iter() {
-            writeln!(formatter, "\t{}", value)?;
+impl<T, ID: MVLookupTableID + Send + Sync + Copy> Lookup<T, ID>
+where
+    T: Clone
+        + std::ops::Add<T, Output = T>
+        + std::ops::Sub<T, Output = T>
+        + std::ops::Mul<T, Output = T>
+        + std::fmt::Debug
+        + One
+        + Zero,
+{
+    fn numerator(&self) -> T {
+        match self.mode {
+            LookupMode::Read => T::zero() - self.magnitude.clone(),
+            LookupMode::Write => self.magnitude.clone(),
         }
-        write!(formatter, "]")?;
-        Ok(())
     }
-}
-
-impl<T: One> RAMLookup<T> {
     /// Reads one value when `if_is_true` is 1.
-    pub fn read_if(if_is_true: T, table_id: LookupTableIDs, value: Vec<T>) -> Self {
+    pub fn read_if(if_is_true: T, table_id: ID, value: Vec<T>) -> Self {
         Self {
             mode: LookupMode::Read,
             magnitude: if_is_true,
@@ -82,7 +43,7 @@ impl<T: One> RAMLookup<T> {
     }
 
     /// Writes one value when `if_is_true` is 1.
-    pub fn write_if(if_is_true: T, table_id: LookupTableIDs, value: Vec<T>) -> Self {
+    pub fn write_if(if_is_true: T, table_id: ID, value: Vec<T>) -> Self {
         Self {
             mode: LookupMode::Write,
             magnitude: if_is_true,
@@ -92,7 +53,7 @@ impl<T: One> RAMLookup<T> {
     }
 
     /// Reads one value from a table.
-    pub fn read_one(table_id: LookupTableIDs, value: Vec<T>) -> Self {
+    pub fn read_one(table_id: ID, value: Vec<T>) -> Self {
         Self {
             mode: LookupMode::Read,
             magnitude: T::one(),
@@ -102,7 +63,7 @@ impl<T: One> RAMLookup<T> {
     }
 
     /// Writes one value to a table.
-    pub fn write_one(table_id: LookupTableIDs, value: Vec<T>) -> Self {
+    pub fn write_one(table_id: ID, value: Vec<T>) -> Self {
         Self {
             mode: LookupMode::Write,
             magnitude: T::one(),
@@ -112,130 +73,35 @@ impl<T: One> RAMLookup<T> {
     }
 }
 
-/// This trait adds basic methods to deal with lookups inside an environment
-pub trait Lookups {
-    type Column;
-    type Variable: std::ops::Mul<Self::Variable, Output = Self::Variable>
-        + std::ops::Add<Self::Variable, Output = Self::Variable>
-        + std::ops::Sub<Self::Variable, Output = Self::Variable>
-        + Clone;
-
-    /// Adds a given Lookup to the environment
-    fn add_lookup(&mut self, lookup: RAMLookup<Self::Variable>);
-
-    /// Adds all lookups of Self to the environment
-    fn lookups(&mut self);
+impl<F: std::fmt::Display + Field, ID: MVLookupTableID + Send + Sync + Copy> std::fmt::Display
+    for Lookup<F, ID>
+{
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let numerator = match self.mode {
+            LookupMode::Read => -self.magnitude,
+            LookupMode::Write => self.magnitude,
+        };
+        write!(
+            formatter,
+            "numerator: {}\ntable_id: {:?}\nvalue:\n[\n",
+            numerator,
+            self.table_id.into_field::<F>()
+        )?;
+        for value in self.value.iter() {
+            writeln!(formatter, "\t{}", value)?;
+        }
+        write!(formatter, "]")?;
+        Ok(())
+    }
 }
 
 /// A table of values that can be used for a lookup, along with the ID for the table.
 #[derive(Debug, Clone)]
-pub struct LookupTable<F> {
+pub struct LookupTable<F, ID: MVLookupTableID + Send + Sync + Copy> {
     /// Table ID corresponding to this table
     #[allow(dead_code)]
-    table_id: LookupTableIDs,
+    pub table_id: ID,
     /// Vector of values inside each entry of the table
     #[allow(dead_code)]
-    entries: Vec<Vec<F>>,
-}
-
-impl<F: Field> LookupTable<F> {
-    #[allow(dead_code)]
-    fn table_terms(&self, mixer: F) -> Vec<F> {
-        self.entries
-            .iter()
-            .map(|entry| {
-                entry
-                    .iter()
-                    .fold(F::from(self.table_id as u32), |acc, value| {
-                        acc + *value * mixer
-                    })
-            })
-            .collect()
-    }
-
-    #[allow(dead_code)]
-    fn table_range_check_16() -> Self {
-        Self {
-            table_id: LookupTableIDs::RangeCheck16Lookup,
-            entries: (0..TWO_TO_16_UPPERBOUND)
-                .map(|i| vec![F::from(i)])
-                .collect(),
-        }
-    }
-
-    #[allow(dead_code)]
-    fn table_sparse() -> Self {
-        Self {
-            table_id: LookupTableIDs::SparseLookup,
-            entries: (0..TWO_TO_16_UPPERBOUND)
-                .map(|i| {
-                    vec![F::from(
-                        u64::from_str_radix(&format!("{:b}", i), 16).unwrap(),
-                    )]
-                })
-                .collect(),
-        }
-    }
-
-    #[allow(dead_code)]
-    fn table_reset() -> Self {
-        Self {
-            table_id: LookupTableIDs::ResetLookup,
-            entries: (0..TWO_TO_16_UPPERBOUND)
-                .map(|i| {
-                    vec![
-                        F::from(i),
-                        F::from(u64::from_str_radix(&format!("{:b}", i), 16).unwrap()),
-                    ]
-                })
-                .collect(),
-        }
-    }
-
-    #[allow(dead_code)]
-    fn table_round_constants() -> Self {
-        Self {
-            table_id: LookupTableIDs::RoundConstantsLookup,
-            entries: (0..=ROUNDS)
-                .map(|i| {
-                    vec![
-                        F::from(i as u32),
-                        F::from(Keccak::sparse(RC[i])[3]),
-                        F::from(Keccak::sparse(RC[i])[2]),
-                        F::from(Keccak::sparse(RC[i])[1]),
-                        F::from(Keccak::sparse(RC[i])[0]),
-                    ]
-                })
-                .collect(),
-        }
-    }
-
-    #[allow(dead_code)]
-    fn table_pad() -> Self {
-        Self {
-            table_id: LookupTableIDs::PadLookup,
-            entries: (1..=RATE_IN_BYTES)
-                .map(|i| {
-                    let suffix = pad_blocks(i);
-                    vec![
-                        F::from(i as u64),
-                        F::two_pow(i as u64),
-                        suffix[0],
-                        suffix[1],
-                        suffix[2],
-                        suffix[3],
-                        suffix[4],
-                    ]
-                })
-                .collect(),
-        }
-    }
-
-    #[allow(dead_code)]
-    fn table_byte() -> Self {
-        Self {
-            table_id: LookupTableIDs::ByteLookup,
-            entries: (0..(1 << 8) as u32).map(|i| vec![F::from(i)]).collect(),
-        }
-    }
+    pub entries: Vec<Vec<F>>,
 }

--- a/optimism/src/ramlookup.rs
+++ b/optimism/src/ramlookup.rs
@@ -43,7 +43,7 @@ pub enum LookupTableIDs {
 }
 
 #[derive(Clone, Debug)]
-pub struct Lookup<T> {
+pub struct RAMLookup<T> {
     pub mode: LookupMode,
     /// The number of times that this lookup value should be added to / subtracted from the lookup accumulator.
     pub magnitude: T,
@@ -51,7 +51,7 @@ pub struct Lookup<T> {
     pub value: Vec<T>,
 }
 
-impl<F: std::fmt::Display + Field> std::fmt::Display for Lookup<F> {
+impl<F: std::fmt::Display + Field> std::fmt::Display for RAMLookup<F> {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let numerator = match self.mode {
             LookupMode::Read => self.magnitude,
@@ -70,7 +70,7 @@ impl<F: std::fmt::Display + Field> std::fmt::Display for Lookup<F> {
     }
 }
 
-impl<T: One> Lookup<T> {
+impl<T: One> RAMLookup<T> {
     /// Reads one value when `if_is_true` is 1.
     pub fn read_if(if_is_true: T, table_id: LookupTableIDs, value: Vec<T>) -> Self {
         Self {
@@ -121,7 +121,7 @@ pub trait Lookups {
         + Clone;
 
     /// Adds a given Lookup to the environment
-    fn add_lookup(&mut self, lookup: Lookup<Self::Variable>);
+    fn add_lookup(&mut self, lookup: RAMLookup<Self::Variable>);
 
     /// Adds all lookups of Self to the environment
     fn lookups(&mut self);

--- a/optimism/src/ramlookup.rs
+++ b/optimism/src/ramlookup.rs
@@ -1,5 +1,5 @@
 use ark_ff::{Field, One, Zero};
-use kimchi_msm::{MVLookup, MVLookupTableID};
+use kimchi_msm::{LookupTableID, MVLookup};
 
 /// Enum representing the two different modes of a RAMLookup
 #[derive(Copy, Clone, Debug)]
@@ -10,7 +10,7 @@ pub enum LookupMode {
 
 /// Struct containing a RAMLookup
 #[derive(Clone, Debug)]
-pub struct Lookup<T, ID: MVLookupTableID + Send + Sync + Copy> {
+pub struct RAMLookup<T, ID: LookupTableID + Send + Sync + Copy> {
     /// The table ID corresponding to this lookup
     pub(crate) table_id: ID,
     /// Whether it is a read or write lookup
@@ -21,7 +21,7 @@ pub struct Lookup<T, ID: MVLookupTableID + Send + Sync + Copy> {
     pub(crate) value: Vec<T>,
 }
 
-impl<T, ID> Lookup<T, ID>
+impl<T, ID> RAMLookup<T, ID>
 where
     T: Clone
         + std::ops::Add<T, Output = T>
@@ -30,7 +30,7 @@ where
         + std::fmt::Debug
         + One
         + Zero,
-    ID: MVLookupTableID + Send + Sync + Copy,
+    ID: LookupTableID + Send + Sync + Copy,
 {
     /// Creates a new RAMLookup from a mode, a table ID, a magnitude, and a value
     pub fn new(mode: LookupMode, table_id: ID, magnitude: T, value: &[T]) -> Self {
@@ -96,8 +96,8 @@ where
     }
 }
 
-impl<F: std::fmt::Display + Field, ID: MVLookupTableID + Send + Sync + Copy> std::fmt::Display
-    for Lookup<F, ID>
+impl<F: std::fmt::Display + Field, ID: LookupTableID + Send + Sync + Copy> std::fmt::Display
+    for RAMLookup<F, ID>
 {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let numerator = match self.mode {
@@ -116,15 +116,4 @@ impl<F: std::fmt::Display + Field, ID: MVLookupTableID + Send + Sync + Copy> std
         write!(formatter, "]")?;
         Ok(())
     }
-}
-
-/// A table of values that can be used for a lookup, along with the ID for the table.
-#[derive(Debug, Clone)]
-pub struct LookupTable<F, ID: MVLookupTableID + Send + Sync + Copy> {
-    /// Table ID corresponding to this table
-    #[allow(dead_code)]
-    pub table_id: ID,
-    /// Vector of values inside each entry of the table
-    #[allow(dead_code)]
-    pub entries: Vec<Vec<F>>,
 }

--- a/optimism/src/ramlookup.rs
+++ b/optimism/src/ramlookup.rs
@@ -1,22 +1,27 @@
 use ark_ff::{Field, One, Zero};
-use kimchi_msm::MVLookupTableID;
+use kimchi_msm::{MVLookup, MVLookupTableID};
 
+/// Enum representing the two different modes of a RAMLookup
 #[derive(Copy, Clone, Debug)]
 pub enum LookupMode {
     Read,
     Write,
 }
 
+/// Struct containing a RAMLookup
 #[derive(Clone, Debug)]
 pub struct Lookup<T, ID: MVLookupTableID + Send + Sync + Copy> {
-    pub mode: LookupMode,
+    /// The table ID corresponding to this lookup
+    pub(crate) table_id: ID,
+    /// Whether it is a read or write lookup
+    pub(crate) mode: LookupMode,
     /// The number of times that this lookup value should be added to / subtracted from the lookup accumulator.
-    pub magnitude: T,
-    pub table_id: ID,
-    pub value: Vec<T>,
+    pub(crate) magnitude: T,
+    /// The columns containing the content of this lookup
+    pub(crate) value: Vec<T>,
 }
 
-impl<T, ID: MVLookupTableID + Send + Sync + Copy> Lookup<T, ID>
+impl<T, ID> Lookup<T, ID>
 where
     T: Clone
         + std::ops::Add<T, Output = T>
@@ -25,13 +30,31 @@ where
         + std::fmt::Debug
         + One
         + Zero,
+    ID: MVLookupTableID + Send + Sync + Copy,
 {
-    fn numerator(&self) -> T {
+    /// Creates a new RAMLookup from a mode, a table ID, a magnitude, and a value
+    pub fn new(mode: LookupMode, table_id: ID, magnitude: T, value: &[T]) -> Self {
+        Self {
+            mode,
+            table_id,
+            magnitude,
+            value: value.to_vec(),
+        }
+    }
+
+    /// Returns the numerator corresponding to this lookup in the MVLookup argument
+    pub fn numerator(&self) -> T {
         match self.mode {
             LookupMode::Read => T::zero() - self.magnitude.clone(),
             LookupMode::Write => self.magnitude.clone(),
         }
     }
+
+    /// Transforms the current RAMLookup into an equivalent MVLookup
+    pub fn into_mvlookup(self) -> MVLookup<T, ID> {
+        MVLookup::new(self.table_id, self.numerator(), &self.value)
+    }
+
     /// Reads one value when `if_is_true` is 1.
     pub fn read_if(if_is_true: T, table_id: ID, value: Vec<T>) -> Self {
         Self {


### PR DESCRIPTION
This PR includes some initial interfaces to deal with RAMLookups, built on top of the MVLookups from the kimchi-msm crate. It provides a converter from RAMLookups into MVLookups, with the idea of being able to reuse the argument being built for MSM. Nonetheless, if we realize that the protocol is not general enough, further PRs will build on top of these changes to adapt the existing argument and make it more flexible.