### PR TITLE
MSM FFA Addition: Rewrite test circuit using interpreter pattern

### DIFF
--- a/msm/src/ffa/columns.rs
+++ b/msm/src/ffa/columns.rs
@@ -29,3 +29,22 @@ impl ColumnIndexer for FFAColumnIndexer {
         }
     }
 }
+
+impl FFAColumnIndexer {
+    pub fn column_to_ix(col: Column) -> Self {
+        let Column::X(pos) = col;
+        let upper_bound = |i: usize| (i + 1) * N_LIMBS;
+        let pos_map = |i: usize| pos - upper_bound(i - 1);
+        if pos < upper_bound(0) {
+            FFAColumnIndexer::A(pos_map(0))
+        } else if pos < upper_bound(1) {
+            FFAColumnIndexer::B(pos_map(1))
+        } else if pos < upper_bound(2) {
+            FFAColumnIndexer::C(pos_map(2))
+        } else if pos < upper_bound(3) {
+            FFAColumnIndexer::D(pos_map(3))
+        } else {
+            panic!("column_to_ix: Invalid column index")
+        }
+    }
+}

--- a/msm/src/ffa/constraint.rs
+++ b/msm/src/ffa/constraint.rs
@@ -10,17 +10,17 @@ use kimchi::circuits::{
 };
 
 /// Contains constraints for just one row.
