### PR TITLE
Move variable-related functions inside the interpreter

### DIFF
--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -79,12 +79,6 @@ pub trait Constraints {
         + Clone;
     type Fp: std::ops::Neg<Output = Self::Fp>;
 
-    /// Returns the variable corresponding to a given column alias.
-    fn variable(&self, column: Self::Column) -> Self::Variable;
-
-    /// Adds one constraint to the environment.
-    fn constrain(&mut self, x: Self::Variable);
-
     /// Adds all 887 constraints to the environment and triggers read lookups:
     /// - 143 constraints of degree 1
     /// - 739 constraints of degree 2
@@ -96,19 +90,6 @@ impl<Fp: Field> Constraints for KeccakEnv<Fp> {
     type Column = KeccakColumn;
     type Variable = E<Fp>;
     type Fp = Fp;
-
-    fn variable(&self, column: Self::Column) -> Self::Variable {
-        // Despite `KeccakWitness` containing both `curr` and `next` fields,
-        // the Keccak step spans across one row only.
-        Expr::Atom(ExprInner::Cell(Variable {
-            col: column,
-            row: CurrOrNext::Curr,
-        }))
-    }
-
-    fn constrain(&mut self, x: Self::Variable) {
-        self.constraints_env.constraints.push(x);
-    }
 
     fn constraints(&mut self) {
         // CORRECTNESS OF FLAGS: 144 CONSTRAINTS

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -1,5 +1,6 @@
 //! This module defines the Keccak interpreter in charge of triggering the Keccak workflow
 
+use crate::keccak::KeccakColumn;
 use ark_ff::{One, Zero};
 use std::fmt::Debug;
 
@@ -80,4 +81,14 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
 
     /// Returns a variable representing the value 2^x
     fn two_pow(x: u64) -> Self::Variable;
+
+    ////////////////////////////
+    // CONSTRAINTS OPERATIONS //
+    ////////////////////////////
+
+    /// Returns the variable corresponding to a given column alias.
+    fn variable(&self, column: KeccakColumn) -> Self::Variable;
+
+    /// Adds one constraint to the environment.
+    fn constrain(&mut self, x: Self::Variable);
 }

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -6,7 +6,7 @@
 //!
 //! For a pseudo code implementation of Keccap-f, see
 //! <https://keccak.team/keccak_specs_summary.html>
-use crate::keccak::{column::KeccakWitness, interpreter::KeccakInterpreter};
+use crate::keccak::{column::KeccakWitness, interpreter::KeccakInterpreter, KeccakColumn};
 use ark_ff::Field;
 use kimchi::o1_utils::Two;
 
@@ -46,5 +46,24 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
 
     fn two_pow(x: u64) -> Self::Variable {
         Self::constant_field(F::two_pow(x))
+    }
+
+    ////////////////////////////
+    // CONSTRAINTS OPERATIONS //
+    ////////////////////////////
+
+    fn variable(&self, column: KeccakColumn) -> Self::Variable {
+        self.witness[column]
+    }
+
+    /// Assert that the input is zero
+    fn constrain(&mut self, x: Self::Variable) {
+        self.check_idx += 1;
+        assert_eq!(
+            x,
+            F::zero(),
+            "Keccak witness failed at constraint index {}",
+            self.check_idx
+        );
     }
 }


### PR DESCRIPTION
Note that here `variable` and `constrain` are defined differently for witness and constraints environments.