### PR TITLE
MSM FF Mul: Outline column structure

### DIFF
--- a/msm/src/serialization/column.rs
+++ b/msm/src/serialization/column.rs
@@ -7,16 +7,15 @@ use crate::{
 /// Total number of columns in the serialization circuit
 pub const SER_N_COLUMNS: usize = 6 * N_LIMBS + N_INTERMEDIATE_LIMBS + 9;
 
-/// Column used by the serialization subcircuit
-/// It is not used yet.
+/// Columns used by the serialization subcircuit.
 pub enum SerializationColumn {
-    /// 3 88 bits inputs. For the row #i this represents the IPA challenge xi_{log(i)}.
-    KimchiLimb(usize),
-    /// N_INTERMEDIATE_LIMBS intermediate values, 4 bits long.
-    IntermediateLimb(usize),
-    /// N_LIMBS values, representing the limbs used by the MSM
-    MSMLimb(usize),
-    /// Previous C_j, this one is looked up. For the row i, the expected
+    /// 3 88-bit inputs. For the row #i this represents the IPA challenge xi_{log(i)}.
+    ChalKimchi(usize),
+    /// N_INTERMEDIATE_LIMBS intermediate values, 4 bits long. Represent parts of the IPA challenge.
+    ChalIntermediate(usize),
+    /// N_LIMBS values, representing the converted IPA challenge.
+    ChalConverted(usize),
+    /// Previous coefficient C_j, this one is looked up. For the row i, the expected
     /// value is (C_i >> 1).
     CoeffInput(usize),
     /// Trusted (for range) foreign field modulus, in 4 big limbs.
@@ -32,15 +31,15 @@ pub enum SerializationColumn {
 impl ColumnIndexer for SerializationColumn {
     fn ix_to_column(self) -> Column {
         match self {
-            Self::KimchiLimb(j) => {
+            Self::ChalKimchi(j) => {
                 assert!(j < 3);
                 Column::X(j)
             }
-            Self::IntermediateLimb(j) => {
+            Self::ChalIntermediate(j) => {
                 assert!(j < N_INTERMEDIATE_LIMBS);
                 Column::X(3 + j)
             }
-            Self::MSMLimb(j) => {
+            Self::ChalConverted(j) => {
                 assert!(j < N_LIMBS);
                 Column::X(N_INTERMEDIATE_LIMBS + 3 + j)
             }

--- a/msm/src/serialization/column.rs
+++ b/msm/src/serialization/column.rs
@@ -4,15 +4,29 @@ use crate::{
     N_LIMBS,
 };
 
+/// Total number of columns in the serialization circuit
+pub const SER_N_COLUMNS: usize = 6 * N_LIMBS + N_INTERMEDIATE_LIMBS + 9;
+
 /// Column used by the serialization subcircuit
 /// It is not used yet.
 pub enum SerializationColumn {
-    /// 3 88 bits inputs
+    /// 3 88 bits inputs. For the row #i this represents the IPA challenge xi_{log(i)}.
     KimchiLimb(usize),
-    /// N_LIMBS values, representing the limbs used by the MSM
-    MSMLimb(usize),
     /// N_INTERMEDIATE_LIMBS intermediate values, 4 bits long.
     IntermediateLimb(usize),
+    /// N_LIMBS values, representing the limbs used by the MSM
+    MSMLimb(usize),
+    /// Previous C_j, this one is looked up. For the row i, the expected
+    /// value is (C_i >> 1).
+    CoeffInput(usize),
+    /// Trusted (for range) foreign field modulus, in 4 big limbs.
+    FFieldModulus(usize),
+    /// Quotient limbs
+    Quotient(usize),
+    /// Carry limbs
+    Carry(usize),
+    /// The resulting coefficient C_i = (C_i >> 1) * xi_{log(i)}. In small limbs.
+    CoeffResult(usize),
 }
 
 impl ColumnIndexer for SerializationColumn {
@@ -22,13 +36,33 @@ impl ColumnIndexer for SerializationColumn {
                 assert!(j < 3);
                 Column::X(j)
             }
-            Self::MSMLimb(j) => {
-                assert!(j < N_LIMBS);
-                Column::X(j + 3)
-            }
             Self::IntermediateLimb(j) => {
                 assert!(j < N_INTERMEDIATE_LIMBS);
-                Column::X(j + N_LIMBS + 3)
+                Column::X(3 + j)
+            }
+            Self::MSMLimb(j) => {
+                assert!(j < N_LIMBS);
+                Column::X(N_INTERMEDIATE_LIMBS + 3 + j)
+            }
+            Self::CoeffInput(j) => {
+                assert!(j < N_LIMBS);
+                Column::X(N_INTERMEDIATE_LIMBS + N_LIMBS + 3 + j)
+            }
+            Self::FFieldModulus(j) => {
+                assert!(j < 4);
+                Column::X(N_INTERMEDIATE_LIMBS + 2 * N_LIMBS + 3 + j)
+            }
+            Self::Quotient(j) => {
+                assert!(j < N_LIMBS);
+                Column::X(N_INTERMEDIATE_LIMBS + 2 * N_LIMBS + 7 + j)
+            }
+            Self::Carry(j) => {
+                assert!(j < 2 * N_LIMBS + 2);
+                Column::X(N_INTERMEDIATE_LIMBS + 3 * N_LIMBS + 7 + j)
+            }
+            Self::CoeffResult(j) => {
+                assert!(j < N_LIMBS);
+                Column::X(N_INTERMEDIATE_LIMBS + 5 * N_LIMBS + 9 + j)
             }
         }
     }

--- a/msm/src/serialization/constraints.rs
+++ b/msm/src/serialization/constraints.rs
@@ -126,6 +126,13 @@ impl<F: PrimeField> InterpreterEnv<F> for Env<F> {
         y
     }
 
+    fn read_column(&self, position: Self::Position) -> Self::Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
+            col: position,
+            row: CurrOrNext::Curr,
+        }))
+    }
+
     fn get_column(pos: SerializationColumn) -> Self::Position {
         pos.ix_to_column()
     }

--- a/msm/src/serialization/constraints.rs
+++ b/msm/src/serialization/constraints.rs
@@ -5,10 +5,10 @@ use kimchi::circuits::{
 };
 
 use crate::{
-    columns::Column,
+    columns::{Column, ColumnIndexer},
     expr::{curr_cell, next_cell, E},
-    serialization::N_INTERMEDIATE_LIMBS,
-    MVLookupTableID as _, N_LIMBS,
+    serialization::column::SerializationColumn,
+    MVLookupTableID as _,
 };
 
 use super::{interpreter::InterpreterEnv, Lookup, LookupTable};
@@ -126,19 +126,8 @@ impl<F: PrimeField> InterpreterEnv<F> for Env<F> {
         y
     }
 
-    fn get_column_for_kimchi_limb(j: usize) -> Self::Position {
-        assert!(j < 3);
-        Column::X(j)
-    }
-
-    fn get_column_for_intermediate_limb(j: usize) -> Self::Position {
-        assert!(j < N_INTERMEDIATE_LIMBS);
-        Column::X(3 + N_LIMBS + j)
-    }
-
-    fn get_column_for_msm_limb(j: usize) -> Self::Position {
-        assert!(j < N_LIMBS);
-        Column::X(3 + j)
+    fn get_column(pos: SerializationColumn) -> Self::Position {
+        pos.ix_to_column()
     }
 
     fn range_check15(&mut self, value: &Self::Variable) {

--- a/msm/src/serialization/interpreter.rs
+++ b/msm/src/serialization/interpreter.rs
@@ -1,5 +1,6 @@
 use ark_ff::PrimeField;
 
+use crate::serialization::column::SerializationColumn;
 use crate::serialization::N_INTERMEDIATE_LIMBS;
 
 pub trait InterpreterEnv<Fp: PrimeField> {
@@ -15,11 +16,7 @@ pub trait InterpreterEnv<Fp: PrimeField> {
 
     fn copy(&mut self, x: &Self::Variable, position: Self::Position) -> Self::Variable;
 
-    fn get_column_for_kimchi_limb(j: usize) -> Self::Position;
-
-    fn get_column_for_intermediate_limb(j: usize) -> Self::Position;
-
-    fn get_column_for_msm_limb(j: usize) -> Self::Position;
+    fn get_column(pos: SerializationColumn) -> Self::Position;
 
     /// Check that the value is in the range [0, 2^15-1]
     fn range_check15(&mut self, _value: &Self::Variable);
@@ -66,9 +63,9 @@ pub fn deserialize_field_element<Fp: PrimeField, Env: InterpreterEnv<Fp>>(
     limbs: [u128; 3],
 ) {
     // Use this to constrain later
-    let kimchi_limbs0 = Env::get_column_for_kimchi_limb(0);
-    let kimchi_limbs1 = Env::get_column_for_kimchi_limb(1);
-    let kimchi_limbs2 = Env::get_column_for_kimchi_limb(2);
+    let kimchi_limbs0 = Env::get_column(SerializationColumn::KimchiLimb(0));
+    let kimchi_limbs1 = Env::get_column(SerializationColumn::KimchiLimb(1));
+    let kimchi_limbs2 = Env::get_column(SerializationColumn::KimchiLimb(2));
 
     let input_limb0 = Env::constant(limbs[0].into());
     let input_limb1 = Env::constant(limbs[1].into());
@@ -88,7 +85,7 @@ pub fn deserialize_field_element<Fp: PrimeField, Env: InterpreterEnv<Fp>>(
     {
         let mut constraint = limb2_var.clone();
         for j in 0..N_INTERMEDIATE_LIMBS {
-            let position = Env::get_column_for_intermediate_limb(j);
+            let position = Env::get_column(SerializationColumn::IntermediateLimb(j));
             let var = env.bitmask_be(&input_limb2, 4 * (j + 1) as u32, 4 * j as u32, position);
             limb2_vars.push(var.clone());
             let pow: u128 = 1 << (4 * j);
@@ -102,37 +99,37 @@ pub fn deserialize_field_element<Fp: PrimeField, Env: InterpreterEnv<Fp>>(
 
     let mut fifteen_bits_vars = vec![];
     {
-        let c0 = Env::get_column_for_msm_limb(0);
+        let c0 = Env::get_column(SerializationColumn::MSMLimb(0));
         let c0_var = env.bitmask_be(&input_limb0, 15, 0, c0);
         fifteen_bits_vars.push(c0_var)
     }
 
     {
-        let c1 = Env::get_column_for_msm_limb(1);
+        let c1 = Env::get_column(SerializationColumn::MSMLimb(1));
         let c1_var = env.bitmask_be(&input_limb0, 30, 15, c1);
         fifteen_bits_vars.push(c1_var);
     }
 
     {
-        let c2 = Env::get_column_for_msm_limb(2);
+        let c2 = Env::get_column(SerializationColumn::MSMLimb(2));
         let c2_var = env.bitmask_be(&input_limb0, 45, 30, c2);
         fifteen_bits_vars.push(c2_var);
     }
 
     {
-        let c3 = Env::get_column_for_msm_limb(3);
+        let c3 = Env::get_column(SerializationColumn::MSMLimb(3));
         let c3_var = env.bitmask_be(&input_limb0, 60, 45, c3);
         fifteen_bits_vars.push(c3_var)
     }
 
     {
-        let c4 = Env::get_column_for_msm_limb(4);
+        let c4 = Env::get_column(SerializationColumn::MSMLimb(4));
         let c4_var = env.bitmask_be(&input_limb0, 75, 60, c4);
         fifteen_bits_vars.push(c4_var);
     }
 
     {
-        let c5 = Env::get_column_for_msm_limb(5);
+        let c5 = Env::get_column(SerializationColumn::MSMLimb(5));
         let res = (limbs[0] >> 75) & ((1 << (88 - 75)) - 1);
         let res_prime = limbs[1] & ((1 << 2) - 1);
         let res = res + (res_prime << (15 - 2));
@@ -142,37 +139,37 @@ pub fn deserialize_field_element<Fp: PrimeField, Env: InterpreterEnv<Fp>>(
     }
 
     {
-        let c6 = Env::get_column_for_msm_limb(6);
+        let c6 = Env::get_column(SerializationColumn::MSMLimb(6));
         let c6_var = env.bitmask_be(&input_limb1, 17, 2, c6);
         fifteen_bits_vars.push(c6_var);
     }
 
     {
-        let c7 = Env::get_column_for_msm_limb(7);
+        let c7 = Env::get_column(SerializationColumn::MSMLimb(7));
         let c7_var = env.bitmask_be(&input_limb1, 32, 17, c7);
         fifteen_bits_vars.push(c7_var);
     }
 
     {
-        let c8 = Env::get_column_for_msm_limb(8);
+        let c8 = Env::get_column(SerializationColumn::MSMLimb(8));
         let c8_var = env.bitmask_be(&input_limb1, 47, 32, c8);
         fifteen_bits_vars.push(c8_var);
     }
 
     {
-        let c9 = Env::get_column_for_msm_limb(9);
+        let c9 = Env::get_column(SerializationColumn::MSMLimb(9));
         let c9_var = env.bitmask_be(&input_limb1, 62, 47, c9);
         fifteen_bits_vars.push(c9_var);
     }
 
     {
-        let c10 = Env::get_column_for_msm_limb(10);
+        let c10 = Env::get_column(SerializationColumn::MSMLimb(10));
         let c10_var = env.bitmask_be(&input_limb1, 77, 62, c10);
         fifteen_bits_vars.push(c10_var);
     }
 
     {
-        let c11 = Env::get_column_for_msm_limb(11);
+        let c11 = Env::get_column(SerializationColumn::MSMLimb(11));
         let res = (limbs[1] >> 77) & ((1 << (88 - 77)) - 1);
         let res_prime = limbs[2] & ((1 << 4) - 1);
         let res = res + (res_prime << (15 - 4));
@@ -182,31 +179,31 @@ pub fn deserialize_field_element<Fp: PrimeField, Env: InterpreterEnv<Fp>>(
     }
 
     {
-        let c12 = Env::get_column_for_msm_limb(12);
+        let c12 = Env::get_column(SerializationColumn::MSMLimb(12));
         let c12_var = env.bitmask_be(&input_limb2, 19, 4, c12);
         fifteen_bits_vars.push(c12_var);
     }
 
     {
-        let c13 = Env::get_column_for_msm_limb(13);
+        let c13 = Env::get_column(SerializationColumn::MSMLimb(13));
         let c13_var = env.bitmask_be(&input_limb2, 34, 19, c13);
         fifteen_bits_vars.push(c13_var);
     }
 
     {
-        let c14 = Env::get_column_for_msm_limb(14);
+        let c14 = Env::get_column(SerializationColumn::MSMLimb(14));
         let c14_var = env.bitmask_be(&input_limb2, 49, 34, c14);
         fifteen_bits_vars.push(c14_var);
     }
 
     {
-        let c15 = Env::get_column_for_msm_limb(15);
+        let c15 = Env::get_column(SerializationColumn::MSMLimb(15));
         let c15_var = env.bitmask_be(&input_limb2, 64, 49, c15);
         fifteen_bits_vars.push(c15_var);
     }
 
     {
-        let c16 = Env::get_column_for_msm_limb(16);
+        let c16 = Env::get_column(SerializationColumn::MSMLimb(16));
         let c16_var = env.bitmask_be(&input_limb2, 79, 64, c16);
         fifteen_bits_vars.push(c16_var);
     }

--- a/msm/src/serialization/interpreter.rs
+++ b/msm/src/serialization/interpreter.rs
@@ -1,7 +1,6 @@
 use ark_ff::PrimeField;
 
-use crate::serialization::column::SerializationColumn;
-use crate::serialization::N_INTERMEDIATE_LIMBS;
+use crate::serialization::{column::SerializationColumn, N_INTERMEDIATE_LIMBS};
 
 pub trait InterpreterEnv<Fp: PrimeField> {
     type Position;
@@ -15,6 +14,8 @@ pub trait InterpreterEnv<Fp: PrimeField> {
     fn add_constraint(&mut self, cst: Self::Variable);
 
     fn copy(&mut self, x: &Self::Variable, position: Self::Position) -> Self::Variable;
+
+    fn read_column(&self, pos: Self::Position) -> Self::Variable;
 
     fn get_column(pos: SerializationColumn) -> Self::Position;
 
@@ -37,6 +38,12 @@ pub trait InterpreterEnv<Fp: PrimeField> {
         lowest_bit: u32,
         position: Self::Position,
     ) -> Self::Variable;
+
+    // Helper
+    // @volhovm I think we could just use indexer directly without Position.
+    fn read_column_direct(&self, pos: SerializationColumn) -> Self::Variable {
+        self.read_column(Self::get_column(pos))
+    }
 }
 
 /// Deserialize a field element of the scalar field of Vesta or Pallas given as

--- a/msm/src/serialization/interpreter.rs
+++ b/msm/src/serialization/interpreter.rs
@@ -63,9 +63,9 @@ pub fn deserialize_field_element<Fp: PrimeField, Env: InterpreterEnv<Fp>>(
     limbs: [u128; 3],
 ) {
     // Use this to constrain later
-    let kimchi_limbs0 = Env::get_column(SerializationColumn::KimchiLimb(0));
-    let kimchi_limbs1 = Env::get_column(SerializationColumn::KimchiLimb(1));
-    let kimchi_limbs2 = Env::get_column(SerializationColumn::KimchiLimb(2));
+    let kimchi_limbs0 = Env::get_column(SerializationColumn::ChalKimchi(0));
+    let kimchi_limbs1 = Env::get_column(SerializationColumn::ChalKimchi(1));
+    let kimchi_limbs2 = Env::get_column(SerializationColumn::ChalKimchi(2));
 
     let input_limb0 = Env::constant(limbs[0].into());
     let input_limb1 = Env::constant(limbs[1].into());
@@ -85,7 +85,7 @@ pub fn deserialize_field_element<Fp: PrimeField, Env: InterpreterEnv<Fp>>(
     {
         let mut constraint = limb2_var.clone();
         for j in 0..N_INTERMEDIATE_LIMBS {
-            let position = Env::get_column(SerializationColumn::IntermediateLimb(j));
+            let position = Env::get_column(SerializationColumn::ChalIntermediate(j));
             let var = env.bitmask_be(&input_limb2, 4 * (j + 1) as u32, 4 * j as u32, position);
             limb2_vars.push(var.clone());
             let pow: u128 = 1 << (4 * j);
@@ -99,37 +99,37 @@ pub fn deserialize_field_element<Fp: PrimeField, Env: InterpreterEnv<Fp>>(
 
     let mut fifteen_bits_vars = vec![];
     {
-        let c0 = Env::get_column(SerializationColumn::MSMLimb(0));
+        let c0 = Env::get_column(SerializationColumn::ChalConverted(0));
         let c0_var = env.bitmask_be(&input_limb0, 15, 0, c0);
         fifteen_bits_vars.push(c0_var)
     }
 
     {
-        let c1 = Env::get_column(SerializationColumn::MSMLimb(1));
+        let c1 = Env::get_column(SerializationColumn::ChalConverted(1));
         let c1_var = env.bitmask_be(&input_limb0, 30, 15, c1);
         fifteen_bits_vars.push(c1_var);
     }
 
     {
-        let c2 = Env::get_column(SerializationColumn::MSMLimb(2));
+        let c2 = Env::get_column(SerializationColumn::ChalConverted(2));
         let c2_var = env.bitmask_be(&input_limb0, 45, 30, c2);
         fifteen_bits_vars.push(c2_var);
     }
 
     {
-        let c3 = Env::get_column(SerializationColumn::MSMLimb(3));
+        let c3 = Env::get_column(SerializationColumn::ChalConverted(3));
         let c3_var = env.bitmask_be(&input_limb0, 60, 45, c3);
         fifteen_bits_vars.push(c3_var)
     }
 
     {
-        let c4 = Env::get_column(SerializationColumn::MSMLimb(4));
+        let c4 = Env::get_column(SerializationColumn::ChalConverted(4));
         let c4_var = env.bitmask_be(&input_limb0, 75, 60, c4);
         fifteen_bits_vars.push(c4_var);
     }
 
     {
-        let c5 = Env::get_column(SerializationColumn::MSMLimb(5));
+        let c5 = Env::get_column(SerializationColumn::ChalConverted(5));
         let res = (limbs[0] >> 75) & ((1 << (88 - 75)) - 1);
         let res_prime = limbs[1] & ((1 << 2) - 1);
         let res = res + (res_prime << (15 - 2));
@@ -139,37 +139,37 @@ pub fn deserialize_field_element<Fp: PrimeField, Env: InterpreterEnv<Fp>>(
     }
 
     {
-        let c6 = Env::get_column(SerializationColumn::MSMLimb(6));
+        let c6 = Env::get_column(SerializationColumn::ChalConverted(6));
         let c6_var = env.bitmask_be(&input_limb1, 17, 2, c6);
         fifteen_bits_vars.push(c6_var);
     }
 
     {
-        let c7 = Env::get_column(SerializationColumn::MSMLimb(7));
+        let c7 = Env::get_column(SerializationColumn::ChalConverted(7));
         let c7_var = env.bitmask_be(&input_limb1, 32, 17, c7);
         fifteen_bits_vars.push(c7_var);
     }
 
     {
-        let c8 = Env::get_column(SerializationColumn::MSMLimb(8));
+        let c8 = Env::get_column(SerializationColumn::ChalConverted(8));
         let c8_var = env.bitmask_be(&input_limb1, 47, 32, c8);
         fifteen_bits_vars.push(c8_var);
     }
 
     {
-        let c9 = Env::get_column(SerializationColumn::MSMLimb(9));
+        let c9 = Env::get_column(SerializationColumn::ChalConverted(9));
         let c9_var = env.bitmask_be(&input_limb1, 62, 47, c9);
         fifteen_bits_vars.push(c9_var);
     }
 
     {
-        let c10 = Env::get_column(SerializationColumn::MSMLimb(10));
+        let c10 = Env::get_column(SerializationColumn::ChalConverted(10));
         let c10_var = env.bitmask_be(&input_limb1, 77, 62, c10);
         fifteen_bits_vars.push(c10_var);
     }
 
     {
-        let c11 = Env::get_column(SerializationColumn::MSMLimb(11));
+        let c11 = Env::get_column(SerializationColumn::ChalConverted(11));
         let res = (limbs[1] >> 77) & ((1 << (88 - 77)) - 1);
         let res_prime = limbs[2] & ((1 << 4) - 1);
         let res = res + (res_prime << (15 - 4));
@@ -179,31 +179,31 @@ pub fn deserialize_field_element<Fp: PrimeField, Env: InterpreterEnv<Fp>>(
     }
 
     {
-        let c12 = Env::get_column(SerializationColumn::MSMLimb(12));
+        let c12 = Env::get_column(SerializationColumn::ChalConverted(12));
         let c12_var = env.bitmask_be(&input_limb2, 19, 4, c12);
         fifteen_bits_vars.push(c12_var);
     }
 
     {
-        let c13 = Env::get_column(SerializationColumn::MSMLimb(13));
+        let c13 = Env::get_column(SerializationColumn::ChalConverted(13));
         let c13_var = env.bitmask_be(&input_limb2, 34, 19, c13);
         fifteen_bits_vars.push(c13_var);
     }
 
     {
-        let c14 = Env::get_column(SerializationColumn::MSMLimb(14));
+        let c14 = Env::get_column(SerializationColumn::ChalConverted(14));
         let c14_var = env.bitmask_be(&input_limb2, 49, 34, c14);
         fifteen_bits_vars.push(c14_var);
     }
 
     {
-        let c15 = Env::get_column(SerializationColumn::MSMLimb(15));
+        let c15 = Env::get_column(SerializationColumn::ChalConverted(15));
         let c15_var = env.bitmask_be(&input_limb2, 64, 49, c15);
         fifteen_bits_vars.push(c15_var);
     }
 
     {
-        let c16 = Env::get_column(SerializationColumn::MSMLimb(16));
+        let c16 = Env::get_column(SerializationColumn::ChalConverted(16));
         let c16_var = env.bitmask_be(&input_limb2, 79, 64, c16);
         fifteen_bits_vars.push(c16_var);
     }

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -1,12 +1,12 @@
 use crate::{mvlookup::LookupTableID, MVLookup};
 
-/// The number of intermediate limbs of 4 bits required for the circuit
-pub const N_INTERMEDIATE_LIMBS: usize = 20;
-
 pub mod column;
 pub mod constraints;
 pub mod interpreter;
 pub mod witness;
+
+/// The number of intermediate limbs of 4 bits required for the circuit
+pub const N_INTERMEDIATE_LIMBS: usize = 20;
 
 #[derive(Clone, Copy, Debug)]
 pub enum LookupTable {

--- a/msm/src/serialization/witness.rs
+++ b/msm/src/serialization/witness.rs
@@ -3,8 +3,10 @@ use num_bigint::BigUint;
 use o1_utils::FieldHelpers;
 
 use crate::{
-    columns::Column,
-    serialization::{interpreter::InterpreterEnv, Lookup, LookupTable},
+    columns::{Column, ColumnIndexer},
+    serialization::{
+        column::SerializationColumn, interpreter::InterpreterEnv, Lookup, LookupTable,
+    },
     N_LIMBS,
 };
 use kimchi::circuits::domains::EvaluationDomains;
@@ -58,14 +60,8 @@ impl<Fp: PrimeField> InterpreterEnv<Fp> for Env<Fp> {
         value
     }
 
-    fn get_column_for_kimchi_limb(j: usize) -> Self::Position {
-        assert!(j < 3);
-        Column::X(j)
-    }
-
-    fn get_column_for_intermediate_limb(j: usize) -> Self::Position {
-        assert!(j < N_INTERMEDIATE_LIMBS);
-        Column::X(3 + N_LIMBS + j)
+    fn get_column(pos: SerializationColumn) -> Self::Position {
+        pos.ix_to_column()
     }
 
     fn range_check15(&mut self, value: &Self::Variable) {
@@ -97,11 +93,6 @@ impl<Fp: PrimeField> InterpreterEnv<Fp> for Env<Fp> {
     fn copy(&mut self, x: &Self::Variable, position: Self::Position) -> Self::Variable {
         self.write_column(position, *x);
         *x
-    }
-
-    fn get_column_for_msm_limb(j: usize) -> Self::Position {
-        assert!(j < N_LIMBS);
-        Column::X(3 + j)
     }
 
     /// Returns the bits between [highest_bit, lowest_bit] of the variable `x`,

--- a/msm/src/serialization/witness.rs
+++ b/msm/src/serialization/witness.rs
@@ -5,23 +5,23 @@ use o1_utils::FieldHelpers;
 use crate::{
     columns::{Column, ColumnIndexer},
     serialization::{
-        column::SerializationColumn, interpreter::InterpreterEnv, Lookup, LookupTable,
+        column::{SerializationColumn, SER_N_COLUMNS},
+        interpreter::InterpreterEnv,
+        Lookup, LookupTable,
     },
+    witness::Witness,
     N_LIMBS,
 };
 use kimchi::circuits::domains::EvaluationDomains;
 use std::iter;
 
-use super::N_INTERMEDIATE_LIMBS;
-
+// TODO The parameter `Fp` clashes with the `Fp` type alias in the lib. Rename this into `F.`
+// TODO `WitnessEnv`
 /// Environment for the serializer interpreter
 pub struct Env<Fp> {
-    pub current_kimchi_limbs: [Fp; 3],
-    /// The LIMB_NUM limbs that is used to encode a field element for the MSM
-    pub msm_limbs: [Fp; N_LIMBS],
-    /// Used for the decomposition in base 4 of the last limb of the foreign
-    /// field Kimchi gate
-    pub intermediate_limbs: [Fp; N_INTERMEDIATE_LIMBS],
+    /// Single-row witness columns, in raw form. For accessing [`Witness`], see the
+    /// `get_witness` method.
+    pub witness: Witness<SER_N_COLUMNS, Fp>,
 
     /// Keep track of the RangeCheck4 lookup multiplicities
     // Boxing to avoid stack overflow
@@ -45,6 +45,7 @@ pub struct Env<Fp> {
     pub rangecheck15_lookups: Vec<Lookup<Fp>>,
 }
 
+// TODO The parameter `Fp` clashes with the `Fp` type alias in the lib. Rename this into `F.`
 impl<Fp: PrimeField> InterpreterEnv<Fp> for Env<Fp> {
     type Position = Column;
 
@@ -62,6 +63,11 @@ impl<Fp: PrimeField> InterpreterEnv<Fp> for Env<Fp> {
 
     fn get_column(pos: SerializationColumn) -> Self::Position {
         pos.ix_to_column()
+    }
+
+    fn read_column(&self, ix: Column) -> Self::Variable {
+        let Column::X(i) = ix else { todo!() };
+        self.witness.cols[i]
     }
 
     fn range_check15(&mut self, value: &Self::Variable) {
@@ -119,17 +125,7 @@ impl<Fp: PrimeField> InterpreterEnv<Fp> for Env<Fp> {
 impl<Fp: PrimeField> Env<Fp> {
     pub fn write_column(&mut self, position: Column, value: Fp) {
         match position {
-            Column::X(i) => {
-                if i < 3 {
-                    self.current_kimchi_limbs[i] = value
-                } else if i < 3 + N_LIMBS {
-                    self.msm_limbs[i - 3] = value;
-                } else if i < 3 + N_LIMBS + N_INTERMEDIATE_LIMBS {
-                    self.intermediate_limbs[i - 3 - N_LIMBS] = value;
-                } else {
-                    panic!("Invalid column index")
-                }
-            }
+            Column::X(i) => self.witness.cols[i] = value,
             Column::LookupPartialSum(_) => {
                 panic!(
                     "This is a lookup related column. The environment is
@@ -203,9 +199,9 @@ impl<Fp: PrimeField> Env<Fp> {
 impl<Fp: PrimeField> Env<Fp> {
     pub fn create() -> Self {
         Self {
-            current_kimchi_limbs: [Fp::zero(); 3],
-            msm_limbs: [Fp::zero(); N_LIMBS],
-            intermediate_limbs: [Fp::zero(); N_INTERMEDIATE_LIMBS],
+            witness: Witness {
+                cols: Box::new([Fp::zero(); SER_N_COLUMNS]),
+            },
 
             lookup_multiplicities_rangecheck4: Box::new([Fp::zero(); 1 << 4]),
             lookup_t_multiplicities_rangecheck4: Box::new([Fp::zero(); 1 << 4]),
@@ -224,7 +220,10 @@ mod tests {
     use crate::{serialization::N_INTERMEDIATE_LIMBS, LIMB_BITSIZE, N_LIMBS};
 
     use super::Env;
-    use crate::serialization::interpreter::deserialize_field_element;
+    use crate::serialization::{
+        column::SerializationColumn,
+        interpreter::{deserialize_field_element, InterpreterEnv},
+    };
     use ark_ff::{BigInteger, FpParameters as _, One, PrimeField, UniformRand, Zero};
     use mina_curves::pasta::Fp;
     use num_bigint::BigUint;
@@ -262,9 +261,13 @@ mod tests {
         deserialize_field_element(&mut dummy_env, [limb0, limb1, limb2]);
 
         // Check limb are copied into the environment
-        assert_eq!(Fp::from(limb0), dummy_env.current_kimchi_limbs[0]);
-        assert_eq!(Fp::from(limb1), dummy_env.current_kimchi_limbs[1]);
-        assert_eq!(Fp::from(limb2), dummy_env.current_kimchi_limbs[2]);
+        let limbs_to_assert = [limb0, limb1, limb2];
+        for (i, limb) in limbs_to_assert.iter().enumerate() {
+            assert_eq!(
+                Fp::from(*limb),
+                dummy_env.read_column_direct(SerializationColumn::ChalKimchi(i))
+            );
+        }
 
         // Check intermediate limbs
         {
@@ -277,14 +280,16 @@ mod tests {
                     .take(4)
                     .collect::<Vec<bool>>();
                 let t = Fp::from_bits(le_bits).unwrap();
+                let intermediate_v =
+                    dummy_env.read_column_direct(SerializationColumn::ChalIntermediate(j));
                 assert_eq!(
                     t,
-                    dummy_env.intermediate_limbs[j],
+                    intermediate_v,
                     "{}",
                     format_args!(
                         "Intermediate limb {j}. Exp value is {:?}, computed is {:?}",
                         t.to_biguint(),
-                        dummy_env.intermediate_limbs[j].to_biguint()
+                        intermediate_v.to_biguint()
                     )
                 )
             }
@@ -299,14 +304,15 @@ mod tests {
                 .take(LIMB_BITSIZE)
                 .collect::<Vec<bool>>();
             let t = Fp::from_bits(le_bits).unwrap();
+            let converted_v = dummy_env.read_column_direct(SerializationColumn::ChalConverted(i));
             assert_eq!(
                 t,
-                dummy_env.msm_limbs[i],
+                converted_v,
                 "{}",
                 format_args!(
                     "MSM limb {i}. Exp value is {:?}, computed is {:?}",
                     t.to_biguint(),
-                    dummy_env.msm_limbs[i].to_biguint()
+                    converted_v.to_biguint()
                 )
             )
         }

--- a/msm/src/serialization/witness.rs
+++ b/msm/src/serialization/witness.rs
@@ -10,7 +10,6 @@ use crate::{
         Lookup, LookupTable,
     },
     witness::Witness,
-    N_LIMBS,
 };
 use kimchi::circuits::domains::EvaluationDomains;
 use std::iter;


### PR DESCRIPTION
Creates some columns for FF multiplication in serialization circuit + describes how they're going to be used + lots of cosmetics to unify `serialization` with other two crates somewhat...

Addresses #1792 

Master PR: https://github.com/o1-labs/proof-systems/pull/2048