### PR TITLE
Keccak bug fix: Include column for block index

### DIFF
--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -383,6 +383,8 @@ pub(crate) trait KeccakEnvironment {
 
     /// Returns the hash index as a variable
     fn hash_index(&self) -> Self::Variable;
+    /// Returns the block index as a variable
+    fn block_index(&self) -> Self::Variable;
     /// Returns the step index as a variable
     fn step_index(&self) -> Self::Variable;
 
@@ -712,6 +714,9 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
 
     fn hash_index(&self) -> Self::Variable {
         self.variable(KeccakColumn::HashIndex)
+    }
+    fn block_index(&self) -> Self::Variable {
+        self.variable(KeccakColumn::BlockIndex)
     }
     fn step_index(&self) -> Self::Variable {
         self.variable(KeccakColumn::StepIndex)

--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -110,7 +110,8 @@ impl<Fp: Field> KeccakLookups for KeccakEnv<Fp> {
                 LookupTableIDs::SyscallLookup,
                 vec![
                     self.hash_index(),
-                    Self::constant(self.block_idx * RATE_IN_BYTES as u64 + i as u64),
+                    self.block_index() * Self::constant(RATE_IN_BYTES as u64)
+                        + Self::constant(i as u64),
                     self.sponge_byte(i),
                 ],
             ));

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -142,6 +142,7 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
         // Compute witness values
         let ini_idx = RATE_IN_BYTES * self.block_idx as usize;
         let mut block = self.padded[ini_idx..ini_idx + RATE_IN_BYTES].to_vec();
+        self.write_column(KeccakColumn::BlockIndex, self.block_idx);
 
         // Pad with zeros
         block.append(&mut vec![0; CAPACITY_IN_BYTES]);

--- a/optimism/src/proof.rs
+++ b/optimism/src/proof.rs
@@ -400,7 +400,7 @@ mod tests {
         srs.full_srs.add_lagrange_basis(domain.d1);
 
         let proof: Proof<
-            2074,
+            ZKVM_KECCAK_COLS,
             ark_ec::short_weierstrass_jacobian::GroupAffine<ark_bn254::g1::Parameters>,
             PairingProof<ark_ec::bn::Bn<ark_bn254::Parameters>>,
         > = prove::<ZKVM_KECCAK_COLS, _, PairingProof<BN254Parameters>, BaseSponge, ScalarSponge>(


### PR DESCRIPTION
I realized that the syscalls lookups in the Keccak side were using a value that was being stored as part of the environment but did not have a corresponding column for the block index (used to give a byte index for each byte read from the preimage). Then, this PR adds the alias for the block index, increases by 1 the witness columns width, adds a function to access that variable, and updates the witness code to initialize this value in absorb steps.