### PR TITLE
Cargo fmt: Automatic imports sorting

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,32 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  run_formatting:
+    name: Formatting
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust_toolchain_version: ["nightly"]
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Rust toolchain ${{ matrix.rust_toolchain_version }}
+        run:
+          |
+            curl --proto '=https' --tlsv1.2 -sSf -o rustup-init \
+            https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init
+            chmod +x ./rustup-init
+            ./rustup-init -y --default-toolchain "${{ matrix.rust_toolchain_version }}" --profile default
+            rm ./rustup-init
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+            # overwriting default rust-toolchain
+            echo ${{ matrix.rust_toolchain_version }} > rust-toolchain
+
+      - name: Run cargo fmt
+        run: |
+          cargo fmt -- --check
+
   run_checks:
     strategy:
       matrix:
@@ -87,10 +113,6 @@ jobs:
       # Coding guidelines
       #
 
-      - name: Enforce formating
-        run: |
-          eval $(opam env)
-          cargo fmt -- --check
 
       - name: Lint (clippy)
         run: |

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,3 @@
+indent_style = "Block"
+imports_granularity = "Crate"
+reorder_imports = true

--- a/hasher/src/tests/hasher.rs
+++ b/hasher/src/tests/hasher.rs
@@ -1,8 +1,7 @@
 use crate::{create_kimchi, create_legacy, Fp, Hashable, Hasher, ROInput};
 use o1_utils::FieldHelpers;
 use serde::Deserialize;
-use std::fs::File;
-use std::path::PathBuf;
+use std::{fs::File, path::PathBuf};
 
 //
 // Helpers for test vectors

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -28,8 +28,7 @@ use once_cell::sync::OnceCell;
 use poly_commitment::OpenProof;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
-use std::array;
-use std::sync::Arc;
+use std::{array, sync::Arc};
 
 //
 // ConstraintSystem

--- a/kimchi/src/circuits/domain_constant_evaluation.rs
+++ b/kimchi/src/circuits/domain_constant_evaluation.rs
@@ -2,9 +2,10 @@
 
 use crate::circuits::domains::EvaluationDomains;
 use ark_ff::FftField;
-use ark_poly::EvaluationDomain;
-use ark_poly::UVPolynomial;
-use ark_poly::{univariate::DensePolynomial as DP, Evaluations as E, Radix2EvaluationDomain as D};
+use ark_poly::{
+    univariate::DensePolynomial as DP, EvaluationDomain, Evaluations as E,
+    Radix2EvaluationDomain as D, UVPolynomial,
+};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -23,15 +23,12 @@ use itertools::Itertools;
 use o1_utils::{foreign_field::ForeignFieldHelpers, FieldHelpers};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::ops::{Add, AddAssign, Mul, Neg, Sub};
 use std::{
     cmp::Ordering,
+    collections::{HashMap, HashSet},
     fmt::{self, Debug},
     iter::FromIterator,
-};
-use std::{
-    collections::{HashMap, HashSet},
-    ops::MulAssign,
+    ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub},
 };
 use thiserror::Error;
 use CurrOrNext::{Curr, Next};
@@ -3499,8 +3496,7 @@ pub mod test {
         srs::{endos, SRS},
     };
     use rand::{prelude::StdRng, SeedableRng};
