### PR TITLE
Improve complexity of multiplicities computation from linear to constant

### DIFF
--- a/msm/src/mvlookup.rs
+++ b/msm/src/mvlookup.rs
@@ -45,10 +45,8 @@ pub trait LookupTableID {
 #[derive(Debug, Clone)]
 pub struct LookupTable<F, ID: LookupTableID + Send + Sync + Copy> {
     /// Table ID corresponding to this table
-    #[allow(dead_code)]
     pub table_id: ID,
     /// Vector of values inside each entry of the table
-    #[allow(dead_code)]
     pub entries: Vec<Vec<F>>,
 }
 

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -119,11 +119,12 @@ impl<F: Field> KeccakEnv<F> {
         self.witness_env.witness[column] = value;
     }
 
-    /// Nullifies the Witness environment by resetting it to default values (except for multiplicities)
+    /// Nullifies the Witness environment by resetting it to default values (except for lookup-related)
     pub fn null_state(&mut self) {
         self.witness_env.witness = KeccakWitness::default();
         self.witness_env.errors = vec![];
         // The multiplicities are not reset.
+        // The fixed tables are not modified.
     }
 
     /// Entrypoint for the interpreter. It executes one step of the Keccak circuit (one row),

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -23,10 +23,8 @@ pub struct Env<F> {
     /// The full state of the Keccak gate (witness)
     pub witness: KeccakWitness<F>,
     /// The fixed tables used in the Keccak gate
-    // FIXME: too costly to store them all for each step. Should be once for the whole execution.
     pub tables: Vec<LookupTable<F>>,
     /// The multiplicities of each lookup entry. Should not be cleared between steps.
-    // FIXME: too costly to store them all for each step. Should be once for the whole execution.
     pub multiplicities: Vec<Vec<u32>>,
     /// If any, an error that occurred during the execution of the constraints, to help with debugging
     pub(crate) errors: Vec<Error>,

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -17,11 +17,16 @@ use kimchi::o1_utils::Two;
 use kimchi_msm::LookupTableID;
 
 /// This struct contains all that needs to be kept track of during the execution of the Keccak step interpreter
+// TODO: the fixed tables information should be inferred from the general environment
 #[derive(Clone, Debug)]
-pub struct Env<Fp> {
+pub struct Env<F> {
     /// The full state of the Keccak gate (witness)
-    pub witness: KeccakWitness<Fp>,
+    pub witness: KeccakWitness<F>,
+    /// The fixed tables used in the Keccak gate
+    // FIXME: too costly to store them all for each step. Should be once for the whole execution.
+    pub tables: Vec<LookupTable<F>>,
     /// The multiplicities of each lookup entry. Should not be cleared between steps.
+    // FIXME: too costly to store them all for each step. Should be once for the whole execution.
     pub multiplicities: Vec<Vec<u32>>,
     /// If any, an error that occurred during the execution of the constraints, to help with debugging
     pub(crate) errors: Vec<Error>,
@@ -31,6 +36,14 @@ impl<F: Field> Default for Env<F> {
     fn default() -> Self {
         Self {
             witness: KeccakWitness::default(),
+            tables: vec![
+                LookupTable::table_pad(),
+                LookupTable::table_round_constants(),
+                LookupTable::table_byte(),
+                LookupTable::table_range_check_16(),
+                LookupTable::table_sparse(),
+                LookupTable::table_reset(),
+            ],
             multiplicities: vec![
                 vec![0; PadLookup.length()],
                 vec![0; RoundConstantsLookup.length()],
@@ -88,7 +101,10 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
             | ByteLookup => {
                 if lookup.magnitude == Self::one() {
                     // Check that the lookup value is in the table
-                    if let Some(idx) = LookupTable::is_in_table(lookup.table_id, lookup.value) {
+                    if let Some(idx) = LookupTable::is_in_table(
+                        &self.tables[lookup.table_id as usize],
+                        lookup.value,
+                    ) {
                         self.multiplicities[lookup.table_id as usize][idx] += 1;
                     } else {
                         self.errors.push(Error::Lookup(lookup.table_id));


### PR DESCRIPTION
Note that now the tests can run all of the `lookups()` at each step (before, I was just running a subset of them) and the running time is FAST. 

TODO: this still does not address the generalization to use hash maps for the multiplicities. Also, I would like to abstract away the exact tables being used and infer them from a generic which is instantiated only once in the general environment.

Closes https://github.com/MinaProtocol/mina/issues/15171