### PR TITLE
Add ProverError to prover.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,6 +1433,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 1.14.0",
+ "thiserror",
 ]
 
 [[package]]

--- a/msm/Cargo.toml
+++ b/msm/Cargo.toml
@@ -39,3 +39,4 @@ ark-ff = { version = "0.3.0", features = [ "parallel" ] }
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 rand = "0.8.5"
 rayon = "1.5.0"
+thiserror.workspace = true

--- a/msm/src/ffa/main.rs
+++ b/msm/src/ffa/main.rs
@@ -54,7 +54,8 @@ pub fn main() {
         _,
         FFA_N_COLUMNS,
         LookupTableIDs,
-    >(domain, &srs, &constraint_exprs, proof_inputs, &mut rng);
+    >(domain, &srs, &constraint_exprs, proof_inputs, &mut rng)
+    .unwrap();
 
     println!("Verifying the proof");
     let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, FFA_N_COLUMNS>(

--- a/msm/src/lib.rs
+++ b/msm/src/lib.rs
@@ -117,7 +117,8 @@ mod tests {
             _,
             FFA_N_COLUMNS,
             LookupTableIDs,
-        >(domain, &srs, &constraints, inputs, &mut rng);
+        >(domain, &srs, &constraints, inputs, &mut rng)
+        .unwrap();
 
         // verify the proof
         let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, FFA_N_COLUMNS>(
@@ -158,7 +159,8 @@ mod tests {
             _,
             FFA_N_COLUMNS,
             LookupTableIDs,
-        >(domain, &srs, &constraints, inputs, &mut rng);
+        >(domain, &srs, &constraints, inputs, &mut rng)
+        .unwrap();
 
         let witness_builder_prime = gen_random_mul_witness(domain_size);
         let inputs_prime = witness_builder_prime.get_witness();
@@ -171,7 +173,8 @@ mod tests {
             _,
             FFA_N_COLUMNS,
             LookupTableIDs,
-        >(domain, &srs, &constraints, inputs_prime, &mut rng);
+        >(domain, &srs, &constraints, inputs_prime, &mut rng)
+        .unwrap();
 
         // Swap the opening proof. The verification should fail.
         {
@@ -246,13 +249,15 @@ mod tests {
         // Overwriting the first looked up value
         inputs.mvlookups[0].f[0][0] = wrong_looked_up_value;
         // generate the proof
-        let proof = prove::<_, OpeningProof, BaseSponge, ScalarSponge, Column, _, N, LookupTableIDs>(
-            domain,
-            &srs,
-            &constraints,
-            inputs,
-            &mut rng,
-        );
+        let proof =
+            prove::<_, OpeningProof, BaseSponge, ScalarSponge, Column, _, N, LookupTableIDs>(
+                domain,
+                &srs,
+                &constraints,
+                inputs,
+                &mut rng,
+            )
+            .unwrap();
         let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, N>(
             domain,
             &srs,

--- a/msm/src/serialization/main.rs
+++ b/msm/src/serialization/main.rs
@@ -59,7 +59,8 @@ pub fn main() {
         _,
         SERIALIZATION_N_COLUMNS,
         LookupTableIDs,
-    >(domain, &srs, &_constraints, proof_inputs, &mut rng);
+    >(domain, &srs, &_constraints, proof_inputs, &mut rng)
+    .unwrap();
 
     println!("Verifying the proof");
     let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, SERIALIZATION_N_COLUMNS>(


### PR DESCRIPTION
Closes #1708. Adds `ProverError` that can be used instead of panicking in `prover.rs`.