### PR TITLE
[no-op] Split Keccak constraints into smaller functions

### DIFF
--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -167,9 +167,6 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
         {
             self.constraints_round();
         }
-
-        // READ LOOKUP CONSTRAINTS
-        self.lookups();
     }
 
     /// ROUND CONSTRAINTS: 35 + 150 + 200 + 4 = 389 CONSTRAINTS

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -124,20 +124,20 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
         // - 143 constraints of degree 1
         // - 1 constraint of degree 2
         {
-            self.constraints_flags();
+            self.constrain_flags();
         }
 
         // SPONGE CONSTRAINTS: 32 + 3*100 + 16 + 6 = 354 CONSTRAINTS OF DEGREE 2
         // - 354 constraints of degree 2
         {
-            self.constraints_sponge();
+            self.constrain_sponge();
         }
 
         // ROUND CONSTRAINTS: 35 + 150 + 200 + 4 = 389 CONSTRAINTS
         // - 384 constraints of degree 2
         // - 5 constraints of degree 3
         {
-            self.constraints_round();
+            self.constrain_round();
         }
     }
 
@@ -149,16 +149,16 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     /// - 1 constraint is sponge+round related
     // TODO: when Round and Sponge circuits are separated, the last one will be removed
     //       (in particular, the one involving round and sponge together)
