### PR TITLE
Logup: add table ID as a parameter for proofs

### DIFF
--- a/msm/src/ffa/main.rs
+++ b/msm/src/ffa/main.rs
@@ -71,6 +71,7 @@ pub fn main() {
         ScalarSponge,
         FFA_N_COLUMNS,
         FFA_NPUB_COLUMNS,
+        LookupTableIDs,
     >(domain, &srs, &constraints, &proof, pub_inputs);
     println!("Proof verification result: {verifies}")
 }

--- a/msm/src/lib.rs
+++ b/msm/src/lib.rs
@@ -137,13 +137,14 @@ mod tests {
         .unwrap();
 
         // verify the proof
-        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, TEST_N_COLUMNS, 0>(
-            domain,
-            &srs,
-            &constraints,
-            &proof,
-            Witness::zero_vec(domain_size),
-        );
+        let verifies =
+            verify::<_, OpeningProof, BaseSponge, ScalarSponge, TEST_N_COLUMNS, 0, LookupTableIDs>(
+                domain,
+                &srs,
+                &constraints,
+                &proof,
+                Witness::zero_vec(domain_size),
+            );
 
         assert!(verifies);
     }
@@ -204,7 +205,15 @@ mod tests {
         {
             let mut proof_clone = proof.clone();
             proof_clone.opening_proof = proof_prime.opening_proof;
-            let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, TEST_N_COLUMNS, 0>(
+            let verifies = verify::<
+                _,
+                OpeningProof,
+                BaseSponge,
+                ScalarSponge,
+                TEST_N_COLUMNS,
+                0,
+                LookupTableIDs,
+            >(
                 domain,
                 &srs,
                 &constraints,
@@ -220,7 +229,15 @@ mod tests {
         {
             let mut proof_clone = proof.clone();
             proof_clone.proof_comms = proof_prime.proof_comms;
-            let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, TEST_N_COLUMNS, 0>(
+            let verifies = verify::<
+                _,
+                OpeningProof,
+                BaseSponge,
+                ScalarSponge,
+                TEST_N_COLUMNS,
+                0,
+                LookupTableIDs,
+            >(
                 domain,
                 &srs,
                 &constraints,
@@ -237,7 +254,15 @@ mod tests {
         {
             let mut proof_clone = proof.clone();
             proof_clone.proof_evals.witness_evals = proof_prime.proof_evals.witness_evals;
-            let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, TEST_N_COLUMNS, 0>(
+            let verifies = verify::<
+                _,
+                OpeningProof,
+                BaseSponge,
+                ScalarSponge,
+                TEST_N_COLUMNS,
+                0,
+                LookupTableIDs,
+            >(
                 domain,
                 &srs,
                 &constraints,
@@ -285,7 +310,7 @@ mod tests {
                 &mut rng,
             )
             .unwrap();
-        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, N, 0>(
+        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, N, 0, LookupTableIDs>(
             domain,
             &srs,
             &constraints,

--- a/msm/src/mvlookup.rs
+++ b/msm/src/mvlookup.rs
@@ -97,19 +97,21 @@ pub struct MVLookupWitness<F, ID: LookupTableID> {
 /// FIXME: We should have a fixed number of m and h. Should we encode that in
 /// the type?
 #[derive(Debug, Clone)]
-pub struct LookupProof<T> {
+pub struct LookupProof<T, ID> {
     /// The multiplicity polynomials
     pub(crate) m: Vec<T>,
     /// The polynomial keeping the sum of each row
     pub(crate) h: Vec<T>,
     /// The "running-sum" over the rows, coined `\phi`
     pub(crate) sum: T,
+    // FIXME: use a hashmap for the multiplicity, and get rid of me.
+    pub id: std::marker::PhantomData<ID>,
 }
 
 /// Iterator implementation to abstract the content of the structure.
 /// It can be used to iterate over the commitments (resp. the evaluations)
 /// without requiring to have a look at the inner fields.
-impl<'lt, G> IntoIterator for &'lt LookupProof<G> {
+impl<'lt, G, ID: LookupTableID> IntoIterator for &'lt LookupProof<G, ID> {
     type Item = &'lt G;
     type IntoIter = std::vec::IntoIter<&'lt G>;
 

--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -56,7 +56,7 @@ pub fn prove<
     constraints: &Vec<E<G::ScalarField>>,
     inputs: ProofInputs<N, G, ID>,
     rng: &mut RNG,
-) -> Result<Proof<N, G, OpeningProof>, ProverError>
+) -> Result<Proof<N, G, OpeningProof, ID>, ProverError>
 where
     OpeningProof::SRS: Sync,
     RNG: RngCore + CryptoRng,
@@ -136,6 +136,7 @@ where
         m: lookup_env.lookup_counters_comm_d1.clone(),
         h: lookup_env.lookup_terms_comms_d1.clone(),
         sum: lookup_env.lookup_aggregation_comm_d1.clone(),
+        id: std::marker::PhantomData,
     });
 
     // -- end computing the running sum in lookup_aggregation
@@ -328,6 +329,7 @@ where
                     zeta: sum_zeta,
                     zeta_omega: sum_zeta_omega,
                 },
+                id: std::marker::PhantomData,
             })
         } else {
             None
@@ -436,7 +438,7 @@ where
         rng,
     );
 
-    let proof_evals: ProofEvaluations<N, G::ScalarField> = {
+    let proof_evals: ProofEvaluations<N, G::ScalarField, ID> = {
         ProofEvaluations {
             witness_evals,
             mvlookup_evals,

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -244,14 +244,21 @@ mod tests {
         >(domain, &srs, &constraints, proof_inputs, &mut rng)
         .unwrap();
 
-        let verifies =
-            verify::<_, OpeningProof, BaseSponge, ScalarSponge, SERIALIZATION_N_COLUMNS, 0>(
-                domain,
-                &srs,
-                &constraints,
-                &proof,
-                Witness::zero_vec(DOMAIN_SIZE),
-            );
+        let verifies = verify::<
+            _,
+            OpeningProof,
+            BaseSponge,
+            ScalarSponge,
+            SERIALIZATION_N_COLUMNS,
+            0,
+            LookupTable,
+        >(
+            domain,
+            &srs,
+            &constraints,
+            &proof,
+            Witness::zero_vec(DOMAIN_SIZE),
+        );
         assert!(verifies)
     }
 }

--- a/msm/src/test/mod.rs
+++ b/msm/src/test/mod.rs
@@ -98,7 +98,7 @@ mod tests {
             }
         }
 
-        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, N, 0>(
+        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, N, 0, LookupTableIDs>(
             domain,
             &srs,
             &constraints,

--- a/msm/src/verifier.rs
+++ b/msm/src/verifier.rs
@@ -1,3 +1,4 @@
+use crate::mvlookup::LookupTableID;
 use ark_ff::{Field, One, Zero};
 use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as R2D};
 use rand::thread_rng;
@@ -28,11 +29,12 @@ pub fn verify<
     EFrSponge: FrSponge<G::ScalarField>,
     const N: usize,
     const NPUB: usize,
+    ID: LookupTableID,
 >(
     domain: EvaluationDomains<G::ScalarField>,
     srs: &OpeningProof::SRS,
     constraint_exprs: &Vec<E<G::ScalarField>>,
-    proof: &Proof<N, G, OpeningProof>,
+    proof: &Proof<N, G, OpeningProof, ID>,
     public_inputs: Witness<NPUB, Vec<G::ScalarField>>,
 ) -> bool
 where


### PR DESCRIPTION
I want to enforce at the type level that the proof is only for a set of tables.
Also, coming in a following PR, we use a hashmap for the multiplicities and the fixed lookup tables, as discussed in previous PRs.