### PR TITLE
MSM: Add basic public input support

### DIFF
--- a/msm/src/ffa/columns.rs
+++ b/msm/src/ffa/columns.rs
@@ -5,6 +5,7 @@ use crate::N_LIMBS;
 
 /// Number of columns in the FFA circuits.
 pub const FFA_N_COLUMNS: usize = 5 * N_LIMBS;
+pub const FFA_NPUB_COLUMNS: usize = N_LIMBS;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 /// Column indexer for MSM columns.

--- a/msm/src/ffa/main.rs
+++ b/msm/src/ffa/main.rs
@@ -5,7 +5,7 @@ use poly_commitment::pairing_proof::PairingSRS;
 
 use kimchi_msm::columns::Column;
 use kimchi_msm::ffa::{
-    columns::FFA_N_COLUMNS,
+    columns::{FFA_NPUB_COLUMNS, FFA_N_COLUMNS},
     constraint::ConstraintBuilderEnv as FFAConstraintBuilderEnv,
     interpreter::{self as ffa_interpreter, FFAInterpreterEnv},
     witness::WitnessBuilderEnv as FFAWitnessBuilderEnv,
@@ -47,6 +47,7 @@ pub fn main() {
     }
 
     let inputs = witness_env.get_witness(domain_size);
+    let pub_inputs = inputs.evaluations.to_pub_columns::<FFA_NPUB_COLUMNS>();
     let constraints = constraint_env.constraints;
 
     println!("Generating the proof");
@@ -63,11 +64,13 @@ pub fn main() {
     .unwrap();
 
     println!("Verifying the proof");
-    let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, FFA_N_COLUMNS>(
-        domain,
-        &srs,
-        &constraints,
-        &proof,
-    );
+    let verifies = verify::<
+        _,
+        OpeningProof,
+        BaseSponge,
+        ScalarSponge,
+        FFA_N_COLUMNS,
+        FFA_NPUB_COLUMNS,
+    >(domain, &srs, &constraints, &proof, pub_inputs);
     println!("Proof verification result: {verifies}")
 }

--- a/msm/src/lib.rs
+++ b/msm/src/lib.rs
@@ -74,6 +74,7 @@ mod tests {
             witness::WitnessBuilderEnv as TestWitnessBuilderEnv,
         },
         verifier::verify,
+        witness::Witness,
         BaseSponge, Ff1, Fp, OpeningProof, ScalarSponge, BN254,
     };
     use ark_ff::UniformRand;
