### PR TITLE
[easy] Add tests for zkVM Keccak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.11.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ded684142010808eb980d9974ef794da2bcf97d13396143b1515e9f0fb4a10e"
+dependencies = [
+ "crypto-common 0.2.0-pre.5",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +663,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e3352a27098ba6b09546e5f13b15165e6a88b5c2723afecb3ea9576b27e3ea"
+
+[[package]]
 name = "const-random"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +808,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7aa2ec04f5120b830272a481e8d9d8ba4dda140d2cda59b0f1110d5eb93c38e"
+dependencies = [
+ "getrandom",
+ "hybrid-array",
+ "rand_core",
+]
+
+[[package]]
 name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,9 +936,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065d93ead7c220b85d5b4be4795d8398eac4ff68b5ee63895de0a3c1fb6edf25"
+dependencies = [
+ "block-buffer 0.11.0-pre.5",
+ "const-oid",
+ "crypto-common 0.2.0-pre.5",
 ]
 
 [[package]]
@@ -1193,6 +1230,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "hybrid-array"
+version = "0.2.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c2311a0adecbffff284aabcf1249b1485193b16e685f9ef171b1ba82979cff"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "iai"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +1385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1522,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 3.6.0",
+ "sha3",
  "strum",
  "strum_macros",
 ]
@@ -2555,6 +2611,16 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f32c02b9987a647a3d6af14c3e88df86594e4283050d9d8ee3a035df247785b9"
+dependencies = [
+ "digest 0.11.0-pre.8",
+ "keccak",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.79"
 serde_with = "3.6.0"
 sha2 = "0.10.0"
+sha3 = "0.11.0-pre.3"
 strum = "0.26.1"
 strum_macros = "0.26.1"
 syn = { version = "1.0.109", features = ["full"] }

--- a/optimism/Cargo.toml
+++ b/optimism/Cargo.toml
@@ -46,3 +46,4 @@ os_pipe.workspace = true
 rand.workspace = true
 libc.workspace = true
 rayon.workspace = true
+sha3.workspace = true

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -10,6 +10,8 @@ pub mod column;
 pub mod constraints;
 pub mod environment;
 pub mod interpreter;
+#[cfg(test)]
+pub mod tests;
 pub mod witness;
 
 /// Desired output length of the hash in bits

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -1,0 +1,53 @@
+use crate::keccak::{environment::KeccakEnv, interpreter::KeccakInterpreter};
+use kimchi::o1_utils::{self, FieldHelpers};
+use mina_curves::pasta::Fp;
+use rand::Rng;
+use sha3::{Digest, Keccak256};
+
+#[test]
+fn test_pad_blocks() {
+    let blocks_1 = crate::keccak::pad_blocks::<Fp>(1);
+    assert_eq!(blocks_1[0], Fp::from(0x00));
+    assert_eq!(blocks_1[1], Fp::from(0x00));
+    assert_eq!(blocks_1[2], Fp::from(0x00));
+    assert_eq!(blocks_1[3], Fp::from(0x00));
+    assert_eq!(blocks_1[4], Fp::from(0x81));
+
+    let blocks_136 = crate::keccak::pad_blocks::<Fp>(136);
+    assert_eq!(blocks_136[0], Fp::from(0x010000000000000000000000u128));
+    assert_eq!(blocks_136[1], Fp::from(0x00));
+    assert_eq!(blocks_136[2], Fp::from(0x00));
+    assert_eq!(blocks_136[3], Fp::from(0x00));
+    assert_eq!(blocks_136[4], Fp::from(0x80));
+}
+
+#[test]
+fn test_keccak_witness_satisfies_constraints() {
+    let mut rng = o1_utils::tests::make_test_rng();
+
+    // Generate random bytelength and preimage for Keccak
+    let bytelength = rng.gen_range(1..1000);
+    let preimage: Vec<u8> = (0..bytelength).map(|_| rng.gen()).collect();
+    // Use an external library to compute the hash
+    let mut hasher = Keccak256::new();
+    hasher.update(&preimage);
+    let hash = hasher.finalize();
+
+    // Initialize the environment and run the interpreter
+    let mut keccak_env = KeccakEnv::<Fp>::new(0, &preimage);
+    while keccak_env.keccak_step.is_some() {
+        keccak_env.step();
+        // Simulate the constraints for each row (still checks nothing about lookups)
+        keccak_env.witness_env.constraints();
+    }
+    // Extract the hash from the witness
+    let output = keccak_env.witness_env.sponge_bytes()[0..32]
+        .iter()
+        .map(|byte| byte.to_bytes()[0])
+        .collect::<Vec<_>>();
+
+    // Check that the hash matches
+    for (i, byte) in output.iter().enumerate() {
+        assert_eq!(*byte, hash[i]);
+    }
+}


### PR DESCRIPTION
Includes two tests: one for the pad_blocks function and another one for the whole Keccak witness computation and checking of the constraints. This shows the potential of the refactor to make the interpreter generic over the variable type.