### PR TITLE
[easy] Implement length function inside the table trait

### DIFF
--- a/msm/src/lookups.rs
+++ b/msm/src/lookups.rs
@@ -24,6 +24,13 @@ impl LookupTableID for LookupTableIDs {
             LookupTableIDs::Custom(id) => F::from(id as u64) + F::one(),
         }
     }
+
+    fn length(&self) -> usize {
+        match self {
+            LookupTableIDs::RangeCheck16 => 1 << 16,
+            LookupTableIDs::Custom(_) => todo!(),
+        }
+    }
 }
 
 /// Additive lookups used in the MSM project based on MVLookup

--- a/msm/src/mvlookup.rs
+++ b/msm/src/mvlookup.rs
@@ -36,6 +36,9 @@ where
 pub trait LookupTableID {
     /// Assign a unique ID to the lookup tables.
     fn into_field<F: Field>(self) -> F;
+
+    /// Returns the length of each table.
+    fn length(&self) -> usize;
 }
 
 /// A table of values that can be used for a lookup, along with the ID for the table.

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -22,6 +22,13 @@ impl LookupTableID for LookupTable {
             Self::RangeCheck4 => F::one() + F::one(),
         }
     }
+
+    fn length(&self) -> usize {
+        match self {
+            Self::RangeCheck15 => 1 << 15,
+            Self::RangeCheck4 => 1 << 4,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/optimism/src/lookups.rs
+++ b/optimism/src/lookups.rs
@@ -77,7 +77,7 @@ impl<F: Field> FixedLookupTables<F> for LookupTable<F> {
         Self {
             table_id: LookupTableIDs::RangeCheck16Lookup,
             entries: (0..LookupTableIDs::RangeCheck16Lookup.length())
-                .map(|i| vec![F::from(i)])
+                .map(|i| vec![F::from(i as u32)])
                 .collect(),
         }
     }
@@ -103,7 +103,7 @@ impl<F: Field> FixedLookupTables<F> for LookupTable<F> {
             entries: (0..LookupTableIDs::ResetLookup.length())
                 .map(|i| {
                     vec![
-                        F::from(i),
+                        F::from(i as u32),
                         F::from(u64::from_str_radix(&format!("{:b}", i), 16).unwrap()),
                     ]
                 })
@@ -155,7 +155,7 @@ impl<F: Field> FixedLookupTables<F> for LookupTable<F> {
         Self {
             table_id: LookupTableIDs::ByteLookup,
             entries: (0..LookupTableIDs::ByteLookup.length())
-                .map(|i| vec![F::from(i)])
+                .map(|i| vec![F::from(i as u32)])
                 .collect(),
         }
     }


### PR DESCRIPTION
When starting to create the multiplicities inside the Keccak witness environment, I realized that having the functionality of accessing a table's fixed length would come in handy. For this reason I modified the trait of lookup table ids to provide not just the converter into field index, but also a length function. 

@dannywillems Feel free to use it in any way you find useful in your code.