### PR TITLE
MSM: using iterator in the verifier

### DIFF
--- a/msm/src/verifier.rs
+++ b/msm/src/verifier.rs
@@ -36,10 +36,8 @@ pub fn verify<
 
     // -- Absorbing the commitments
     let mut fq_sponge = EFqSponge::new(G::other_curve_sponge_params());
-    proof_comms
-        .witness_comms
-        .cols
-        .iter()
+    (&proof_comms.witness_comms)
+        .into_iter()
         .for_each(|comm| absorb_commitment(&mut fq_sponge, comm));
 
     if let Some(mvlookup_comms) = &proof_comms.mvlookup_comms {
@@ -67,11 +65,9 @@ pub fn verify<
     let mut coms_and_evaluations: Vec<Evaluation<_>> = vec![];
 
     coms_and_evaluations.extend(
-        proof_comms
-            .witness_comms
-            .cols
-            .iter()
-            .zip(proof_evals.witness_evals.cols.iter())
+        (&proof_comms.witness_comms)
+            .into_iter()
+            .zip(&proof_evals.witness_evals)
             .map(|(commitment, point_eval)| Evaluation {
                 commitment: commitment.clone(),
                 evaluations: vec![vec![point_eval.zeta], vec![point_eval.zeta_omega]],
@@ -96,7 +92,7 @@ pub fn verify<
     let mut fr_sponge = EFrSponge::new(G::sponge_params());
     fr_sponge.absorb(&fq_sponge.digest());
 
-    for PointEvaluations { zeta, zeta_omega } in proof_evals.witness_evals.cols.iter() {
+    for PointEvaluations { zeta, zeta_omega } in (&proof_evals.witness_evals).into_iter() {
         fr_sponge.absorb(zeta);
         fr_sponge.absorb(zeta_omega);
     }


### PR DESCRIPTION
Bringing back the iterator, reversing some changes introduced by https://github.com/o1-labs/proof-systems/pull/1839.
Changed related to https://github.com/o1-labs/proof-systems/pull/1839#discussion_r1511607711 