@@ -136,11 +137,12 @@ mod tests {
         .unwrap();
 
         // verify the proof
-        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, TEST_N_COLUMNS>(
+        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, TEST_N_COLUMNS, 0>(
             domain,
             &srs,
             &constraints,
             &proof,
+            Witness::zero_vec(domain_size),
         );
 
         assert!(verifies);
@@ -202,11 +204,12 @@ mod tests {
         {
             let mut proof_clone = proof.clone();
             proof_clone.opening_proof = proof_prime.opening_proof;
-            let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, TEST_N_COLUMNS>(
+            let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, TEST_N_COLUMNS, 0>(
                 domain,
                 &srs,
                 &constraints,
                 &proof_clone,
+                Witness::zero_vec(domain_size),
             );
             assert!(!verifies);
         }
@@ -217,11 +220,12 @@ mod tests {
         {
             let mut proof_clone = proof.clone();
             proof_clone.proof_comms = proof_prime.proof_comms;
-            let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, TEST_N_COLUMNS>(
+            let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, TEST_N_COLUMNS, 0>(
                 domain,
                 &srs,
                 &constraints,
                 &proof_clone,
+                Witness::zero_vec(domain_size),
             );
             assert!(!verifies);
         }
@@ -233,11 +237,12 @@ mod tests {
         {
             let mut proof_clone = proof.clone();
             proof_clone.proof_evals.witness_evals = proof_prime.proof_evals.witness_evals;
-            let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, TEST_N_COLUMNS>(
+            let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, TEST_N_COLUMNS, 0>(
                 domain,
                 &srs,
                 &constraints,
                 &proof_clone,
+                Witness::zero_vec(domain_size),
             );
             assert!(!verifies);
         }
@@ -280,11 +285,12 @@ mod tests {
                 &mut rng,
             )
             .unwrap();
-        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, N>(
+        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, N, 0>(
             domain,
             &srs,
             &constraints,
             &proof,
+            Witness::zero_vec(domain_size),
         );
         // FIXME: At the moment, it does verify. It should not. We are missing constraints.
         assert!(!verifies);

--- a/msm/src/proof.rs
+++ b/msm/src/proof.rs
@@ -20,6 +20,9 @@ pub struct ProofInputs<const N: usize, G: KimchiCurve, ID: LookupTableID + Send 
     /// evaluations of polynomial P_w that interpolates w_i.
     pub evaluations: Witness<N, Vec<G::ScalarField>>,
     pub mvlookups: Vec<MVLookupWitness<G::ScalarField, ID>>,
+    // TODO Unless we use ZK rows, this is unused by the prover, since
+    // public inputs are modelled as a prefix of the witness that is
+    // committed w/o blinders.
     /// The number of public inputs. It is supposed that the first
     /// `public_input_size` columns of the witness represent the public values
     pub public_input_size: usize,
@@ -47,11 +50,9 @@ impl<const N: usize, G: KimchiCurve> ProofInputs<N, G, LookupTableIDs> {
 
 #[derive(Debug, Clone)]
 pub struct ProofEvaluations<const N: usize, F> {
-    /// public input polynomials
-    pub(crate) _public_evals: Option<PointEvaluations<F>>,
-    /// witness polynomials
+    /// Witness evaluations, including public input
     pub(crate) witness_evals: Witness<N, PointEvaluations<F>>,
-    /// MVLookup argument
+    /// MVLookup argument evaluations
     pub(crate) mvlookup_evals: Option<LookupProof<PointEvaluations<F>>>,
     /// Evaluation of Z_H(xi) (t_0(X) + xi^n t_1(X) + ...) at xi.
     pub(crate) ft_eval1: F,

--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -71,6 +71,8 @@ where
     // Round 1: Creating and absorbing column commitments
     ////////////////////////////////////////////////////////////////////////////
 
+    let mut fq_sponge = EFqSponge::new(G::other_curve_sponge_params());
+
     // Interpolate all columns on d1, using trait Into.
     let witness_evals: Witness<N, Evaluations<G::ScalarField, R2D<G::ScalarField>>> = inputs
         .evaluations
@@ -98,8 +100,6 @@ where
             .map(comm)
             .collect::<Witness<N, PolyComm<G>>>()
     };
-
-    let mut fq_sponge = EFqSponge::new(G::other_curve_sponge_params());
 
     // Do not use parallelism
     (&witness_comms)
@@ -436,7 +436,6 @@ where
 
     let proof_evals: ProofEvaluations<N, G::ScalarField> = {
         ProofEvaluations {
-            _public_evals: None,
             witness_evals,
             mvlookup_evals,
             ft_eval1,

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -244,12 +244,14 @@ mod tests {
         >(domain, &srs, &constraints, proof_inputs, &mut rng)
         .unwrap();
 
-        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, SERIALIZATION_N_COLUMNS>(
-            domain,
-            &srs,
-            &constraints,
-            &proof,
-        );
+        let verifies =
+            verify::<_, OpeningProof, BaseSponge, ScalarSponge, SERIALIZATION_N_COLUMNS, 0>(
+                domain,
+                &srs,
+                &constraints,
+                &proof,
+                Witness::zero_vec(DOMAIN_SIZE),
+            );
         assert!(verifies)
     }
 }

--- a/msm/src/test/mod.rs
+++ b/msm/src/test/mod.rs
@@ -98,11 +98,12 @@ mod tests {
             }
         }
 
-        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, N>(
+        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, N, 0>(
             domain,
             &srs,
             &constraints,
             &proof,
+            Witness::zero_vec(domain_size),
         );
         assert!(verifies)
     }
@@ -147,11 +148,12 @@ mod tests {
                 rng,
             )
             .unwrap();
-        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, N>(
+        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, N, 0>(
             domain,
             &srs,
             &constraints,
             &proof,
+            Witness::zero_vec(domain_size),
         );
         assert!(!verifies)
     }

--- a/msm/src/witness.rs
+++ b/msm/src/witness.rs
@@ -41,6 +41,24 @@ impl<const N: usize, T> Witness<N, T> {
     }
 }
 
+impl<const N: usize, T: Zero + Clone> Witness<N, Vec<T>> {
+    pub fn zero_vec(domain_size: usize) -> Self {
+        Witness {
+            // Ideally the vector should be of domain size, but
+            // one-element vector should be a reasonable default too.
+            cols: std::array::from_fn(|_| vec![T::zero(); domain_size]),
+        }
+    }
+
+    pub fn to_pub_columns<const NPUB: usize>(&self) -> Witness<NPUB, Vec<T>> {
+        let mut newcols: [Vec<T>; NPUB] = std::array::from_fn(|_| vec![]);
+        for (i, vec) in self.cols[0..NPUB].iter().enumerate() {
+            newcols[i] = vec.clone();
+        }
+        Witness { cols: newcols }
+    }
+}
+
 // IMPLEMENTATION OF ITERATORS FOR THE WITNESS STRUCTURE
 
 impl<'lt, const N: usize, G> IntoIterator for &'lt Witness<N, G> {


### PR DESCRIPTION
This adds very basic public input support, namely that the verifier can explicitly specify some columns of the witness (its prefix) instead of fully relying on the commitments in the proof.