### PR TITLE
MSM/Serialization: InterpreterEnv param by PrimeField

### DIFF
--- a/msm/src/serialization/constraints.rs
+++ b/msm/src/serialization/constraints.rs
@@ -1,4 +1,4 @@
-use ark_ff::Field;
+use ark_ff::PrimeField;
 use kimchi::circuits::{
     expr::{ConstantExpr, ConstantTerm, Expr, ExprInner, Variable},
     gate::CurrOrNext,
@@ -12,7 +12,7 @@ pub struct Env<Fp> {
     pub constraints: Vec<Expr<ConstantExpr<Fp>, Column>>,
 }
 
-impl<F: Field> InterpreterEnv<F> for Env<F> {
+impl<F: PrimeField> InterpreterEnv<F> for Env<F> {
     type Position = Column;
 
     type Variable = Expr<ConstantExpr<F>, Column>;

--- a/msm/src/serialization/interpreter.rs
+++ b/msm/src/serialization/interpreter.rs
@@ -1,8 +1,8 @@
-use ark_ff::Field;
+use ark_ff::PrimeField;
 
 use crate::serialization::N_INTERMEDIATE_LIMBS;
 
-pub trait InterpreterEnv<Fp> {
+pub trait InterpreterEnv<Fp: PrimeField> {
     type Position;
 
     type Variable: Clone
@@ -65,7 +65,7 @@ pub trait InterpreterEnv<Fp> {
 /// ```
 /// And we can ignore the last 10 bits (i.e. `limbs2[78..87]`) as a field element
 /// is 254bits long.
-pub fn deserialize_field_element<Fp: Field, Env: InterpreterEnv<Fp>>(
+pub fn deserialize_field_element<Fp: PrimeField, Env: InterpreterEnv<Fp>>(
     env: &mut Env,
     limbs: [u128; 3],
 ) {

--- a/msm/src/serialization/witness.rs
+++ b/msm/src/serialization/witness.rs
@@ -1,4 +1,4 @@
-use ark_ff::Field;
+use ark_ff::PrimeField;
 use o1_utils::FieldHelpers;
 
 use crate::columns::Column;
@@ -17,7 +17,7 @@ pub struct Env<Fp> {
     pub intermediate_limbs: [Fp; N_INTERMEDIATE_LIMBS],
 }
 
-impl<Fp: Field> InterpreterEnv<Fp> for Env<Fp> {
+impl<Fp: PrimeField> InterpreterEnv<Fp> for Env<Fp> {
     type Position = Column;
 
     // Requiring an Fp element as we would need to compute values up to 180 bits
@@ -73,7 +73,7 @@ impl<Fp: Field> InterpreterEnv<Fp> for Env<Fp> {
     }
 }
 
-impl<Fp: Field> Env<Fp> {
+impl<Fp: PrimeField> Env<Fp> {
     pub fn write_column(&mut self, position: Column, value: Fp) {
         match position {
             Column::X(i) => {
@@ -91,7 +91,7 @@ impl<Fp: Field> Env<Fp> {
     }
 }
 
-impl<Fp: Field> Env<Fp> {
+impl<Fp: PrimeField> Env<Fp> {
     pub fn create() -> Self {
         Self {
             current_kimchi_limbs: [Fp::zero(); 3],


### PR DESCRIPTION
Instead of Field.
It makes more sense as it is supposed to be values of a circuit