### PR TITLE
MSM: Store Boxed array in Witness

### DIFF
--- a/msm/src/ffa/witness.rs
+++ b/msm/src/ffa/witness.rs
@@ -29,7 +29,7 @@ impl<F: PrimeField> FFAInterpreterEnv<F> for WitnessBuilderEnv<F> {
     fn empty() -> Self {
         WitnessBuilderEnv {
             witness: vec![Witness {
-                cols: [Zero::zero(); FFA_N_COLUMNS],
+                cols: Box::new([Zero::zero(); FFA_N_COLUMNS]),
             }],
         }
     }
@@ -99,7 +99,9 @@ impl WitnessBuilderEnv<Fp> {
         }
 
         ProofInputs {
-            evaluations: Witness { cols },
+            evaluations: Witness {
+                cols: Box::new(cols),
+            },
             mvlookups: vec![],
             public_input_size: 0,
         }
@@ -107,7 +109,7 @@ impl WitnessBuilderEnv<Fp> {
 
     pub fn next_row(&mut self) {
         self.witness.push(Witness {
-            cols: [Zero::zero(); FFA_N_COLUMNS],
+            cols: Box::new([Zero::zero(); FFA_N_COLUMNS]),
         });
     }
 }

--- a/msm/src/proof.rs
+++ b/msm/src/proof.rs
@@ -35,11 +35,11 @@ pub struct ProofInputs<const N: usize, G: KimchiCurve, ID: LookupTableID + Send 
 impl<const N: usize, G: KimchiCurve> ProofInputs<N, G, LookupTableIDs> {
     pub fn random(domain: EvaluationDomains<G::ScalarField>) -> Self {
         let mut rng = thread_rng();
-        let cols: [Vec<G::ScalarField>; N] = std::array::from_fn(|_| {
+        let cols: Box<[Vec<G::ScalarField>; N]> = Box::new(std::array::from_fn(|_| {
             (0..domain.d1.size as usize)
                 .map(|_| G::ScalarField::rand(&mut rng))
                 .collect::<Vec<_>>()
-        });
+        }));
         ProofInputs {
             evaluations: Witness { cols },
             mvlookups: vec![LookupWitness::<G::ScalarField>::random(domain)],

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -103,7 +103,7 @@ mod tests {
         let mut witness_env = witness::Env::<Fp>::create();
         // Boxing to avoid stack overflow
         let mut witness: Box<Witness<SERIALIZATION_N_COLUMNS, Vec<Fp>>> = Box::new(Witness {
-            cols: std::array::from_fn(|_| Vec::with_capacity(DOMAIN_SIZE)),
+            cols: Box::new(std::array::from_fn(|_| Vec::with_capacity(DOMAIN_SIZE))),
         });
 
         // Boxing to avoid stack overflow

--- a/msm/src/test/mod.rs
+++ b/msm/src/test/mod.rs
@@ -174,7 +174,7 @@ mod tests {
         let random_x0s: Vec<Fp> = (0..domain_size).map(|_| Fp::rand(&mut rng)).collect();
         let exp_x1 = random_x0s.clone();
         let witness: Witness<N, Vec<Fp>> = Witness {
-            cols: [random_x0s, exp_x1],
+            cols: Box::new([random_x0s, exp_x1]),
         };
 
         test_completeness_generic::<N, _>(
@@ -210,7 +210,7 @@ mod tests {
             .map(|(x0, x1)| (*x0) * (*x0) - x1)
             .collect::<Vec<Fp>>();
         let witness: Witness<N, Vec<Fp>> = Witness {
-            cols: [random_x0s, random_x1s, exp_x2],
+            cols: Box::new([random_x0s, random_x1s, exp_x2]),
         };
 
         test_completeness_generic::<N, _>(
@@ -255,7 +255,7 @@ mod tests {
             .map(|((x0, x1), x2)| -((*x0) * (*x0) * (*x0) - Fp::from(42) * (*x1) * (*x2)))
             .collect::<Vec<Fp>>();
         let witness: Witness<N, Vec<Fp>> = Witness {
-            cols: [random_x0s, random_x1s, random_x2s, exp_x3],
+            cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
         test_completeness_generic::<N, _>(
@@ -294,7 +294,7 @@ mod tests {
             .map(|(x1, x2)| -Fp::one() / (*x1 * *x2))
             .collect::<Vec<Fp>>();
         let witness: Witness<N, Vec<Fp>> = Witness {
-            cols: [random_x0s, random_x1s, random_x2s, exp_x3],
+            cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
         test_completeness_generic::<N, _>(
@@ -327,7 +327,7 @@ mod tests {
             .map(|x0| -*x0 * *x0 * *x0 * *x0 * *x0)
             .collect::<Vec<Fp>>();
         let witness: Witness<N, Vec<Fp>> = Witness {
-            cols: [random_x0s, exp_x1],
+            cols: Box::new([random_x0s, exp_x1]),
         };
 
         test_completeness_generic::<N, _>(
@@ -370,7 +370,7 @@ mod tests {
             .map(|x2| (Fp::one() / Fp::from(3)) * x2 * x2)
             .collect::<Vec<Fp>>();
         let witness: Witness<N, Vec<Fp>> = Witness {
-            cols: [random_x0s, exp_x1, random_x2s, exp_x3],
+            cols: Box::new([random_x0s, exp_x1, random_x2s, exp_x3]),
         };
 
         test_completeness_generic::<N, _>(
@@ -425,7 +425,7 @@ mod tests {
             })
             .collect::<Vec<Fp>>();
         let witness: Witness<N, Vec<Fp>> = Witness {
-            cols: [random_x0s, random_x1s, random_x2s, exp_x3],
+            cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
         test_completeness_generic::<N, _>(
@@ -480,7 +480,7 @@ mod tests {
             })
             .collect::<Vec<Fp>>();
         let witness: Witness<N, Vec<Fp>> = Witness {
-            cols: [random_x0s, random_x1s, random_x2s, exp_x3],
+            cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
         test_completeness_generic::<N, _>(

--- a/msm/src/test/witness.rs
+++ b/msm/src/test/witness.rs
@@ -29,7 +29,7 @@ impl<F: PrimeField> TestInterpreterEnv<F> for WitnessBuilderEnv<F> {
     fn empty() -> Self {
         WitnessBuilderEnv {
             witness: vec![Witness {
-                cols: [Zero::zero(); TEST_N_COLUMNS],
+                cols: Box::new([Zero::zero(); TEST_N_COLUMNS]),
             }],
         }
     }
@@ -91,7 +91,9 @@ impl WitnessBuilderEnv<Fp> {
         }
 
         ProofInputs {
-            evaluations: Witness { cols },
+            evaluations: Witness {
+                cols: Box::new(cols),
+            },
             mvlookups: vec![],
             public_input_size: 0,
         }
@@ -99,7 +101,7 @@ impl WitnessBuilderEnv<Fp> {
 
     pub fn next_row(&mut self) {
         self.witness.push(Witness {
-            cols: [Zero::zero(); TEST_N_COLUMNS],
+            cols: Box::new([Zero::zero(); TEST_N_COLUMNS]),
         });
     }
 }

--- a/msm/src/witness.rs
+++ b/msm/src/witness.rs
@@ -12,13 +12,13 @@ use std::ops::Index;
 pub struct Witness<const N: usize, T> {
     /// A witness row is represented by an array of N witness columns
     /// When T is a vector, then the witness describes the rows of the circuit.
-    pub cols: [T; N],
+    pub cols: Box<[T; N]>,
 }
 
 impl<const N: usize, T: Zero + Clone> Default for Witness<N, T> {
     fn default() -> Self {
         Witness {
-            cols: std::array::from_fn(|_| T::zero()),
+            cols: Box::new(std::array::from_fn(|_| T::zero())),
         }
     }
 }
@@ -46,7 +46,7 @@ impl<const N: usize, T: Zero + Clone> Witness<N, Vec<T>> {
         Witness {
             // Ideally the vector should be of domain size, but
             // one-element vector should be a reasonable default too.
-            cols: std::array::from_fn(|_| vec![T::zero(); domain_size]),
+            cols: Box::new(std::array::from_fn(|_| vec![T::zero(); domain_size])),
         }
     }
 
@@ -55,7 +55,9 @@ impl<const N: usize, T: Zero + Clone> Witness<N, Vec<T>> {
         for (i, vec) in self.cols[0..NPUB].iter().enumerate() {
             newcols[i] = vec.clone();
         }
-        Witness { cols: newcols }
+        Witness {
+            cols: Box::new(newcols),
+        }
     }
 }
 
@@ -67,7 +69,7 @@ impl<'lt, const N: usize, G> IntoIterator for &'lt Witness<N, G> {
 
     fn into_iter(self) -> Self::IntoIter {
         let mut iter_contents = Vec::with_capacity(N);
-        iter_contents.extend(&self.cols);
+        iter_contents.extend(&*self.cols);
         iter_contents.into_iter()
     }
 }
@@ -79,7 +81,7 @@ impl<const N: usize, F: Clone> IntoIterator for Witness<N, F> {
     /// Iterate over the columns in the circuit.
     fn into_iter(self) -> Self::IntoIter {
         let mut iter_contents = Vec::with_capacity(N);
-        iter_contents.extend(self.cols);
+        iter_contents.extend(*self.cols);
         iter_contents.into_iter()
     }
 }
@@ -94,7 +96,7 @@ where
     /// Iterate over the columns in the circuit, in parallel.
     fn into_par_iter(self) -> Self::Iter {
         let mut iter_contents = Vec::with_capacity(N);
-        iter_contents.extend(self.cols);
+        iter_contents.extend(*self.cols);
         iter_contents.into_par_iter()
     }
 }
@@ -123,7 +125,7 @@ where
 
     fn into_par_iter(self) -> Self::Iter {
         let mut iter_contents = Vec::with_capacity(N);
-        iter_contents.extend(&self.cols);
+        iter_contents.extend(&*self.cols);
         iter_contents.into_par_iter()
     }
 }
@@ -137,7 +139,7 @@ where
 
     fn into_par_iter(self) -> Self::Iter {
         let mut iter_contents = Vec::with_capacity(N);
-        iter_contents.extend(&mut self.cols);
+        iter_contents.extend(&mut *self.cols);
         iter_contents.into_par_iter()
     }
 }

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -85,7 +85,7 @@ pub fn main() -> ExitCode {
     };
 
     let mut mips_current_pre_folding_witness = MIPSWitness {
-        cols: std::array::from_fn(|_| Vec::with_capacity(DOMAIN_SIZE)),
+        cols: Box::new(std::array::from_fn(|_| Vec::with_capacity(DOMAIN_SIZE))),
     };
 
     // The keccak environment is extracted inside the loop
@@ -103,7 +103,7 @@ pub fn main() -> ExitCode {
 
     let mut keccak_current_pre_folding_witness: KeccakWitness<Vec<Fp256<FrParameters>>> =
         KeccakWitness {
-            cols: std::array::from_fn(|_| Vec::with_capacity(DOMAIN_SIZE)),
+            cols: Box::new(std::array::from_fn(|_| Vec::with_capacity(DOMAIN_SIZE))),
         };
 
     while !env.halt {

--- a/optimism/src/proof.rs
+++ b/optimism/src/proof.rs
@@ -30,9 +30,9 @@ impl<const N: usize, G: KimchiCurve> Default for ProofInputs<N, G> {
     fn default() -> Self {
         ProofInputs {
             evaluations: Witness {
-                cols: std::array::from_fn(|_| {
+                cols: Box::new(std::array::from_fn(|_| {
                     (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect()
-                }),
+                })),
             },
         }
     }
@@ -131,7 +131,7 @@ where
                 .collect::<Vec<_>>()
         };
         Witness {
-            cols: eval_array_col(&evaluations.cols).try_into().unwrap(),
+            cols: Box::new(eval_array_col(&(*evaluations.cols)).try_into().unwrap()),
         }
     };
     let commitments = {
@@ -140,7 +140,7 @@ where
             polys.into_par_iter().map(comm).collect::<Vec<_>>()
         };
         Witness {
-            cols: comm_array(&polys.cols).try_into().unwrap(),
+            cols: Box::new(comm_array(&(*polys.cols)).try_into().unwrap()),
         }
     };
 
@@ -161,7 +161,7 @@ where
             polys.par_iter().map(comm).collect::<Vec<_>>()
         };
         Witness {
-            cols: comm_array(&polys.cols).try_into().unwrap(),
+            cols: Box::new(comm_array(&(*polys.cols)).try_into().unwrap()),
         }
     };
     let zeta_evaluations = evals(&zeta);
@@ -338,7 +338,9 @@ mod tests {
                 (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>()
             });
             ProofInputs {
-                evaluations: MIPSWitness { cols },
+                evaluations: MIPSWitness {
+                    cols: Box::new(cols),
+                },
             }
         };
         let domain = EvaluationDomains::<Fp>::create(DOMAIN_SIZE).unwrap();
@@ -385,9 +387,9 @@ mod tests {
         let proof_inputs = {
             ProofInputs {
                 evaluations: KeccakWitness {
-                    cols: std::array::from_fn(|_| {
+                    cols: Box::new(std::array::from_fn(|_| {
                         (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>()
-                    }),
+                    })),
                 },
             }
         };


### PR DESCRIPTION
Problem: When dealing with long columns (200+), msm/prover.rs was failing with stack overflow while creating the first witness evaluations. The tests were passing if stack size was increased via an environment variable (`RUST_MIN_STACK` it was I think).

Solution: Insead of storing a potentially long array directly in the witness, storing just a reference to it (Box) solves the problem.