-pub struct ConstraintBuilder<F> {
+pub struct ConstraintBuilderEnv<F> {
     pub constraints: Vec<MSMExpr<F>>,
 }
 
-impl<F: PrimeField> FFAInterpreterEnv<F> for ConstraintBuilder<F> {
+impl<F: PrimeField> FFAInterpreterEnv<F> for ConstraintBuilderEnv<F> {
     type Position = Column;
 
     type Variable = MSMExpr<F>;
 
     fn empty() -> Self {
-        ConstraintBuilder {
+        ConstraintBuilderEnv {
             constraints: vec![],
         }
     }

--- a/msm/src/ffa/constraint.rs
+++ b/msm/src/ffa/constraint.rs
@@ -1,62 +1,61 @@
 use crate::{
     columns::{Column, ColumnIndexer},
     expr::MSMExpr,
-    ffa::columns::FFAColumnIndexer,
-    {Fp, N_LIMBS},
+    ffa::{columns::FFAColumnIndexer, interpreter::FFAInterpreterEnv},
 };
+use ark_ff::PrimeField;
 use kimchi::circuits::{
-    expr::{ConstantExprInner, ExprInner, Operations, Variable},
+    expr::{ConstantExpr, ConstantTerm, Expr, ExprInner, Variable},
     gate::CurrOrNext,
 };
 
-/// Access exprs for addition
-pub fn get_exprs_add() -> Vec<MSMExpr<Fp>> {
-    let mut limb_exprs: Vec<_> = vec![];
-    for i in 0..N_LIMBS {
-        let limb_constraint = {
-            let a_i = MSMExpr::Atom(
-                ExprInner::<Operations<ConstantExprInner<Fp>>, Column>::Cell(Variable {
-                    col: FFAColumnIndexer::A(i).ix_to_column(),
-                    row: CurrOrNext::Curr,
-                }),
-            );
-            let b_i = MSMExpr::Atom(ExprInner::Cell(Variable {
-                col: FFAColumnIndexer::B(i).ix_to_column(),
-                row: CurrOrNext::Curr,
-            }));
-            let c_i = MSMExpr::Atom(ExprInner::Cell(Variable {
-                col: FFAColumnIndexer::C(i).ix_to_column(),
-                row: CurrOrNext::Curr,
-            }));
-            a_i + b_i - c_i
-        };
-        limb_exprs.push(limb_constraint);
-    }
-    limb_exprs
+/// Contains constraints for just one row.
+pub struct ConstraintBuilder<F> {
+    pub constraints: Vec<MSMExpr<F>>,
 }
 
-/// Get expressions for multiplication
-pub fn get_exprs_mul() -> Vec<MSMExpr<Fp>> {
-    let mut limb_exprs: Vec<_> = vec![];
-    for i in 0..N_LIMBS {
-        let limb_constraint = {
-            let a_i = MSMExpr::Atom(
-                ExprInner::<Operations<ConstantExprInner<Fp>>, Column>::Cell(Variable {
-                    col: FFAColumnIndexer::A(i).ix_to_column(),
-                    row: CurrOrNext::Curr,
-                }),
-            );
-            let b_i = MSMExpr::Atom(ExprInner::Cell(Variable {
-                col: FFAColumnIndexer::B(i).ix_to_column(),
-                row: CurrOrNext::Curr,
-            }));
-            let d_i = MSMExpr::Atom(ExprInner::Cell(Variable {
-                col: FFAColumnIndexer::D(i).ix_to_column(),
-                row: CurrOrNext::Curr,
-            }));
-            a_i * b_i - d_i
-        };
-        limb_exprs.push(limb_constraint);
+impl<F: PrimeField> FFAInterpreterEnv<F> for ConstraintBuilder<F> {
+    type Position = Column;
+
+    type Variable = MSMExpr<F>;
+
+    fn empty() -> Self {
+        ConstraintBuilder {
+            constraints: vec![],
+        }
     }
-    limb_exprs
+
+    fn assert_zero(&mut self, cst: Self::Variable) {
+        self.constraints.push(cst)
+    }
+
+    fn copy(&mut self, x: &Self::Variable, position: Self::Position) -> Self::Variable {
+        let y = Expr::Atom(ExprInner::Cell(Variable {
+            col: position,
+            row: CurrOrNext::Curr,
+        }));
+        self.constraints.push(y.clone() - x.clone());
+        y
+    }
+
+    fn constant(value: F) -> Self::Variable {
+        let cst_expr_inner = ConstantExpr::from(ConstantTerm::Literal(value));
+        Expr::Atom(ExprInner::Constant(cst_expr_inner))
+    }
+
+    // TODO deduplicate, remove this
+    fn column_pos(ix: FFAColumnIndexer) -> Self::Position {
+        ix.ix_to_column()
+    }
+
+    fn read_column(&self, ix: FFAColumnIndexer) -> Self::Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
+            col: ix.ix_to_column(),
+            row: CurrOrNext::Curr,
+        }))
+    }
+
+    fn next_row(&mut self) {
+        panic!("Please don't call this");
+    }
 }

--- a/msm/src/ffa/interpreter.rs
+++ b/msm/src/ffa/interpreter.rs
@@ -1,7 +1,9 @@
-use crate::ffa::columns::FFAColumnIndexer;
-use ark_ff::PrimeField;
+use crate::{ffa::columns::FFAColumnIndexer, Ff1, N_LIMBS};
+use ark_ff::{PrimeField, Zero};
+use num_bigint::BigUint;
+use o1_utils::{field_helpers::FieldHelpers, foreign_field::ForeignElement};
 
-pub trait FFAInterpreterEnv<Fp: PrimeField> {
+pub trait FFAInterpreterEnv<F: PrimeField> {
     type Position;
 
     type Variable: Clone
@@ -10,11 +12,99 @@ pub trait FFAInterpreterEnv<Fp: PrimeField> {
         + std::ops::Mul<Self::Variable, Output = Self::Variable>
         + std::fmt::Debug;
 
-    fn add_constraint(&mut self, cst: Self::Variable);
+    fn empty() -> Self;
+
+    fn assert_zero(&mut self, cst: Self::Variable);
 
     fn copy(&mut self, x: &Self::Variable, position: Self::Position) -> Self::Variable;
 
-    fn constant(value: Fp) -> Self::Variable;
+    fn constant(value: F) -> Self::Variable;
 
-    fn get_column(ix: FFAColumnIndexer) -> Self::Position;
+    fn column_pos(ix: FFAColumnIndexer) -> Self::Position;
+
+    fn read_column(&self, ix: FFAColumnIndexer) -> Self::Variable;
+
+    /// In constraint environment does nothing (?). In witness environment progresses to the next row.
+    fn next_row(&mut self);
+}
+
+// TODO use more foreign_field.rs with from/to bigint conversion
+fn limb_decompose<F: PrimeField>(input: &Ff1) -> [F; N_LIMBS] {
+    let input_bi: BigUint = FieldHelpers::to_biguint(input);
+    let ff_el: ForeignElement<F, N_LIMBS> = ForeignElement::from_biguint(input_bi);
+    ff_el.limbs
+}
+
+/// Reads values from limbs A and B, returns resulting value in C.
+pub fn constrain_multiplication<F: PrimeField, Env: FFAInterpreterEnv<F>>(
+    env: &mut Env,
+) -> [Env::Variable; N_LIMBS] {
+    let a_limbs: [Env::Variable; N_LIMBS] =
+        core::array::from_fn(|i| Env::read_column(env, FFAColumnIndexer::A(i)));
+    let b_limbs: [Env::Variable; N_LIMBS] =
+        core::array::from_fn(|i| Env::read_column(env, FFAColumnIndexer::B(i)));
+    // fix cloning
+    let c_limbs: [Env::Variable; N_LIMBS] =
+        core::array::from_fn(|i| a_limbs[i].clone() * b_limbs[i].clone());
+    c_limbs.iter().enumerate().for_each(|(i, var)| {
+        env.copy(var, Env::column_pos(FFAColumnIndexer::C(i)));
+    });
+    c_limbs
+}
+
+pub fn test_multiplication<F: PrimeField, Env: FFAInterpreterEnv<F>>(
+    env: &mut Env,
+    a: Ff1,
+    b: Ff1,
+) {
+    let a_limbs: [Env::Variable; N_LIMBS] = limb_decompose(&a).map(Env::constant);
+    let b_limbs: [Env::Variable; N_LIMBS] = limb_decompose(&b).map(Env::constant);
+    a_limbs.iter().enumerate().for_each(|(i, var)| {
+        env.copy(var, Env::column_pos(FFAColumnIndexer::A(i)));
+    });
+    b_limbs.iter().enumerate().for_each(|(i, var)| {
+        env.copy(var, Env::column_pos(FFAColumnIndexer::B(i)));
+    });
+
+    let _ = constrain_multiplication(env); // we don't do anything else further with c_limbs
+
+    let d_limbs: [Env::Variable; N_LIMBS] = [Zero::zero(); N_LIMBS].map(Env::constant);
+    d_limbs.iter().enumerate().for_each(|(i, var)| {
+        env.copy(var, Env::column_pos(FFAColumnIndexer::D(i)));
+    });
+}
+
+/// Reads values from limbs A and B, returns resulting value in C.
+pub fn constrain_addition<F: PrimeField, Env: FFAInterpreterEnv<F>>(
+    env: &mut Env,
+) -> [Env::Variable; N_LIMBS] {
+    let a_limbs: [Env::Variable; N_LIMBS] =
+        core::array::from_fn(|i| Env::read_column(env, FFAColumnIndexer::A(i)));
+    let b_limbs: [Env::Variable; N_LIMBS] =
+        core::array::from_fn(|i| Env::read_column(env, FFAColumnIndexer::B(i)));
+    // fix cloning
+    let c_limbs: [Env::Variable; N_LIMBS] =
+        core::array::from_fn(|i| a_limbs[i].clone() + b_limbs[i].clone());
+    c_limbs.iter().enumerate().for_each(|(i, var)| {
+        env.copy(var, Env::column_pos(FFAColumnIndexer::C(i)));
+    });
+    c_limbs
+}
+
+pub fn test_addition<F: PrimeField, Env: FFAInterpreterEnv<F>>(env: &mut Env, a: Ff1, b: Ff1) {
+    let a_limbs: [Env::Variable; N_LIMBS] = limb_decompose(&a).map(Env::constant);
+    let b_limbs: [Env::Variable; N_LIMBS] = limb_decompose(&b).map(Env::constant);
+    a_limbs.iter().enumerate().for_each(|(i, var)| {
+        env.copy(var, Env::column_pos(FFAColumnIndexer::A(i)));
+    });
+    b_limbs.iter().enumerate().for_each(|(i, var)| {
+        env.copy(var, Env::column_pos(FFAColumnIndexer::B(i)));
+    });
+
+    let _ = constrain_addition(env); // we don't do anything else further with c_limbs
+
+    let d_limbs: [Env::Variable; N_LIMBS] = [Zero::zero(); N_LIMBS].map(Env::constant);
+    d_limbs.iter().enumerate().for_each(|(i, var)| {
+        env.copy(var, Env::column_pos(FFAColumnIndexer::D(i)));
+    });
 }

--- a/msm/src/ffa/interpreter.rs
+++ b/msm/src/ffa/interpreter.rs
@@ -1,0 +1,17 @@
+use ark_ff::PrimeField;
+
+pub trait FFAInterpreterEnv<Fp: PrimeField> {
+    type Position;
+
+    type Variable: Clone
+        + std::ops::Add<Self::Variable, Output = Self::Variable>
+        + std::ops::Sub<Self::Variable, Output = Self::Variable>
+        + std::ops::Mul<Self::Variable, Output = Self::Variable>
+        + std::fmt::Debug;
+
+    fn add_constraint(&mut self, cst: Self::Variable);
+
+    fn copy(&mut self, x: &Self::Variable, position: Self::Position) -> Self::Variable;
+
+    fn constant(value: Fp) -> Self::Variable;
+}

--- a/msm/src/ffa/interpreter.rs
+++ b/msm/src/ffa/interpreter.rs
@@ -1,3 +1,4 @@
+use crate::ffa::columns::FFAColumnIndexer;
 use ark_ff::PrimeField;
 
 pub trait FFAInterpreterEnv<Fp: PrimeField> {
@@ -14,4 +15,6 @@ pub trait FFAInterpreterEnv<Fp: PrimeField> {
     fn copy(&mut self, x: &Self::Variable, position: Self::Position) -> Self::Variable;
 
     fn constant(value: Fp) -> Self::Variable;
+
+    fn get_column(ix: FFAColumnIndexer) -> Self::Position;
 }

--- a/msm/src/ffa/main.rs
+++ b/msm/src/ffa/main.rs
@@ -11,12 +11,10 @@ use kimchi_msm::lookups::LookupTableIDs;
 use kimchi_msm::precomputed_srs::get_bn254_srs;
 use kimchi_msm::prover::prove;
 use kimchi_msm::verifier::verify;
-use kimchi_msm::{
-    BN254G1Affine, BaseSponge, Ff1, Fp, OpeningProof, ScalarSponge, BN254, DOMAIN_SIZE,
-};
+use kimchi_msm::{BaseSponge, Ff1, Fp, OpeningProof, ScalarSponge, BN254, DOMAIN_SIZE};
 
-pub fn generate_random_msm_witness() -> FFAWitnessBuilder<BN254G1Affine> {
-    let mut circuit_env = FFAWitnessBuilder::<BN254G1Affine>::empty();
+pub fn generate_random_msm_witness() -> FFAWitnessBuilder<Fp> {
+    let mut circuit_env = FFAWitnessBuilder::<Fp>::empty();
     let mut rng = thread_rng();
 
     let row_num = DOMAIN_SIZE;

--- a/msm/src/ffa/main.rs
+++ b/msm/src/ffa/main.rs
@@ -1,11 +1,14 @@
-use rand::{thread_rng, Rng};
+use rand::Rng;
 
 use kimchi::circuits::domains::EvaluationDomains;
 use poly_commitment::pairing_proof::PairingSRS;
 
 use kimchi_msm::columns::Column;
 use kimchi_msm::ffa::{
-    columns::FFA_N_COLUMNS, constraint::get_exprs_add, witness::WitnessBuilder as FFAWitnessBuilder,
+    columns::FFA_N_COLUMNS,
+    constraint::ConstraintBuilder as FFAConstraintBuilder,
+    interpreter::{self as ffa_interpreter, FFAInterpreterEnv},
+    witness::WitnessBuilder as FFAWitnessBuilder,
 };
 use kimchi_msm::lookups::LookupTableIDs;
 use kimchi_msm::precomputed_srs::get_bn254_srs;
@@ -13,34 +16,33 @@ use kimchi_msm::prover::prove;
 use kimchi_msm::verifier::verify;
 use kimchi_msm::{BaseSponge, Ff1, Fp, OpeningProof, ScalarSponge, BN254, DOMAIN_SIZE};
 
-pub fn generate_random_msm_witness() -> FFAWitnessBuilder<Fp> {
-    let mut circuit_env = FFAWitnessBuilder::<Fp>::empty();
-    let mut rng = thread_rng();
-
-    let row_num = DOMAIN_SIZE;
-    assert!(row_num <= DOMAIN_SIZE);
-
-    for _row_i in 0..row_num {
-        let a: Ff1 = From::from(rng.gen_range(0..(1 << 16)));
-        let b: Ff1 = From::from(rng.gen_range(0..(1 << 16)));
-        circuit_env.add_test_addition(a, b);
-    }
-
-    circuit_env
-}
-
 pub fn main() {
     // FIXME: use a proper RNG
     let mut rng = o1_utils::tests::make_test_rng();
 
     println!("Creating the domain and SRS");
-    let domain = EvaluationDomains::<Fp>::create(DOMAIN_SIZE).unwrap();
+    let domain_size = DOMAIN_SIZE;
+    let domain = EvaluationDomains::<Fp>::create(domain_size).unwrap();
 
     let srs: PairingSRS<BN254> = get_bn254_srs(domain);
 
-    let circuit_env = generate_random_msm_witness();
-    let proof_inputs = circuit_env.get_witness();
-    let constraint_exprs = get_exprs_add();
+    let mut witness_env = FFAWitnessBuilder::<Fp>::empty();
+    let mut constraint_env = FFAConstraintBuilder::<Fp>::empty();
+
+    ffa_interpreter::constrain_multiplication(&mut constraint_env);
+
+    let row_num = 10;
+    assert!(row_num <= DOMAIN_SIZE);
+
+    for _row_i in 0..row_num {
+        let a: Ff1 = From::from(rng.gen_range(0..(1 << 16)));
+        let b: Ff1 = From::from(rng.gen_range(0..(1 << 16)));
+        ffa_interpreter::test_multiplication(&mut witness_env, a, b);
+        witness_env.next_row();
+    }
+
+    let inputs = witness_env.get_witness(domain_size);
+    let constraints = constraint_env.constraints;
 
     println!("Generating the proof");
     let proof = prove::<
@@ -52,14 +54,14 @@ pub fn main() {
         _,
         FFA_N_COLUMNS,
         LookupTableIDs,
-    >(domain, &srs, &constraint_exprs, proof_inputs, &mut rng)
+    >(domain, &srs, &constraints, inputs, &mut rng)
     .unwrap();
 
     println!("Verifying the proof");
     let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, FFA_N_COLUMNS>(
         domain,
         &srs,
-        &constraint_exprs,
+        &constraints,
         &proof,
     );
     println!("Proof verification result: {verifies}")

--- a/msm/src/ffa/main.rs
+++ b/msm/src/ffa/main.rs
@@ -6,9 +6,9 @@ use poly_commitment::pairing_proof::PairingSRS;
 use kimchi_msm::columns::Column;
 use kimchi_msm::ffa::{
     columns::FFA_N_COLUMNS,
-    constraint::ConstraintBuilder as FFAConstraintBuilder,
+    constraint::ConstraintBuilderEnv as FFAConstraintBuilderEnv,
     interpreter::{self as ffa_interpreter, FFAInterpreterEnv},
-    witness::WitnessBuilder as FFAWitnessBuilder,
+    witness::WitnessBuilderEnv as FFAWitnessBuilderEnv,
 };
 use kimchi_msm::lookups::LookupTableIDs;
 use kimchi_msm::precomputed_srs::get_bn254_srs;
@@ -26,8 +26,8 @@ pub fn main() {
 
     let srs: PairingSRS<BN254> = get_bn254_srs(domain);
 
-    let mut witness_env = FFAWitnessBuilder::<Fp>::empty();
-    let mut constraint_env = FFAConstraintBuilder::<Fp>::empty();
+    let mut witness_env = FFAWitnessBuilderEnv::<Fp>::empty();
+    let mut constraint_env = FFAConstraintBuilderEnv::<Fp>::empty();
 
     ffa_interpreter::constrain_multiplication(&mut constraint_env);
 

--- a/msm/src/ffa/mod.rs
+++ b/msm/src/ffa/mod.rs
@@ -1,4 +1,4 @@
 pub mod columns;
 pub mod constraint;
-//pub mod interpreter;
+pub mod interpreter;
 pub mod witness;

--- a/msm/src/ffa/witness.rs
+++ b/msm/src/ffa/witness.rs
@@ -3,7 +3,7 @@ use ark_ff::Zero;
 use num_bigint::BigUint;
 
 use crate::{
-    columns::Column,
+    columns::{Column, ColumnIndexer},
     ffa::{
         columns::{FFAColumnIndexer, FFA_N_COLUMNS},
         interpreter::FFAInterpreterEnv,
@@ -46,6 +46,10 @@ impl<F: PrimeField> FFAInterpreterEnv<F> for WitnessBuilder<F> {
     fn copy(&mut self, x: &Self::Variable, position: Self::Position) -> Self::Variable {
         self.write_column(position, *x);
         *x
+    }
+
+    fn get_column(ix: FFAColumnIndexer) -> Self::Position {
+        ix.ix_to_column()
     }
 }
 

--- a/msm/src/ffa/witness.rs
+++ b/msm/src/ffa/witness.rs
@@ -15,19 +15,19 @@ use crate::{
 
 #[allow(dead_code)]
 /// Builder environment for a native group `G`.
-pub struct WitnessBuilder<F: PrimeField> {
+pub struct WitnessBuilderEnv<F: PrimeField> {
     /// Aggregated witness, in raw form. For accessing [`Witness`], see the
     /// `get_witness` method.
     witness: Vec<Witness<FFA_N_COLUMNS, F>>,
 }
 
-impl<F: PrimeField> FFAInterpreterEnv<F> for WitnessBuilder<F> {
+impl<F: PrimeField> FFAInterpreterEnv<F> for WitnessBuilderEnv<F> {
     type Position = Column;
 
     type Variable = F;
 
     fn empty() -> Self {
-        WitnessBuilder {
+        WitnessBuilderEnv {
             witness: vec![Witness {
                 cols: [Zero::zero(); FFA_N_COLUMNS],
             }],
@@ -65,7 +65,7 @@ impl<F: PrimeField> FFAInterpreterEnv<F> for WitnessBuilder<F> {
     }
 }
 
-impl WitnessBuilder<Fp> {
+impl WitnessBuilderEnv<Fp> {
     /// Each WitnessColumn stands for both one row and multirow. This
     /// function converts from a vector of one-row instantiation to a
     /// single multi-row form (which is a `Witness`).

--- a/msm/src/lib.rs
+++ b/msm/src/lib.rs
@@ -58,9 +58,9 @@ mod tests {
         columns::Column,
         ffa::{
             columns::FFA_N_COLUMNS,
-            constraint::ConstraintBuilder as FFAConstraintBuilder,
+            constraint::ConstraintBuilderEnv as FFAConstraintBuilderEnv,
             interpreter::{self as ffa_interpreter, FFAInterpreterEnv},
-            witness::WitnessBuilder as FFAWitnessBuilder,
+            witness::WitnessBuilderEnv as FFAWitnessBuilderEnv,
         },
         lookups::{Lookup, LookupTableIDs},
         proof::ProofInputs,
@@ -78,7 +78,7 @@ mod tests {
 
     // Creates a test witness for a * b = c constraint.
     fn gen_random_mul_witness<RNG: RngCore + CryptoRng>(
-        witness_env: &mut FFAWitnessBuilder<Fp>,
+        witness_env: &mut FFAWitnessBuilderEnv<Fp>,
         rng: &mut RNG,
     ) {
         let row_num = 10;
@@ -105,8 +105,8 @@ mod tests {
         let mut srs: PairingSRS<BN254> = PairingSRS::create(x, domain.d1.size as usize);
         srs.full_srs.add_lagrange_basis(domain.d1);
 
-        let mut witness_env = FFAWitnessBuilder::<Fp>::empty();
-        let mut constraint_env = FFAConstraintBuilder::<Fp>::empty();
+        let mut witness_env = FFAWitnessBuilderEnv::<Fp>::empty();
+        let mut constraint_env = FFAConstraintBuilderEnv::<Fp>::empty();
 
         ffa_interpreter::constrain_multiplication(&mut constraint_env);
         gen_random_mul_witness(&mut witness_env, &mut rng);
@@ -152,11 +152,11 @@ mod tests {
         let mut srs: PairingSRS<BN254> = PairingSRS::create(x, domain.d1.size as usize);
         srs.full_srs.add_lagrange_basis(domain.d1);
 
-        let mut constraint_env = FFAConstraintBuilder::<Fp>::empty();
+        let mut constraint_env = FFAConstraintBuilderEnv::<Fp>::empty();
         ffa_interpreter::constrain_multiplication(&mut constraint_env);
         let constraints = constraint_env.constraints;
 
-        let mut witness_env = FFAWitnessBuilder::<Fp>::empty();
+        let mut witness_env = FFAWitnessBuilderEnv::<Fp>::empty();
         gen_random_mul_witness(&mut witness_env, &mut rng);
         let inputs = witness_env.get_witness(domain_size);
 
@@ -173,7 +173,7 @@ mod tests {
         >(domain, &srs, &constraints, inputs, &mut rng)
         .unwrap();
 
-        let mut witness_env_prime = FFAWitnessBuilder::<Fp>::empty();
+        let mut witness_env_prime = FFAWitnessBuilderEnv::<Fp>::empty();
         gen_random_mul_witness(&mut witness_env_prime, &mut rng);
         let inputs_prime = witness_env_prime.get_witness(domain_size);
 


### PR DESCRIPTION
Resolves #1791 . 

This PR splits existing test `a * b - c` and `a + b - c` circuit (together with witness generation) into interpreter-witness-circuit pattern. Does not change the circuit itself, only how it's represented. Moving some code around.

Previous part: https://github.com/o1-labs/proof-systems/pull/1904

Next part will implement the actual FFA addition circuit (or part of it, depending on the diff size).