### PR TITLE
MSM: witness_evals_env as a Witness structure

### DIFF
--- a/msm/src/column_env.rs
+++ b/msm/src/column_env.rs
@@ -2,6 +2,7 @@ use ark_ff::FftField;
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 
 use crate::mvlookup;
+use crate::witness::Witness;
 use kimchi::circuits::domains::EvaluationDomains;
 use kimchi::circuits::expr::{
     Challenges, ColumnEnvironment as TColumnEnvironment, Constants, Domain,
@@ -11,9 +12,9 @@ use kimchi::circuits::expr::{
 /// required to evaluate an expression as a polynomial.
 ///
 /// All are evaluations.
-pub struct ColumnEnvironment<'a, F: FftField> {
+pub struct ColumnEnvironment<'a, const N: usize, F: FftField> {
     /// The witness column polynomials
-    pub witness: &'a Vec<Evaluations<F, Radix2EvaluationDomain<F>>>,
+    pub witness: &'a Witness<N, Evaluations<F, Radix2EvaluationDomain<F>>>,
     /// The coefficient column polynomials
     pub coefficients: &'a Vec<Evaluations<F, Radix2EvaluationDomain<F>>>,
     /// The value `prod_{j != 1} (1 - omega^j)`, used for efficiently
@@ -31,7 +32,7 @@ pub struct ColumnEnvironment<'a, F: FftField> {
     pub lookup: Option<mvlookup::prover::QuotientPolynomialEnvironment<'a, F>>,
 }
 
-impl<'a, F: FftField> TColumnEnvironment<'a, F> for ColumnEnvironment<'a, F> {
+impl<'a, const N: usize, F: FftField> TColumnEnvironment<'a, F> for ColumnEnvironment<'a, N, F> {
     type Column = crate::columns::Column;
 
     fn get_column(

--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -132,10 +132,11 @@ where
     // TODO rename this
     // The evaluations should be at least the degree of our expressions. Higher?
     // Maybe we can only use d4, we don't have degree-7 gates anyway
-    let witness_evals_env: Vec<Evaluations<G::ScalarField, R2D<G::ScalarField>>> = (&witness_polys)
-        .into_par_iter()
-        .map(|witness_poly| witness_poly.evaluate_over_domain_by_ref(domain.d4))
-        .collect();
+    let witness_evals_env: Witness<N, Evaluations<G::ScalarField, R2D<G::ScalarField>>> =
+        (&witness_polys)
+            .into_par_iter()
+            .map(|witness_poly| witness_poly.evaluate_over_domain_by_ref(domain.d4))
+            .collect();
 
     ////////////////////////////////////////////////////////////////////////////
     // Round 2: Creating and committing to the quotient polynomial

--- a/msm/src/witness.rs
+++ b/msm/src/witness.rs
@@ -1,5 +1,6 @@
 use ark_ff::Zero;
 use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelIterator};
+use std::ops::Index;
 
 /// The witness columns used by a gate of the MSM circuits.
 /// It is generic over the number of columns, N, and the type of the witness, T.
@@ -19,6 +20,24 @@ impl<const N: usize, T: Zero + Clone> Default for Witness<N, T> {
         Witness {
             cols: std::array::from_fn(|_| T::zero()),
         }
+    }
+}
+
+impl<const N: usize, T> Index<usize> for Witness<N, T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.cols[index]
+    }
+}
+
+impl<const N: usize, T> Witness<N, T> {
+    pub fn len(&self) -> usize {
+        self.cols.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.cols.is_empty()
     }
 }
 


### PR DESCRIPTION
To keep the number of columns abstract through the type, and rely on types.

Later, this variable changes.

Cherry-picked commits from [dw/tmp-eval-8/](https://github.com/o1-labs/proof-systems/commits/dw/tmp-eval-8/)