### PR TITLE
[easy] Create witness environment for Keccak

### DIFF
--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -11,7 +11,7 @@ pub mod constraints;
 pub mod environment;
 pub mod interpreter;
 pub mod lookups;
-//pub mod witness;
+pub mod witness;
 
 /// Desired output length of the hash in bits
 pub(crate) const HASH_BITLENGTH: usize = 256;

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -6,9 +6,25 @@
 //!
 //! For a pseudo code implementation of Keccap-f, see
 //! https://keccak.team/keccak_specs_summary.html
-use crate::{
-    keccak::{column::KeccakWitness, interpreter::KeccakInterpreter, KeccakColumn},
-    lookups::Lookup,
-};
+use crate::keccak::column::KeccakWitness;
 use ark_ff::Field;
-use kimchi::o1_utils::Two;
+
+/// This struct contains all that needs to be kept track of during the execution of the Keccak step interpreter
+#[derive(Clone, Debug)]
+pub struct Env<Fp> {
+    /// The full state of the Keccak gate (witness)
+    pub witness: KeccakWitness<Fp>,
+    // The multiplicities of each lookup table
+    // TODO
+    /// A counter of constraints to help with debugging, starts with 1
+    pub(crate) check_idx: usize,
+}
+
+impl<F: Field> Default for Env<F> {
+    fn default() -> Self {
+        Self {
+            witness: KeccakWitness::default(),
+            check_idx: 0,
+        }
+    }
+}

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -5,7 +5,7 @@
 //! to avoid code duplication and reduce error-proneness.
 //!
 //! For a pseudo code implementation of Keccap-f, see
-//! https://keccak.team/keccak_specs_summary.html
+//! <https://keccak.team/keccak_specs_summary.html>
 use crate::keccak::column::KeccakWitness;
 use ark_ff::Field;
 

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -118,7 +118,8 @@ pub fn main() -> ExitCode {
             // Update the witness with the Keccak step columns before resetting the environment
             // TODO: simplify the contents of the KeccakWitness or create an iterator for it
             for (env_wit, pre_fold_wit) in keccak_env
-                .keccak_witness
+                .witness_env
+                .witness
                 .cols
                 .iter()
                 .zip(keccak_current_pre_folding_witness.cols.iter_mut())


### PR DESCRIPTION
This PR introduces the notion of a witness environment, which will substitute the plain witness that was being stored inside `KeccakEnv`. It provides some basic creation functions for it and renames the contents of the struct accordingly. More PRs will build on top of this change. A similar PR will come afterwards, referring to a constraints environment instead.