### PR TITLE
Keccak bug fix: move padding flags out from sponge columns

### DIFF
--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -138,7 +138,7 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
             }
             // Check that the padding is located at the end of the message
             let pad_at_end = (0..RATE_IN_BYTES).fold(Self::zero(), |acc, i| {
-                acc * Self::two() + self.sponge_byte(i)
+                acc * Self::two() + self.in_padding(i)
             });
             self.constrain(self.is_pad() * (self.two_to_pad() - Self::one() - pad_at_end));
             // Check that the padding value is correct

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -479,10 +479,7 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
     }
 
     fn is_pad(&self) -> Self::Variable {
-        Self::not(Self::is_nonzero(
-            self.pad_length(),
-            self.variable(KeccakColumn::InvPadLength),
-        ))
+        self.pad_length() * self.variable(KeccakColumn::InvPadLength)
     }
 
     fn is_round(&self) -> Self::Variable {

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -534,7 +534,7 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
             .iter()
             .zip(flags)
             .fold(Self::zero(), |acc, (byte, flag)| {
-                acc + byte.clone() * flag.clone() * Self::two_pow(8)
+                acc * Self::two_pow(8) + byte.clone() * flag.clone()
             });
 
         pad

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -1,6 +1,7 @@
+use ark_ff::Field;
 use kimchi::circuits::{
     expr::{ConstantExpr, Expr},
-    polynomials::keccak::constants::{DIM, KECCAK_COLS, QUARTERS, STATE_LEN},
+    polynomials::keccak::constants::{DIM, KECCAK_COLS, QUARTERS, RATE_IN_BYTES, STATE_LEN},
 };
 
 use self::column::Column as KeccakColumn;
@@ -37,6 +38,34 @@ fn grid_index(length: usize, i: usize, y: usize, x: usize, q: usize) -> usize {
         400 => q + QUARTERS * (x + DIM * (y + DIM * i)),
         _ => panic!("Invalid grid size"),
     }
+}
+
+/// This function returns a vector of field elements that represent the 5 padding suffixes.
+/// The first one uses at most 12 bytes, and the rest use at most 31 bytes.
+pub fn pad_blocks<F: Field>(pad_bytelength: usize) -> Vec<F> {
+    assert!(pad_bytelength > 0, "Padding length must be at least 1 byte");
+    assert!(
+        pad_bytelength <= 136,
+        "Padding length must be at most 136 bytes",
+    );
+    // Blocks to store padding. The first one uses at most 12 bytes, and the rest use at most 31 bytes.
+    let mut blocks = vec![F::zero(); 5];
+    let mut pad = [F::zero(); RATE_IN_BYTES];
+    pad[RATE_IN_BYTES - pad_bytelength] = F::one();
+    pad[RATE_IN_BYTES - 1] += F::from(0x80u8);
+    blocks[0] = pad
+        .iter()
+        .take(12)
+        .fold(F::zero(), |acc, x| acc * F::from(256u32) + *x);
+    for (i, block) in blocks.iter_mut().enumerate().take(5).skip(1) {
+        // take 31 elements from pad, starting at 12 + (i - 1) * 31 and fold them into a single Fp
+        *block = pad
+            .iter()
+            .skip(12 + (i - 1) * 31)
+            .take(31)
+            .fold(F::zero(), |acc, x| acc * F::from(256u32) + *x);
+    }
+    blocks
 }
 
 /// This trait defines common boolean operations used in the Keccak circuit

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -13,13 +13,16 @@ use crate::keccak::{
     pad_blocks, KeccakColumn, DIM, HASH_BYTELENGTH, QUARTERS, WORDS_IN_HASH,
 };
 use ark_ff::Field;
-use kimchi::circuits::polynomials::keccak::{
-    constants::{
-        CAPACITY_IN_BYTES, PIRHO_SHIFTS_E_LEN, RATE_IN_BYTES, ROUNDS, SHIFTS, SHIFTS_LEN,
-        STATE_LEN, THETA_SHIFTS_C_LEN, THETA_STATE_A_LEN,
+use kimchi::{
+    circuits::polynomials::keccak::{
+        constants::{
+            CAPACITY_IN_BYTES, PIRHO_SHIFTS_E_LEN, RATE_IN_BYTES, ROUNDS, SHIFTS, SHIFTS_LEN,
+            STATE_LEN, THETA_SHIFTS_C_LEN, THETA_STATE_A_LEN,
+        },
+        witness::{Chi, Iota, PiRho, Theta},
+        Keccak,
     },
-    witness::{Chi, Iota, PiRho, Theta},
-    Keccak,
+    o1_utils::Two,
 };
 
 impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
@@ -50,6 +53,7 @@ impl<Fp: Field> KeccakInterpreter for KeccakEnv<Fp> {
             KeccakColumn::InvPadLength,
             Fp::inverse(&Fp::from(self.pad_len)).unwrap(),
         );
+        self.write_column_field(KeccakColumn::TwoToPad, Fp::two_pow(self.pad_len));
         let pad_range = RATE_IN_BYTES - self.pad_len as usize..RATE_IN_BYTES;
         for i in pad_range {
             self.write_column(KeccakColumn::PadBytesFlags(i), 1);

--- a/optimism/src/lookups.rs
+++ b/optimism/src/lookups.rs
@@ -1,6 +1,6 @@
 //! Instantiation of the lookups for the VM project.
 
-use crate::{keccak::witness::pad_blocks, ramlookup::RAMLookup};
+use crate::{keccak::pad_blocks, ramlookup::RAMLookup};
 use ark_ff::Field;
 use kimchi::{
     circuits::polynomials::keccak::{


### PR DESCRIPTION
Related to https://github.com/o1-labs/proof-systems/pull/1938, this PR fixes some constraints bugs due to having the padding flags in shared columns in sponge steps. Again, this could have been fixed otherwise by increasing the degree of the constraints by adding the `is_sponge` selector. But it is not worth it given that quadricization would have to increase the column width regardless.

This PR also includes other fixes in definitions of `pad_at_end` and `padding_blocks`. I had also forgotten about instantiating the inverse length column inside the witness.