### PR TITLE
Clippy: remove old annotation regarding type complexity

### DIFF
--- a/poly-commitment/src/tests/commitment.rs
+++ b/poly-commitment/src/tests/commitment.rs
@@ -171,7 +171,6 @@ fn test_randomised<RNG: Rng + CryptoRng>(mut rng: &mut RNG) {
         }
 
         // create aggregated evaluation proof
-        #[allow(clippy::type_complexity)]
         let mut polynomials: Vec<(
             DensePolynomialOrEvaluations<Fp, Radix2EvaluationDomain<Fp>>,
             PolyComm<_>,


### PR DESCRIPTION
It seems to have changed, and clippy does not complain anymore.