### PR TITLE
Move `BoolOps` inside the Keccak interpreter

### DIFF
--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -433,39 +433,6 @@ impl<F: Field> KeccakEnv<F> {
     }
 }
 /*
-impl<Fp: Field> BoolOps for KeccakEnv<Fp> {
-    type Column = KeccakColumn;
-    type Variable = E<Fp>;
-    type Fp = Fp;
-
-    fn is_boolean(x: Self::Variable) -> Self::Variable {
-        x.clone() * (x - Self::Variable::one())
-    }
-
-    fn not(x: Self::Variable) -> Self::Variable {
-        Self::Variable::one() - x
-    }
-
-    fn is_one(x: Self::Variable) -> Self::Variable {
-        Self::not(x)
-    }
-
-    fn is_nonzero(x: Self::Variable, x_inv: Self::Variable) -> Self::Variable {
-        Self::is_one(x * x_inv)
-    }
-
-    fn xor(x: Self::Variable, y: Self::Variable) -> Self::Variable {
-        x.clone() + y.clone() - Self::constant(2) * x * y
-    }
-
-    fn or(x: Self::Variable, y: Self::Variable) -> Self::Variable {
-        x.clone() + y.clone() - x * y
-    }
-
-    fn either_zero(x: Self::Variable, y: Self::Variable) -> Self::Variable {
-        x * y
-    }
-}
 
 /// This trait includes functionalities needed to obtain the variables of the Keccak circuit needed for constraints
 pub(crate) trait KeccakEnvironment {

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -13,6 +13,48 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
         + One
         + Zero;
 
+    ////////////////////////
+    // BOOLEAN OPERATIONS //
+    ////////////////////////
+
+    /// Degree-2 variable encoding whether the input is a boolean value (0 = yes)
+    fn is_boolean(x: Self::Variable) -> Self::Variable {
+        x.clone() * (x - Self::Variable::one())
+    }
+
+    /// Degree-1 variable encoding the negation of the input
+    /// Note: it only works as expected if the input is a boolean value
+    fn not(x: Self::Variable) -> Self::Variable {
+        Self::Variable::one() - x
+    }
+
+    /// Degree-1 variable encoding whether the input is the value one (0 = yes)
+    fn is_one(x: Self::Variable) -> Self::Variable {
+        Self::not(x)
+    }
+
+    /// Degree-2 variable encoding whether the first input is nonzero (0 = yes).
+    /// It requires the second input to be the multiplicative inverse of the first.
+    /// Note: if the first input is zero, there is no multiplicative inverse.
+    fn is_nonzero(x: Self::Variable, x_inv: Self::Variable) -> Self::Variable {
+        Self::is_one(x * x_inv)
+    }
+
+    /// Degree-1 variable encoding the XOR of two variables which should be boolean (1 = true)
+    fn xor(x: Self::Variable, y: Self::Variable) -> Self::Variable {
+        x.clone() + y.clone() - Self::constant(2) * x * y
+    }
+
+    /// Degree-1 variable encoding the OR of two variables, which should be boolean (1 = true)
+    fn or(x: Self::Variable, y: Self::Variable) -> Self::Variable {
+        x.clone() + y.clone() - x * y
+    }
+
+    /// Degree-2 variable encoding whether at least one of the two inputs is zero (0 = yes)
+    fn either_zero(x: Self::Variable, y: Self::Variable) -> Self::Variable {
+        x * y
+    }
+
     //////////////////////////
     // ARITHMETIC OPERATIONS //
     ///////////////////////////

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -67,37 +67,3 @@ pub fn pad_blocks<F: Field>(pad_bytelength: usize) -> Vec<F> {
     }
     blocks
 }
-
-/// This trait defines common boolean operations used in the Keccak circuit
-pub(crate) trait BoolOps {
-    type Column;
-    type Variable: std::ops::Mul<Self::Variable, Output = Self::Variable>
-        + std::ops::Add<Self::Variable, Output = Self::Variable>
-        + std::ops::Sub<Self::Variable, Output = Self::Variable>
-        + Clone;
-    type Fp: std::ops::Neg<Output = Self::Fp>;
-
-    /// Degree-2 variable encoding whether the input is a boolean value (0 = yes)
-    fn is_boolean(x: Self::Variable) -> Self::Variable;
-
-    /// Degree-1 variable encoding the negation of the input
-    /// Note: it only works as expected if the input is a boolean value
-    fn not(x: Self::Variable) -> Self::Variable;
-
-    /// Degree-1 variable encoding whether the input is the value one (0 = yes)
-    fn is_one(x: Self::Variable) -> Self::Variable;
-
-    /// Degree-2 variable encoding whether the first input is nonzero (0 = yes).
-    /// It requires the second input to be the multiplicative inverse of the first.
-    /// Note: if the first input is zero, there is no multiplicative inverse.
-    fn is_nonzero(x: Self::Variable, x_inv: Self::Variable) -> Self::Variable;
-
-    /// Degree-1 variable encoding the XOR of two variables which should be boolean (1 = true)
-    fn xor(x: Self::Variable, y: Self::Variable) -> Self::Variable;
-
-    /// Degree-1 variable encoding the OR of two variables, which should be boolean (1 = true)
-    fn or(x: Self::Variable, y: Self::Variable) -> Self::Variable;
-
-    /// Degree-2 variable encoding whether at least one of the two inputs is zero (0 = yes)
-    fn either_zero(x: Self::Variable, y: Self::Variable) -> Self::Variable;
-}


### PR DESCRIPTION
Boolean counterpart of https://github.com/o1-labs/proof-systems/pull/1950. Because the implementation is not different for witness and constraints, it can be generically described inside the trait description itself.