### PR TITLE
Get rid of some MSM prefixes

### DIFF
--- a/msm/src/column_env.rs
+++ b/msm/src/column_env.rs
@@ -2,13 +2,15 @@ use ark_ff::FftField;
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 
 use kimchi::circuits::domains::EvaluationDomains;
-use kimchi::circuits::expr::{Challenges, ColumnEnvironment, Constants, Domain};
+use kimchi::circuits::expr::{
+    Challenges, ColumnEnvironment as TColumnEnvironment, Constants, Domain,
+};
 
 /// The collection of polynomials (all in evaluation form) and constants
 /// required to evaluate an expression as a polynomial.
 ///
 /// All are evaluations.
-pub struct MSMColumnEnvironment<'a, F: FftField> {
+pub struct ColumnEnvironment<'a, F: FftField> {
     /// The witness column polynomials
     pub witness: &'a Vec<Evaluations<F, Radix2EvaluationDomain<F>>>,
     /// The coefficient column polynomials
@@ -27,7 +29,7 @@ pub struct MSMColumnEnvironment<'a, F: FftField> {
     pub lookup: Option<()>,
 }
 
-impl<'a, F: FftField> ColumnEnvironment<'a, F> for MSMColumnEnvironment<'a, F> {
+impl<'a, F: FftField> TColumnEnvironment<'a, F> for ColumnEnvironment<'a, F> {
     type Column = crate::columns::Column;
 
     fn get_column(

--- a/msm/src/expr.rs
+++ b/msm/src/expr.rs
@@ -2,7 +2,11 @@
 // alias, but maybe more code will come.
 // Consider moving to lib.rs
 
-use kimchi::circuits::expr::{ConstantExpr, Expr};
+use ark_ff::Field;
+use kimchi::circuits::{
+    expr::{ConstantExpr, Expr, ExprInner, Variable},
+    gate::CurrOrNext,
+};
 
 use crate::columns::Column;
 
@@ -18,21 +22,21 @@ use crate::columns::Column;
 /// use kimchi::circuits::expr::{ConstantExprInner, ExprInner, Operations, Variable};
 /// use kimchi::circuits::gate::CurrOrNext;
 /// use kimchi_msm::columns::Column;
-/// use kimchi_msm::expr::MSMExpr;
+/// use kimchi_msm::expr::E;
 /// pub type Fp = ark_bn254::Fr;
-/// let x1 = MSMExpr::<Fp>::Atom(
+/// let x1 = E::<Fp>::Atom(
 ///     ExprInner::<Operations<ConstantExprInner<Fp>>, Column>::Cell(Variable {
 ///         col: Column::X(1),
 ///         row: CurrOrNext::Curr,
 ///     }),
 /// );
-/// let x2 = MSMExpr::<Fp>::Atom(
+/// let x2 = E::<Fp>::Atom(
 ///     ExprInner::<Operations<ConstantExprInner<Fp>>, Column>::Cell(Variable {
 ///         col: Column::X(1),
 ///         row: CurrOrNext::Curr,
 ///     }),
 /// );
-/// let x3 = MSMExpr::<Fp>::Atom(
+/// let x3 = E::<Fp>::Atom(
 ///     ExprInner::<Operations<ConstantExprInner<Fp>>, Column>::Cell(Variable {
 ///         col: Column::X(1),
 ///         row: CurrOrNext::Curr,
@@ -42,4 +46,18 @@ use crate::columns::Column;
 /// ```
 /// A list of such constraints is used to represent the entire circuit and will
 /// be used to build the quotient polynomial.
-pub type MSMExpr<F> = Expr<ConstantExpr<F>, Column>;
+pub type E<F> = Expr<ConstantExpr<F>, Column>;
+
+pub fn curr_cell<F: Field>(col: Column) -> E<F> {
+    E::Atom(ExprInner::Cell(Variable {
+        col,
+        row: CurrOrNext::Curr,
+    }))
+}
+
+pub fn next_cell<F: Field>(col: Column) -> E<F> {
+    E::Atom(ExprInner::Cell(Variable {
+        col,
+        row: CurrOrNext::Next,
+    }))
+}

--- a/msm/src/ffa/constraint.rs
+++ b/msm/src/ffa/constraint.rs
@@ -1,6 +1,6 @@
 use crate::{
     columns::{Column, ColumnIndexer},
-    expr::MSMExpr,
+    expr::E,
     ffa::{columns::FFAColumnIndexer, interpreter::FFAInterpreterEnv},
 };
 use ark_ff::PrimeField;
@@ -11,13 +11,13 @@ use kimchi::circuits::{
 
 /// Contains constraints for just one row.
 pub struct ConstraintBuilderEnv<F> {
-    pub constraints: Vec<MSMExpr<F>>,
+    pub constraints: Vec<E<F>>,
 }
 
 impl<F: PrimeField> FFAInterpreterEnv<F> for ConstraintBuilderEnv<F> {
     type Position = Column;
 
-    type Variable = MSMExpr<F>;
+    type Variable = E<F>;
 
     fn empty() -> Self {
         ConstraintBuilderEnv {

--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -1,6 +1,6 @@
 use crate::{
     column_env::MSMColumnEnvironment,
-    expr::MSMExpr,
+    expr::E,
     mvlookup::{prover::Env, LookupProof, LookupTableID},
     proof::{Proof, ProofCommitments, ProofEvaluations, ProofInputs},
     witness::Witness,
@@ -52,7 +52,7 @@ pub fn prove<
 >(
     domain: EvaluationDomains<G::ScalarField>,
     srs: &OpeningProof::SRS,
-    constraints: &Vec<MSMExpr<G::ScalarField>>,
+    constraints: &Vec<E<G::ScalarField>>,
     inputs: ProofInputs<N, G, ID>,
     rng: &mut RNG,
 ) -> Result<Proof<N, G, OpeningProof>, ProverError>

--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -1,5 +1,5 @@
 use crate::{
-    column_env::MSMColumnEnvironment,
+    column_env::ColumnEnvironment,
     expr::E,
     mvlookup::{prover::Env, LookupProof, LookupTableID},
     proof::{Proof, ProofCommitments, ProofEvaluations, ProofInputs},
@@ -161,7 +161,7 @@ where
             gamma: G::ScalarField::zero(),
             joint_combiner: Option::map(lookup_env.as_ref(), |x| x.joint_combiner),
         };
-        MSMColumnEnvironment {
+        ColumnEnvironment {
             constants: Constants {
                 endo_coefficient: *endo_r,
                 mds: &G::sponge_params().mds,

--- a/msm/src/serialization/constraints.rs
+++ b/msm/src/serialization/constraints.rs
@@ -4,7 +4,7 @@ use kimchi::circuits::{
     gate::CurrOrNext,
 };
 
-use crate::{columns::Column, serialization::N_INTERMEDIATE_LIMBS, N_LIMBS};
+use crate::{columns::Column, expr::E, serialization::N_INTERMEDIATE_LIMBS, N_LIMBS};
 
 use super::interpreter::InterpreterEnv;
 
@@ -29,7 +29,7 @@ impl<Fp: PrimeField> Env<Fp> {
 impl<F: PrimeField> InterpreterEnv<F> for Env<F> {
     type Position = Column;
 
-    type Variable = Expr<ConstantExpr<F>, Column>;
+    type Variable = E<F>;
 
     fn add_constraint(&mut self, cst: Self::Variable) {
         // FIXME: We should enforce that we add the same expression

--- a/msm/src/verifier.rs
+++ b/msm/src/verifier.rs
@@ -13,7 +13,7 @@ use poly_commitment::{
 };
 use rand::thread_rng;
 
-use crate::expr::MSMExpr;
+use crate::expr::E;
 use crate::proof::Proof;
 
 pub fn verify<
@@ -25,7 +25,7 @@ pub fn verify<
 >(
     domain: EvaluationDomains<G::ScalarField>,
     srs: &OpeningProof::SRS,
-    constraint_exprs: &Vec<MSMExpr<G::ScalarField>>,
+    constraint_exprs: &Vec<E<G::ScalarField>>,
     proof: &Proof<N, G, OpeningProof>,
 ) -> bool {
     let Proof {


### PR DESCRIPTION
We want to keep it generic for the future. Part of https://github.com/o1-labs/proof-systems/pull/1966