-    use std::array;
-    use std::sync::Arc;
+    use std::{array, sync::Arc};
 
     #[test]
     #[should_panic]

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -495,8 +495,11 @@ mod tests {
 
     use super::{LookupError, LookupTable, RuntimeTableCfg};
     use crate::{
-        circuits::constraints::ConstraintSystem, circuits::gate::CircuitGate,
-        circuits::lookup::tables::xor, circuits::polynomials::range_check, error::SetupError,
+        circuits::{
+            constraints::ConstraintSystem, gate::CircuitGate, lookup::tables::xor,
+            polynomials::range_check,
+        },
+        error::SetupError,
     };
     use mina_curves::pasta::Fp;
 

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -1,18 +1,22 @@
 use crate::circuits::{
     domains::EvaluationDomains,
     gate::{CircuitGate, CurrOrNext, GateType},
-    lookup::index::LookupSelectors,
-    lookup::tables::{
-        combine_table_entry, get_table, GateLookupTable, LookupTable, RANGE_CHECK_TABLE_ID,
-        XOR_TABLE_ID,
+    lookup::{
+        index::LookupSelectors,
+        tables::{
+            combine_table_entry, get_table, GateLookupTable, LookupTable, RANGE_CHECK_TABLE_ID,
+            XOR_TABLE_ID,
+        },
     },
 };
 use ark_ff::{Field, One, PrimeField, Zero};
 use ark_poly::{EvaluationDomain, Evaluations as E, Radix2EvaluationDomain as D};
 use o1_utils::field_helpers::i32_to_field;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
-use std::ops::{Mul, Neg};
+use std::{
+    collections::HashSet,
+    ops::{Mul, Neg},
+};
 use strum_macros::EnumIter;
 
 type Evaluations<Field> = E<Field, D<Field>>;

--- a/kimchi/src/circuits/polynomials/endomul_scalar.rs
+++ b/kimchi/src/circuits/polynomials/endomul_scalar.rs
@@ -12,8 +12,7 @@ use crate::{
     curve::KimchiCurve,
 };
 use ark_ff::{BitIteratorLE, Field, PrimeField};
-use std::array;
-use std::marker::PhantomData;
+use std::{array, marker::PhantomData};
 
 impl<F: PrimeField> CircuitGate<F> {
     /// Verify the `EndoMulscalar` gate.

--- a/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
@@ -1,14 +1,13 @@
 //! This module computes the witness of a foreign field addition circuit.
 
-use crate::circuits::expr::constraints::compact_limb;
-use crate::circuits::witness::Variables;
 use crate::{
     circuits::{
+        expr::constraints::compact_limb,
         polynomial::COLUMNS,
         polynomials::foreign_field_common::{
             BigUintForeignFieldHelpers, KimchiForeignElement, HI, LIMB_BITS, LO, MI,
         },
-        witness::{self, ConstantCell, VariableCell, WitnessCell},
+        witness::{self, ConstantCell, VariableCell, Variables, WitnessCell},
     },
     variable_map,
 };

--- a/kimchi/src/circuits/polynomials/foreign_field_common.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_common.rs
@@ -1,7 +1,9 @@
 //! Common parameters and functions for kimchi's foreign field circuits.
 
-use o1_utils::field_helpers::FieldHelpers;
-use o1_utils::foreign_field::{ForeignElement, ForeignFieldHelpers};
+use o1_utils::{
+    field_helpers::FieldHelpers,
+    foreign_field::{ForeignElement, ForeignFieldHelpers},
+};
 
 use ark_ff::{Field, PrimeField};
 use num_bigint::BigUint;

--- a/kimchi/src/circuits/polynomials/foreign_field_mul/witness.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_mul/witness.rs
@@ -4,11 +4,14 @@ use crate::{
     auto_clone_array,
     circuits::{
         polynomial::COLUMNS,
-        polynomials::foreign_field_common::{
-            BigUintArrayFieldHelpers, BigUintForeignFieldHelpers, FieldArrayBigUintHelpers,
-            KimchiForeignElement,
+        polynomials::{
+            foreign_field_add,
+            foreign_field_common::{
+                BigUintArrayFieldHelpers, BigUintForeignFieldHelpers, FieldArrayBigUintHelpers,
+                KimchiForeignElement,
+            },
+            range_check,
         },
-        polynomials::{foreign_field_add, range_check},
         witness::{self, ConstantCell, VariableBitsCell, VariableCell, Variables, WitnessCell},
     },
     variable_map,

--- a/kimchi/src/circuits/polynomials/generic.rs
+++ b/kimchi/src/circuits/polynomials/generic.rs
@@ -33,19 +33,21 @@
 //~ and c1 (resp. c2) the constant selector for the first (resp. second) gate.
 //~
 
-use crate::circuits::{
-    argument::{Argument, ArgumentEnv, ArgumentType},
-    expr::{constraints::ExprOps, Cache},
-    gate::{CircuitGate, GateType},
-    polynomial::COLUMNS,
-    wires::GateWires,
+use crate::{
+    circuits::{
+        argument::{Argument, ArgumentEnv, ArgumentType},
+        expr::{constraints::ExprOps, Cache},
+        gate::{CircuitGate, GateType},
+        polynomial::COLUMNS,
+        wires::GateWires,
+    },
+    curve::KimchiCurve,
+    prover_index::ProverIndex,
 };
-use crate::{curve::KimchiCurve, prover_index::ProverIndex};
 use ark_ff::{FftField, PrimeField, Zero};
 use ark_poly::univariate::DensePolynomial;
 use poly_commitment::OpenProof;
-use std::array;
-use std::marker::PhantomData;
+use std::{array, marker::PhantomData};
 
 /// Number of constraints produced by the gate.
 pub const CONSTRAINTS: u32 = 2;

--- a/kimchi/src/circuits/polynomials/keccak/mod.rs
+++ b/kimchi/src/circuits/polynomials/keccak/mod.rs
@@ -207,8 +207,7 @@ impl Keccak {
 #[cfg(test)]
 mod tests {
 
-    use rand::thread_rng;
-    use rand::{rngs::StdRng, Rng};
+    use rand::{rngs::StdRng, thread_rng, Rng};
     use rand_core::SeedableRng;
 
     use super::*;

--- a/kimchi/src/circuits/polynomials/permutation.rs
+++ b/kimchi/src/circuits/polynomials/permutation.rs
@@ -52,9 +52,8 @@ use crate::{
 use ark_ff::{FftField, PrimeField, SquareRootField, Zero};
 use ark_poly::{
     univariate::{DenseOrSparsePolynomial, DensePolynomial},
-    EvaluationDomain, Evaluations, Radix2EvaluationDomain as D,
+    EvaluationDomain, Evaluations, Polynomial, Radix2EvaluationDomain as D, UVPolynomial,
 };
-use ark_poly::{Polynomial, UVPolynomial};
 use blake2::{Blake2b512, Digest};
 use o1_utils::{ExtendedDensePolynomial, ExtendedEvaluations};
 use poly_commitment::OpenProof;

--- a/kimchi/src/circuits/polynomials/range_check/witness.rs
+++ b/kimchi/src/circuits/polynomials/range_check/witness.rs
@@ -3,19 +3,16 @@
 use ark_ff::PrimeField;
 use num_bigint::BigUint;
 use num_integer::Integer;
-use o1_utils::field_helpers::BigUintFieldHelpers;
-use o1_utils::{FieldHelpers, ForeignElement};
+use o1_utils::{field_helpers::BigUintFieldHelpers, FieldHelpers, ForeignElement};
 use std::array;
 
-use crate::circuits::witness::Variables;
-use crate::variable_map;
 use crate::{
     circuits::{
         polynomial::COLUMNS,
         polynomials::foreign_field_common::{BigUintForeignFieldHelpers, LIMB_BITS},
-        witness::{init_row, CopyBitsCell, CopyCell, VariableCell, WitnessCell},
+        witness::{init_row, CopyBitsCell, CopyCell, VariableCell, Variables, WitnessCell},
     },
-    variables,
+    variable_map, variables,
 };
 
 /// Witness layout

--- a/kimchi/src/circuits/polynomials/turshi.rs
+++ b/kimchi/src/circuits/polynomials/turshi.rs
@@ -93,8 +93,7 @@ use crate::{
 };
 use ark_ff::{FftField, Field, PrimeField, SquareRootField};
 use rand::{prelude::StdRng, SeedableRng};
-use std::array;
-use std::marker::PhantomData;
+use std::{array, marker::PhantomData};
 use turshi::{
     runner::{CairoInstruction, CairoProgram, Pointers},
     word::{FlagBits, Offsets},

--- a/kimchi/src/circuits/serialization_helper.rs
+++ b/kimchi/src/circuits/serialization_helper.rs
@@ -5,8 +5,7 @@ use serde::{
     Deserialize, Deserializer, Serializer,
 };
 use serde_with::{de::DeserializeAsWrap, ser::SerializeAsWrap, DeserializeAs, SerializeAs};
-use std::fmt::Formatter;
-use std::marker::PhantomData;
+use std::{fmt::Formatter, marker::PhantomData};
 
 impl<F, G> SerializeAs<JointLookupValue<F>> for JointLookupValue<G>
 where

--- a/kimchi/src/circuits/wires.rs
+++ b/kimchi/src/circuits/wires.rs
@@ -2,8 +2,10 @@
 
 use ark_ff::bytes::{FromBytes, ToBytes};
 use serde::{Deserialize, Serialize};
-use std::array;
-use std::io::{Read, Result as IoResult, Write};
+use std::{
+    array,
+    io::{Read, Result as IoResult, Write},
+};
 
 /// Number of registers
 pub const COLUMNS: usize = 15;

--- a/kimchi/src/folding/test.rs
+++ b/kimchi/src/folding/test.rs
@@ -98,9 +98,10 @@ mod mock {
     #[test]
     //not testing much right now, just to observe what quadraticization does
     fn test_term_separation() {
-        use crate::circuits::expr::Variable;
-        use crate::folding::expressions::ExtendedFoldingColumn;
-        use crate::folding::expressions::FoldingExp;
+        use crate::{
+            circuits::expr::Variable,
+            folding::expressions::{ExtendedFoldingColumn, FoldingExp},
+        };
         let col = |col| FoldingExp::Atom(ExtendedFoldingColumn::Inner(Variable { col, row: Curr }));
         let t1: FoldingExp<TestConfig> = (col(0) + col(1)) * (col(2) + col(3));
         let t2 = col(1).double()

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -1,25 +1,28 @@
 //! This module implements the linearization.
 
-use crate::alphas::Alphas;
-use crate::circuits::argument::{Argument, ArgumentType};
-use crate::circuits::expr;
-use crate::circuits::lookup;
-use crate::circuits::lookup::{
-    constraints::LookupConfiguration,
-    lookups::{LookupFeatures, LookupInfo, LookupPattern, LookupPatterns},
-};
-use crate::circuits::polynomials::{
-    complete_add::CompleteAdd,
-    endomul_scalar::EndomulScalar,
-    endosclmul::EndosclMul,
-    foreign_field_add::circuitgates::ForeignFieldAdd,
-    foreign_field_mul::circuitgates::ForeignFieldMul,
-    generic, permutation,
-    poseidon::Poseidon,
-    range_check::circuitgates::{RangeCheck0, RangeCheck1},
-    rot,
-    varbasemul::VarbaseMul,
-    xor,
+use crate::{
+    alphas::Alphas,
+    circuits::{
+        argument::{Argument, ArgumentType},
+        expr, lookup,
+        lookup::{
+            constraints::LookupConfiguration,
+            lookups::{LookupFeatures, LookupInfo, LookupPattern, LookupPatterns},
+        },
+        polynomials::{
+            complete_add::CompleteAdd,
+            endomul_scalar::EndomulScalar,
+            endosclmul::EndosclMul,
+            foreign_field_add::circuitgates::ForeignFieldAdd,
+            foreign_field_mul::circuitgates::ForeignFieldMul,
+            generic, permutation,
+            poseidon::Poseidon,
+            range_check::circuitgates::{RangeCheck0, RangeCheck1},
+            rot,
+            varbasemul::VarbaseMul,
+            xor,
+        },
+    },
 };
 
 use crate::circuits::{

--- a/kimchi/src/plonk_sponge.rs
+++ b/kimchi/src/plonk_sponge.rs
@@ -1,8 +1,8 @@
 use ark_ff::{Field, PrimeField};
-use mina_poseidon::sponge::{DefaultFrSponge, ScalarChallenge};
 use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi as SC,
     poseidon::{ArithmeticSponge, ArithmeticSpongeParams, Sponge},
+    sponge::{DefaultFrSponge, ScalarChallenge},
 };
 
 use crate::proof::{PointEvaluations, ProofEvaluations};

--- a/kimchi/src/precomputed_srs.rs
+++ b/kimchi/src/precomputed_srs.rs
@@ -5,8 +5,7 @@
 //! We generate the SRS within the test in this module.
 //! If you modify the SRS, you will need to regenerate the SRS by passing the `SRS_OVERWRITE` env var.
 
-use std::path::PathBuf;
-use std::{fs::File, io::BufReader};
+use std::{fs::File, io::BufReader, path::PathBuf};
 
 use poly_commitment::srs::SRS;
 

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -49,8 +49,7 @@ use poly_commitment::{
     OpenProof, SRS as _,
 };
 use rayon::prelude::*;
-use std::array;
-use std::collections::HashMap;
+use std::{array, collections::HashMap};
 
 /// The result of a proof creation or verification.
 type Result<T> = std::result::Result<T, ProverError>;

--- a/kimchi/src/snarky/asm.rs
+++ b/kimchi/src/snarky/asm.rs
@@ -1,13 +1,17 @@
 //! An ASM-like language to print a human-friendly version of a circuit.
 
 use itertools::Itertools;
-use std::collections::{HashMap, HashSet};
-use std::fmt::Write;
-use std::hash::Hash;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Write,
+    hash::Hash,
+};
 
-use crate::circuits::gate::{Circuit, CircuitGate, GateType};
-use crate::circuits::polynomials::generic::{GENERIC_COEFFS, GENERIC_REGISTERS};
-use crate::circuits::wires::Wire;
+use crate::circuits::{
+    gate::{Circuit, CircuitGate, GateType},
+    polynomials::generic::{GENERIC_COEFFS, GENERIC_REGISTERS},
+    wires::Wire,
+};
 use ark_ff::PrimeField;
 
 use super::api::Witness;

--- a/kimchi/src/snarky/folding.rs
+++ b/kimchi/src/snarky/folding.rs
@@ -1,18 +1,15 @@
 use self::instance::{Instance, RelaxedInstance};
-use super::poseidon::DuplexState;
-use super::prelude::*;
+use super::{poseidon::DuplexState, prelude::*};
 use crate::{
     curve::KimchiCurve,
     loc,
-    snarky::api::SnarkyCircuit,
-    snarky::{cvar::FieldVar, runner::RunState},
+    snarky::{api::SnarkyCircuit, cvar::FieldVar, runner::RunState},
 };
 use ark_ec::AffineCurve;
 use ark_ff::{BigInteger, One, PrimeField};
 use mina_curves::pasta::Fp;
 use poly_commitment::{evaluation_proof::OpeningProof, OpenProof};
-use std::marker::PhantomData;
-use std::ops::Add;
+use std::{marker::PhantomData, ops::Add};
 
 mod instance;
 

--- a/kimchi/src/snarky/tests.rs
+++ b/kimchi/src/snarky/tests.rs
@@ -3,9 +3,10 @@ use crate::{
     snarky::{
         api::SnarkyCircuit,
         boolean::Boolean,
+        cvar::FieldVar,
         errors::{SnarkyError, SnarkyRuntimeError},
+        runner::RunState,
     },
-    snarky::{cvar::FieldVar, runner::RunState},
 };
 use ark_ff::One;
 use mina_curves::pasta::{Fp, Vesta, VestaParameters};

--- a/kimchi/src/snarky/union_find.rs
+++ b/kimchi/src/snarky/union_find.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-use std::hash::Hash;
+use std::{collections::HashMap, hash::Hash};
 
 #[derive(Debug, Clone, Default)]
 /// Tarjan's Union-Find Data structure

--- a/kimchi/src/tests/chunked.rs
+++ b/kimchi/src/tests/chunked.rs
@@ -1,7 +1,7 @@
 use super::framework::TestFramework;
-use crate::circuits::polynomials::generic::GenericGateSpec;
 use crate::circuits::{
     gate::CircuitGate,
+    polynomials::generic::GenericGateSpec,
     wires::{Wire, COLUMNS},
 };
 use ark_ff::{UniformRand, Zero};

--- a/kimchi/src/tests/endomul.rs
+++ b/kimchi/src/tests/endomul.rs
@@ -1,9 +1,11 @@
-use crate::circuits::{
-    gate::{CircuitGate, GateType},
-    polynomials::endosclmul,
-    wires::*,
+use crate::{
+    circuits::{
+        gate::{CircuitGate, GateType},
+        polynomials::endosclmul,
+        wires::*,
+    },
+    tests::framework::TestFramework,
 };
-use crate::tests::framework::TestFramework;
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{BigInteger, BitIteratorLE, Field, One, PrimeField, UniformRand, Zero};
 use mina_curves::pasta::{Fp as F, Pallas as Other, Vesta, VestaParameters};

--- a/kimchi/src/tests/foreign_field_add.rs
+++ b/kimchi/src/tests/foreign_field_add.rs
@@ -1,19 +1,22 @@
 use super::framework::TestFramework;
-use crate::circuits::gate::CircuitGateResult;
-use crate::circuits::polynomials::generic::GenericGateSpec;
-use crate::circuits::{
-    constraints::ConstraintSystem,
-    gate::{CircuitGate, CircuitGateError, Connect, GateType},
-    polynomial::COLUMNS,
-    polynomials::{
-        foreign_field_add::witness::{self, FFOps},
-        foreign_field_common::{BigUintForeignFieldHelpers, HI, LIMB_BITS, LO, MI, TWO_TO_LIMB},
-        range_check::{self, witness::extend_multi},
+use crate::{
+    circuits::{
+        constraints::ConstraintSystem,
+        gate::{CircuitGate, CircuitGateError, CircuitGateResult, Connect, GateType},
+        polynomial::COLUMNS,
+        polynomials::{
+            foreign_field_add::witness::{self, FFOps},
+            foreign_field_common::{
+                BigUintForeignFieldHelpers, HI, LIMB_BITS, LO, MI, TWO_TO_LIMB,
+            },
+            generic::GenericGateSpec,
+            range_check::{self, witness::extend_multi},
+        },
+        wires::Wire,
     },
-    wires::Wire,
+    curve::KimchiCurve,
+    prover_index::ProverIndex,
 };
-use crate::curve::KimchiCurve;
-use crate::prover_index::ProverIndex;
 use ark_ec::AffineCurve;
 use ark_ff::{One, PrimeField, SquareRootField, Zero};
 use ark_poly::EvaluationDomain;
@@ -24,15 +27,13 @@ use mina_poseidon::{
 };
 use num_bigint::{BigUint, RandBigInt};
 use num_traits::FromPrimitive;
-use o1_utils::tests::make_test_rng;
-use o1_utils::{foreign_field::ForeignElement, FieldHelpers, Two};
+use o1_utils::{foreign_field::ForeignElement, tests::make_test_rng, FieldHelpers, Two};
 use poly_commitment::{
     evaluation_proof::OpeningProof,
     srs::{endos, SRS},
 };
 use rand::{rngs::StdRng, Rng};
-use std::array;
-use std::sync::Arc;
+use std::{array, sync::Arc};
 
 type PallasField = <Pallas as AffineCurve>::BaseField;
 type VestaField = <Vesta as AffineCurve>::BaseField;

--- a/kimchi/src/tests/generic.rs
+++ b/kimchi/src/tests/generic.rs
@@ -1,6 +1,8 @@
 use super::framework::TestFramework;
-use crate::circuits::polynomials::generic::testing::{create_circuit, fill_in_witness};
-use crate::circuits::wires::COLUMNS;
+use crate::circuits::{
+    polynomials::generic::testing::{create_circuit, fill_in_witness},
+    wires::COLUMNS,
+};
 use ark_ff::Zero;
 use mina_curves::pasta::{Fp, Vesta, VestaParameters};
 use mina_poseidon::{

--- a/kimchi/src/tests/lookup.rs
+++ b/kimchi/src/tests/lookup.rs
@@ -14,8 +14,7 @@ use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
-use rand::prelude::*;
-use rand::Rng;
+use rand::{prelude::*, Rng};
 use std::array;
 
 type SpongeParams = PlonkSpongeConstantsKimchi;

--- a/kimchi/src/tests/range_check.rs
+++ b/kimchi/src/tests/range_check.rs
@@ -24,8 +24,7 @@ use mina_curves::pasta::{Fp, Pallas, Vesta, VestaParameters};
 use num_bigint::{BigUint, RandBigInt};
 use o1_utils::{foreign_field::ForeignFieldHelpers, FieldHelpers};
 
-use std::array;
-use std::sync::Arc;
+use std::{array, sync::Arc};
 
 use crate::{prover_index::ProverIndex, verifier::verify};
 use groupmap::GroupMap;

--- a/kimchi/src/tests/recursion.rs
+++ b/kimchi/src/tests/recursion.rs
@@ -1,10 +1,13 @@
 use super::framework::TestFramework;
-use crate::circuits::polynomials::generic::testing::{create_circuit, fill_in_witness};
-use crate::circuits::wires::COLUMNS;
-use crate::proof::RecursionChallenge;
+use crate::{
+    circuits::{
+        polynomials::generic::testing::{create_circuit, fill_in_witness},
+        wires::COLUMNS,
+    },
+    proof::RecursionChallenge,
+};
 use ark_ff::{UniformRand, Zero};
-use ark_poly::univariate::DensePolynomial;
-use ark_poly::UVPolynomial;
+use ark_poly::{univariate::DensePolynomial, UVPolynomial};
 use mina_curves::pasta::{Fp, Vesta, VestaParameters};
 use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi,

--- a/kimchi/src/tests/serde.rs
+++ b/kimchi/src/tests/serde.rs
@@ -18,8 +18,7 @@ use mina_poseidon::{
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use poly_commitment::{commitment::CommitmentCurve, evaluation_proof::OpeningProof, srs::SRS};
-use std::array;
-use std::time::Instant;
+use std::{array, time::Instant};
 
 type SpongeParams = PlonkSpongeConstantsKimchi;
 type BaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;

--- a/kimchi/src/tests/varbasemul.rs
+++ b/kimchi/src/tests/varbasemul.rs
@@ -1,9 +1,11 @@
-use crate::circuits::{
-    gate::{CircuitGate, GateType},
-    polynomials::varbasemul,
-    wires::*,
+use crate::{
+    circuits::{
+        gate::{CircuitGate, GateType},
+        polynomials::varbasemul,
+        wires::*,
+    },
+    tests::framework::TestFramework,
 };
-use crate::tests::framework::TestFramework;
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{BigInteger, BitIteratorLE, Field, One, PrimeField, UniformRand, Zero};
 use colored::Colorize;
@@ -13,8 +15,7 @@ use mina_poseidon::{
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use rand::{rngs::StdRng, SeedableRng};
-use std::array;
-use std::time::Instant;
+use std::{array, time::Instant};
 
 type SpongeParams = PlonkSpongeConstantsKimchi;
 type BaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -23,8 +23,8 @@ use poly_commitment::{
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
-use std::array;
 use std::{
+    array,
     fs::{File, OpenOptions},
     io::{BufReader, BufWriter, Seek, SeekFrom::Start},
     path::Path,

--- a/msm/src/column_env.rs
+++ b/msm/src/column_env.rs
@@ -1,11 +1,10 @@
 use ark_ff::FftField;
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 
-use crate::mvlookup;
-use crate::witness::Witness;
-use kimchi::circuits::domains::EvaluationDomains;
-use kimchi::circuits::expr::{
-    Challenges, ColumnEnvironment as TColumnEnvironment, Constants, Domain,
+use crate::{mvlookup, witness::Witness};
+use kimchi::circuits::{
+    domains::EvaluationDomains,
+    expr::{Challenges, ColumnEnvironment as TColumnEnvironment, Constants, Domain},
 };
 
 /// The collection of polynomials (all in evaluation form) and constants

--- a/msm/src/ffa/columns.rs
+++ b/msm/src/ffa/columns.rs
@@ -1,5 +1,4 @@
-use crate::columns::Column;
-use crate::columns::ColumnIndexer;
+use crate::columns::{Column, ColumnIndexer};
 
 use crate::N_LIMBS;
 

--- a/msm/src/ffa/main.rs
+++ b/msm/src/ffa/main.rs
@@ -3,18 +3,20 @@ use ark_ff::UniformRand;
 use kimchi::circuits::domains::EvaluationDomains;
 use poly_commitment::pairing_proof::PairingSRS;
 
-use kimchi_msm::columns::Column;
-use kimchi_msm::ffa::{
-    columns::{FFA_NPUB_COLUMNS, FFA_N_COLUMNS},
-    constraint::ConstraintBuilderEnv as FFAConstraintBuilderEnv,
-    interpreter::{self as ffa_interpreter, FFAInterpreterEnv},
-    witness::WitnessBuilderEnv as FFAWitnessBuilderEnv,
+use kimchi_msm::{
+    columns::Column,
+    ffa::{
+        columns::{FFA_NPUB_COLUMNS, FFA_N_COLUMNS},
+        constraint::ConstraintBuilderEnv as FFAConstraintBuilderEnv,
+        interpreter::{self as ffa_interpreter, FFAInterpreterEnv},
+        witness::WitnessBuilderEnv as FFAWitnessBuilderEnv,
+    },
+    lookups::LookupTableIDs,
+    precomputed_srs::get_bn254_srs,
+    prover::prove,
+    verifier::verify,
+    BaseSponge, Ff1, Fp, OpeningProof, ScalarSponge, BN254,
 };
-use kimchi_msm::lookups::LookupTableIDs;
-use kimchi_msm::precomputed_srs::get_bn254_srs;
-use kimchi_msm::prover::prove;
-use kimchi_msm::verifier::verify;
-use kimchi_msm::{BaseSponge, Ff1, Fp, OpeningProof, ScalarSponge, BN254};
 
 pub fn main() {
     // FIXME: use a proper RNG

--- a/msm/src/ffa/mod.rs
+++ b/msm/src/ffa/mod.rs
@@ -6,11 +6,13 @@ pub mod witness;
 #[cfg(test)]
 mod tests {
 
-    use crate::ffa::{
-        interpreter::{self as ffa_interpreter, FFAInterpreterEnv},
-        witness::WitnessBuilderEnv as FFAWitnessBuilderEnv,
+    use crate::{
+        ffa::{
+            interpreter::{self as ffa_interpreter, FFAInterpreterEnv},
+            witness::WitnessBuilderEnv as FFAWitnessBuilderEnv,
+        },
+        Ff1, Fp,
     };
-    use crate::{Ff1, Fp};
     use ark_ff::UniformRand;
     use rand::Rng;
 

--- a/msm/src/ffa/witness.rs
+++ b/msm/src/ffa/witness.rs
@@ -1,5 +1,4 @@
-use ark_ff::PrimeField;
-use ark_ff::Zero;
+use ark_ff::{PrimeField, Zero};
 
 use crate::{
     columns::{Column, ColumnIndexer},
@@ -10,7 +9,7 @@ use crate::{
     lookups::LookupTableIDs,
     proof::ProofInputs,
     witness::Witness,
-    {BN254G1Affine, Fp},
+    BN254G1Affine, Fp,
 };
 
 #[allow(dead_code)]

--- a/msm/src/mvlookup.rs
+++ b/msm/src/mvlookup.rs
@@ -131,18 +131,19 @@ impl<'lt, G, ID: LookupTableID> IntoIterator for &'lt LookupProof<G, ID> {
 }
 
 pub mod prover {
-    use crate::mvlookup::{LookupTableID, MVLookup, MVLookupWitness};
-    use crate::MAX_SUPPORTED_DEGREE;
+    use crate::{
+        mvlookup::{LookupTableID, MVLookup, MVLookupWitness},
+        MAX_SUPPORTED_DEGREE,
+    };
     use ark_ff::{FftField, Zero};
-    use ark_poly::Evaluations;
-    use ark_poly::{univariate::DensePolynomial, Radix2EvaluationDomain as D};
-    use kimchi::circuits::domains::EvaluationDomains;
-    use kimchi::curve::KimchiCurve;
+    use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+    use kimchi::{circuits::domains::EvaluationDomains, curve::KimchiCurve};
     use mina_poseidon::FqSponge;
-    use poly_commitment::commitment::{absorb_commitment, PolyComm};
-    use poly_commitment::{OpenProof, SRS as _};
-    use rayon::iter::IntoParallelIterator;
-    use rayon::iter::ParallelIterator;
+    use poly_commitment::{
+        commitment::{absorb_commitment, PolyComm},
+        OpenProof, SRS as _,
+    };
+    use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
     pub struct QuotientPolynomialEnvironment<'a, F: FftField> {
         pub lookup_terms_evals_d8: &'a Vec<Evaluations<F, D<F>>>,

--- a/msm/src/proof.rs
+++ b/msm/src/proof.rs
@@ -8,10 +8,14 @@ use crate::{
 use ark_ff::UniformRand;
 use rand::thread_rng;
 
-use kimchi::circuits::domains::EvaluationDomains;
-use kimchi::circuits::expr::{ColumnEvaluations, ExprError};
-use kimchi::curve::KimchiCurve;
-use kimchi::proof::PointEvaluations;
+use kimchi::{
+    circuits::{
+        domains::EvaluationDomains,
+        expr::{ColumnEvaluations, ExprError},
+    },
+    curve::KimchiCurve,
+    proof::PointEvaluations,
+};
 use poly_commitment::{commitment::PolyComm, OpenProof};
 
 #[derive(Debug)]

--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -1,21 +1,27 @@
 use crate::{
     column_env::ColumnEnvironment,
     expr::E,
+    mvlookup,
     mvlookup::{prover::Env, LookupProof, LookupTableID},
     proof::{Proof, ProofCommitments, ProofEvaluations, ProofInputs},
     witness::Witness,
+    MAX_SUPPORTED_DEGREE,
 };
-use crate::{mvlookup, MAX_SUPPORTED_DEGREE};
 use ark_ff::{Field, One, Zero};
-use ark_poly::Evaluations;
-use ark_poly::{univariate::DensePolynomial, Polynomial, Radix2EvaluationDomain as R2D};
-use kimchi::circuits::domains::EvaluationDomains;
-use kimchi::circuits::expr::{l0_1, Challenges, Constants, Expr};
-use kimchi::plonk_sponge::FrSponge;
-use kimchi::proof::PointEvaluations;
-use kimchi::{curve::KimchiCurve, groupmap::GroupMap};
-use mina_poseidon::sponge::ScalarChallenge;
-use mina_poseidon::FqSponge;
+use ark_poly::{
+    univariate::DensePolynomial, Evaluations, Polynomial, Radix2EvaluationDomain as R2D,
+};
+use kimchi::{
+    circuits::{
+        domains::EvaluationDomains,
+        expr::{l0_1, Challenges, Constants, Expr},
+    },
+    curve::KimchiCurve,
+    groupmap::GroupMap,
+    plonk_sponge::FrSponge,
+    proof::PointEvaluations,
+};
+use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
 use o1_utils::ExtendedDensePolynomial;
 use poly_commitment::{
     commitment::{absorb_commitment, PolyComm},
@@ -23,8 +29,7 @@ use poly_commitment::{
     OpenProof, SRS,
 };
 use rand::{CryptoRng, RngCore};
-use rayon::iter::IntoParallelIterator;
-use rayon::iter::ParallelIterator;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use thiserror::Error;
 
 /// Errors that can arise when creating a proof

--- a/msm/src/serialization/column.rs
+++ b/msm/src/serialization/column.rs
@@ -1,6 +1,8 @@
-use crate::columns::{Column, ColumnIndexer};
-use crate::serialization::N_INTERMEDIATE_LIMBS;
-use crate::N_LIMBS;
+use crate::{
+    columns::{Column, ColumnIndexer},
+    serialization::N_INTERMEDIATE_LIMBS,
+    N_LIMBS,
+};
 
 /// Column used by the serialization subcircuit
 /// It is not used yet.

--- a/msm/src/serialization/constraints.rs
+++ b/msm/src/serialization/constraints.rs
@@ -11,8 +11,7 @@ use crate::{
     MVLookupTableID as _, N_LIMBS,
 };
 
-use super::Lookup;
-use super::{interpreter::InterpreterEnv, LookupTable};
+use super::{interpreter::InterpreterEnv, Lookup, LookupTable};
 
 /// Compute the following constraint:
 /// ```text

--- a/msm/src/serialization/witness.rs
+++ b/msm/src/serialization/witness.rs
@@ -2,10 +2,11 @@ use ark_ff::PrimeField;
 use num_bigint::BigUint;
 use o1_utils::FieldHelpers;
 
-use crate::columns::Column;
-use crate::serialization::interpreter::InterpreterEnv;
-use crate::serialization::{Lookup, LookupTable};
-use crate::N_LIMBS;
+use crate::{
+    columns::Column,
+    serialization::{interpreter::InterpreterEnv, Lookup, LookupTable},
+    N_LIMBS,
+};
 use kimchi::circuits::domains::EvaluationDomains;
 use std::iter;
 
@@ -229,15 +230,11 @@ impl<Fp: PrimeField> Env<Fp> {
 mod tests {
     use std::str::FromStr;
 
-    use crate::serialization::N_INTERMEDIATE_LIMBS;
-    use crate::{LIMB_BITSIZE, N_LIMBS};
+    use crate::{serialization::N_INTERMEDIATE_LIMBS, LIMB_BITSIZE, N_LIMBS};
 
     use super::Env;
     use crate::serialization::interpreter::deserialize_field_element;
-    use ark_ff::BigInteger;
-    use ark_ff::FpParameters as _;
-    use ark_ff::PrimeField;
-    use ark_ff::{One, UniformRand, Zero};
+    use ark_ff::{BigInteger, FpParameters as _, One, PrimeField, UniformRand, Zero};
     use mina_curves::pasta::Fp;
     use num_bigint::BigUint;
     use o1_utils::{tests::make_test_rng, FieldHelpers};

--- a/msm/src/test/columns.rs
+++ b/msm/src/test/columns.rs
@@ -1,5 +1,7 @@
-use crate::columns::{Column, ColumnIndexer};
-use crate::N_LIMBS;
+use crate::{
+    columns::{Column, ColumnIndexer},
+    N_LIMBS,
+};
 
 /// Number of columns in the test circuits.
 pub const TEST_N_COLUMNS: usize = 4 * N_LIMBS;

--- a/msm/src/test/witness.rs
+++ b/msm/src/test/witness.rs
@@ -1,5 +1,4 @@
-use ark_ff::PrimeField;
-use ark_ff::Zero;
+use ark_ff::{PrimeField, Zero};
 
 use crate::{
     columns::{Column, ColumnIndexer},
@@ -10,7 +9,7 @@ use crate::{
         interpreter::TestInterpreterEnv,
     },
     witness::Witness,
-    {BN254G1Affine, Fp},
+    BN254G1Affine, Fp,
 };
 
 #[allow(dead_code)]

--- a/msm/src/verifier.rs
+++ b/msm/src/verifier.rs
@@ -2,16 +2,19 @@ use crate::mvlookup::LookupTableID;
 use ark_ff::{Field, One, Zero};
 use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as R2D};
 use rand::thread_rng;
-use rayon::iter::IntoParallelIterator;
-use rayon::iter::ParallelIterator;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
-use kimchi::circuits::domains::EvaluationDomains;
-use kimchi::circuits::expr::{Challenges, Constants, Expr, PolishToken};
-use kimchi::plonk_sponge::FrSponge;
-use kimchi::proof::PointEvaluations;
-use kimchi::{curve::KimchiCurve, groupmap::GroupMap};
-use mina_poseidon::sponge::ScalarChallenge;
-use mina_poseidon::FqSponge;
+use kimchi::{
+    circuits::{
+        domains::EvaluationDomains,
+        expr::{Challenges, Constants, Expr, PolishToken},
+    },
+    curve::KimchiCurve,
+    groupmap::GroupMap,
+    plonk_sponge::FrSponge,
+    proof::PointEvaluations,
+};
+use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
 use poly_commitment::{
     commitment::{
         absorb_commitment, combined_inner_product, BatchEvaluationProof, Evaluation, PolyComm,
@@ -19,8 +22,7 @@ use poly_commitment::{
     OpenProof, SRS,
 };
 
-use crate::expr::E;
-use crate::{proof::Proof, witness::Witness};
+use crate::{expr::E, proof::Proof, witness::Witness};
 
 pub fn verify<
     G: KimchiCurve,

--- a/optimism/src/cannon.rs
+++ b/optimism/src/cannon.rs
@@ -5,8 +5,7 @@ use base64::{engine::general_purpose, Engine as _};
 use libflate::zlib::{Decoder, Encoder};
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::io::Read;
-use std::io::Write;
+use std::io::{Read, Write};
 
 pub const PAGE_ADDRESS_SIZE: u32 = 12;
 pub const PAGE_SIZE: u32 = 1 << PAGE_ADDRESS_SIZE;
@@ -289,8 +288,10 @@ impl Meta {
 mod tests {
 
     use super::*;
-    use std::fs::File;
-    use std::io::{BufReader, Write};
+    use std::{
+        fs::File,
+        io::{BufReader, Write},
+    };
 
     #[test]
     fn sp_parser() {

--- a/optimism/src/preimage_oracle.rs
+++ b/optimism/src/preimage_oracle.rs
@@ -5,9 +5,11 @@ use crate::cannon::{
 use command_fds::{CommandFdExt, FdMapping};
 use log::debug;
 use os_pipe::{PipeReader, PipeWriter};
-use std::io::{Read, Write};
-use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
-use std::process::{Child, Command};
+use std::{
+    io::{Read, Write},
+    os::fd::{AsRawFd, FromRawFd, OwnedFd},
+    process::{Child, Command},
+};
 
 pub struct PreImageOracle {
     pub cmd: Command,

--- a/poly-commitment/src/chunked.rs
+++ b/poly-commitment/src/chunked.rs
@@ -1,8 +1,7 @@
 use ark_ec::ProjectiveCurve;
 use ark_ff::{Field, Zero};
 
-use crate::commitment::CommitmentCurve;
-use crate::PolyComm;
+use crate::{commitment::CommitmentCurve, PolyComm};
 
 impl<C> PolyComm<C>
 where

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -6,9 +6,11 @@
 //!     producing the batched opening proof
 //! 3. Verify batch of batched opening proofs
 
-use crate::srs::endos;
-use crate::SRS as SRSTrait;
-use crate::{error::CommitmentError, srs::SRS};
+use crate::{
+    error::CommitmentError,
+    srs::{endos, SRS},
+    SRS as SRSTrait,
+};
 use ark_ec::{
     models::short_weierstrass_jacobian::GroupAffine as SWJAffine, msm::VariableBaseMSM,
     AffineCurve, ProjectiveCurve, SWModelParameters,
@@ -23,8 +25,7 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use core::ops::{Add, Sub};
 use groupmap::{BWParameters, GroupMap};
 use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
-use o1_utils::math;
-use o1_utils::ExtendedDensePolynomial as _;
+use o1_utils::{math, ExtendedDensePolynomial as _};
 use rand_core::{CryptoRng, RngCore};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -867,8 +868,7 @@ mod tests {
     use crate::srs::SRS;
     use ark_poly::{Polynomial, Radix2EvaluationDomain, UVPolynomial};
     use mina_curves::pasta::{Fp, Vesta as VestaG};
-    use mina_poseidon::constants::PlonkSpongeConstantsKimchi as SC;
-    use mina_poseidon::sponge::DefaultFqSponge;
+    use mina_poseidon::{constants::PlonkSpongeConstantsKimchi as SC, sponge::DefaultFqSponge};
     use rand::{rngs::StdRng, SeedableRng};
     use std::array;
 

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -1,9 +1,11 @@
-use crate::{commitment::*, srs::endos};
-use crate::{srs::SRS, PolynomialsToCombine, SRS as _};
+use crate::{
+    commitment::*,
+    srs::{endos, SRS},
+    PolynomialsToCombine, SRS as _,
+};
 use ark_ec::{msm::VariableBaseMSM, AffineCurve, ProjectiveCurve};
 use ark_ff::{FftField, Field, One, PrimeField, UniformRand, Zero};
-use ark_poly::{univariate::DensePolynomial, UVPolynomial};
-use ark_poly::{EvaluationDomain, Evaluations};
+use ark_poly::{univariate::DensePolynomial, EvaluationDomain, Evaluations, UVPolynomial};
 use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
 use o1_utils::{math, ExtendedDensePolynomial};
 use rand_core::{CryptoRng, RngCore};

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -11,9 +11,11 @@ mod tests;
 
 pub use commitment::PolyComm;
 
-use crate::commitment::{BatchEvaluationProof, BlindedCommitment, CommitmentCurve};
-use crate::error::CommitmentError;
-use crate::evaluation_proof::DensePolynomialOrEvaluations;
+use crate::{
+    commitment::{BatchEvaluationProof, BlindedCommitment, CommitmentCurve},
+    error::CommitmentError,
+    evaluation_proof::DensePolynomialOrEvaluations,
+};
 use ark_ec::AffineCurve;
 use ark_ff::UniformRand;
 use ark_poly::{

--- a/poly-commitment/src/pairing_proof.rs
+++ b/poly-commitment/src/pairing_proof.rs
@@ -1,7 +1,7 @@
-use crate::commitment::*;
-use crate::evaluation_proof::combine_polys;
-use crate::srs::SRS;
-use crate::{CommitmentError, PolynomialsToCombine, SRS as SRSTrait};
+use crate::{
+    commitment::*, evaluation_proof::combine_polys, srs::SRS, CommitmentError,
+    PolynomialsToCombine, SRS as SRSTrait,
+};
 use ark_ec::{msm::VariableBaseMSM, AffineCurve, PairingEngine};
 use ark_ff::{PrimeField, Zero};
 use ark_poly::{
@@ -340,12 +340,10 @@ impl<
 #[cfg(test)]
 mod tests {
     use super::{PairingProof, PairingSRS};
-    use crate::commitment::Evaluation;
-    use crate::evaluation_proof::DensePolynomialOrEvaluations;
-    use crate::srs::SRS;
-    use crate::SRS as _;
-    use ark_bn254::Fr as ScalarField;
-    use ark_bn254::{G1Affine as G1, G2Affine as G2, Parameters};
+    use crate::{
+        commitment::Evaluation, evaluation_proof::DensePolynomialOrEvaluations, srs::SRS, SRS as _,
+    };
+    use ark_bn254::{Fr as ScalarField, G1Affine as G1, G2Affine as G2, Parameters};
     use ark_ec::bn::Bn;
     use ark_ff::UniformRand;
     use ark_poly::{

--- a/poly-commitment/src/srs.rs
+++ b/poly-commitment/src/srs.rs
@@ -1,7 +1,6 @@
 //! This module implements the Marlin structured reference string primitive
 
-use crate::commitment::CommitmentCurve;
-use crate::PolyComm;
+use crate::{commitment::CommitmentCurve, PolyComm};
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{BigInteger, Field, One, PrimeField, Zero};
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as D};
@@ -11,9 +10,7 @@ use groupmap::GroupMap;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::array;
-use std::cmp::min;
-use std::collections::HashMap;
+use std::{array, cmp::min, collections::HashMap};
 
 #[serde_as]
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Eq)]

--- a/poly-commitment/src/tests/batch_15_wires.rs
+++ b/poly-commitment/src/tests/batch_15_wires.rs
@@ -12,9 +12,9 @@ use ark_poly::{univariate::DensePolynomial, Radix2EvaluationDomain, UVPolynomial
 use colored::Colorize;
 use groupmap::GroupMap;
 use mina_curves::pasta::{Fp, Vesta, VestaParameters};
-use mina_poseidon::constants::PlonkSpongeConstantsKimchi as SC;
-use mina_poseidon::sponge::DefaultFqSponge;
-use mina_poseidon::FqSponge;
+use mina_poseidon::{
+    constants::PlonkSpongeConstantsKimchi as SC, sponge::DefaultFqSponge, FqSponge,
+};
 use o1_utils::ExtendedDensePolynomial as _;
 use rand::Rng;
 use std::time::{Duration, Instant};

--- a/poly-commitment/src/tests/commitment.rs
+++ b/poly-commitment/src/tests/commitment.rs
@@ -12,9 +12,9 @@ use ark_poly::{univariate::DensePolynomial, Radix2EvaluationDomain, UVPolynomial
 use colored::Colorize;
 use groupmap::GroupMap;
 use mina_curves::pasta::{Fp, Vesta, VestaParameters};
-use mina_poseidon::constants::PlonkSpongeConstantsKimchi as SC;
-use mina_poseidon::sponge::DefaultFqSponge;
-use mina_poseidon::FqSponge as _;
+use mina_poseidon::{
+    constants::PlonkSpongeConstantsKimchi as SC, sponge::DefaultFqSponge, FqSponge as _,
+};
 use o1_utils::{tests::make_test_rng, ExtendedDensePolynomial as _};
 use rand::{CryptoRng, Rng, SeedableRng};
 use std::time::{Duration, Instant};

--- a/poseidon/export_test_vectors/src/main.rs
+++ b/poseidon/export_test_vectors/src/main.rs
@@ -8,10 +8,12 @@ fn main() {
 
 mod inner {
     use super::vectors;
-    use std::env;
-    use std::fs::File;
-    use std::io::{self, Write};
-    use std::str::FromStr;
+    use std::{
+        env,
+        fs::File,
+        io::{self, Write},
+        str::FromStr,
+    };
 
     #[derive(Debug)]
     pub enum Mode {

--- a/poseidon/src/permutation.rs
+++ b/poseidon/src/permutation.rs
@@ -1,7 +1,9 @@
 //! The permutation module contains the function implementing the permutation used in Poseidon
 
-use crate::constants::SpongeConstants;
-use crate::poseidon::{sbox, ArithmeticSpongeParams};
+use crate::{
+    constants::SpongeConstants,
+    poseidon::{sbox, ArithmeticSpongeParams},
+};
 use ark_ff::Field;
 
 fn apply_mds_matrix<F: Field, SC: SpongeConstants>(

--- a/poseidon/src/poseidon.rs
+++ b/poseidon/src/poseidon.rs
@@ -1,7 +1,9 @@
 //! This module implements Poseidon Hash Function primitive
 
-use crate::constants::SpongeConstants;
-use crate::permutation::{full_round, poseidon_block_cipher};
+use crate::{
+    constants::SpongeConstants,
+    permutation::{full_round, poseidon_block_cipher},
+};
 use ark_ff::Field;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;

--- a/poseidon/src/sponge.rs
+++ b/poseidon/src/sponge.rs
@@ -1,5 +1,7 @@
-use crate::constants::SpongeConstants;
-use crate::poseidon::{ArithmeticSponge, ArithmeticSpongeParams, Sponge};
+use crate::{
+    constants::SpongeConstants,
+    poseidon::{ArithmeticSponge, ArithmeticSpongeParams, Sponge},
+};
 use ark_ec::{short_weierstrass_jacobian::GroupAffine, SWModelParameters};
 use ark_ff::{BigInteger, Field, FpParameters, One, PrimeField, Zero};
 

--- a/poseidon/src/tests/poseidon_tests.rs
+++ b/poseidon/src/tests/poseidon_tests.rs
@@ -1,15 +1,12 @@
 use crate::{
     constants::{PlonkSpongeConstantsKimchi, PlonkSpongeConstantsLegacy},
-    pasta::fp_kimchi as SpongeParametersKimchi,
-    pasta::fp_legacy as SpongeParametersLegacy,
-    poseidon::ArithmeticSponge as Poseidon,
-    poseidon::Sponge as _,
+    pasta::{fp_kimchi as SpongeParametersKimchi, fp_legacy as SpongeParametersLegacy},
+    poseidon::{ArithmeticSponge as Poseidon, Sponge as _},
 };
 use mina_curves::pasta::Fp;
 use o1_utils::FieldHelpers;
 use serde::Deserialize;
-use std::fs::File;
-use std::path::PathBuf; // needed for ::new() sponge
+use std::{fs::File, path::PathBuf}; // needed for ::new() sponge
 
 //
 // Helpers for test vectors

--- a/turshi/src/memory.rs
+++ b/turshi/src/memory.rs
@@ -1,11 +1,12 @@
 //! This module represents the Cairo memory, containing the
 //! compiled Cairo program that occupies the first few entries
 
-use std::fmt::{Display, Formatter, Result};
-use std::ops::{Index, IndexMut};
+use std::{
+    fmt::{Display, Formatter, Result},
+    ops::{Index, IndexMut},
+};
 
-use crate::helper::*;
-use crate::word::CairoWord;
+use crate::{helper::*, word::CairoWord};
 use ark_ff::Field;
 use core::iter::repeat;
 

--- a/turshi/src/runner.rs
+++ b/turshi/src/runner.rs
@@ -1,9 +1,11 @@
 //! This module represents a run of a Cairo program as a series of consecutive
 //! execution steps, each of which define the execution logic of Cairo instructions
 
-use crate::flags::*;
-use crate::memory::CairoMemory;
-use crate::word::{CairoWord, FlagBits, FlagSets, Offsets};
+use crate::{
+    flags::*,
+    memory::CairoMemory,
+    word::{CairoWord, FlagBits, FlagSets, Offsets},
+};
 use ark_ff::Field;
 
 /// A structure to store program counter, allocation pointer and frame pointer

--- a/turshi/src/word.rs
+++ b/turshi/src/word.rs
@@ -4,8 +4,7 @@
 //! Our Pallas curves have 255 bits, so Cairo native instructions will fit.
 //! This means that our Cairo implementation can admit a larger domain for immediate values than theirs.
 
-use crate::flags::*;
-use crate::helper::CairoFieldHelpers;
+use crate::{flags::*, helper::CairoFieldHelpers};
 use ark_ff::Field;
 use o1_utils::field_helpers::FieldHelpers;
 
@@ -244,8 +243,10 @@ impl<F: Field> FlagSets<F> for CairoWord<F> {
 
 #[cfg(test)]
 mod tests {
-    use crate::flags::*;
-    use crate::word::{FlagBits, FlagSets, Offsets};
+    use crate::{
+        flags::*,
+        word::{FlagBits, FlagSets, Offsets},
+    };
     use ark_ff::{One, Zero};
     use mina_curves::pasta::Fp as F;
 

--- a/utils/src/foreign_field.rs
+++ b/utils/src/foreign_field.rs
@@ -6,8 +6,10 @@
 use crate::field_helpers::FieldHelpers;
 use ark_ff::{Field, PrimeField};
 use num_bigint::BigUint;
-use std::fmt::{Debug, Formatter};
-use std::ops::{Index, IndexMut};
+use std::{
+    fmt::{Debug, Formatter},
+    ops::{Index, IndexMut},
+};
 
 /// Represents a foreign field element
 #[derive(Clone, PartialEq, Eq)]


### PR DESCRIPTION
This adds rustfmt for the repo + `imports_granularity = "Crate"`

Since we build our project w.r.t. a stable rust release, you need to rust `rustfmt` with nightly explicitly in your editor.
- On emacs, do this: `(setq rustic-rustfmt-args "+nightly")`
- On VSCode: modify `rustFmtArgs` https://github.com/rust-lang/rust-analyzer/issues/3627