### PR TITLE
MSM: Add lookup IDs in tests, fixes broken master

### DIFF
--- a/msm/src/fec/interpreter.rs
+++ b/msm/src/fec/interpreter.rs
@@ -1,5 +1,4 @@
-use crate::columns::Column;
-use crate::{LIMB_BITSIZE, N_LIMBS};
+use crate::{columns::Column, LIMB_BITSIZE, N_LIMBS};
 use ark_ff::{FpParameters, PrimeField, Zero};
 use num_bigint::{BigInt, BigUint, ToBigInt};
 use num_integer::Integer;

--- a/msm/src/fec/mod.rs
+++ b/msm/src/fec/mod.rs
@@ -6,15 +6,19 @@ pub mod witness;
 #[cfg(test)]
 mod tests {
 
-    use crate::fec::{
-        columns::FEC_N_COLUMNS,
-        constraint::ConstraintBuilderEnv as FECConstraintBuilderEnv,
-        interpreter::{self as fec_interpreter, FECInterpreterEnv},
-        witness::WitnessBuilderEnv as FECWitnessBuilderEnv,
-    };
     use crate::{
-        columns::Column, lookups::LookupTableIDs, prover::prove, verifier::verify,
-        witness::Witness, BaseSponge, Ff1, Fp, OpeningProof, ScalarSponge, BN254,
+        columns::Column,
+        fec::{
+            columns::FEC_N_COLUMNS,
+            constraint::ConstraintBuilderEnv as FECConstraintBuilderEnv,
+            interpreter::{self as fec_interpreter, FECInterpreterEnv},
+            witness::WitnessBuilderEnv as FECWitnessBuilderEnv,
+        },
+        lookups::LookupTableIDs,
+        prover::prove,
+        verifier::verify,
+        witness::Witness,
+        BaseSponge, Ff1, Fp, OpeningProof, ScalarSponge, BN254,
     };
     use ark_ff::UniformRand;
     use kimchi::circuits::domains::EvaluationDomains;
@@ -81,13 +85,14 @@ mod tests {
         .unwrap();
 
         // verify the proof
-        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, FEC_N_COLUMNS, 0>(
-            domain,
-            &srs,
-            &constraints,
-            &proof,
-            Witness::zero_vec(domain_size),
-        );
+        let verifies =
+            verify::<_, OpeningProof, BaseSponge, ScalarSponge, FEC_N_COLUMNS, 0, LookupTableIDs>(
+                domain,
+                &srs,
+                &constraints,
+                &proof,
+                Witness::zero_vec(domain_size),
+            );
 
         assert!(verifies);
     }

--- a/msm/src/fec/witness.rs
+++ b/msm/src/fec/witness.rs
@@ -10,7 +10,7 @@ use crate::{
     lookups::LookupTableIDs,
     proof::ProofInputs,
     witness::Witness,
-    {BN254G1Affine, Fp, LIMB_BITSIZE, N_LIMBS},
+    BN254G1Affine, Fp, LIMB_BITSIZE, N_LIMBS,
 };
 
 #[allow(dead_code)]

--- a/msm/src/test/mod.rs
+++ b/msm/src/test/mod.rs
@@ -146,7 +146,7 @@ mod tests {
                 rng,
             )
             .unwrap();
-        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, N, 0>(
+        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, N, 0, LookupTableIDs>(
             domain,
             &srs,
             &constraints,


### PR DESCRIPTION
Somehow https://github.com/o1-labs/proof-systems/pull/2006 managed to trick CI into thinking it compiles well. Probably CI result was outdated. Here's a few lines fix.