### PR TITLE
Move `ArithOps` inside the interpreter trait

### DIFF
--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -3,19 +3,21 @@ use crate::{
     keccak::{
         column::PAD_SUFFIX_LEN,
         environment::{KeccakEnv, KeccakEnvironment},
-        ArithOps, BoolOps, KeccakColumn, E, WORDS_IN_HASH,
+        BoolOps, KeccakColumn, E, WORDS_IN_HASH,
     },
     lookups::{Lookup, Lookups},
 };
 use ark_ff::Field;
 use kimchi::circuits::{
-    expr::{Expr, ExprInner, Variable},
+    expr::{ConstantTerm::Literal, Expr, ExprInner, Operations, Variable},
     gate::CurrOrNext,
     polynomials::keccak::{
         constants::{DIM, QUARTERS, RATE_IN_BYTES},
         OFF,
     },
 };
+
+use super::interpreter::KeccakInterpreter;
 
 /// This struct contains all that needs to be kept track of during the execution of the Keccak step interpreter
 #[derive(Clone, Debug)]
@@ -32,6 +34,26 @@ impl<F: Field> Default for Env<F> {
             constraints: Vec::new(),
             lookups: Vec::new(),
         }
+    }
+}
+
+impl<F> KeccakInterpreter<F> for Env<F> {
+    type Variable = E<F>;
+
+    ///////////////////////////
+    // ARITHMETIC OPERATIONS //
+    ///////////////////////////
+
+    fn constant(x: u64) -> Self::Variable {
+        Self::constant_field(F::from(x))
+    }
+
+    fn constant_field(x: F) -> Self::Variable {
+        Self::Variable::constant(Operations::from(Literal(x)))
+    }
+
+    fn two_pow(x: u64) -> Self::Variable {
+        Self::constant_field(F::two_pow(x))
     }
 }
 

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -1,20 +1,9 @@
 //! This module contains the constraints for one Keccak step.
-use crate::{
-    keccak::{
-        column::PAD_SUFFIX_LEN,
-        environment::{KeccakEnv, KeccakEnvironment},
-        BoolOps, KeccakColumn, E, WORDS_IN_HASH,
-    },
-    lookups::{Lookup, Lookups},
-};
+use crate::{keccak::E, lookups::Lookup};
 use ark_ff::Field;
-use kimchi::circuits::{
-    expr::{ConstantTerm::Literal, Expr, ExprInner, Operations, Variable},
-    gate::CurrOrNext,
-    polynomials::keccak::{
-        constants::{DIM, QUARTERS, RATE_IN_BYTES},
-        OFF,
-    },
+use kimchi::{
+    circuits::expr::{ConstantTerm::Literal, Operations},
+    o1_utils::Two,
 };
 
 use super::interpreter::KeccakInterpreter;
@@ -37,7 +26,7 @@ impl<F: Field> Default for Env<F> {
     }
 }
 
-impl<F> KeccakInterpreter<F> for Env<F> {
+impl<F: Field> KeccakInterpreter<F> for Env<F> {
     type Variable = E<F>;
 
     ///////////////////////////
@@ -57,6 +46,7 @@ impl<F> KeccakInterpreter<F> for Env<F> {
     }
 }
 
+/*
 /// This trait contains the constraints for one Keccak step.
 pub trait Constraints {
     type Column;
@@ -322,3 +312,5 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
         self.lookups();
     }
 }
+
+*/

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -476,30 +476,6 @@ impl<Fp: Field> BoolOps for KeccakEnv<Fp> {
     }
 }
 
-impl<Fp: Field> ArithOps for KeccakEnv<Fp> {
-    type Column = KeccakColumn;
-    type Variable = E<Fp>;
-    type Fp = Fp;
-    fn constant(x: u64) -> Self::Variable {
-        Self::constant_field(Self::Fp::from(x))
-    }
-    fn constant_field(x: Self::Fp) -> Self::Variable {
-        Self::Variable::constant(Operations::from(Literal(x)))
-    }
-    fn zero() -> Self::Variable {
-        Self::constant(0)
-    }
-    fn one() -> Self::Variable {
-        Self::constant(1)
-    }
-    fn two() -> Self::Variable {
-        Self::constant(2)
-    }
-    fn two_pow(x: u64) -> Self::Variable {
-        Self::constant_field(Self::Fp::two_pow(x))
-    }
-}
-
 /// This trait includes functionalities needed to obtain the variables of the Keccak circuit needed for constraints
 pub(crate) trait KeccakEnvironment {
     type Column;

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -476,6 +476,30 @@ impl<Fp: Field> BoolOps for KeccakEnv<Fp> {
     }
 }
 
