### PR TITLE
ASCII Keccak doc comment + remove redundancy

### DIFF
--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -139,7 +139,7 @@ impl FoldingColumnTrait for Column {
 ///                                              | -> 1220..1319: PiRhoExpandRotE
 ///                                              | -> 1320..1719: ChiShiftsB
 ///                                              | -> 1720..2119: ChiShiftsSum
-///   2124..2223 -> next
+///   2119..2219 -> next
 ///        -> 2124..2223: Output (if Round, then IotaStateG, if Sponge then SpongeXorState)
 ///
 pub type KeccakWitness<T> = Witness<ZKVM_KECCAK_COLS, T>;

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -21,7 +21,7 @@ pub(crate) const HASH_BYTELENGTH: usize = HASH_BITLENGTH / 8;
 /// Length of each word in the Keccak state, in bits
 pub(crate) const WORD_LENGTH_IN_BITS: usize = 64;
 /// Number of columns required in the `curr` part of the witness
-pub(crate) const ZKVM_KECCAK_COLS_CURR: usize = KECCAK_COLS + QUARTERS;
+pub(crate) const ZKVM_KECCAK_COLS_CURR: usize = KECCAK_COLS;
 /// Number of columns required in the `next` part of the witness, corresponding to the output length
 pub(crate) const ZKVM_KECCAK_COLS_NEXT: usize = STATE_LEN;
 /// Number of words that fit in the hash digest


### PR DESCRIPTION
This PR addresses a follow-up issue brought up by Danny, who was suggesting to include a more ASCII-like type of comment to better visualize the content of the Keccak columns. 

While doing so, I realized that 4 columns were being reserved for the round constants both inside `mode_flags` and inside `curr`. I removed this redundancy to only be stored inside the former. That makes the column count 2220. This "fix" was not really a bug, but rather a non-necessary duplicate. Thus, tests worked both with it and without it.

TODO: when the instances are split into types (probably just round and sponge), we will be able to split the columns further and use less columns for sponge instances, and run fewer constraints on them.