### PR TITLE
MSM/Serialization: split range checks implementations + add multiplicities

### DIFF
--- a/msm/src/serialization/constraints.rs
+++ b/msm/src/serialization/constraints.rs
@@ -45,6 +45,14 @@ impl<F: PrimeField> InterpreterEnv<F> for Env<F> {
         Column::X(3 + j)
     }
 
+    fn range_check15(&mut self, _value: &Self::Variable) {
+        unimplemented!()
+    }
+
+    fn range_check4(&mut self, _value: &Self::Variable) {
+        unimplemented!()
+    }
+
     fn constant(value: F) -> Self::Variable {
         let cst_expr_inner = ConstantExpr::from(ConstantTerm::Literal(value));
         Expr::Atom(ExprInner::Constant(cst_expr_inner))

--- a/msm/src/serialization/interpreter.rs
+++ b/msm/src/serialization/interpreter.rs
@@ -22,14 +22,10 @@ pub trait InterpreterEnv<Fp: PrimeField> {
     fn get_column_for_msm_limb(j: usize) -> Self::Position;
 
     /// Check that the value is in the range [0, 2^15-1]
-    fn range_check15(&mut self, _value: &Self::Variable) {
-        // TODO
-    }
+    fn range_check15(&mut self, _value: &Self::Variable);
 
     /// Check that the value is in the range [0, 2^4-1]
-    fn range_check4(&mut self, _value: &Self::Variable) {
-        // TODO
-    }
+    fn range_check4(&mut self, _value: &Self::Variable);
 
     fn constant(value: Fp) -> Self::Variable;
 

--- a/msm/src/serialization/witness.rs
+++ b/msm/src/serialization/witness.rs
@@ -17,8 +17,9 @@ pub struct Env<Fp> {
     /// field Kimchi gate
     pub intermediate_limbs: [Fp; N_INTERMEDIATE_LIMBS],
 
-    pub lookup_multiplicities_rangecheck4: [Fp; 1 << 4],
-    pub lookup_multiplicities_rangecheck15: [Fp; 1 << 15],
+    // Boxing to avoid stack overflow
+    pub lookup_multiplicities_rangecheck4: Box<[Fp; 1 << 4]>,
+    pub lookup_multiplicities_rangecheck15: Box<[Fp; 1 << 15]>,
 }
 
 impl<Fp: PrimeField> InterpreterEnv<Fp> for Env<Fp> {
@@ -119,8 +120,8 @@ impl<Fp: PrimeField> Env<Fp> {
             current_kimchi_limbs: [Fp::zero(); 3],
             msm_limbs: [Fp::zero(); N_LIMBS],
             intermediate_limbs: [Fp::zero(); N_INTERMEDIATE_LIMBS],
-            lookup_multiplicities_rangecheck4: [Fp::zero(); 1 << 4],
-            lookup_multiplicities_rangecheck15: [Fp::zero(); 1 << 15],
+            lookup_multiplicities_rangecheck4: Box::new([Fp::zero(); 1 << 4]),
+            lookup_multiplicities_rangecheck15: Box::new([Fp::zero(); 1 << 15]),
         }
     }
 }

--- a/msm/src/serialization/witness.rs
+++ b/msm/src/serialization/witness.rs
@@ -1,4 +1,5 @@
 use ark_ff::PrimeField;
+use num_bigint::BigUint;
 use o1_utils::FieldHelpers;
 
 use crate::columns::Column;
@@ -40,6 +41,18 @@ impl<Fp: PrimeField> InterpreterEnv<Fp> for Env<Fp> {
     fn get_column_for_intermediate_limb(j: usize) -> Self::Position {
         assert!(j < N_INTERMEDIATE_LIMBS);
         Column::X(3 + N_LIMBS + j)
+    }
+
+    fn range_check15(&mut self, value: &Self::Variable) {
+        // FIXME: this is not the full intended implementation
+        let value_biguint = value.to_biguint();
+        assert!(value_biguint < BigUint::from(2u128.pow(15)));
+    }
+
+    fn range_check4(&mut self, value: &Self::Variable) {
+        // FIXME: this is not the full intended implementation
+        let value_biguint = value.to_biguint();
+        assert!(value_biguint < BigUint::from(2u128.pow(4)));
     }
 
     fn copy(&mut self, x: &Self::Variable, position: Self::Position) -> Self::Variable {

--- a/msm/src/serialization/witness.rs
+++ b/msm/src/serialization/witness.rs
@@ -16,6 +16,9 @@ pub struct Env<Fp> {
     /// Used for the decomposition in base 4 of the last limb of the foreign
     /// field Kimchi gate
     pub intermediate_limbs: [Fp; N_INTERMEDIATE_LIMBS],
+
+    pub lookup_multiplicities_rangecheck4: [Fp; 1 << 4],
+    pub lookup_multiplicities_rangecheck15: [Fp; 1 << 15],
 }
 
 impl<Fp: PrimeField> InterpreterEnv<Fp> for Env<Fp> {
@@ -47,12 +50,18 @@ impl<Fp: PrimeField> InterpreterEnv<Fp> for Env<Fp> {
         // FIXME: this is not the full intended implementation
         let value_biguint = value.to_biguint();
         assert!(value_biguint < BigUint::from(2u128.pow(15)));
+        // Adding multiplicities
+        let value_usize: usize = value_biguint.clone().try_into().unwrap();
+        self.lookup_multiplicities_rangecheck15[value_usize] += Fp::one();
     }
 
     fn range_check4(&mut self, value: &Self::Variable) {
         // FIXME: this is not the full intended implementation
         let value_biguint = value.to_biguint();
         assert!(value_biguint < BigUint::from(2u128.pow(4)));
+        // Adding multiplicities
+        let value_usize: usize = value_biguint.clone().try_into().unwrap();
+        self.lookup_multiplicities_rangecheck4[value_usize] += Fp::one();
     }
 
     fn copy(&mut self, x: &Self::Variable, position: Self::Position) -> Self::Variable {
@@ -110,6 +119,8 @@ impl<Fp: PrimeField> Env<Fp> {
             current_kimchi_limbs: [Fp::zero(); 3],
             msm_limbs: [Fp::zero(); N_LIMBS],
             intermediate_limbs: [Fp::zero(); N_INTERMEDIATE_LIMBS],
+            lookup_multiplicities_rangecheck4: [Fp::zero(); 1 << 4],
+            lookup_multiplicities_rangecheck15: [Fp::zero(); 1 << 15],
         }
     }
 }


### PR DESCRIPTION
Asserting for now on the witness side.

The multiplicities are computing while we are computing the witness. In the next PRs, we will build the lookup witness from it.

~Note: box is added in 68ae3581439feff26f312272077be5615e2b3432 (next PR)~. Added now for CI