### PR TITLE
Improve `Literal` so that folding expressions can take special constants as well

### DIFF
--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -71,6 +71,7 @@ pub struct Challenges<F> {
 }
 
 /// The collection of constants required to evaluate an `Expr`.
+#[derive(Clone)]
 pub struct Constants<F: 'static> {
     /// The endomorphism coefficient
     pub endo_coefficient: F,
@@ -288,11 +289,12 @@ pub enum ConstantTerm<F> {
     Literal(F),
 }
 
-pub trait Literal: Sized {
+pub trait Literal: Sized + Clone {
     type F;
     fn literal(x: Self::F) -> Self;
     fn to_literal(self) -> Result<Self::F, Self>;
     fn to_literal_ref(&self) -> Option<&Self::F>;
+    fn as_literal(&self, constants: &Constants<Self::F>) -> Self;
 }
 
 impl<F: Field> Literal for F {
@@ -306,9 +308,12 @@ impl<F: Field> Literal for F {
     fn to_literal_ref(&self) -> Option<&Self::F> {
         Some(self)
     }
+    fn as_literal(&self, _constants: &Constants<Self::F>) -> Self {
+        *self
+    }
 }
 
-impl<F> Literal for ConstantTerm<F> {
+impl<F: Clone> Literal for ConstantTerm<F> {
     type F = F;
     fn literal(x: Self::F) -> Self {
         ConstantTerm::Literal(x)
@@ -325,6 +330,17 @@ impl<F> Literal for ConstantTerm<F> {
             _ => None,
         }
     }
+    fn as_literal(&self, constants: &Constants<Self::F>) -> Self {
+        match self {
+            ConstantTerm::EndoCoefficient => {
+                ConstantTerm::Literal(constants.endo_coefficient.clone())
+            }
+            ConstantTerm::Mds { row, col } => {
+                ConstantTerm::Literal(constants.mds[*row][*col].clone())
+            }
+            ConstantTerm::Literal(_) => self.clone(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -333,7 +349,7 @@ pub enum ConstantExprInner<F> {
     Constant(ConstantTerm<F>),
 }
 
-impl<F> Literal for ConstantExprInner<F> {
+impl<F: Clone> Literal for ConstantExprInner<F> {
     type F = F;
     fn literal(x: Self::F) -> Self {
         Self::Constant(ConstantTerm::literal(x))
@@ -351,6 +367,12 @@ impl<F> Literal for ConstantExprInner<F> {
         match self {
             Self::Constant(x) => x.to_literal_ref(),
             _ => None,
+        }
+    }
+    fn as_literal(&self, constants: &Constants<Self::F>) -> Self {
+        match self {
+            Self::Constant(x) => Self::Constant(x.as_literal(constants)),
+            Self::Challenge(_) => self.clone(),
         }
     }
 }
@@ -386,7 +408,7 @@ impl<T> From<T> for Operations<T> {
     }
 }
 
-impl<T: Literal> Literal for Operations<T> {
+impl<T: Literal + Clone> Literal for Operations<T> {
     type F = T::F;
     fn literal(x: Self::F) -> Self {
         Self::Atom(T::literal(x))
@@ -404,6 +426,32 @@ impl<T: Literal> Literal for Operations<T> {
         match self {
             Self::Atom(x) => x.to_literal_ref(),
             _ => None,
+        }
+    }
+    fn as_literal(&self, constants: &Constants<Self::F>) -> Self {
+        match self {
+            Self::Atom(x) => Self::Atom(x.as_literal(constants)),
+            Self::Pow(x, n) => Self::Pow(Box::new(x.as_literal(constants)), *n),
+            Self::Add(x, y) => Self::Add(
+                Box::new(x.as_literal(constants)),
+                Box::new(y.as_literal(constants)),
+            ),
+            Self::Mul(x, y) => Self::Mul(
+                Box::new(x.as_literal(constants)),
+                Box::new(y.as_literal(constants)),
+            ),
+            Self::Sub(x, y) => Self::Sub(
+                Box::new(x.as_literal(constants)),
+                Box::new(y.as_literal(constants)),
+            ),
+            Self::Double(x) => Self::Double(Box::new(x.as_literal(constants))),
+            Self::Square(x) => Self::Square(Box::new(x.as_literal(constants))),
+            Self::Cache(id, x) => Self::Cache(*id, Box::new(x.as_literal(constants))),
+            Self::IfFeature(flag, if_true, if_false) => Self::IfFeature(
+                *flag,
+                Box::new(if_true.as_literal(constants)),
+                Box::new(if_false.as_literal(constants)),
+            ),
         }
     }
 }
@@ -709,7 +757,7 @@ impl<F, Column> From<ChallengeTerm> for Expr<ConstantExpr<F>, Column> {
     }
 }
 
-impl<T: Literal, Column> Literal for ExprInner<T, Column> {
+impl<T: Literal, Column: Clone> Literal for ExprInner<T, Column> {
     type F = T::F;
     fn literal(x: Self::F) -> Self {
         ExprInner::Constant(T::literal(x))
@@ -729,9 +777,17 @@ impl<T: Literal, Column> Literal for ExprInner<T, Column> {
             _ => None,
         }
     }
+    fn as_literal(&self, constants: &Constants<Self::F>) -> Self {
+        match self {
+            ExprInner::Constant(x) => ExprInner::Constant(x.as_literal(constants)),
+            ExprInner::Cell(_)
+            | ExprInner::VanishesOnZeroKnowledgeAndPreviousRows
+            | ExprInner::UnnormalizedLagrangeBasis(_) => self.clone(),
+        }
+    }
 }
 
-impl<T: Literal + Clone + PartialEq> Operations<T>
+impl<T: Literal + PartialEq> Operations<T>
 where
     T::F: Field,
 {
@@ -1684,7 +1740,7 @@ impl<'a, F: FftField> EvalResult<'a, F> {
     }
 }
 
-impl<F: Field, Column: PartialEq> Expr<ConstantExpr<F>, Column> {
+impl<F: Field, Column: PartialEq + Copy> Expr<ConstantExpr<F>, Column> {
     /// Convenience function for constructing expressions from literal
     /// field elements.
     pub fn literal(x: F) -> Self {
@@ -2722,7 +2778,7 @@ impl<F: Field> From<u64> for ConstantExpr<F> {
     }
 }
 
-impl<F: Field, Column: PartialEq> Mul<F> for Expr<ConstantExpr<F>, Column> {
+impl<F: Field, Column: PartialEq + Copy> Mul<F> for Expr<ConstantExpr<F>, Column> {
     type Output = Expr<ConstantExpr<F>, Column>;
 
     fn mul(self, y: F) -> Self::Output {

--- a/kimchi/src/folding/example.rs
+++ b/kimchi/src/folding/example.rs
@@ -5,8 +5,10 @@ use crate::{
     },
     curve::KimchiCurve,
     folding::{
-        error_term::Side, expressions::FoldingColumnTrait, FoldingConfig, FoldingEnv, Instance,
-        Sponge, Witness,
+        error_term::Side,
+        expressions::{FoldingColumnTrait, FoldingCompatibleExprInner},
+        ExpExtension, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance, RelaxedInstance,
+        RelaxedWitness, Sponge, Witness,
     },
 };
 use ark_bn254;
@@ -25,11 +27,6 @@ use std::{
     iter::successors,
     rc::Rc,
     sync::atomic::{AtomicUsize, Ordering},
-};
-
-use super::{
-    expressions::FoldingCompatibleExprInner, ExpExtension, FoldingCompatibleExpr, RelaxedInstance,
-    RelaxedWitness,
 };
 
 /// Field = BN254 prime field
@@ -176,6 +173,7 @@ impl Witness<Curve> for TestWitness {
 struct TestStructure<F: Clone> {
     s_add: Vec<F>,
     s_mul: Vec<F>,
+    constants: Vec<F>,
 }
 
 struct TestFoldingEnv {
@@ -301,6 +299,7 @@ impl FoldingConfig for TestFoldingConfig {
         2
     }
 }
+
 fn instance_from_witness(
     witness: &TestWitness,
     srs: &<TestFoldingConfig as FoldingConfig>::Srs,
@@ -517,7 +516,11 @@ mod tests {
         let mut srs = poly_commitment::srs::SRS::<Curve>::create(2);
         srs.add_lagrange_basis(domain);
         let [s_add, s_mul] = circuit();
-        let structure = TestStructure { s_add, s_mul };
+        let structure = TestStructure {
+            s_add,
+            s_mul,
+            constants: vec![],
+        };
 
         let (scheme, final_constraint) = FoldingScheme::<TestFoldingConfig>::new(
             constraints.clone(),

--- a/kimchi/src/folding/expressions.rs
+++ b/kimchi/src/folding/expressions.rs
@@ -506,7 +506,7 @@ pub fn folding_expression<C: FoldingConfig>(
 impl<F, Config: FoldingConfig> From<ConstantExprInner<F>> for FoldingCompatibleExprInner<Config>
 where
     Config::Curve: AffineCurve<ScalarField = F>,
-    <Config as FoldingConfig>::Challenge: From<ChallengeTerm>,
+    Config::Challenge: From<ChallengeTerm>,
 {
     fn from(expr: ConstantExprInner<F>) -> Self {
         match expr {
@@ -515,7 +515,9 @@ where
             }
             ConstantExprInner::Constant(c) => match c {
                 ConstantTerm::Literal(f) => FoldingCompatibleExprInner::Constant(f),
-                _ => panic!("ConstantExprInner not supported in folding expressions"),
+                ConstantTerm::EndoCoefficient | ConstantTerm::Mds { row: _, col: _ } => {
+                    panic!("When special constants are involved, don't forget to simplify the expression before.")
+                }
             },
         }
     }

--- a/kimchi/src/folding/mock.rs
+++ b/kimchi/src/folding/mock.rs
@@ -7,6 +7,7 @@ use crate::{
     },
 };
 use ark_ec::AffineCurve;
+use ark_ff::Field;
 use itertools::Itertools;
 use mina_curves::pasta::Pallas;
 use num_traits::Zero;
@@ -15,6 +16,13 @@ use std::marker::PhantomData;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 struct Mock;
+
+impl<F: Field> From<F> for Mock {
+    fn from(_x: F) -> Self {
+        Mock
+    }
+}
+
 impl FoldingColumnTrait for u8 {
     fn is_witness(&self) -> bool {
         true


### PR DESCRIPTION
This PR adds a `as_literal()` function inside the `Literal` trait of the `Expr` framework which is meant to transform expressions with special constants (meaning, EndoCoefficient, MDS, etc) to be represented as plain literal constants using as field value the content of a `Constants` variable passed as argument. 

This way, when using the folding library, one can first "literize" your expressions before converting them into folding compatible expressions. Otherwise, `from` will panic when reaching any special constant.

Closes https://github.com/o1-labs/proof-systems/issues/2034