### PR TITLE
MSM/MVLookup: add challenges into column environment

### DIFF
--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -153,22 +153,13 @@ where
 
     let zk_rows = 0;
     let column_env = {
-        let challenges = if let Some(lookup_env) = lookup_env.as_ref() {
-            Challenges {
-                alpha,
-                // NB: as there is on permutation argument, we do use the beta
-                // field instead of a new one for the evaluation point.
-                beta: lookup_env.beta,
-                gamma: G::ScalarField::zero(),
-                joint_combiner: Some(lookup_env.joint_combiner),
-            }
-        } else {
-            Challenges {
-                alpha,
-                beta: G::ScalarField::zero(),
-                gamma: G::ScalarField::zero(),
-                joint_combiner: None,
-            }
+        let challenges = Challenges {
+            alpha,
+            // NB: as there is on permutation argument, we do use the beta
+            // field instead of a new one for the evaluation point.
+            beta: Option::map(lookup_env.as_ref(), |x| x.beta).unwrap_or(G::ScalarField::zero()),
+            gamma: G::ScalarField::zero(),
+            joint_combiner: Option::map(lookup_env.as_ref(), |x| x.joint_combiner),
         };
         MSMColumnEnvironment {
             constants: Constants {


### PR DESCRIPTION
The generation of the challenges should be at the same round for both the prover and the verifier.
We do not have a typed sponge unfortunately to detect that we coin at the right time. Maybe later.
I am integrating lookups for the serialization subcircuits. We will have tests when this is done.