+impl<Fp: Field> ArithOps for KeccakEnv<Fp> {
+    type Column = KeccakColumn;
+    type Variable = E<Fp>;
+    type Fp = Fp;
+    fn constant(x: u64) -> Self::Variable {
+        Self::constant_field(Self::Fp::from(x))
+    }
+    fn constant_field(x: Self::Fp) -> Self::Variable {
+        Self::Variable::constant(Operations::from(Literal(x)))
+    }
+    fn zero() -> Self::Variable {
+        Self::constant(0)
+    }
+    fn one() -> Self::Variable {
+        Self::constant(1)
+    }
+    fn two() -> Self::Variable {
+        Self::constant(2)
+    }
+    fn two_pow(x: u64) -> Self::Variable {
+        Self::constant_field(Self::Fp::two_pow(x))
+    }
+}
+
 /// This trait includes functionalities needed to obtain the variables of the Keccak circuit needed for constraints
 pub(crate) trait KeccakEnvironment {
     type Column;

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -6,7 +6,7 @@ use crate::keccak::{
     constraints::{Constraints, Env as ConstraintsEnv},
     grid_index, pad_blocks,
     witness::Env as WitnessEnv,
-    ArithOps, BoolOps, KeccakColumn, DIM, E, HASH_BYTELENGTH, QUARTERS, WORDS_IN_HASH,
+    BoolOps, KeccakColumn, DIM, E, HASH_BYTELENGTH, QUARTERS, WORDS_IN_HASH,
 };
 use ark_ff::{Field, One};
 use kimchi::{

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -2,27 +2,18 @@
 //! including the common functions between the witness and the constraints environments
 //! for arithmetic, boolean, and column operations.
 use crate::keccak::{
-    column::{KeccakWitness, PAD_BYTES_LEN, ROUND_COEFFS_LEN},
-    constraints::{Constraints, Env as ConstraintsEnv},
-    grid_index, pad_blocks,
-    witness::Env as WitnessEnv,
-    BoolOps, KeccakColumn, DIM, E, HASH_BYTELENGTH, QUARTERS, WORDS_IN_HASH,
+    column::KeccakWitness, constraints::Env as ConstraintsEnv, grid_index, pad_blocks,
+    witness::Env as WitnessEnv, KeccakColumn, DIM, HASH_BYTELENGTH, QUARTERS, WORDS_IN_HASH,
 };
-use ark_ff::{Field, One};
+use ark_ff::Field;
 use kimchi::{
-    auto_clone_array,
-    circuits::{
-        expr::{ConstantTerm::Literal, Operations},
-        polynomials::keccak::{
-            constants::*,
-            witness::{Chi, Iota, PiRho, Theta},
-            Keccak,
-        },
+    circuits::polynomials::keccak::{
+        constants::*,
+        witness::{Chi, Iota, PiRho, Theta},
+        Keccak,
     },
-    grid,
     o1_utils::Two,
 };
-use std::array;
 
 /// This struct contains all that needs to be kept track of during the execution of the Keccak step interpreter
 #[derive(Clone, Debug)]
@@ -441,7 +432,7 @@ impl<F: Field> KeccakEnv<F> {
         state_g
     }
 }
-
+/*
 impl<Fp: Field> BoolOps for KeccakEnv<Fp> {
     type Column = KeccakColumn;
     type Variable = E<Fp>;
@@ -1021,3 +1012,5 @@ impl<Fp: Field> KeccakEnvironment for KeccakEnv<Fp> {
         output_of_step
     }
 }
+
+*/

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -12,4 +12,30 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
         + Debug
         + One
         + Zero;
+
+    //////////////////////////
+    // ARITHMETIC OPERATIONS //
+    ///////////////////////////
+
+    /// Creates a variable from a constant integer
+    fn constant(x: u64) -> Self::Variable;
+
+    /// Creates a variable from a constant field element
+    fn constant_field(x: F) -> Self::Variable;
+
+    /// Returns a variable representing the value zero
+    fn zero() -> Self::Variable {
+        Self::constant(0)
+    }
+    /// Returns a variable representing the value one
+    fn one() -> Self::Variable {
+        Self::constant(1)
+    }
+    /// Returns a variable representing the value two
+    fn two() -> Self::Variable {
+        Self::constant(2)
+    }
+
+    /// Returns a variable representing the value 2^x
+    fn two_pow(x: u64) -> Self::Variable;
 }

--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -2,7 +2,7 @@
 use crate::{
     keccak::{
         environment::{KeccakEnv, KeccakEnvironment},
-        ArithOps, BoolOps, KeccakColumn, E,
+        BoolOps, KeccakColumn, E,
     },
     lookups::{Lookup, LookupTableIDs, Lookups},
 };

--- a/optimism/src/keccak/lookups.rs
+++ b/optimism/src/keccak/lookups.rs
@@ -1,9 +1,7 @@
 //! This module includes the lookups of the Keccak circuit
+/*
 use crate::{
-    keccak::{
-        environment::{KeccakEnv, KeccakEnvironment},
-        BoolOps, KeccakColumn, E,
-    },
+    keccak::{environment::KeccakEnv, BoolOps, KeccakColumn, E},
     lookups::{Lookup, LookupTableIDs, Lookups},
 };
 use ark_ff::Field;
@@ -287,3 +285,4 @@ impl<Fp: Field> KeccakLookups for KeccakEnv<Fp> {
         ));
     }
 }
+*/

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -101,28 +101,3 @@ pub(crate) trait BoolOps {
     /// Degree-2 variable encoding whether at least one of the two inputs is zero (0 = yes)
     fn either_zero(x: Self::Variable, y: Self::Variable) -> Self::Variable;
 }
-
-/// This trait defines common arithmetic operations used in the Keccak circuit
-pub(crate) trait ArithOps {
-    type Column;
-    type Variable: std::ops::Mul<Self::Variable, Output = Self::Variable>
-        + std::ops::Add<Self::Variable, Output = Self::Variable>
-        + std::ops::Sub<Self::Variable, Output = Self::Variable>
-        + Clone;
-    type Fp: std::ops::Neg<Output = Self::Fp>;
-
-    /// Creates a variable from a constant integer
-    fn constant(x: u64) -> Self::Variable;
-    /// Creates a variable from a constant field element
-    fn constant_field(x: Self::Fp) -> Self::Variable;
-
-    /// Returns a variable representing the value zero
-    fn zero() -> Self::Variable;
-    /// Returns a variable representing the value one
-    fn one() -> Self::Variable;
-    /// Returns a variable representing the value two
-    fn two() -> Self::Variable;
-
-    /// Returns a variable representing the value 2^x
-    fn two_pow(x: u64) -> Self::Variable;
-}

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -6,8 +6,9 @@
 //!
 //! For a pseudo code implementation of Keccap-f, see
 //! <https://keccak.team/keccak_specs_summary.html>
-use crate::keccak::column::KeccakWitness;
+use crate::keccak::{column::KeccakWitness, interpreter::KeccakInterpreter};
 use ark_ff::Field;
+use kimchi::o1_utils::Two;
 
 /// This struct contains all that needs to be kept track of during the execution of the Keccak step interpreter
 #[derive(Clone, Debug)]
@@ -26,5 +27,24 @@ impl<F: Field> Default for Env<F> {
             witness: KeccakWitness::default(),
             check_idx: 0,
         }
+    }
+}
+
+impl<F: Field> KeccakInterpreter<F> for Env<F> {
+    type Variable = F;
+    ///////////////////////////
+    // ARITHMETIC OPERATIONS //
+    ///////////////////////////
+
+    fn constant(x: u64) -> Self::Variable {
+        Self::constant_field(F::from(x))
+    }
+
+    fn constant_field(x: F) -> Self::Variable {
+        x
+    }
+
+    fn two_pow(x: u64) -> Self::Variable {
+        Self::constant_field(F::two_pow(x))
     }
 }


### PR DESCRIPTION
This PR inlines `ArithOps` inside `KeccakInterpreter` and implements it for both the constraints and the witness environments. It also comments out a lot of the code so that it compiles, because at this point the functions are still not completely moved into the right traits.