### PR TITLE
Logup: prepare the column environment to add the lookup

### DIFF
--- a/msm/src/column_env.rs
+++ b/msm/src/column_env.rs
@@ -25,8 +25,9 @@ pub struct ColumnEnvironment<'a, F: FftField> {
     /// The domains used in the PLONK argument.
     pub domain: EvaluationDomains<F>,
     /// Lookup specific polynomials
-    // TODO define MVlookup one
     pub lookup: Option<()>,
+    // TODO: rename in additive lookup or "logup"
+    // We do not use multi-variate lookups, only the additive part
 }
 
 impl<'a, F: FftField> TColumnEnvironment<'a, F> for ColumnEnvironment<'a, F> {
@@ -36,19 +37,28 @@ impl<'a, F: FftField> TColumnEnvironment<'a, F> for ColumnEnvironment<'a, F> {
         &self,
         col: &Self::Column,
     ) -> Option<&'a Evaluations<F, Radix2EvaluationDomain<F>>> {
-        let witness_columns_n: usize = self.witness.len();
-        let coefficients_columns_n: usize = self.coefficients.len();
-        let crate::columns::Column::X(i) = col else {
-            todo!()
-        };
-        let i = *i;
-        if i < witness_columns_n {
-            let res = &self.witness[i];
-            Some(res)
-        } else if i < witness_columns_n + coefficients_columns_n {
-            Some(&self.coefficients[i])
-        } else {
-            None
+        let witness_length: usize = self.witness.len();
+        let coefficients_length: usize = self.coefficients.len();
+        match *col {
+            // Handling the "relation columns"
+            Self::Column::X(i) => {
+                if i < witness_length {
+                    let res = &self.witness[i];
+                    Some(res)
+                } else if i < witness_length + coefficients_length {
+                    // FIXME and add a test
+                    Some(&self.coefficients[i])
+                } else {
+                    // TODO: add a test for this
+                    panic!("Requested column with index {:?} but the given witness is meant for {:?} columns", i, witness_length)
+                }
+            }
+            Self::Column::LookupPartialSum(_)
+            | Self::Column::LookupFixedTable(_)
+            | Self::Column::LookupAggregation
+            | Self::Column::LookupMultiplicity(_) => {
+                panic!("Logup is not yet implemented.")
+            }
         }
     }
 


### PR DESCRIPTION
No-op. Only reorganizing the method `get_column` to handle case by case the lookup columns.