### PR TITLE
Keccak bug fix: move root flag into mode flags

### DIFF
--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -21,11 +21,12 @@ pub const ZKVM_KECCAK_COLS: usize =
 // The number of columns used by the Keccak circuit to represent the status flags.
 const STATUS_FLAGS_LEN: usize = 3;
 // The number of columns used by the Keccak circuit to represent the mode flags.
-const MODE_FLAGS_COLS_LEN: usize = 3;
+const MODE_FLAGS_COLS_LEN: usize = 4;
 
 const FLAG_ROUND_OFF: usize = 0; // Offset of the FlagRound column inside the mode flags
 const FLAG_ABSORB_OFF: usize = 1; // Offset of the FlagAbsorb column inside the mode flags
 const FLAG_SQUEEZE_OFF: usize = 2; // Offset of the FlagSqueeze column inside the mode flags
+const FLAG_ROOT_OFF: usize = 3; // Offset of the FlagRoot column inside the mode flags
 
 // The round constants are located after the witness columns used by the Keccak round.
 const ROUND_COEFFS_OFF: usize = KECCAK_COLS;
@@ -34,12 +35,10 @@ pub(crate) const ROUND_COEFFS_LEN: usize = QUARTERS;
 
 // The following elements do not increase the total column count
 // because they only appear in sponge rows, which only have 800 curr columns used.
-const SPONGE_COEFFS_OFF: usize = 800; // The sponge coefficients start after the sponge columns
-const FLAG_ROOT_OFF: usize = SPONGE_COEFFS_OFF; // Offset of the FlagRoot column inside the sponge coefficients
-const PAD_LEN_OFF: usize = 801; // Offset of the PadLength column inside the sponge coefficients
-const PAD_INV_OFF: usize = 802; // Offset of the InvPadLength column inside the sponge coefficients
-const PAD_TWO_OFF: usize = 803; // Offset of the TwoToPad column inside the sponge coefficients
-const PAD_BYTES_OFF: usize = 804; // Offset of the PadBytesFlags inside the sponge coefficients
+const PAD_LEN_OFF: usize = 800; // Offset of the PadLength column inside the sponge coefficients
+const PAD_INV_OFF: usize = 801; // Offset of the InvPadLength column inside the sponge coefficients
+const PAD_TWO_OFF: usize = 802; // Offset of the TwoToPad column inside the sponge coefficients
+const PAD_BYTES_OFF: usize = 803; // Offset of the PadBytesFlags inside the sponge coefficients
 pub(crate) const PAD_BYTES_LEN: usize = RATE_IN_BYTES; // The maximum number of padding bytes involved
 const PAD_SUFFIX_OFF: usize = PAD_BYTES_OFF + RATE_IN_BYTES; // Offset of the PadSuffix column inside the sponge coefficients
 pub(crate) const PAD_SUFFIX_LEN: usize = 5; // The padding suffix of 1088 bits is stored as 5 field elements: 1x12 + 4x31 bytes
@@ -190,7 +189,7 @@ impl<T: Clone> Index<Column> for KeccakWitness<T> {
             Column::FlagRound => &self.mode_flags()[FLAG_ROUND_OFF],
             Column::FlagAbsorb => &self.mode_flags()[FLAG_ABSORB_OFF],
             Column::FlagSqueeze => &self.mode_flags()[FLAG_SQUEEZE_OFF],
-            Column::FlagRoot => &self.curr()[FLAG_ROOT_OFF],
+            Column::FlagRoot => &self.mode_flags()[FLAG_ROOT_OFF],
             Column::PadLength => &self.curr()[PAD_LEN_OFF],
             Column::InvPadLength => &self.curr()[PAD_INV_OFF],
             Column::TwoToPad => &self.curr()[PAD_TWO_OFF],
@@ -229,7 +228,7 @@ impl<T: Clone> IndexMut<Column> for KeccakWitness<T> {
             Column::FlagRound => &mut self.mode_flags_mut()[FLAG_ROUND_OFF],
             Column::FlagAbsorb => &mut self.mode_flags_mut()[FLAG_ABSORB_OFF],
             Column::FlagSqueeze => &mut self.mode_flags_mut()[FLAG_SQUEEZE_OFF],
-            Column::FlagRoot => &mut self.curr_mut()[FLAG_ROOT_OFF],
+            Column::FlagRoot => &mut self.mode_flags_mut()[FLAG_ROOT_OFF],
             Column::PadLength => &mut self.curr_mut()[PAD_LEN_OFF],
             Column::InvPadLength => &mut self.curr_mut()[PAD_INV_OFF],
             Column::TwoToPad => &mut self.curr_mut()[PAD_TWO_OFF],


### PR DESCRIPTION
I realized that the optimization about moving sponge-related flags into shared column positions (starting on column 800) is not fully correct. Even if that seemed to reduce the number of total witness columns, because they are not supposed to be used in round steps, booleanity constraints would need to increase their degree by 1 or 2 so that they are only run when it is a sponge. Thus, because quadricization would increase the columns regardless, by a higher amount, I decided to revert that optimization for the sake of completeness and less complex constraints.

A similar PR is coming moving the rest of padding flags into the mode flags as well.