### PR TITLE
Make MSM dependencies use workspace pattern as other crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,7 +1432,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "serde_with 1.14.0",
+ "serde_with 3.6.0",
 ]
 
 [[package]]

--- a/msm/Cargo.toml
+++ b/msm/Cargo.toml
@@ -21,21 +21,21 @@ name = "serialization"
 path = "src/serialization/main.rs"
 
 [dependencies]
-ark-bn254 = { version = "0.3.0" }
-ark-serialize = "0.3.0"
-o1-utils = { path = "../utils" }
-kimchi = { path = "../kimchi", version = "0.1.0", features = [ "bn254" ] }
-poly-commitment = { path = "../poly-commitment", version = "0.1.0" }
-groupmap = { path = "../groupmap", version = "0.1.0" }
-mina-curves = { path = "../curves", version = "0.1.0" }
-mina-poseidon = { path = "../poseidon", version = "0.1.0" }
-num-bigint = { version = "0.4.3", features = ["rand"] }
-rmp-serde = "1.1.1"
-serde_json = "1.0.91"
-serde = "1.0.130"
-serde_with = "1.10.0"
-ark-poly = { version = "0.3.0", features = [ "parallel" ] }
-ark-ff = { version = "0.3.0", features = [ "parallel" ] }
-ark-ec = { version = "0.3.0", features = [ "parallel" ] }
-rand = "0.8.5"
-rayon = "1.5.0"
+ark-bn254.workspace = true
+ark-serialize.workspace = true
+o1-utils.workspace = true
+kimchi.workspace = true
+poly-commitment.workspace = true
+groupmap.workspace = true
+mina-curves.workspace = true
+mina-poseidon.workspace = true
+num-bigint.workspace = true
+rmp-serde.workspace = true
+serde_json.workspace = true
+serde.workspace = true
+serde_with.workspace = true
+ark-poly.workspace = true
+ark-ff.workspace = true
+ark-ec.workspace = true
+rand.workspace = true
+rayon.workspace = true


### PR DESCRIPTION
Makes MSM project use top level workspace dependencies instead of individual one, as other crates in the repository do unless necessary.