### PR TITLE
[easy] Fine-grain negative tests for Keccak constraints

### DIFF
--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -1,6 +1,6 @@
 //! This module contains the constraints for one Keccak step.
 use crate::{
-    keccak::{KeccakColumn, E},
+    keccak::{Constraint, KeccakColumn, E},
     lookups::{Lookup, LookupTableIDs},
 };
 use ark_ff::Field;
@@ -65,7 +65,7 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
         }))
     }
 
-    fn constrain(&mut self, x: Self::Variable) {
+    fn constrain(&mut self, _tag: Constraint, x: Self::Variable) {
         self.constraints.push(x);
     }
 

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -120,8 +120,7 @@ impl<F: Field> KeccakEnv<F> {
     /// Nullifies the KeccakWitness of the environment by resetting it to default values
     pub fn null_state(&mut self) {
         self.witness_env.witness = KeccakWitness::default();
-        self.witness_env.check_idx = 0; // Reset constraint count for debugging
-        self.witness_env.error = None; // Reset results of constraints for the new row
+        self.witness_env.errors = vec![]; // Reset errors of constraints for the new row
     }
 
     /// Entrypoint for the interpreter. It executes one step of the Keccak circuit (one row),

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -121,6 +121,7 @@ impl<F: Field> KeccakEnv<F> {
     pub fn null_state(&mut self) {
         self.witness_env.witness = KeccakWitness::default();
         self.witness_env.check_idx = 0; // Reset constraint count for debugging
+        self.witness_env.error = None; // Reset results of constraints for the new row
     }
 
     /// Entrypoint for the interpreter. It executes one step of the Keccak circuit (one row),

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -4,6 +4,7 @@ use crate::{
     keccak::{
         column::{PAD_BYTES_LEN, ROUND_COEFFS_LEN},
         grid_index, KeccakColumn,
+        KeccakConstraint::*,
     },
     lookups::Lookup,
 };
@@ -112,8 +113,8 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     /// Returns the variable corresponding to a given column alias.
     fn variable(&self, column: KeccakColumn) -> Self::Variable;
 
-    /// Adds one constraint to the environment.
-    fn constrain(&mut self, x: Self::Variable);
+    /// Adds one KeccakConstraint to the environment.
+    fn constrain(&mut self, tag: KeccakConstraint, x: Self::Variable);
 
     /// Adds all 887 constraints/checks to the environment:
     /// - 143 constraints of degree 1
@@ -148,7 +149,7 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     /// - 142 constraints are sponge-only
     /// - 1 constraint is sponge+round related
     // TODO: when Round and Sponge circuits are separated, the last one will be removed
-    //       (in particular, the one involving round and sponge together)
+    //       (in particular, the ones involving round and sponge together)
     fn constrain_flags(&mut self) {
         // Booleanity of sponge flags: 139 constraints of degree 1
         {
@@ -166,32 +167,49 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     /// These involve sponge-only related variables.
     fn constrain_booleanity(&mut self) {
         // Absorb is either true or false
-        self.constrain(Self::is_boolean(self.is_absorb()));
+        self.constrain(BooleanityAbsorb, Self::is_boolean(self.is_absorb()));
         // Squeeze is either true or false
-        self.constrain(Self::is_boolean(self.is_squeeze()));
+        self.constrain(BooleanitySqueeze, Self::is_boolean(self.is_squeeze()));
         // Root is either true or false
-        self.constrain(Self::is_boolean(self.is_root()));
+        self.constrain(BooleanityRoot, Self::is_boolean(self.is_root()));
         for i in 0..RATE_IN_BYTES {
             // Bytes are either involved on padding or not
-            self.constrain(Self::is_boolean(self.in_padding(i)));
+            self.constrain(BooleanityPadding(i), Self::is_boolean(self.in_padding(i)));
         }
     }
 
     /// Constrains 5 checks of mutual exclusivity between some mode flags.
-    /// - 4 involve sponge-only related variables
-    /// - 1 involves sponge+round  variables
+    /// - 3 involve sponge-only related variables
+    /// - 2 involves sponge+round variables
+    // TODO: when Round and Sponge circuits are separated, the last one will be removed
+    //       (in particular, the ones involving round and sponge together)
     fn constrain_mutex(&mut self) {
         // Squeeze and Root are not both true
-        self.constrain(Self::either_zero(self.is_squeeze(), self.is_root()));
+        self.constrain(
+            MutexSqueezeRoot,
+            Self::either_zero(self.is_squeeze(), self.is_root()),
+        );
         // Squeeze and Pad are not both true
-        self.constrain(Self::either_zero(self.is_squeeze(), self.is_pad()));
+        self.constrain(
+            MutexSqueezePad,
+            Self::either_zero(self.is_squeeze(), self.is_pad()),
+        );
         // Round and Pad are not both true
-        self.constrain(Self::either_zero(self.is_round(), self.is_pad()));
+        self.constrain(
+            MutexRoundPad,
+            Self::either_zero(self.is_round(), self.is_pad()),
+        );
         // Round and Root are not both true
-        self.constrain(Self::either_zero(self.is_round(), self.is_root()));
+        self.constrain(
+            MutexRoundRoot,
+            Self::either_zero(self.is_round(), self.is_root()),
+        );
         // Absorb and Squeeze cannot happen at the same time.
         // Equivalent to is_boolean(is_sponge())
-        self.constrain(Self::either_zero(self.is_absorb(), self.is_squeeze()));
+        self.constrain(
+            MutexAbsorbSqueeze,
+            Self::either_zero(self.is_absorb(), self.is_squeeze()),
+        );
         // Trivially, is_sponge and is_round are mutually exclusive
     }
 
@@ -204,21 +222,26 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
 
     /// Constrains 332 checks of absorb sponges
     fn constrain_absorb(&mut self) {
-        for zero in self.sponge_zeros() {
+        for (i, zero) in self.sponge_zeros().iter().enumerate() {
             // Absorb phase pads with zeros the new state
-            self.constrain(self.is_absorb() * zero);
+            self.constrain(AbsorbZeroPad(i), self.is_absorb() * zero);
         }
         for i in 0..QUARTERS * DIM * DIM {
             // In first absorb, root state is all zeros
-            self.constrain(self.is_root() * self.old_state(i).clone());
+            self.constrain(
+                AbsorbRootZero(i),
+                self.is_root() * self.old_state(i).clone(),
+            );
             // Absorbs the new block by performing XOR with the old state
             self.constrain(
+                AbsorbXor(i),
                 self.is_absorb()
                     * (self.xor_state(i).clone()
                         - (self.old_state(i).clone() + self.new_state(i).clone())),
             );
             // In absorb, Check shifts correspond to the decomposition of the new state
             self.constrain(
+                AbsorbShifts(i),
                 self.is_absorb()
                     * (self.new_state(i).clone()
                         - Self::from_shifts(&self.vec_sponge_shifts(), Some(i), None, None, None)),
@@ -232,10 +255,16 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
         let pad_at_end = (0..RATE_IN_BYTES).fold(Self::zero(), |acc, i| {
             acc * Self::two() + self.in_padding(i)
         });
-        self.constrain(self.is_pad() * (self.two_to_pad() - Self::one() - pad_at_end));
+        self.constrain(
+            PadAtEnd,
+            self.is_pad() * (self.two_to_pad() - Self::one() - pad_at_end),
+        );
         // Check that the padding value is correct
         for i in 0..PAD_SUFFIX_LEN {
-            self.constrain(self.is_pad() * (self.block_in_padding(i) - self.pad_suffix(i)));
+            self.constrain(
+                BlockInPadding(i),
+                self.is_pad() * (self.block_in_padding(i) - self.pad_suffix(i)),
+            );
         }
     }
 
@@ -245,6 +274,7 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
         for i in 0..QUARTERS * WORDS_IN_HASH {
             // In squeeze, check shifts correspond to the 256-bit prefix digest of the old state (current)
             self.constrain(
+                SqueezeShifts(i),
                 self.is_squeeze()
                     * (self.old_state(i).clone()
                         - Self::from_shifts(&sponge_shifts, Some(i), None, None, None)),
@@ -287,12 +317,19 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
             let rot_c = Self::from_quarters(&self.vec_dense_rot_c(), None, x);
 
             self.constrain(
+                ThetaWordC(x),
                 self.is_round()
                     * (word_c * Self::two_pow(1)
                         - (self.quotient_c(x) * Self::two_pow(64) + rem_c.clone())),
             );
-            self.constrain(self.is_round() * (rot_c - (self.quotient_c(x) + rem_c)));
-            self.constrain(self.is_round() * (Self::is_boolean(self.quotient_c(x))));
+            self.constrain(
+                ThetaRotatedC(x),
+                self.is_round() * (rot_c - (self.quotient_c(x) + rem_c)),
+            );
+            self.constrain(
+                ThetaQuotientC(x),
+                self.is_round() * (Self::is_boolean(self.quotient_c(x))),
+            );
 
             for q in 0..QUARTERS {
                 state_c[x][q] = self.state_a(0, x, q)
@@ -301,6 +338,7 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
                     + self.state_a(3, x, q)
                     + self.state_a(4, x, q);
                 self.constrain(
+                    ThetaShiftsC(x, q),
                     self.is_round()
                         * (state_c[x][q].clone()
                             - Self::from_shifts(
@@ -340,14 +378,19 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
                 let rot_e = Self::from_quarters(&self.vec_dense_rot_e(), Some(y), x);
 
                 self.constrain(
+                    PiRhoWordE(y, x),
                     self.is_round()
                         * (word_e * Self::two_pow(*off)
                             - (quo_e.clone() * Self::two_pow(64) + rem_e.clone())),
                 );
-                self.constrain(self.is_round() * (rot_e - (quo_e.clone() + rem_e)));
+                self.constrain(
+                    PiRhoRotatedE(y, x),
+                    self.is_round() * (rot_e - (quo_e.clone() + rem_e)),
+                );
 
                 for q in 0..QUARTERS {
                     self.constrain(
+                        PiRhoShiftsE(y, x, q),
                         self.is_round()
                             * (state_e[y][x][q].clone()
                                 - Self::from_shifts(
@@ -383,6 +426,7 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
                     let and = self.shifts_sum(1, y, x, q);
 
                     self.constrain(
+                        ChiShiftsB(y, x, q),
                         self.is_round()
                             * (state_b[y][x][q].clone()
                                 - Self::from_shifts(
@@ -394,6 +438,7 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
                                 )),
                     );
                     self.constrain(
+                        ChiShiftsSum(y, x, q),
                         self.is_round()
                             * (sum
                                 - Self::from_shifts(
@@ -416,6 +461,7 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     fn constrain_iota(&mut self, state_f: Vec<Vec<Vec<Self::Variable>>>) {
         for (q, c) in self.round_constants().to_vec().iter().enumerate() {
             self.constrain(
+                IotaStateG(q),
                 self.is_round()
                     * (self.state_g(q).clone() - (state_f[0][0][q].clone() + c.clone())),
             );

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -254,7 +254,7 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
         // Check that the padding value is correct
         for i in 0..PAD_SUFFIX_LEN {
             self.constrain(
-                BlockInPadding(i),
+                PaddingSuffix(i),
                 self.is_pad() * (self.block_in_padding(i) - self.pad_suffix(i)),
             );
         }

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -29,6 +29,42 @@ pub(crate) const WORDS_IN_HASH: usize = HASH_BITLENGTH / WORD_LENGTH_IN_BITS;
 
 pub(crate) type E<F> = Expr<ConstantExpr<F>, KeccakColumn>;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeccakError {
+    Constraint(KeccakConstraint),
+    #[allow(dead_code)]
+    Lookup(usize),
+}
+
+pub enum KeccakConstraint {
+    BooleanityAbsorb,
+    BooleanitySqueeze,
+    BooleanityRoot,
+    BooleanityPadding(usize),
+    MutexSqueezeRoot,
+    MutexSqueezePad,
+    MutexRoundPad,
+    MutexRoundRoot,
+    MutexAbsorbSqueeze,
+    AbsorbZeroPad(usize),
+    AbsorbRootZero(usize),
+    AbsorbXor(usize),
+    AbsorbShifts(usize),
+    PadAtEnd,
+    BlockInPadding(usize),
+    SqueezeShifts(usize),
+    ThetaWordC(usize),
+    ThetaRotatedC(usize),
+    ThetaQuotientC(usize),
+    ThetaShiftsC(usize, usize),
+    PiRhoWordE(usize, usize),
+    PiRhoRotatedE(usize, usize),
+    PiRhoShiftsE(usize, usize, usize),
+    ChiShiftsB(usize, usize, usize),
+    ChiShiftsSum(usize, usize, usize),
+    IotaStateG(usize),
+}
+
 // This function maps a 4D index into a 1D index depending on the length of the grid
 fn grid_index(length: usize, i: usize, y: usize, x: usize, q: usize) -> usize {
     match length {

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -54,7 +54,7 @@ pub enum Constraint {
     AbsorbXor(usize),
     AbsorbShifts(usize),
     PadAtEnd,
-    BlockInPadding(usize),
+    PaddingSuffix(usize),
     SqueezeShifts(usize),
     ThetaWordC(usize),
     ThetaRotatedC(usize),

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -29,14 +29,17 @@ pub(crate) const WORDS_IN_HASH: usize = HASH_BITLENGTH / WORD_LENGTH_IN_BITS;
 
 pub(crate) type E<F> = Expr<ConstantExpr<F>, KeccakColumn>;
 
+/// Errors that can occur during the check of the witness
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum KeccakError {
-    Constraint(KeccakConstraint),
+pub enum Error {
+    Constraint(Constraint),
     #[allow(dead_code)]
     Lookup(usize),
 }
 
-pub enum KeccakConstraint {
+/// All the names for constraints involved in the Keccak circuit
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Constraint {
     BooleanityAbsorb,
     BooleanitySqueeze,
     BooleanityRoot,

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -1,5 +1,5 @@
 use crate::keccak::{
-    environment::KeccakEnv, interpreter::KeccakInterpreter, KeccakColumn, KeccakError,
+    environment::KeccakEnv, interpreter::KeccakInterpreter, Constraint::*, Error, KeccakColumn,
 };
 use kimchi::o1_utils::{self, FieldHelpers};
 use mina_curves::pasta::Fp;
@@ -41,6 +41,7 @@ fn test_keccak_witness_satisfies_constraints() {
         keccak_env.step();
         // Simulate the constraints for each row
         keccak_env.witness_env.constraints();
+        assert!(keccak_env.witness_env.errors.is_empty());
         // Simulate the lookups for each row (it is still a no-op)
         keccak_env.witness_env.lookups();
     }
@@ -80,6 +81,7 @@ fn test_keccak_fake_witness_wont_satisfy_constraints() {
         witness_env.push(keccak_env.witness_env.clone());
         // Make sure that the constraints of that row hold
         keccak_env.witness_env.constraints();
+        assert!(keccak_env.witness_env.errors.is_empty());
     }
     assert_eq!(witness_env.len(), n_steps);
 
@@ -87,7 +89,7 @@ fn test_keccak_fake_witness_wont_satisfy_constraints() {
     witness_env[0].witness[KeccakColumn::FlagAbsorb] = Fp::from(2u32);
     witness_env[0].constrain_booleanity();
     assert_eq!(
-        witness_env[0].error.as_ref().unwrap(),
-        KeccakError::Constraint(1)
+        witness_env[0].errors,
+        vec![Error::Constraint(BooleanityAbsorb)]
     );
 }

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -85,11 +85,141 @@ fn test_keccak_fake_witness_wont_satisfy_constraints() {
     }
     assert_eq!(witness_env.len(), n_steps);
 
-    // Negativize mode flags in the witness
+    // NEGATIVIZE THE WITNESS
+
+    // Break padding constraints
+    witness_env[0].witness[KeccakColumn::PadBytesFlags(0)] = Fp::from(1u32);
+    witness_env[0].constrain_padding();
+    assert_eq!(
+        witness_env[0].errors,
+        vec![
+            Error::Constraint(PadAtEnd),
+            Error::Constraint(PaddingSuffix(0))
+        ]
+    );
+    witness_env[0].errors.clear();
+
+    // Break booleanity constraints
     witness_env[0].witness[KeccakColumn::FlagAbsorb] = Fp::from(2u32);
+    witness_env[0].witness[KeccakColumn::FlagSqueeze] = Fp::from(2u32);
+    witness_env[0].witness[KeccakColumn::FlagRoot] = Fp::from(2u32);
+    witness_env[0].witness[KeccakColumn::PadBytesFlags(0)] = Fp::from(2u32);
     witness_env[0].constrain_booleanity();
     assert_eq!(
         witness_env[0].errors,
-        vec![Error::Constraint(BooleanityAbsorb)]
+        vec![
+            Error::Constraint(BooleanityAbsorb),
+            Error::Constraint(BooleanitySqueeze),
+            Error::Constraint(BooleanityRoot),
+            Error::Constraint(BooleanityPadding(0))
+        ]
     );
+    witness_env[0].errors.clear();
+
+    // Break mutex constraints
+    witness_env[0].witness[KeccakColumn::FlagAbsorb] = Fp::from(1u32);
+    witness_env[0].witness[KeccakColumn::FlagSqueeze] = Fp::from(1u32);
+    witness_env[0].witness[KeccakColumn::FlagRound] = Fp::from(1u32);
+    witness_env[0].constrain_mutex();
+    assert_eq!(
+        witness_env[0].errors,
+        vec![
+            Error::Constraint(MutexSqueezeRoot),
+            Error::Constraint(MutexSqueezePad),
+            Error::Constraint(MutexRoundPad),
+            Error::Constraint(MutexRoundRoot),
+            Error::Constraint(MutexAbsorbSqueeze)
+        ]
+    );
+    witness_env[0].errors.clear();
+
+    // Break absorb constraints
+    witness_env[0].witness[KeccakColumn::Input(68)] += Fp::from(1u32);
+    witness_env[0].witness[KeccakColumn::SpongeNewState(68)] += Fp::from(1u32);
+    witness_env[0].witness[KeccakColumn::Output(68)] += Fp::from(1u32);
+    witness_env[0].constrain_absorb();
+    assert_eq!(
+        witness_env[0].errors,
+        vec![
+            Error::Constraint(AbsorbZeroPad(0)), // 68th SpongeNewState is the 0th SpongeZeros
+            Error::Constraint(AbsorbRootZero(68)),
+            Error::Constraint(AbsorbXor(68)),
+            Error::Constraint(AbsorbShifts(68)),
+        ]
+    );
+    witness_env[0].errors.clear();
+
+    // Break squeeze constraints
+    witness_env[25].witness[KeccakColumn::Input(0)] += Fp::from(1u32);
+    witness_env[25].constrain_squeeze();
+    assert_eq!(
+        witness_env[25].errors,
+        vec![Error::Constraint(SqueezeShifts(0))]
+    );
+    witness_env[25].errors.clear();
+
+    // Break theta constraints
+    witness_env[1].witness[KeccakColumn::ThetaQuotientC(0)] += Fp::from(2u32);
+    witness_env[1].witness[KeccakColumn::ThetaShiftsC(0)] += Fp::from(1u32);
+    witness_env[1].constrain_theta();
+    assert_eq!(
+        witness_env[1].errors,
+        vec![
+            Error::Constraint(ThetaWordC(0)),
+            Error::Constraint(ThetaRotatedC(0)),
+            Error::Constraint(ThetaQuotientC(0)),
+            Error::Constraint(ThetaShiftsC(0, 0))
+        ]
+    );
+    witness_env[1].errors.clear();
+    witness_env[1].witness[KeccakColumn::ThetaQuotientC(0)] -= Fp::from(2u32);
+    witness_env[1].witness[KeccakColumn::ThetaShiftsC(0)] -= Fp::from(1u32);
+    let state_e = witness_env[1].constrain_theta();
+    assert!(witness_env[1].errors.is_empty());
+
+    // Break pi-rho constraints
+    witness_env[1].witness[KeccakColumn::PiRhoRemainderE(0)] += Fp::from(1u32);
+    witness_env[1].witness[KeccakColumn::PiRhoShiftsE(0)] += Fp::from(1u32);
+    witness_env[1].constrain_pirho(state_e.clone());
+    assert_eq!(
+        witness_env[1].errors,
+        vec![
+            Error::Constraint(PiRhoWordE(0, 0)),
+            Error::Constraint(PiRhoRotatedE(0, 0)),
+            Error::Constraint(PiRhoShiftsE(0, 0, 0)),
+        ]
+    );
+    witness_env[1].errors.clear();
+    witness_env[1].witness[KeccakColumn::PiRhoRemainderE(0)] -= Fp::from(1u32);
+    witness_env[1].witness[KeccakColumn::PiRhoShiftsE(0)] -= Fp::from(1u32);
+    let state_b = witness_env[1].constrain_pirho(state_e);
+    assert!(witness_env[1].errors.is_empty());
+
+    // Break chi constraints
+    witness_env[1].witness[KeccakColumn::ChiShiftsB(0)] += Fp::from(1u32);
+    witness_env[1].witness[KeccakColumn::ChiShiftsSum(0)] += Fp::from(1u32);
+    witness_env[1].constrain_chi(state_b.clone());
+    assert_eq!(
+        witness_env[1].errors,
+        vec![
+            Error::Constraint(ChiShiftsB(0, 0, 0)),
+            Error::Constraint(ChiShiftsSum(0, 0, 0)),
+            Error::Constraint(ChiShiftsSum(0, 3, 0)),
+            Error::Constraint(ChiShiftsSum(0, 4, 0)),
+        ]
+    );
+    witness_env[1].errors.clear();
+    witness_env[1].witness[KeccakColumn::ChiShiftsB(0)] -= Fp::from(1u32);
+    witness_env[1].witness[KeccakColumn::ChiShiftsSum(0)] -= Fp::from(1u32);
+    let state_f = witness_env[1].constrain_chi(state_b);
+    assert!(witness_env[1].errors.is_empty());
+
+    // Break iota constraints
+    witness_env[1].witness[KeccakColumn::Output(0)] += Fp::from(1u32);
+    witness_env[1].constrain_iota(state_f);
+    assert_eq!(
+        witness_env[1].errors,
+        vec![Error::Constraint(IotaStateG(0))]
+    );
+    witness_env[1].errors.clear();
 }


### PR DESCRIPTION
This PR adds negative tests for the Keccak constraints with a fine-grain design.

In particular, I created an error enum to keep track of which constraint failed throughout execution. This way, when the constraints (either all, or just a subset of them) are run over a witness row, they keep track of the errors accumulated so far (if any) inside the `errors` variable in the witness environment. 

This way, each constraint is now paired with a tag with a name. That is the identifier used in the tests to assert that the expected errors were produced.