### PR TITLE
Compute multiplicities of Keccak lookups in the witness environment

### DIFF
--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -15,6 +15,8 @@ use kimchi::{
     o1_utils::Two,
 };
 
+use super::column::KeccakWitness;
+
 /// This struct contains all that needs to be kept track of during the execution of the Keccak step interpreter
 #[derive(Clone, Debug)]
 pub struct KeccakEnv<F> {
@@ -117,9 +119,11 @@ impl<F: Field> KeccakEnv<F> {
         self.witness_env.witness[column] = value;
     }
 
-    /// Nullifies the Witness environment by resetting it to default values
+    /// Nullifies the Witness environment by resetting it to default values (except for multiplicities)
     pub fn null_state(&mut self) {
-        self.witness_env = WitnessEnv::default();
+        self.witness_env.witness = KeccakWitness::default();
+        self.witness_env.errors = vec![];
+        // The multiplicities are not reset.
     }
 
     /// Entrypoint for the interpreter. It executes one step of the Keccak circuit (one row),

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -2,8 +2,8 @@
 //! including the common functions between the witness and the constraints environments
 //! for arithmetic, boolean, and column operations.
 use crate::keccak::{
-    column::KeccakWitness, constraints::Env as ConstraintsEnv, grid_index, pad_blocks,
-    witness::Env as WitnessEnv, KeccakColumn, DIM, HASH_BYTELENGTH, QUARTERS, WORDS_IN_HASH,
+    constraints::Env as ConstraintsEnv, grid_index, pad_blocks, witness::Env as WitnessEnv,
+    KeccakColumn, DIM, HASH_BYTELENGTH, QUARTERS, WORDS_IN_HASH,
 };
 use ark_ff::Field;
 use kimchi::{
@@ -117,10 +117,9 @@ impl<F: Field> KeccakEnv<F> {
         self.witness_env.witness[column] = value;
     }
 
-    /// Nullifies the KeccakWitness of the environment by resetting it to default values
+    /// Nullifies the Witness environment by resetting it to default values
     pub fn null_state(&mut self) {
-        self.witness_env.witness = KeccakWitness::default();
-        self.witness_env.errors = vec![]; // Reset errors of constraints for the new row
+        self.witness_env = WitnessEnv::default();
     }
 
     /// Entrypoint for the interpreter. It executes one step of the Keccak circuit (one row),

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -1,10 +1,9 @@
+use crate::{keccak::column::Column as KeccakColumn, lookups::LookupTableIDs};
 use ark_ff::Field;
 use kimchi::circuits::{
     expr::{ConstantExpr, Expr},
     polynomials::keccak::constants::{DIM, KECCAK_COLS, QUARTERS, RATE_IN_BYTES, STATE_LEN},
 };
-
-use self::column::Column as KeccakColumn;
 
 pub mod column;
 pub mod constraints;
@@ -34,7 +33,7 @@ pub(crate) type E<F> = Expr<ConstantExpr<F>, KeccakColumn>;
 pub enum Error {
     Constraint(Constraint),
     #[allow(dead_code)]
-    Lookup(usize),
+    Lookup(LookupTableIDs),
 }
 
 /// All the names for constraints involved in the Keccak circuit

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -32,7 +32,6 @@ pub(crate) type E<F> = Expr<ConstantExpr<F>, KeccakColumn>;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
     Constraint(Constraint),
-    #[allow(dead_code)]
     Lookup(LookupTableIDs),
 }
 

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -21,7 +21,7 @@ use kimchi_msm::LookupTableID;
 pub struct Env<Fp> {
     /// The full state of the Keccak gate (witness)
     pub witness: KeccakWitness<Fp>,
-    /// The multiplicities of each lookup entry
+    /// The multiplicities of each lookup entry. Should not be cleared between steps.
     pub multiplicities: Vec<Vec<u32>>,
     /// If any, an error that occurred during the execution of the constraints, to help with debugging
     pub(crate) errors: Vec<Error>,

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -70,7 +70,7 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
         self.witness[column]
     }
 
-    /// Assert that the input is zero
+    /// Checks the constraint `tag` by checking that the input `x` is zero
     fn constrain(&mut self, tag: Constraint, x: Self::Variable) {
         if x != F::zero() {
             self.errors.push(Error::Constraint(tag));
@@ -88,14 +88,14 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
             | ByteLookup => {
                 if lookup.magnitude == Self::one() {
                     // Check that the lookup value is in the table
-                    if let Some(idx) = LookupTable::in_table(lookup.table_id, lookup.value) {
+                    if let Some(idx) = LookupTable::is_in_table(lookup.table_id, lookup.value) {
                         self.multiplicities[lookup.table_id as usize][idx] += 1;
                     } else {
                         self.errors.push(Error::Lookup(lookup.table_id));
                     }
                 }
             }
-            _ => (),
+            MemoryLookup | RegisterLookup | SyscallLookup | KeccakStepLookup => (),
         }
     }
 }

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -10,7 +10,7 @@ use crate::{
     keccak::{
         column::KeccakWitness, interpreter::KeccakInterpreter, Constraint, Error, KeccakColumn,
     },
-    lookups::{Lookup, LookupTableIDs::*},
+    lookups::{FixedLookupTables, Lookup, LookupTable, LookupTableIDs::*},
 };
 use ark_ff::Field;
 use kimchi::o1_utils::Two;
@@ -88,7 +88,11 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
             | ByteLookup => {
                 if lookup.magnitude == Self::Variable::one() {
                     // Check that the lookup value is in the table
-                    //self.multiplicities[lookup.table_id as usize][entry] += 1;
+                    if let Some(idx) = LookupTable::in_table(lookup.table_id, lookup.value) {
+                        self.multiplicities[lookup.table_id as usize][idx] += 1;
+                    } else {
+                        self.errors.push(Error::Lookup(lookup.table_id));
+                    }
                 }
             }
             _ => (),

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -81,21 +81,18 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
     // LOOKUPS OPERATIONS //
     ////////////////////////
 
-    fn add_lookup(&mut self, _lookup: Lookup<Self::Variable>) {
+    fn add_lookup(&mut self, lookup: Lookup<Self::Variable>) {
         // Keep track of multiplicities for fixed lookups
-        todo!()
-    }
-
-    fn lookup_syscall_preimage(&mut self) {
-        // No-op for witness
-    }
-
-    fn lookup_syscall_hash(&mut self) {
-        // No-op for witness
-    }
-
-    fn lookup_steps(&mut self) {
-        // No-op for witness
+        match lookup.table_id {
+            RangeCheck16Lookup | SparseLookup | ResetLookup | RoundConstantsLookup | PadLookup
+            | ByteLookup => {
+                if lookup.magnitude == Self::Variable::one() {
+                    // Check that the lookup value is in the table
+                    //self.multiplicities[lookup.table_id as usize][entry] += 1;
+                }
+            }
+            _ => (),
+        }
     }
 
     fn lookup_rc16(&mut self, flag: Self::Variable, _value: Self::Variable) {

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -32,12 +32,12 @@ impl<F: Field> Default for Env<F> {
         Self {
             witness: KeccakWitness::default(),
             multiplicities: vec![
-                Vec::with_capacity(RangeCheck16Lookup.length()),
-                Vec::with_capacity(SparseLookup.length()),
-                Vec::with_capacity(ResetLookup.length()),
-                Vec::with_capacity(RoundConstantsLookup.length()),
-                Vec::with_capacity(PadLookup.length()),
-                Vec::with_capacity(ByteLookup.length()),
+                vec![0; RangeCheck16Lookup.length()],
+                vec![0; SparseLookup.length()],
+                vec![0; ResetLookup.length()],
+                vec![0; RoundConstantsLookup.length()],
+                vec![0; PadLookup.length()],
+                vec![0; ByteLookup.length()],
             ],
             errors: vec![],
         }

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -32,12 +32,12 @@ impl<F: Field> Default for Env<F> {
         Self {
             witness: KeccakWitness::default(),
             multiplicities: vec![
+                vec![0; PadLookup.length()],
+                vec![0; RoundConstantsLookup.length()],
+                vec![0; ByteLookup.length()],
                 vec![0; RangeCheck16Lookup.length()],
                 vec![0; SparseLookup.length()],
                 vec![0; ResetLookup.length()],
-                vec![0; RoundConstantsLookup.length()],
-                vec![0; PadLookup.length()],
-                vec![0; ByteLookup.length()],
             ],
             errors: vec![],
         }

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -10,18 +10,19 @@ use crate::{
     keccak::{
         column::KeccakWitness, interpreter::KeccakInterpreter, Constraint, Error, KeccakColumn,
     },
-    lookups::Lookup,
+    lookups::{Lookup, LookupTableIDs::*},
 };
 use ark_ff::Field;
 use kimchi::o1_utils::Two;
+use kimchi_msm::LookupTableID;
 
 /// This struct contains all that needs to be kept track of during the execution of the Keccak step interpreter
 #[derive(Clone, Debug)]
 pub struct Env<Fp> {
     /// The full state of the Keccak gate (witness)
     pub witness: KeccakWitness<Fp>,
-    // The multiplicities of each lookup table
-    // TODO
+    /// The multiplicities of each lookup entry
+    pub multiplicities: Vec<Vec<u32>>,
     /// If any, an error that occurred during the execution of the constraints, to help with debugging
     pub(crate) errors: Vec<Error>,
 }
@@ -30,6 +31,14 @@ impl<F: Field> Default for Env<F> {
     fn default() -> Self {
         Self {
             witness: KeccakWitness::default(),
+            multiplicities: vec![
+                Vec::with_capacity(RangeCheck16Lookup.length()),
+                Vec::with_capacity(SparseLookup.length()),
+                Vec::with_capacity(ResetLookup.length()),
+                Vec::with_capacity(RoundConstantsLookup.length()),
+                Vec::with_capacity(PadLookup.length()),
+                Vec::with_capacity(ByteLookup.length()),
+            ],
             errors: vec![],
         }
     }

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -86,7 +86,7 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
         match lookup.table_id {
             RangeCheck16Lookup | SparseLookup | ResetLookup | RoundConstantsLookup | PadLookup
             | ByteLookup => {
-                if lookup.magnitude == Self::Variable::one() {
+                if lookup.magnitude == Self::one() {
                     // Check that the lookup value is in the table
                     if let Some(idx) = LookupTable::in_table(lookup.table_id, lookup.value) {
                         self.multiplicities[lookup.table_id as usize][idx] += 1;
@@ -96,53 +96,6 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
                 }
             }
             _ => (),
-        }
-    }
-
-    fn lookup_rc16(&mut self, flag: Self::Variable, _value: Self::Variable) {
-        if flag == Self::one() {
-            // TODO: keep track of multiplicity of range check 16 entry
-            // TODO: check that [value] is in the RangeCheck16Lookup
-        }
-    }
-
-    fn lookup_reset(
-        &mut self,
-        flag: Self::Variable,
-        _dense: Self::Variable,
-        _sparse: Self::Variable,
-    ) {
-        if flag == Self::one() {
-            // TODO: keep track of multiplicity of range check 16 entry
-            // TODO: check that [dense, sparse] is in the ResetLookup
-        }
-    }
-
-    fn lookup_sparse(&mut self, flag: Self::Variable, _value: Self::Variable) {
-        if flag == Self::one() {
-            // TODO: keep track of multiplicity of range check 16 entry
-            // TODO: check that [value] is in the SparseLookup
-        }
-    }
-
-    fn lookup_byte(&mut self, flag: Self::Variable, _value: Self::Variable) {
-        if flag == Self::one() {
-            // TODO: keep track of multiplicity of range check 16 entry
-            // TODO: check that [value] is in the ByteLookup
-        }
-    }
-
-    fn lookup_pad(&mut self, flag: Self::Variable, _value: Vec<Self::Variable>) {
-        if flag == Self::one() {
-            // TODO: keep track of multiplicity of range check 16 entry
-            // TODO: check that [value] is in the PadLookup
-        }
-    }
-
-    fn lookup_round_constants(&mut self, flag: Self::Variable, _value: Vec<Self::Variable>) {
-        if flag == Self::one() {
-            // TODO: keep track of multiplicity of range check 16 entry
-            // TODO: check that [value] is in the RoundConstantsLookup
         }
     }
 }

--- a/optimism/src/lookups.rs
+++ b/optimism/src/lookups.rs
@@ -7,7 +7,7 @@ use kimchi::{
         constants::{RATE_IN_BYTES, ROUNDS},
         Keccak, RC,
     },
-    o1_utils::Two,
+    o1_utils::{FieldHelpers, Two},
 };
 use kimchi_msm::{LookupTableID, MVLookupTable};
 
@@ -62,7 +62,8 @@ pub(crate) type Lookup<F> = RAMLookup<F, LookupTableIDs>;
 pub(crate) type LookupTable<F> = MVLookupTable<F, LookupTableIDs>;
 
 /// Trait that creates all the fixed lookup tables used in the VM
-pub(crate) trait FixedLookupTables<F> {
+pub(crate) trait FixedLookupTables<F, ID: LookupTableID> {
+    fn in_table(id: ID, value: Vec<F>) -> Option<usize>;
     fn table_range_check_16() -> LookupTable<F>;
     fn table_sparse() -> LookupTable<F>;
     fn table_reset() -> LookupTable<F>;
@@ -71,7 +72,51 @@ pub(crate) trait FixedLookupTables<F> {
     fn table_byte() -> LookupTable<F>;
 }
 
-impl<F: Field> FixedLookupTables<F> for LookupTable<F> {
+impl<F: Field> FixedLookupTables<F, LookupTableIDs> for LookupTable<F> {
+    fn in_table(id: LookupTableIDs, entry: Vec<F>) -> Option<usize> {
+        let table = match id {
+            LookupTableIDs::RangeCheck16Lookup => Self::table_range_check_16().entries,
+            LookupTableIDs::SparseLookup => Self::table_sparse().entries,
+            LookupTableIDs::ResetLookup => Self::table_reset().entries,
+            LookupTableIDs::RoundConstantsLookup => Self::table_round_constants().entries,
+            LookupTableIDs::PadLookup => Self::table_pad().entries,
+            LookupTableIDs::ByteLookup => Self::table_byte().entries,
+            _ => return None,
+        };
+        let bytes = entry[0].to_bytes();
+        assert!(bytes.len() <= 8); // To make sure it is a u64 at most
+        let value = bytes.iter().fold(0u64, |acc, &x| (acc << 8) + x as u64) as usize;
+
+        match id {
+            LookupTableIDs::RangeCheck16Lookup
+            | LookupTableIDs::ResetLookup
+            | LookupTableIDs::ByteLookup
+            | LookupTableIDs::RoundConstantsLookup => {
+                if table[value] == entry {
+                    Some(value)
+                } else {
+                    None
+                }
+            }
+            LookupTableIDs::SparseLookup => {
+                let dense = u64::from_str_radix(&format!("{:x}", value), 2).unwrap() as usize;
+                if table[dense] == entry {
+                    Some(value)
+                } else {
+                    None
+                }
+            }
+            LookupTableIDs::PadLookup => {
+                if table[value - 1] == entry {
+                    Some(value - 1)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
     #[allow(dead_code)]
     fn table_range_check_16() -> Self {
         Self {

--- a/optimism/src/lookups.rs
+++ b/optimism/src/lookups.rs
@@ -119,8 +119,8 @@ impl<F: Field> FixedLookupTables<F, LookupTableIDs> for LookupTable<F> {
             }
             SparseLookup => {
                 let res = u64::from_str_radix(&format!("{:x}", idx), 2);
-                let dense = if res.is_ok() {
-                    res.unwrap() as usize
+                let dense = if let Ok(ok) = res {
+                    ok as usize
                 } else {
                     id.length() // So that it returns None
                 };

--- a/optimism/src/lookups.rs
+++ b/optimism/src/lookups.rs
@@ -83,9 +83,11 @@ impl<F: Field> FixedLookupTables<F, LookupTableIDs> for LookupTable<F> {
             LookupTableIDs::ByteLookup => Self::table_byte().entries,
             _ => return None,
         };
-        let bytes = value[0].to_bytes();
-        assert!(bytes.len() <= 8); // To make sure it is a u64 at most
-        let idx = bytes.iter().fold(0u64, |acc, &x| (acc << 8) + x as u64) as usize;
+        let idx = value[0]
+            .to_bytes()
+            .iter()
+            .rev()
+            .fold(0u64, |acc, &x| acc * 256 + x as u64) as usize;
 
         match id {
             LookupTableIDs::RangeCheck16Lookup

--- a/optimism/src/lookups.rs
+++ b/optimism/src/lookups.rs
@@ -14,27 +14,27 @@ use kimchi_msm::{LookupTableID, MVLookupTable};
 /// All of the possible lookup table IDs used in the zkVM
 #[derive(Copy, Clone, Debug)]
 pub enum LookupTableIDs {
-    // RAM Tables
-    MemoryLookup = 0,
-    RegisterLookup = 1,
-    /// Syscalls communication channel
-    SyscallLookup = 2,
-    /// Input/Output of Keccak steps
-    KeccakStepLookup = 3,
-
-    // Read Tables
+    // Read tables come first to allow indexing with the table ID for the multiplicities
     /// Single-column table of all values in the range [0, 2^16)
-    RangeCheck16Lookup = 4,
+    RangeCheck16Lookup = 0,
     /// Single-column table of 2^16 entries with the sparse representation of all values
-    SparseLookup = 5,
+    SparseLookup = 1,
     /// Dual-column table of all values in the range [0, 2^16) and their sparse representation
-    ResetLookup = 6,
+    ResetLookup = 2,
     /// 24-row table with all possible values for round and their round constant in expanded form (in big endian)
-    RoundConstantsLookup = 7,
+    RoundConstantsLookup = 3,
     /// All [1..136] values of possible padding lengths, the value 2^len, and the 5 corresponding pad suffixes with the 10*1 rule
-    PadLookup = 8,
+    PadLookup = 4,
     /// All values that can be stored in a byte (amortized table, better than model as RangeCheck16 (x and scaled x)
-    ByteLookup = 9,
+    ByteLookup = 5,
+
+    // RAM Tables
+    MemoryLookup = 6,
+    RegisterLookup = 7,
+    /// Syscalls communication channel
+    SyscallLookup = 8,
+    /// Input/Output of Keccak steps
+    KeccakStepLookup = 9,
 }
 
 impl LookupTableID for LookupTableIDs {

--- a/optimism/src/lookups.rs
+++ b/optimism/src/lookups.rs
@@ -103,7 +103,7 @@ impl<F: Field> FixedLookupTables<F, LookupTableIDs> for LookupTable<F> {
 
         match id {
             RoundConstantsLookup | ByteLookup | RangeCheck16Lookup | ResetLookup => {
-                if table[idx] == value {
+                if idx < id.length() && table[idx] == value {
                     Some(idx)
                 } else {
                     None
@@ -111,15 +111,20 @@ impl<F: Field> FixedLookupTables<F, LookupTableIDs> for LookupTable<F> {
             }
             PadLookup => {
                 // Because this table starts with entry 1
-                if table[idx - 1] == value {
+                if idx - 1 < id.length() && table[idx - 1] == value {
                     Some(idx - 1)
                 } else {
                     None
                 }
             }
             SparseLookup => {
-                let dense = u64::from_str_radix(&format!("{:x}", idx), 2).unwrap() as usize;
-                if table[dense] == value {
+                let res = u64::from_str_radix(&format!("{:x}", idx), 2);
+                let dense = if res.is_ok() {
+                    res.unwrap() as usize
+                } else {
+                    id.length() // So that it returns None
+                };
+                if dense < id.length() && table[dense] == value {
                     Some(dense)
                 } else {
                     None


### PR DESCRIPTION
This PR addresses the `todo!()` inside `add_lookup()` of the witness environment of Keccak.  Here, when the lookup is a "fixed table lookup" (as opposed to read/write lookups, where it is a no-op for the witness), and the condition is satisfied (example, `is_round()` or `is_sponge()`), then it checks that the desired value is indeed in the given table. If this is not the case, the function pushes a lookup error to the list of errors in the environment. This latter behavior will be used in a coming PR in negative tests.

I added one simple positive test just to show that it works. But for now, it seems to be too slow when the tables and the variables are F. Perhaps I will create a follow-up PR where `Self::Variable = i128` instead for witnesses, so it is faster. No priority for now, as this only has an effect in tests speed.