### PR TITLE
Fix test_commit chunking issue

### DIFF
--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -119,10 +119,10 @@ pub fn combine_polys<G: CommitmentCurve, D: EvaluationDomain<G::ScalarField>>(
     if !plnm_evals_part.is_empty() {
         let n = plnm_evals_part.len();
         let max_poly_size = srs_length;
-        let num_chunks = if n % max_poly_size == 0 {
-            n / max_poly_size
+        let num_chunks = if n == 0 {
+            1
         } else {
-            n / max_poly_size + 1
+            n / max_poly_size + if n % max_poly_size == 0 { 0 } else { 1 }
         };
         plnm += &Evaluations::from_vec_and_domain(plnm_evals_part, D::new(n).unwrap())
             .interpolate()

--- a/poly-commitment/src/tests/batch_15_wires.rs
+++ b/poly-commitment/src/tests/batch_15_wires.rs
@@ -82,10 +82,10 @@ where
             let comm = (0..a.len())
                 .map(|i| {
                     let n = a[i].len();
-                    let num_chunks = if n % srs.g.len() == 0 {
-                        n / size
+                    let num_chunks = if n == 0 {
+                        1
                     } else {
-                        n / size + 1
+                        n / srs.g.len() + if n % srs.g.len() == 0 { 0 } else { 1 }
                     };
                     (
                         srs.commit(&a[i].clone(), num_chunks, rng),

--- a/poly-commitment/src/tests/commitment.rs
+++ b/poly-commitment/src/tests/commitment.rs
@@ -151,10 +151,10 @@ fn test_randomised<RNG: Rng + CryptoRng>(mut rng: &mut RNG) {
             let mut chunked_evals = vec![];
             for point in eval_points.clone() {
                 let n = poly.len();
-                let num_chunks = if n % srs.g.len() == 0 {
-                    n / srs.g.len()
+                let num_chunks = if n == 0 {
+                    1
                 } else {
-                    n / srs.g.len() + 1
+                    n / srs.g.len() + if n % srs.g.len() == 0 { 0 } else { 1 }
                 };
                 chunked_evals.push(
                     poly.to_chunked_polynomial(num_chunks, srs.g.len())


### PR DESCRIPTION
After enforcing chunking size to be as expected (See PR #2010) the test_commit became flaky (and got into `master`). The issue was related to the sometimes appearing polynomials of zero degree: whereas previous code would always create at least one chunk, the new code was sometimes requiring and creating zero chunks.