### PR TITLE
CI: use cargo-nextest@=0.9.67 instead of latest

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,8 @@ jobs:
   run_checks:
     strategy:
       matrix:
+        # FIXME: use the latest version of cargo nextest when we get rid of 1.71
+        # and 1.72
         rust_toolchain_version: ["1.71", "1.72", "1.73", "1.74"]
         # FIXME: currently not available for 5.0.0.
         # It might be related to boxroot dependency, and we would need to bump
@@ -112,7 +114,8 @@ jobs:
       - name: Install latest nextest release
         run: |
           eval $(opam env)
-          cargo install cargo-nextest --locked
+          # FIXME: update to 0.9.68 when we get rid of 1.71 and 1.72.
+          cargo install cargo-nextest@=0.9.67 --locked
 
       - name: Test with latest nextest release (faster than cargo test)
         run: |


### PR DESCRIPTION
The CI is currently broken as it does use the most recent release (16th March '24).
From 0.9.68, nextest is only available from 1.73.

Getting rid of Rust 1.71 and 1.72 would be also an option, but it is not in the scope of this PR, and we must also check the consequences on minaprotocol/mina.