-    fn constraints_flags(&mut self) {
+    fn constrain_flags(&mut self) {
         // Booleanity of sponge flags: 139 constraints of degree 1
         {
-            self.constraints_booleanity();
+            self.constrain_booleanity();
         }
         // Mutual exclusivity of flags: 5 constraints:
         // - 4 of degree 1
         // - 1 of degree 2
         {
-            self.constraints_mutex();
+            self.constrain_mutex();
         }
     }
 
@@ -197,9 +197,9 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
 
     /// Constrains 354 checks of sponge steps
     fn constrain_sponge(&mut self) {
-        self.constraints_absorb();
-        self.constraints_squeeze();
-        self.constraints_padding();
+        self.constrain_absorb();
+        self.constrain_squeeze();
+        self.constrain_padding();
     }
 
     /// Constrains 332 checks of absorb sponges

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -158,185 +158,191 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
 
         // SPONGE CONSTRAINTS: 32 + 3*100 + 16 + 6 = 354 CONSTRAINTS OF DEGREE 2
         {
-            for zero in self.sponge_zeros() {
-                // Absorb phase pads with zeros the new state
-                self.constrain(self.is_absorb() * zero);
-            }
-            for i in 0..QUARTERS * DIM * DIM {
-                // In first absorb, root state is all zeros
-                self.constrain(self.is_root() * self.old_state(i).clone());
-                // Absorbs the new block by performing XOR with the old state
-                self.constrain(
-                    self.is_absorb()
-                        * (self.xor_state(i).clone()
-                            - (self.old_state(i).clone() + self.new_state(i).clone())),
-                );
-                // In absorb, Check shifts correspond to the decomposition of the new state
-                self.constrain(
-                    self.is_absorb()
-                        * (self.new_state(i).clone()
-                            - Self::from_shifts(
-                                &self.vec_sponge_shifts(),
-                                Some(i),
-                                None,
-                                None,
-                                None,
-                            )),
-                );
-            }
-            let sponge_shifts = self.vec_sponge_shifts();
-            for i in 0..QUARTERS * WORDS_IN_HASH {
-                // In squeeze, Check shifts correspond to the 256-bit prefix digest of the old state (current)
-                self.constrain(
-                    self.is_squeeze()
-                        * (self.old_state(i).clone()
-                            - Self::from_shifts(&sponge_shifts, Some(i), None, None, None)),
-                );
-            }
-            // Check that the padding is located at the end of the message
-            let pad_at_end = (0..RATE_IN_BYTES).fold(Self::zero(), |acc, i| {
-                acc * Self::two() + self.in_padding(i)
-            });
-            self.constrain(self.is_pad() * (self.two_to_pad() - Self::one() - pad_at_end));
-            // Check that the padding value is correct
-            for i in 0..PAD_SUFFIX_LEN {
-                self.constrain(self.is_pad() * (self.block_in_padding(i) - self.pad_suffix(i)));
-            }
+            self.constraints_sponge();
         }
 
         // ROUND CONSTRAINTS: 35 + 150 + 200 + 4 = 389 CONSTRAINTS
         // - 384 constraints of degree 2
         // - 5 constraints of degree 3
         {
-            // Define vectors storing expressions which are not in the witness layout for efficiency
-            let mut state_c = vec![vec![Self::zero(); QUARTERS]; DIM];
-            let mut state_d = vec![vec![Self::zero(); QUARTERS]; DIM];
-            let mut state_e = vec![vec![vec![Self::zero(); QUARTERS]; DIM]; DIM];
-            let mut state_b = vec![vec![vec![Self::zero(); QUARTERS]; DIM]; DIM];
-            let mut state_f = vec![vec![vec![Self::zero(); QUARTERS]; DIM]; DIM];
-
-            // STEP theta: 5 * ( 3 + 4 * 1 ) = 35 constraints
-            // - 30 constraints of degree 2
-            // - 5 constraints of degree 3
-            for x in 0..DIM {
-                let word_c = Self::from_quarters(&self.vec_dense_c(), None, x);
-                let rem_c = Self::from_quarters(&self.vec_remainder_c(), None, x);
-                let rot_c = Self::from_quarters(&self.vec_dense_rot_c(), None, x);
-
-                self.constrain(
-                    self.is_round()
-                        * (word_c * Self::two_pow(1)
-                            - (self.quotient_c(x) * Self::two_pow(64) + rem_c.clone())),
-                );
-                self.constrain(self.is_round() * (rot_c - (self.quotient_c(x) + rem_c)));
-                self.constrain(self.is_round() * (Self::is_boolean(self.quotient_c(x))));
-
-                for q in 0..QUARTERS {
-                    state_c[x][q] = self.state_a(0, x, q)
-                        + self.state_a(1, x, q)
-                        + self.state_a(2, x, q)
-                        + self.state_a(3, x, q)
-                        + self.state_a(4, x, q);
-                    self.constrain(
-                        self.is_round()
-                            * (state_c[x][q].clone()
-                                - Self::from_shifts(
-                                    &self.vec_shifts_c(),
-                                    None,
-                                    None,
-                                    Some(x),
-                                    Some(q),
-                                )),
-                    );
-
-                    state_d[x][q] = self.shifts_c(0, (x + DIM - 1) % DIM, q)
-                        + self.expand_rot_c((x + 1) % DIM, q);
-
-                    for (y, column_e) in state_e.iter_mut().enumerate() {
-                        column_e[x][q] = self.state_a(y, x, q) + state_d[x][q].clone();
-                    }
-                }
-            } // END theta
-
-            // STEP pirho: 5 * 5 * (2 + 4 * 1) = 150 constraints of degree 2
-            for (y, col) in OFF.iter().enumerate() {
-                for (x, off) in col.iter().enumerate() {
-                    let word_e = Self::from_quarters(&self.vec_dense_e(), Some(y), x);
-                    let quo_e = Self::from_quarters(&self.vec_quotient_e(), Some(y), x);
-                    let rem_e = Self::from_quarters(&self.vec_remainder_e(), Some(y), x);
-                    let rot_e = Self::from_quarters(&self.vec_dense_rot_e(), Some(y), x);
-
-                    self.constrain(
-                        self.is_round()
-                            * (word_e * Self::two_pow(*off)
-                                - (quo_e.clone() * Self::two_pow(64) + rem_e.clone())),
-                    );
-                    self.constrain(self.is_round() * (rot_e - (quo_e.clone() + rem_e)));
-
-                    for q in 0..QUARTERS {
-                        self.constrain(
-                            self.is_round()
-                                * (state_e[y][x][q].clone()
-                                    - Self::from_shifts(
-                                        &self.vec_shifts_e(),
-                                        None,
-                                        Some(y),
-                                        Some(x),
-                                        Some(q),
-                                    )),
-                        );
-                        state_b[(2 * x + 3 * y) % DIM][y][q] = self.expand_rot_e(y, x, q);
-                    }
-                }
-            } // END pirho
-
-            // STEP chi: 4 * 5 * 5 * 2 = 200 constraints of degree 2
-            for q in 0..QUARTERS {
-                for x in 0..DIM {
-                    for y in 0..DIM {
-                        let not = Self::constant(0x1111111111111111u64)
-                            - self.shifts_b(0, y, (x + 1) % DIM, q);
-                        let sum = not + self.shifts_b(0, y, (x + 2) % DIM, q);
-                        let and = self.shifts_sum(1, y, x, q);
-
-                        self.constrain(
-                            self.is_round()
-                                * (state_b[y][x][q].clone()
-                                    - Self::from_shifts(
-                                        &self.vec_shifts_b(),
-                                        None,
-                                        Some(y),
-                                        Some(x),
-                                        Some(q),
-                                    )),
-                        );
-                        self.constrain(
-                            self.is_round()
-                                * (sum
-                                    - Self::from_shifts(
-                                        &self.vec_shifts_sum(),
-                                        None,
-                                        Some(y),
-                                        Some(x),
-                                        Some(q),
-                                    )),
-                        );
-                        state_f[y][x][q] = self.shifts_b(0, y, x, q) + and;
-                    }
-                }
-            } // END chi
-
-            // STEP iota: 4 constraints of degree 2
-            for (q, c) in self.round_constants().to_vec().iter().enumerate() {
-                self.constrain(
-                    self.is_round()
-                        * (self.state_g(q).clone() - (state_f[0][0][q].clone() + c.clone())),
-                );
-            } // END iota
+            self.constraints_round();
         }
 
         // READ LOOKUP CONSTRAINTS
         self.lookups();
+    }
+
+    /// ROUND CONSTRAINTS: 35 + 150 + 200 + 4 = 389 CONSTRAINTS
+    /// - 384 constraints of degree 2
+    /// - 5 constraints of degree 3
+    fn constraints_round(&mut self) {
+        // Define vectors storing expressions which are not in the witness layout for efficiency
+        let mut state_c = vec![vec![Self::zero(); QUARTERS]; DIM];
+        let mut state_d = vec![vec![Self::zero(); QUARTERS]; DIM];
+        let mut state_e = vec![vec![vec![Self::zero(); QUARTERS]; DIM]; DIM];
+        let mut state_b = vec![vec![vec![Self::zero(); QUARTERS]; DIM]; DIM];
+        let mut state_f = vec![vec![vec![Self::zero(); QUARTERS]; DIM]; DIM];
+
+        // STEP theta: 5 * ( 3 + 4 * 1 ) = 35 constraints
+        // - 30 constraints of degree 2
+        // - 5 constraints of degree 3
+        for x in 0..DIM {
+            let word_c = Self::from_quarters(&self.vec_dense_c(), None, x);
+            let rem_c = Self::from_quarters(&self.vec_remainder_c(), None, x);
+            let rot_c = Self::from_quarters(&self.vec_dense_rot_c(), None, x);
+
+            self.constrain(
+                self.is_round()
+                    * (word_c * Self::two_pow(1)
+                        - (self.quotient_c(x) * Self::two_pow(64) + rem_c.clone())),
+            );
+            self.constrain(self.is_round() * (rot_c - (self.quotient_c(x) + rem_c)));
+            self.constrain(self.is_round() * (Self::is_boolean(self.quotient_c(x))));
+
+            for q in 0..QUARTERS {
+                state_c[x][q] = self.state_a(0, x, q)
+                    + self.state_a(1, x, q)
+                    + self.state_a(2, x, q)
+                    + self.state_a(3, x, q)
+                    + self.state_a(4, x, q);
+                self.constrain(
+                    self.is_round()
+                        * (state_c[x][q].clone()
+                            - Self::from_shifts(
+                                &self.vec_shifts_c(),
+                                None,
+                                None,
+                                Some(x),
+                                Some(q),
+                            )),
+                );
+
+                state_d[x][q] =
+                    self.shifts_c(0, (x + DIM - 1) % DIM, q) + self.expand_rot_c((x + 1) % DIM, q);
+
+                for (y, column_e) in state_e.iter_mut().enumerate() {
+                    column_e[x][q] = self.state_a(y, x, q) + state_d[x][q].clone();
+                }
+            }
+        } // END theta
+
+        // STEP pirho: 5 * 5 * (2 + 4 * 1) = 150 constraints of degree 2
+        for (y, col) in OFF.iter().enumerate() {
+            for (x, off) in col.iter().enumerate() {
+                let word_e = Self::from_quarters(&self.vec_dense_e(), Some(y), x);
+                let quo_e = Self::from_quarters(&self.vec_quotient_e(), Some(y), x);
+                let rem_e = Self::from_quarters(&self.vec_remainder_e(), Some(y), x);
+                let rot_e = Self::from_quarters(&self.vec_dense_rot_e(), Some(y), x);
+
+                self.constrain(
+                    self.is_round()
+                        * (word_e * Self::two_pow(*off)
+                            - (quo_e.clone() * Self::two_pow(64) + rem_e.clone())),
+                );
+                self.constrain(self.is_round() * (rot_e - (quo_e.clone() + rem_e)));
+
+                for q in 0..QUARTERS {
+                    self.constrain(
+                        self.is_round()
+                            * (state_e[y][x][q].clone()
+                                - Self::from_shifts(
+                                    &self.vec_shifts_e(),
+                                    None,
+                                    Some(y),
+                                    Some(x),
+                                    Some(q),
+                                )),
+                    );
+                    state_b[(2 * x + 3 * y) % DIM][y][q] = self.expand_rot_e(y, x, q);
+                }
+            }
+        } // END pirho
+
+        // STEP chi: 4 * 5 * 5 * 2 = 200 constraints of degree 2
+        for q in 0..QUARTERS {
+            for x in 0..DIM {
+                for y in 0..DIM {
+                    let not = Self::constant(0x1111111111111111u64)
+                        - self.shifts_b(0, y, (x + 1) % DIM, q);
+                    let sum = not + self.shifts_b(0, y, (x + 2) % DIM, q);
+                    let and = self.shifts_sum(1, y, x, q);
+
+                    self.constrain(
+                        self.is_round()
+                            * (state_b[y][x][q].clone()
+                                - Self::from_shifts(
+                                    &self.vec_shifts_b(),
+                                    None,
+                                    Some(y),
+                                    Some(x),
+                                    Some(q),
+                                )),
+                    );
+                    self.constrain(
+                        self.is_round()
+                            * (sum
+                                - Self::from_shifts(
+                                    &self.vec_shifts_sum(),
+                                    None,
+                                    Some(y),
+                                    Some(x),
+                                    Some(q),
+                                )),
+                    );
+                    state_f[y][x][q] = self.shifts_b(0, y, x, q) + and;
+                }
+            }
+        } // END chi
+
+        // STEP iota: 4 constraints of degree 2
+        for (q, c) in self.round_constants().to_vec().iter().enumerate() {
+            self.constrain(
+                self.is_round()
+                    * (self.state_g(q).clone() - (state_f[0][0][q].clone() + c.clone())),
+            );
+        } // END iota
+    }
+
+    /// SPONGE CONSTRAINTS: 32 + 3*100 + 16 + 6 = 354 CONSTRAINTS OF DEGREE 2
+    fn constraints_sponge(&mut self) {
+        for zero in self.sponge_zeros() {
+            // Absorb phase pads with zeros the new state
+            self.constrain(self.is_absorb() * zero);
+        }
+        for i in 0..QUARTERS * DIM * DIM {
+            // In first absorb, root state is all zeros
+            self.constrain(self.is_root() * self.old_state(i).clone());
+            // Absorbs the new block by performing XOR with the old state
+            self.constrain(
+                self.is_absorb()
+                    * (self.xor_state(i).clone()
+                        - (self.old_state(i).clone() + self.new_state(i).clone())),
+            );
+            // In absorb, Check shifts correspond to the decomposition of the new state
+            self.constrain(
+                self.is_absorb()
+                    * (self.new_state(i).clone()
+                        - Self::from_shifts(&self.vec_sponge_shifts(), Some(i), None, None, None)),
+            );
+        }
+        let sponge_shifts = self.vec_sponge_shifts();
+        for i in 0..QUARTERS * WORDS_IN_HASH {
+            // In squeeze, Check shifts correspond to the 256-bit prefix digest of the old state (current)
+            self.constrain(
+                self.is_squeeze()
+                    * (self.old_state(i).clone()
+                        - Self::from_shifts(&sponge_shifts, Some(i), None, None, None)),
+            );
+        }
+        // Check that the padding is located at the end of the message
+        let pad_at_end = (0..RATE_IN_BYTES).fold(Self::zero(), |acc, i| {
+            acc * Self::two() + self.in_padding(i)
+        });
+        self.constrain(self.is_pad() * (self.two_to_pad() - Self::one() - pad_at_end));
+        // Check that the padding value is correct
+        for i in 0..PAD_SUFFIX_LEN {
+            self.constrain(self.is_pad() * (self.block_in_padding(i) - self.pad_suffix(i)));
+        }
     }
 
     ////////////////////////

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -37,8 +37,10 @@ fn test_keccak_witness_satisfies_constraints() {
     let mut keccak_env = KeccakEnv::<Fp>::new(0, &preimage);
     while keccak_env.keccak_step.is_some() {
         keccak_env.step();
-        // Simulate the constraints for each row (still checks nothing about lookups)
+        // Simulate the constraints for each row
         keccak_env.witness_env.constraints();
+        // Simulate the lookups for each row (it is still a no-op)
+        keccak_env.witness_env.lookups();
     }
     // Extract the hash from the witness
     let output = keccak_env.witness_env.sponge_bytes()[0..32]


### PR DESCRIPTION
This PR simply moves the constraints of the Keccak circuit into smaller functions, each of them targeting "one type" of constraints. This is just a cosmetic change, meant to provide more fine grain access to each part of the checks for future negative tests that can attack specific constraints separately. This will come in a future PR building on top of this one.