### PR TITLE
Split Keccak circuit into steps with specialized constraints

### DIFF
--- a/kimchi/src/circuits/polynomials/keccak/constants.rs
+++ b/kimchi/src/circuits/polynomials/keccak/constants.rs
@@ -78,3 +78,6 @@ pub const SPONGE_SHIFTS_OFF: usize = SPONGE_BYTES_OFF + SPONGE_BYTES_LEN;
 pub const SPONGE_SHIFTS_LEN: usize = SHIFTS_LEN;
 pub const SPONGE_XOR_STATE_OFF: usize = 0;
 pub const SPONGE_XOR_STATE_LEN: usize = STATE_LEN;
+
+/// The number of columns the Sponge circuit uses.
+pub const SPONGE_COLS: usize = SPONGE_SHIFTS_OFF + SPONGE_SHIFTS_LEN;

--- a/kimchi/src/circuits/polynomials/keccak/mod.rs
+++ b/kimchi/src/circuits/polynomials/keccak/mod.rs
@@ -181,7 +181,7 @@ impl Keccak {
     /// That means that if the input has a length that is a multiple of the RATE_IN_BYTES, then
     /// it needs to add one whole block of RATE_IN_BYTES bytes just for padding purposes.
     pub fn padded_length(bytelength: usize) -> usize {
-        (bytelength / RATE_IN_BYTES + 1) * RATE_IN_BYTES
+        Self::num_blocks(bytelength) * RATE_IN_BYTES
     }
 
     /// Pads the message with the 10*1 rule until reaching a length that is a multiple of the rate
@@ -200,7 +200,7 @@ impl Keccak {
 
     /// Number of blocks to be absorbed on input a given preimage bytelength
     pub fn num_blocks(bytelength: usize) -> usize {
-        Self::padded_length(bytelength) / RATE_IN_BYTES
+        bytelength / RATE_IN_BYTES + 1
     }
 }
 

--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -26,7 +26,7 @@ const FLAG_ROUND_OFF: usize = 0; // Offset of the Round selector inside the mode
 const FLAG_ROOT_OFF: usize = 1; // Offset of the Root selector inside the mode flags
 const FLAG_ABSORB_OFF: usize = 2; // Offset of the Absorb selector inside the mode flags
 const FLAG_PAD_OFF: usize = 3; // Offset of the Pad selector  inside the mode flags
-const FLAG_PADROOT_OFF: usize = 4; // Offset of the PadRoot selector  inside the mode flags
+const FLAG_ROOTPAD_OFF: usize = 4; // Offset of the RootPad selector  inside the mode flags
 const FLAG_SQUEEZE_OFF: usize = 5; // Offset of the Squeeze selector inside the mode flags
 
 const STATUS_IDXS_OFF: usize = MODE_LEN; // The offset of the columns reserved for the status indices
@@ -113,12 +113,12 @@ pub enum Flag {
 }
 
 /// The columns used by the Keccak circuit.
-/// The Keccak circuit is split into two main modes: Round and Sponge (split into Root, Absorb, Pad, PadRoot, Squeeze).
+/// The Keccak circuit is split into two main modes: Round and Sponge (split into Root, Absorb, Pad, RootPad, Squeeze).
 /// The columns are shared between the Sponge and Round steps
 /// (the total number of columns refers to the maximum of columns used by each mode)
 /// The hash, block, and step indices are shared between both modes.
 /// The row is split into the following entries:
-/// - mode_flags: what kind of mode is running: round, root, absorb, pad, padroot, squeeze. Only 1 of them can be active.
+/// - mode_flags: what kind of mode is running: round, root, absorb, pad, rootpad, squeeze. Only 1 of them can be active.
 /// - hash_index: Which hash this is inside the circuit
 /// - block_index: Which block this is inside the hash
 /// - step_index: Which step this is inside the hash
@@ -272,7 +272,7 @@ impl<T: Clone> Index<Column> for KeccakWitness<T> {
             Column::Selector(Flag::Root) => &self.mode_flags()[FLAG_ROOT_OFF],
             Column::Selector(Flag::Absorb) => &self.mode_flags()[FLAG_ABSORB_OFF],
             Column::Selector(Flag::Pad) => &self.mode_flags()[FLAG_PAD_OFF],
-            Column::Selector(Flag::PadRoot) => &self.mode_flags()[FLAG_PADROOT_OFF],
+            Column::Selector(Flag::PadRoot) => &self.mode_flags()[FLAG_ROOTPAD_OFF],
             Column::Selector(Flag::Squeeze) => &self.mode_flags()[FLAG_SQUEEZE_OFF],
 
             Column::HashIndex => self.hash_index(),
@@ -389,7 +389,7 @@ impl<T: Clone> IndexMut<Column> for KeccakWitness<T> {
             Column::Selector(Flag::Root) => &mut self.mode_flags_mut()[FLAG_ROOT_OFF],
             Column::Selector(Flag::Absorb) => &mut self.mode_flags_mut()[FLAG_ABSORB_OFF],
             Column::Selector(Flag::Pad) => &mut self.mode_flags_mut()[FLAG_PAD_OFF],
-            Column::Selector(Flag::PadRoot) => &mut self.mode_flags_mut()[FLAG_PADROOT_OFF],
+            Column::Selector(Flag::RootPad) => &mut self.mode_flags_mut()[FLAG_ROOTPAD_OFF],
             Column::Selector(Flag::Squeeze) => &mut self.mode_flags_mut()[FLAG_SQUEEZE_OFF],
 
             Column::HashIndex => &mut self.cols[STATUS_IDXS_OFF],

--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -473,14 +473,14 @@ impl<T: Clone> IndexMut<Column> for KeccakWitness<T> {
                 &mut self.curr_mut()[SPONGE_SHIFTS_OFF + idx]
             }
 
-            Column::RoundNumber => &self.round_flags()[0],
+            Column::RoundNumber => &mut self.round_flags_mut()[0],
             Column::RoundConstants(idx) => {
                 assert!(idx < QUARTERS);
                 &mut self.round_flags_mut()[1 + idx]
             }
 
-            Column::PadLength => &self.pad_flags()[PAD_LEN_OFF],
-            Column::TwoToPad => &self.pad_flags()[PAD_TWO_OFF],
+            Column::PadLength => &mut self.pad_flags_mut()[PAD_LEN_OFF],
+            Column::TwoToPad => &mut self.pad_flags_mut()[PAD_TWO_OFF],
             Column::PadSuffix(idx) => {
                 assert!(idx < PAD_SUFFIX_LEN);
                 &mut self.pad_flags_mut()[PAD_SUFFIX_OFF + idx]

--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -37,7 +37,8 @@ const CURR_LEN: usize = ZKVM_KECCAK_COLS_CURR; // The length of the curr chunk i
 const NEXT_OFF: usize = CURR_OFF + CURR_LEN; // The offset of the next chunk inside the witness columns
 const NEXT_LEN: usize = ZKVM_KECCAK_COLS_NEXT; // The length of the next chunk inside the witness columns
 
-const ROUND_CONST_LEN: usize = QUARTERS;
+/// The number of sparse round constants used per round
+pub(crate) const ROUND_CONST_LEN: usize = QUARTERS;
 const ROUND_FLAGS_LEN: usize = ROUND_CONST_LEN + 1;
 const ROUND_COEFFS_OFF: usize = NEXT_OFF + NEXT_LEN; // The offset of the Round coefficients inside the witness columns
 
@@ -49,7 +50,8 @@ const PAD_SUFFIX_OFF: usize = 2; // Offset of the PadSuffix column inside the sp
 /// The padding suffix of 1088 bits is stored as 5 field elements: 1x12 + 4x31 bytes
 pub(crate) const PAD_SUFFIX_LEN: usize = 5;
 const PAD_BYTES_OFF: usize = PAD_SUFFIX_OFF + PAD_SUFFIX_LEN; // Offset of the PadBytesFlags inside the sponge coefficients
-const PAD_BYTES_LEN: usize = RATE_IN_BYTES; // The maximum number of padding bytes involved
+/// The maximum number of padding bytes involved
+pub(crate) const PAD_BYTES_LEN: usize = RATE_IN_BYTES;
 
 /// Column aliases used by the Keccak circuit.
 /// The number of aliases is not necessarily equal to the actual number of
@@ -272,7 +274,7 @@ impl<T: Clone> Index<Column> for KeccakWitness<T> {
             Column::Selector(Flag::Root) => &self.mode_flags()[FLAG_ROOT_OFF],
             Column::Selector(Flag::Absorb) => &self.mode_flags()[FLAG_ABSORB_OFF],
             Column::Selector(Flag::Pad) => &self.mode_flags()[FLAG_PAD_OFF],
-            Column::Selector(Flag::PadRoot) => &self.mode_flags()[FLAG_ROOTPAD_OFF],
+            Column::Selector(Flag::RootPad) => &self.mode_flags()[FLAG_ROOTPAD_OFF],
             Column::Selector(Flag::Squeeze) => &self.mode_flags()[FLAG_SQUEEZE_OFF],
 
             Column::HashIndex => self.hash_index(),

--- a/optimism/src/keccak/column.rs
+++ b/optimism/src/keccak/column.rs
@@ -1,6 +1,6 @@
 //! This module defines the custom columns used in the Keccak witness, which
 //! are aliases for the actual Keccak witness columns also defined here.
-use self::Sponge::*;
+use self::{Absorbs::*, Flags::*, Sponges::*};
 use crate::keccak::{ZKVM_KECCAK_COLS_CURR, ZKVM_KECCAK_COLS_NEXT};
 use kimchi::circuits::polynomials::keccak::constants::{
     CHI_SHIFTS_B_LEN, CHI_SHIFTS_B_OFF, CHI_SHIFTS_SUM_LEN, CHI_SHIFTS_SUM_OFF, PIRHO_DENSE_E_LEN,
@@ -62,7 +62,7 @@ pub(crate) const PAD_BYTES_LEN: usize = RATE_IN_BYTES;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum Column {
     /// Selectors used to distinguish between different modes of the Keccak step
-    Selector(Flag),
+    Selector(Flags),
 
     /// Hash identifier to distinguish inside the syscalls communication channel
     HashIndex,
@@ -106,21 +106,21 @@ pub enum Column {
 /// These selectors determine the specific behaviour so that Keccak steps
 /// can be split into different instances for folding
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub enum Flag {
-    Round,          // Current step performs a round of the permutation
-    Sponge(Sponge), // Current step is a sponge
+pub enum Flags {
+    Round,           // Current step performs a round of the permutation
+    Sponge(Sponges), // Current step is a sponge
 }
 
 /// Variants of Keccak sponges
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub enum Sponge {
-    Absorb(Absorb),
+pub enum Sponges {
+    Absorb(Absorbs),
     Squeeze,
 }
 
 /// Order of absorb steps in the computation depending on the number of blocks to absorb
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub enum Absorb {
+pub enum Absorbs {
     First,  // Also known as the root absorb
     Middle, // Any other absorb
     Last,   // Also known as the padding absorb
@@ -284,13 +284,13 @@ impl<T: Clone> Index<Column> for KeccakWitness<T> {
     fn index(&self, index: Column) -> &Self::Output {
         match index {
             Column::Selector(flag) => match flag {
-                Flag::Round => &self.mode_flags()[FLAG_ROUND_OFF],
-                Flag::Sponge(sponge) => match sponge {
+                Round => &self.mode_flags()[FLAG_ROUND_OFF],
+                Sponge(sponge) => match sponge {
                     Absorb(absorb) => match absorb {
-                        Absorb::First => &self.mode_flags()[FLAG_FST_OFF],
-                        Absorb::Middle => &self.mode_flags()[FLAG_MID_OFF],
-                        Absorb::Last => &self.mode_flags()[FLAG_LST_OFF],
-                        Absorb::Only => &self.mode_flags()[FLAG_ONE_OFF],
+                        First => &self.mode_flags()[FLAG_FST_OFF],
+                        Middle => &self.mode_flags()[FLAG_MID_OFF],
+                        Last => &self.mode_flags()[FLAG_LST_OFF],
+                        Only => &self.mode_flags()[FLAG_ONE_OFF],
                     },
                     Squeeze => &self.mode_flags()[FLAG_SQUEEZE_OFF],
                 },
@@ -407,13 +407,13 @@ impl<T: Clone> IndexMut<Column> for KeccakWitness<T> {
     fn index_mut(&mut self, index: Column) -> &mut Self::Output {
         match index {
             Column::Selector(flag) => match flag {
-                Flag::Round => &mut self.mode_flags_mut()[FLAG_ROUND_OFF],
-                Flag::Sponge(sponge) => match sponge {
+                Round => &mut self.mode_flags_mut()[FLAG_ROUND_OFF],
+                Sponge(sponge) => match sponge {
                     Absorb(absorb) => match absorb {
-                        Absorb::First => &mut self.mode_flags_mut()[FLAG_FST_OFF],
-                        Absorb::Middle => &mut self.mode_flags_mut()[FLAG_MID_OFF],
-                        Absorb::Last => &mut self.mode_flags_mut()[FLAG_LST_OFF],
-                        Absorb::Only => &mut self.mode_flags_mut()[FLAG_ONE_OFF],
+                        First => &mut self.mode_flags_mut()[FLAG_FST_OFF],
+                        Middle => &mut self.mode_flags_mut()[FLAG_MID_OFF],
+                        Last => &mut self.mode_flags_mut()[FLAG_LST_OFF],
+                        Only => &mut self.mode_flags_mut()[FLAG_ONE_OFF],
                     },
                     Squeeze => &mut self.mode_flags_mut()[FLAG_SQUEEZE_OFF],
                 },

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -70,6 +70,14 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
         }))
     }
 
+    fn check(&mut self, tag: Selector, x: Self::Variable) {
+        // No-op in constraint side
+    }
+
+    fn checks(&self) {
+        // No-op in constraint side
+    }
+
     fn constrain(&mut self, _tag: Constraint, x: Self::Variable) {
         self.constraints.push(x);
     }
@@ -82,48 +90,41 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
         self.lookups.push(lookup);
     }
 
-    ///////////////////////
-    // COLUMN OPERATIONS //
-    ///////////////////////
+    /////////////////////////
+    // SELECTOR OPERATIONS //
+    /////////////////////////
 
-    fn is_sponge(&self) -> Self::Variable {
+    fn mode_absorb(&self) -> Self::Variable {
         match self.selector {
-            Some(Absorb) | Some(Root) | Some(Pad) | Some(PadRoot) | Some(Squeeze) => {
-                Self::Variable::one()
-            }
+            Some(Absorb) => Self::Variable::one(),
             _ => Self::Variable::zero(),
         }
     }
-
-    fn is_absorb(&self) -> Self::Variable {
-        match self.selector {
-            Some(Absorb) | Some(Root) | Some(Pad) | Some(PadRoot) => Self::Variable::one(),
-            _ => Self::Variable::zero(),
-        }
-    }
-
-    fn is_squeeze(&self) -> Self::Variable {
+    fn mode_squeeze(&self) -> Self::Variable {
         match self.selector {
             Some(Squeeze) => Self::Variable::one(),
             _ => Self::Variable::zero(),
         }
     }
-
-    fn is_root(&self) -> Self::Variable {
+    fn mode_root(&self) -> Self::Variable {
         match self.selector {
-            Some(Root) | Some(PadRoot) => Self::Variable::one(),
+            Some(Root) => Self::Variable::one(),
             _ => Self::Variable::zero(),
         }
     }
-
-    fn is_pad(&self) -> Self::Variable {
+    fn mode_pad(&self) -> Self::Variable {
         match self.selector {
-            Some(Pad) | Some(PadRoot) => Self::Variable::one(),
+            Some(Pad) => Self::Variable::one(),
             _ => Self::Variable::zero(),
         }
     }
-
-    fn is_round(&self) -> Self::Variable {
+    fn mode_rootpad(&self) -> Self::Variable {
+        match self.selector {
+            Some(RootPad) => Self::Variable::one(),
+            _ => Self::Variable::zero(),
+        }
+    }
+    fn mode_round(&self) -> Self::Variable {
         match self.selector {
             Some(Round) => Self::Variable::one(),
             _ => Self::Variable::zero(),

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -2,11 +2,11 @@
 use crate::{
     keccak::{
         column::Flag::{self, *},
-        Constraint, KeccakColumn, E,
+        Constraint, KeccakColumn, Selector, E,
     },
     lookups::Lookup,
 };
-use ark_ff::Field;
+use ark_ff::{Field, One, Zero};
 use kimchi::{
     circuits::{
         expr::{ConstantTerm::Literal, Expr, ExprInner, Operations, Variable},
@@ -78,8 +78,10 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
         // No-op in constraint side
     }
 
-    fn constrain(&mut self, _tag: Constraint, x: Self::Variable) {
-        self.constraints.push(x);
+    fn constrain(&mut self, _tag: Constraint, if_true: Self::Variable, x: Self::Variable) {
+        if if_true == Self::Variable::one() {
+            self.constraints.push(x);
+        }
     }
 
     ////////////////////////

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -1,7 +1,11 @@
 //! This module contains the constraints for one Keccak step.
 use crate::{
     keccak::{
-        column::Flag::{self, *},
+        column::{
+            Absorbs::*,
+            Flags::{self, *},
+            Sponges::*,
+        },
         Constraint, KeccakColumn, Selector, E,
     },
     lookups::Lookup,
@@ -25,7 +29,7 @@ pub struct Env<Fp> {
     /// Variables that are looked up in the circuit
     pub lookups: Vec<Lookup<E<Fp>>>,
     /// Selector of the current step
-    pub(crate) selector: Option<Flag>,
+    pub(crate) selector: Option<Flags>,
 }
 
 impl<F: Field> Default for Env<F> {
@@ -70,11 +74,11 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
         }))
     }
 
-    fn check(&mut self, tag: Selector, x: Self::Variable) {
+    fn check(&mut self, _tag: Selector, _x: Self::Variable) {
         // No-op in constraint side
     }
 
-    fn checks(&self) {
+    fn checks(&mut self) {
         // No-op in constraint side
     }
 
@@ -98,31 +102,31 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
 
     fn mode_absorb(&self) -> Self::Variable {
         match self.selector {
-            Some(Absorb) => Self::Variable::one(),
+            Some(Sponge(Absorb(Middle))) => Self::Variable::one(),
             _ => Self::Variable::zero(),
         }
     }
     fn mode_squeeze(&self) -> Self::Variable {
         match self.selector {
-            Some(Squeeze) => Self::Variable::one(),
+            Some(Sponge(Squeeze)) => Self::Variable::one(),
             _ => Self::Variable::zero(),
         }
     }
     fn mode_root(&self) -> Self::Variable {
         match self.selector {
-            Some(Root) => Self::Variable::one(),
+            Some(Sponge(Absorb(First))) => Self::Variable::one(),
             _ => Self::Variable::zero(),
         }
     }
     fn mode_pad(&self) -> Self::Variable {
         match self.selector {
-            Some(Pad) => Self::Variable::one(),
+            Some(Sponge(Absorb(Last))) => Self::Variable::one(),
             _ => Self::Variable::zero(),
         }
     }
     fn mode_rootpad(&self) -> Self::Variable {
         match self.selector {
-            Some(RootPad) => Self::Variable::one(),
+            Some(Sponge(Absorb(Only))) => Self::Variable::one(),
             _ => Self::Variable::zero(),
         }
     }

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -208,6 +208,8 @@ impl<F: Field> KeccakEnv<F> {
 
     /// Assigns the witness values needed in a sponge step (absorb or squeeze)
     fn run_sponge(&mut self, sponge: Sponges) {
+        // Keep track of the round number for ease of debugging
+        self.witness_env.round = 0;
         match sponge {
             Absorb(absorb) => self.run_absorb(absorb),
             Squeeze => self.run_squeeze(),
@@ -292,6 +294,8 @@ impl<F: Field> KeccakEnv<F> {
     /// Assigns the witness values needed in the round step for the given round index
     fn run_round(&mut self, round: u64) {
         self.set_flag_round(round);
+        // Keep track of the round number for ease of debugging
+        self.witness_env.round = round;
 
         let state_a = self.prev_block.clone();
         let state_e = self.run_theta(&state_a);

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -206,10 +206,10 @@ impl<F: Field> KeccakEnv<F> {
     fn set_flag_squeeze(&mut self) {
         self.write_column(KeccakColumn::FlagSqueeze, 1);
     }
-    /// Sets the witness corresponding to the `FlagAbsorb` column to 1 and
+    /// Sets the witness corresponding to the absorb selectors to 1 and
     /// updates and any other sponge flag depending on the kind of absorb step (root, padding, both).
     fn set_flag_absorb(&mut self, absorb: Absorb) {
-        self.write_column(KeccakColumn::FlagAbsorb, 1);
+        self.write_column(KeccakColumn::Selector, 1);
         match absorb {
             Absorb::First => self.set_flag_root(),
             Absorb::Last => self.set_flag_pad(),
@@ -220,12 +220,12 @@ impl<F: Field> KeccakEnv<F> {
             Absorb::Middle => (),
         }
     }
-    /// Sets the witness corresponding to the `FlagRoot` column to 1
+    /// Sets the witness corresponding to the `Root` selector to 1
     fn set_flag_root(&mut self) {
-        self.write_column(KeccakColumn::FlagRoot, 1);
+        self.write_column(KeccakColumn::Selector(Root), 1);
     }
-    /// Sets the witness corresponding to the `FlagPad` column to 1, and updates the remaining columns
-    /// related to padding flags such as `PadLength`, `InvPadLength`, `TwoToPad`, `PadBytesFlags`, and `PadSuffix`.
+    /// Sets the witness corresponding to the `Pad` selector to 1, and updates the remaining columns
+    /// related to padding flags such as `PadLength`, `TwoToPad`, `PadBytesFlags`, and `PadSuffix`.
     fn set_flag_pad(&mut self) {
         // Initialize padding columns with precomputed values to speed up interpreter
         self.write_column(KeccakColumn::PadLength, self.pad_len);

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -2,7 +2,7 @@
 //! including the common functions between the witness and the constraints environments
 //! for arithmetic, boolean, and column operations.
 use crate::keccak::{
-    column::{KeccakWitness, PAD_SUFFIX_LEN},
+    column::{Flag::*, KeccakWitness, PAD_SUFFIX_LEN},
     constraints::Env as ConstraintsEnv,
     grid_index, pad_blocks,
     witness::Env as WitnessEnv,

--- a/optimism/src/keccak/folding.rs
+++ b/optimism/src/keccak/folding.rs
@@ -29,10 +29,7 @@ pub(crate) struct KeccakConfig;
 
 impl FoldingColumnTrait for KeccakColumn {
     fn is_witness(&self) -> bool {
-        match self {
-            KeccakColumn::Selector(_) => false,
-            _ => true,
-        }
+        !matches!(self, KeccakColumn::Selector(_))
     }
 }
 

--- a/optimism/src/keccak/folding.rs
+++ b/optimism/src/keccak/folding.rs
@@ -29,8 +29,10 @@ pub(crate) struct KeccakConfig;
 
 impl FoldingColumnTrait for KeccakColumn {
     fn is_witness(&self) -> bool {
-        // All Keccak columns are witness columns
-        true
+        match self {
+            KeccakColumn::Selector(_) => false,
+            _ => true,
+        }
     }
 }
 

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -118,7 +118,7 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     fn check(&mut self, tag: Selector, x: Self::Variable);
 
     /// Checks that the selectors are set correctly
-    fn checks(&self);
+    fn checks(&mut self);
 
     /// Adds one KeccakConstraint to the environment if the selector holds
     fn constrain(&mut self, tag: Constraint, if_true: Self::Variable, x: Self::Variable);

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -115,7 +115,7 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     fn variable(&self, column: KeccakColumn) -> Self::Variable;
 
     /// Adds one KeccakConstraint to the environment if the selector holds
-    fn constrain(&mut self, tag: Constraint, flag: Self::Variable, x: Self::Variable);
+    fn constrain(&mut self, tag: Constraint, if_true: Self::Variable, x: Self::Variable);
 
     /// Adds all 887 constraints/checks to the environment:
     /// - 489 constraints of degree 2
@@ -140,18 +140,18 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
         self.constrain_round();
     }
 
-    /// Constrains 144 checks of correctness of mode flags
-    /// - 141 constraints of degree 2
+    /// Constrains 141 checks of correctness of mode flags
+    /// - 138 constraints of degree 2
     /// - 2 constraints of degree 3
     /// - 1 constraint of degree 4
     /// Of which:
-    /// - 142 constraints are sponge-only
+    /// - 139 constraints are sponge-only
     /// - 2 constraints are sponge+round related
     // TODO: when Round and Sponge circuits are separated, the last one will be removed
     //       (in particular, the ones involving round and sponge together)
     fn constrain_flags(&mut self) {
         // Booleanity of sponge flags:
-        // - 139 constraints of degree 2
+        // - 136 constraints of degree 2
         self.constrain_booleanity();
 
         // Mutual exclusivity of flags: 5 constraints:
@@ -161,19 +161,17 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
         self.constrain_mutex();
     }
 
-    /// Constrains 139 checks of booleanity for some mode flags.
-    /// - 139 constraints of degree 2
+    /// Constrains 136 checks of booleanity for some mode flags.
+    /// - 136 constraints of degree 2
     /// These involve sponge-only related variables.
     fn constrain_booleanity(&mut self) {
-        // Absorb is either true or false
-        self.constrain(BooleanityAbsorb, Self::is_boolean(self.is_absorb()));
-        // Squeeze is either true or false
-        self.constrain(BooleanitySqueeze, Self::is_boolean(self.is_squeeze()));
-        // Root is either true or false
-        self.constrain(BooleanityRoot, Self::is_boolean(self.is_root()));
         for i in 0..RATE_IN_BYTES {
             // Bytes are either involved on padding or not
-            self.constrain(BooleanityPadding(i), Self::is_boolean(self.in_padding(i)));
+            self.constrain(
+                BooleanityPadding(i),
+                self.is_pad(),
+                Self::is_boolean(self.in_padding(i)),
+            );
         }
     }
 

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -127,12 +127,12 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     /// - 733 constraints of degree 1
     /// - 146 constraints of degree 2
     /// Where:
-    /// - if Flag::Round   -> only 389 constraints added
-    /// - if Flag::Root    -> only 332 constraints added (232 + 100)
-    /// - if Flag::Absorb  -> only 232 constraints added
-    /// - if Flag::Pad     -> only 374 constraints added (232 + 136 + 6)
-    /// - if Flag::PadRoot -> only 474 constraints added (232 + 136 + 100 + 6)
-    /// - if Flag::Squeeze -> only 16  constraints added
+    /// - if Steps::Round(_)                -> only 389 constraints added
+    /// - if Steps::Sponge::Absorb::First   -> only 332 constraints added (232 + 100)
+    /// - if Steps::Sponge::Absorb::Middle  -> only 232 constraints added
+    /// - if Steps::Sponge::Absorb::Last    -> only 374 constraints added (232 + 136 + 6)
+    /// - if Steps::Sponge::Absorb::Only    -> only 474 constraints added (232 + 136 + 100 + 6)
+    /// - if Steps::Sponge::Squeeze         -> only 16  constraints added
     /// So:
     /// - At most, 474 constraints are added per row
     fn constraints(&mut self) {

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -114,8 +114,8 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     /// Returns the variable corresponding to a given column alias.
     fn variable(&self, column: KeccakColumn) -> Self::Variable;
 
-    /// Adds one KeccakConstraint to the environment.
-    fn constrain(&mut self, tag: Constraint, x: Self::Variable);
+    /// Adds one KeccakConstraint to the environment if the selector holds
+    fn constrain(&mut self, tag: Constraint, flag: Self::Variable, x: Self::Variable);
 
     /// Adds all 887 constraints/checks to the environment:
     /// - 489 constraints of degree 2
@@ -786,30 +786,18 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     }
 
     /// Returns a degree-2 variable that encodes whether the current step is a sponge (1 = yes)
-    fn is_sponge(&self) -> Self::Variable {
-        Self::xor(self.is_absorb().clone(), self.is_squeeze().clone())
-    }
+    fn is_sponge(&self) -> Self::Variable;
     /// Returns a variable that encodes whether the current step is an absorb sponge (1 = yes)
-    fn is_absorb(&self) -> Self::Variable {
-        self.variable(KeccakColumn::Selector(Absorb))
-    }
+    fn is_absorb(&self) -> Self::Variable;
     /// Returns a variable that encodes whether the current step is a squeeze sponge (1 = yes)
-    fn is_squeeze(&self) -> Self::Variable {
-        self.variable(KeccakColumn::Selector(Squeeze))
-    }
+    fn is_squeeze(&self) -> Self::Variable;
     /// Returns a variable that encodes whether the current step is the first absorb sponge (1 = yes)
-    fn is_root(&self) -> Self::Variable {
-        self.variable(KeccakColumn::Selector(Root))
-    }
+    fn is_root(&self) -> Self::Variable;
     /// Returns a degree-1 variable that encodes whether the current step is the last absorb sponge (1 = yes)
-    fn is_pad(&self) -> Self::Variable {
-        self.variable(KeccakColumn::Selector(Pad))
-    }
-
+    fn is_pad(&self) -> Self::Variable;
     /// Returns a variable that encodes whether the current step is a permutation round (1 = yes)
-    fn is_round(&self) -> Self::Variable {
-        Self::not(self.is_sponge())
-    }
+    fn is_round(&self) -> Self::Variable;
+
     /// Returns a variable that encodes the current round number [0..24)
     fn round(&self) -> Self::Variable {
         self.variable(KeccakColumn::RoundNumber)

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -140,30 +140,19 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
         self.constrain_round();
     }
 
-    /// Constrains 141 checks of correctness of mode flags
-    /// - 138 constraints of degree 2
-    /// - 2 constraints of degree 3
-    /// - 1 constraint of degree 4
+    /// Constrains 136 checks of correctness of mode flags
+    /// - 136 constraints of degree 2
     /// Of which:
-    /// - 139 constraints are sponge-only
-    /// - 2 constraints are sponge+round related
-    // TODO: when Round and Sponge circuits are separated, the last one will be removed
-    //       (in particular, the ones involving round and sponge together)
+    /// - 136 constraints are added only if is_pad() holds
     fn constrain_flags(&mut self) {
         // Booleanity of sponge flags:
         // - 136 constraints of degree 2
         self.constrain_booleanity();
-
-        // Mutual exclusivity of flags: 5 constraints:
-        // - 2 of degree 2
-        // - 2 of degree 3
-        // - 1 of degree 4
-        self.constrain_mutex();
     }
 
     /// Constrains 136 checks of booleanity for some mode flags.
     /// - 136 constraints of degree 2
-    /// These involve sponge-only related variables.
+    /// These involve pad-only related variables.
     fn constrain_booleanity(&mut self) {
         for i in 0..RATE_IN_BYTES {
             // Bytes are either involved on padding or not
@@ -173,45 +162,6 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
                 Self::is_boolean(self.in_padding(i)),
             );
         }
-    }
-
-    /// Constrains 5 checks of mutual exclusivity between some mode flags.
-    /// - 2 of degree 2
-    /// - 2 of degree 3
-    /// - 1 of degree 4
-    /// Of which
-    /// - 3 involve sponge-only related variables
-    /// - 2 involves sponge+round variables
-    // TODO: when Round and Sponge circuits are separated, the last one will be removed
-    //       (in particular, the ones involving round and sponge together)
-    fn constrain_mutex(&mut self) {
-        // Degree 2: Squeeze and Root are not both true
-        self.constrain(
-            MutexSqueezeRoot,
-            Self::either_zero(self.is_squeeze(), self.is_root()),
-        );
-        // Degree 3: Squeeze and Pad are not both true
-        self.constrain(
-            MutexSqueezePad,
-            Self::either_zero(self.is_squeeze(), self.is_pad()),
-        );
-        // Degree 4: Round and Pad are not both true
-        self.constrain(
-            MutexRoundPad,
-            Self::either_zero(self.is_round(), self.is_pad()),
-        );
-        // Degree 3: Round and Root are not both true
-        self.constrain(
-            MutexRoundRoot,
-            Self::either_zero(self.is_round(), self.is_root()),
-        );
-        // Degree 2: Absorb and Squeeze cannot happen at the same time.
-        // Equivalent to is_boolean(is_sponge())
-        self.constrain(
-            MutexAbsorbSqueeze,
-            Self::either_zero(self.is_absorb(), self.is_squeeze()),
-        );
-        // Trivially, is_sponge and is_round are mutually exclusive
     }
 
     /// Constrains 354 checks of sponge steps

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -273,8 +273,8 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     }
 
     /// Constrains 389 checks of round steps
-    /// - 384 constraints of degree 3
-    /// - 5 constraints of degree 4
+    /// - 384 constraints of degree 1
+    /// - 5 constraints of degree 2
     /// Of which:
     /// - 389 constraints are added only if is_round() holds
     fn constrain_round(&mut self) {

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     keccak::{
-        column::{PAD_BYTES_LEN, ROUND_COEFFS_LEN},
+        column::{Flag::*, PAD_BYTES_LEN, ROUND_CONST_LEN},
         grid_index,
         Constraint::{self, *},
         KeccakColumn,
@@ -791,19 +791,19 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     }
     /// Returns a variable that encodes whether the current step is an absorb sponge (1 = yes)
     fn is_absorb(&self) -> Self::Variable {
-        self.variable(KeccakColumn::FlagAbsorb)
+        self.variable(KeccakColumn::Selector(Absorb))
     }
     /// Returns a variable that encodes whether the current step is a squeeze sponge (1 = yes)
     fn is_squeeze(&self) -> Self::Variable {
-        self.variable(KeccakColumn::FlagSqueeze)
+        self.variable(KeccakColumn::Selector(Squeeze))
     }
     /// Returns a variable that encodes whether the current step is the first absorb sponge (1 = yes)
     fn is_root(&self) -> Self::Variable {
-        self.variable(KeccakColumn::FlagRoot)
+        self.variable(KeccakColumn::Selector(Root))
     }
-    /// Returns a degree-2 variable that encodes whether the current step is the last absorb sponge (1 = yes)
+    /// Returns a degree-1 variable that encodes whether the current step is the last absorb sponge (1 = yes)
     fn is_pad(&self) -> Self::Variable {
-        self.pad_length() * self.variable(KeccakColumn::InvPadLength)
+        self.variable(KeccakColumn::Selector(Pad))
     }
 
     /// Returns a variable that encodes whether the current step is a permutation round (1 = yes)
@@ -812,7 +812,7 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     }
     /// Returns a variable that encodes the current round number [0..24)
     fn round(&self) -> Self::Variable {
-        self.variable(KeccakColumn::FlagRound)
+        self.variable(KeccakColumn::RoundNumber)
     }
 
     /// Returns a variable that encodes the bytelength of the padding if any [0..136)

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    keccak::column::{Column as KeccakColumn, Flags, PAD_SUFFIX_LEN},
+    keccak::column::{Column as KeccakColumn, Steps, PAD_SUFFIX_LEN},
     lookups::LookupTableIDs,
 };
 use ark_ff::Field;
@@ -43,7 +43,7 @@ pub enum Error {
 /// All the names for selector misconfigurations of the Keccak circuit
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Selector {
-    NotBoolean(Flags),
+    NotBoolean(Steps),
     NotMutex,
 }
 

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    keccak::column::{Column as KeccakColumn, PAD_SUFFIX_LEN},
+    keccak::column::{Column as KeccakColumn, Flag, PAD_SUFFIX_LEN},
     lookups::LookupTableIDs,
 };
 use ark_ff::Field;
@@ -35,8 +35,15 @@ pub(crate) type E<F> = Expr<ConstantExpr<F>, KeccakColumn>;
 /// Errors that can occur during the check of the witness
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
+    Selector(Selector),
     Constraint(Constraint),
     Lookup(LookupTableIDs),
+}
+
+/// All the names for selector misconfigurations of the Keccak circuit
+pub enum Selector {
+    NotBoolean(Flag),
+    NotMutex,
 }
 
 /// All the names for constraints involved in the Keccak circuit

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    keccak::column::{Column as KeccakColumn, Flag, PAD_SUFFIX_LEN},
+    keccak::column::{Column as KeccakColumn, Flags, PAD_SUFFIX_LEN},
     lookups::LookupTableIDs,
 };
 use ark_ff::Field;
@@ -43,7 +43,7 @@ pub enum Error {
 /// All the names for selector misconfigurations of the Keccak circuit
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Selector {
-    NotBoolean(Flag),
+    NotBoolean(Flags),
     NotMutex,
 }
 

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -41,6 +41,7 @@ pub enum Error {
 }
 
 /// All the names for selector misconfigurations of the Keccak circuit
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Selector {
     NotBoolean(Flag),
     NotMutex,

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -42,15 +42,7 @@ pub enum Error {
 /// All the names for constraints involved in the Keccak circuit
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Constraint {
-    BooleanityAbsorb,
-    BooleanitySqueeze,
-    BooleanityRoot,
     BooleanityPadding(usize),
-    MutexSqueezeRoot,
-    MutexSqueezePad,
-    MutexRoundPad,
-    MutexRoundRoot,
-    MutexAbsorbSqueeze,
     AbsorbZeroPad(usize),
     AbsorbRootZero(usize),
     AbsorbXor(usize),

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -183,7 +183,6 @@ fn test_regression_number_of_constraints_and_degree() {
             let step = keccak_env.constraints_env.step.unwrap();
             // Push constraints for the current step
             keccak_env.constraints_env.constraints();
-            println!("{:?}", step);
             let mut constraint_degrees: HashMap<u64, u32> = HashMap::new();
             keccak_env
                 .constraints_env

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -277,36 +277,11 @@ fn test_keccak_fake_witness_wont_satisfy_constraints() {
     witness_env[0].errors.clear();
 
     // Break booleanity constraints
-    witness_env[0].witness[KeccakColumn::FlagAbsorb] = Fp::from(2u32);
-    witness_env[0].witness[KeccakColumn::FlagSqueeze] = Fp::from(2u32);
-    witness_env[0].witness[KeccakColumn::FlagRoot] = Fp::from(2u32);
     witness_env[0].witness[KeccakColumn::PadBytesFlags(0)] = Fp::from(2u32);
     witness_env[0].constrain_booleanity();
     assert_eq!(
         witness_env[0].errors,
-        vec![
-            Error::Constraint(BooleanityAbsorb),
-            Error::Constraint(BooleanitySqueeze),
-            Error::Constraint(BooleanityRoot),
-            Error::Constraint(BooleanityPadding(0))
-        ]
-    );
-    witness_env[0].errors.clear();
-
-    // Break mutex constraints
-    witness_env[0].witness[KeccakColumn::FlagAbsorb] = Fp::from(1u32);
-    witness_env[0].witness[KeccakColumn::FlagSqueeze] = Fp::from(1u32);
-    witness_env[0].witness[KeccakColumn::FlagRound] = Fp::from(1u32);
-    witness_env[0].constrain_mutex();
-    assert_eq!(
-        witness_env[0].errors,
-        vec![
-            Error::Constraint(MutexSqueezeRoot),
-            Error::Constraint(MutexSqueezePad),
-            Error::Constraint(MutexRoundPad),
-            Error::Constraint(MutexRoundRoot),
-            Error::Constraint(MutexAbsorbSqueeze)
-        ]
+        vec![Error::Constraint(BooleanityPadding(0))]
     );
     witness_env[0].errors.clear();
 

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -1,6 +1,10 @@
 use crate::{
     keccak::{
-        environment::KeccakEnv, interpreter::KeccakInterpreter, Constraint::*, Error, KeccakColumn,
+        column::{Absorbs::*, Sponges::*, Steps::*},
+        environment::KeccakEnv,
+        interpreter::KeccakInterpreter,
+        Constraint::*,
+        Error, KeccakColumn,
     },
     lookups::{FixedLookupTables, LookupTable, LookupTableIDs::*},
 };
@@ -136,7 +140,7 @@ fn test_keccak_witness_satisfies_constraints() {
 
     // Initialize the environment and run the interpreter
     let mut keccak_env = KeccakEnv::<Fp>::new(0, &preimage);
-    while keccak_env.keccak_step.is_some() {
+    while keccak_env.constraints_env.step.is_some() {
         keccak_env.step();
         // Simulate the constraints for each row
         keccak_env.witness_env.constraints();
@@ -157,42 +161,97 @@ fn test_keccak_witness_satisfies_constraints() {
 fn test_regression_number_of_constraints_and_degree() {
     let mut rng = o1_utils::tests::make_test_rng();
 
-    // Generate random bytelength and preimage for Keccak
-    let bytelength = rng.gen_range(1..1000);
+    // Generate random bytelength and preimage for Keccak of 1, 2 or 3 blocks
+    // so that there can be both First, Middle, Last and Only absorbs
+    let bytelength = rng.gen_range(1..400);
     let preimage: Vec<u8> = (0..bytelength).map(|_| rng.gen()).collect();
 
     let mut keccak_env = KeccakEnv::<Fp>::new(0, &preimage);
-    keccak_env.constraints_env.constraints();
-    keccak_env.constraints_env.lookups();
 
-    // Checking relation constraints
+    // Checking lookup constraints (for now, all of them)
     {
-        // Check that the number of constraints is correct
-        assert_eq!(keccak_env.constraints_env.constraints.len(), 887);
-
-        let mut constraint_degrees: HashMap<u64, u32> = HashMap::new();
-        keccak_env
-            .constraints_env
-            .constraints
-            .iter()
-            .for_each(|constraint| {
-                let degree = constraint.degree(1, 0);
-                let entry = constraint_degrees.entry(degree).or_insert(0);
-                *entry += 1;
-            });
-        // We have 3 different degrees of constraints
-        assert_eq!(constraint_degrees.len(), 3);
-        // 489 degree-2 constraints
-        assert_eq!(constraint_degrees[&2], 489);
-        // 387 degree-3 constraints
-        assert_eq!(constraint_degrees[&3], 387);
-        // 11 degree-4 constraints
-        assert_eq!(constraint_degrees[&4], 11);
+        // Add the lookups (for now, all of them)
+        keccak_env.constraints_env.lookups();
+        assert_eq!(keccak_env.constraints_env.lookups.len(), 2361);
     }
 
-    // Checking lookup constraints
+    // Checking relation constraints for each step selector
     {
-        assert_eq!(keccak_env.constraints_env.lookups.len(), 2361);
+        // Execute the interpreter to obtain constraints for each step
+        while keccak_env.constraints_env.step.is_some() {
+            // Current step to be executed
+            let step = keccak_env.constraints_env.step.unwrap();
+            // Push constraints for the current step
+            keccak_env.constraints_env.constraints();
+            println!("{:?}", step);
+            let mut constraint_degrees: HashMap<u64, u32> = HashMap::new();
+            keccak_env
+                .constraints_env
+                .constraints
+                .iter()
+                .for_each(|constraint| {
+                    let degree = constraint.degree(1, 0);
+                    let entry = constraint_degrees.entry(degree).or_insert(0);
+                    *entry += 1;
+                });
+
+            // Check that the number of constraints is correct for that step type
+            // Check that the degrees of the constraints are correct
+
+            match step {
+                Sponge(Absorb(First)) => {
+                    assert_eq!(keccak_env.constraints_env.constraints.len(), 332);
+                    // We have 1 different degrees of constraints in Absorbs::First
+                    assert_eq!(constraint_degrees.len(), 1);
+                    // 332 degree-1 constraints
+                    assert_eq!(constraint_degrees[&1], 332);
+                }
+                Sponge(Absorb(Middle)) => {
+                    assert_eq!(keccak_env.constraints_env.constraints.len(), 232);
+                    // We have 1 different degrees of constraints in Absorbs::Middle
+                    assert_eq!(constraint_degrees.len(), 1);
+                    // 232 degree-1 constraints
+                    assert_eq!(constraint_degrees[&1], 232);
+                }
+                Sponge(Absorb(Last)) => {
+                    assert_eq!(keccak_env.constraints_env.constraints.len(), 374);
+                    // We have 2 different degrees of constraints in Squeeze
+                    assert_eq!(constraint_degrees.len(), 2);
+                    // 232 degree-2 constraints
+                    assert_eq!(constraint_degrees[&1], 233);
+                    // 136 degree-2 constraints
+                    assert_eq!(constraint_degrees[&2], 141);
+                }
+                Sponge(Absorb(Only)) => {
+                    assert_eq!(keccak_env.constraints_env.constraints.len(), 474);
+                    // We have 2 different degrees of constraints in Squeeze
+                    assert_eq!(constraint_degrees.len(), 2);
+                    // 232 degree-2 constraints
+                    assert_eq!(constraint_degrees[&1], 333);
+                    // 136 degree-2 constraints
+                    assert_eq!(constraint_degrees[&2], 141);
+                }
+                Sponge(Squeeze) => {
+                    assert_eq!(keccak_env.constraints_env.constraints.len(), 16);
+                    // We have 1 different degrees of constraints in Squeeze
+                    assert_eq!(constraint_degrees.len(), 1);
+                    // 16 degree-1 constraints
+                    assert_eq!(constraint_degrees[&1], 16);
+                }
+                Round(_) => {
+                    assert_eq!(keccak_env.constraints_env.constraints.len(), 389);
+                    // We have 2 different degrees of constraints in Round
+                    assert_eq!(constraint_degrees.len(), 2);
+                    // 384 degree-1 constraints
+                    assert_eq!(constraint_degrees[&1], 384);
+                    // 5 degree-2 constraints
+                    assert_eq!(constraint_degrees[&2], 5);
+                }
+            }
+            // Execute the step updating the witness
+            // (no need to happen before constraints if we are not checking the witness)
+            keccak_env.step(); // This updates the step for the next
+        }
     }
 }
 
@@ -205,7 +264,7 @@ fn test_keccak_witness_satisfies_lookups() {
 
     // Initialize the environment and run the interpreter
     let mut keccak_env = KeccakEnv::<Fp>::new(0, &preimage);
-    while keccak_env.keccak_step.is_some() {
+    while keccak_env.constraints_env.step.is_some() {
         keccak_env.step();
         keccak_env.witness_env.lookups();
         assert!(keccak_env.witness_env.errors.is_empty());
@@ -230,7 +289,7 @@ fn test_keccak_fake_witness_wont_satisfy_constraints() {
     let mut keccak_env = KeccakEnv::<Fp>::new(0, &preimage);
 
     // Run the interpreter and keep track of the witness
-    while keccak_env.keccak_step.is_some() {
+    while keccak_env.constraints_env.step.is_some() {
         keccak_env.step();
         // Store a copy of the witness to be altered later
         witness_env.push(keccak_env.witness_env.clone());
@@ -394,7 +453,7 @@ fn test_keccak_multiplicities() {
 
     // Run the interpreter and keep track of the witness
     let mut keccak_env = KeccakEnv::<Fp>::new(0, &preimage);
-    while keccak_env.keccak_step.is_some() {
+    while keccak_env.constraints_env.step.is_some() {
         keccak_env.step();
         keccak_env.witness_env.lookups();
         // Store a copy of the witness

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -11,6 +11,7 @@ use crate::{
         column::{Flag::*, KeccakWitness},
         interpreter::KeccakInterpreter,
         Constraint, Error, KeccakColumn,
+        Selector::{self, *},
     },
     lookups::{FixedLookupTables, Lookup, LookupTable, LookupTableIDs::*},
 };
@@ -111,7 +112,7 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
             // Check only one of them is one
             self.check(
                 NotMutex,
-                self.is_one(
+                Self::is_one(
                     self.mode_round()
                         + self.mode_absorb()
                         + self.mode_squeeze()
@@ -124,9 +125,11 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
     }
 
     /// Checks the constraint `tag` by checking that the input `x` is zero
-    fn constrain(&mut self, tag: Constraint, x: Self::Variable) {
-        if x != F::zero() {
-            self.errors.push(Error::Constraint(tag));
+    fn constrain(&mut self, tag: Constraint, if_true: Self::Variable, x: Self::Variable) {
+        if if_true == Self::Variable::one() {
+            if x != F::zero() {
+                self.errors.push(Error::Constraint(tag));
+            }
         }
     }
 

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -31,7 +31,7 @@ pub struct Env<F> {
     pub multiplicities: Vec<Vec<u32>>,
     /// If any, an error that occurred during the execution of the constraints, to help with debugging
     pub(crate) errors: Vec<Error>,
-    /// The round number, if nonzero
+    /// The round number [0..23]
     pub(crate) round: u64,
 }
 

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -8,7 +8,7 @@
 //! <https://keccak.team/keccak_specs_summary.html>
 use crate::{
     keccak::{
-        column::{Flag::*, KeccakWitness},
+        column::{Absorb::*, Flag::*, KeccakWitness, Sponge::*},
         interpreter::KeccakInterpreter,
         Constraint, Error, KeccakColumn,
         Selector::{self, *},
@@ -96,15 +96,30 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
             // Round is either true or false
             self.check(NotBoolean(Round), Self::is_boolean(self.mode_round()));
             // Absorb is either true or false
-            self.check(NotBoolean(Absorb), Self::is_boolean(self.mode_absorb()));
+            self.check(
+                NotBoolean(Sponge(Absorb(Middle))),
+                Self::is_boolean(self.mode_absorb()),
+            );
             // Squeeze is either true or false
-            self.check(NotBoolean(Squeeze), Self::is_boolean(self.mode_squeeze()));
+            self.check(
+                NotBoolean(Sponge(Squeeze)),
+                Self::is_boolean(self.mode_squeeze()),
+            );
             // Root is either true or false
-            self.check(NotBoolean(Root), Self::is_boolean(self.mode_root()));
+            self.check(
+                NotBoolean(Sponge(Absorb(First))),
+                Self::is_boolean(self.mode_root()),
+            );
             // Pad is either true or false
-            self.check(NotBoolean(Pad), Self::is_boolean(self.mode_pad()));
+            self.check(
+                NotBoolean(Sponge(Absorb(Last))),
+                Self::is_boolean(self.mode_pad()),
+            );
             // RootPad is either true or false
-            self.check(NotBoolean(RootPad), Self::is_boolean(self.mode_rootpad()));
+            self.check(
+                NotBoolean(Sponge(Absorb(Only))),
+                Self::is_boolean(self.mode_rootpad()),
+            );
         }
 
         // MUTUAL EXCLUSIVITY CHECKS
@@ -159,19 +174,19 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
     /////////////////////////
 
     fn mode_absorb(&self) -> Self::Variable {
-        self.variable(KeccakColumn::Selector(Absorb))
+        self.variable(KeccakColumn::Selector(Sponge(Absorb(Middle))))
     }
     fn mode_squeeze(&self) -> Self::Variable {
-        self.variable(KeccakColumn::Selector(Squeeze))
+        self.variable(KeccakColumn::Selector(Sponge(Squeeze)))
     }
     fn mode_root(&self) -> Self::Variable {
-        self.variable(KeccakColumn::Selector(Root))
+        self.variable(KeccakColumn::Selector(Sponge(Absorb(First))))
     }
     fn mode_pad(&self) -> Self::Variable {
-        self.variable(KeccakColumn::Selector(Pad))
+        self.variable(KeccakColumn::Selector(Sponge(Absorb(Last))))
     }
     fn mode_rootpad(&self) -> Self::Variable {
-        self.variable(KeccakColumn::Selector(RootPad))
+        self.variable(KeccakColumn::Selector(Sponge(Absorb(Only))))
     }
     fn mode_round(&self) -> Self::Variable {
         self.variable(KeccakColumn::Selector(Round))

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -31,6 +31,8 @@ pub struct Env<F> {
     pub multiplicities: Vec<Vec<u32>>,
     /// If any, an error that occurred during the execution of the constraints, to help with debugging
     pub(crate) errors: Vec<Error>,
+    /// The round number, if nonzero
+    pub(crate) round: u64,
 }
 
 impl<F: Field> Default for Env<F> {
@@ -54,6 +56,7 @@ impl<F: Field> Default for Env<F> {
                 vec![0; ResetLookup.length()],
             ],
             errors: vec![],
+            round: 0,
         }
     }
 }
@@ -94,7 +97,10 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
         // BOOLEANITY CHECKS
         {
             // Round is either true or false
-            self.check(NotBoolean(Round(0)), Self::is_boolean(self.mode_round()));
+            self.check(
+                NotBoolean(Round(self.round)),
+                Self::is_boolean(self.mode_round()),
+            );
             // Absorb is either true or false
             self.check(
                 NotBoolean(Sponge(Absorb(Middle))),
@@ -191,6 +197,6 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
     fn mode_round(&self) -> Self::Variable {
         // The actual round number in the selector carries no information for witness nor constraints
         // because in the witness, any usize is mapped to the same index inside the mode flags
-        self.variable(KeccakColumn::Selector(Round(0)))
+        self.variable(KeccakColumn::Selector(Round(self.round)))
     }
 }

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -108,4 +108,27 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
             }
         }
     }
+
+    ///////////////////////
+    // COLUMN OPERATIONS //
+    ///////////////////////
+
+    fn is_sponge(&self) -> Self::Variable {
+        Self::xor(self.is_absorb().clone(), self.is_squeeze().clone())
+    }
+    fn is_absorb(&self) -> Self::Variable {
+        self.variable(KeccakColumn::Selector(Absorb))
+    }
+    fn is_squeeze(&self) -> Self::Variable {
+        self.variable(KeccakColumn::Selector(Squeeze))
+    }
+    fn is_root(&self) -> Self::Variable {
+        self.variable(KeccakColumn::Selector(Root))
+    }
+    fn is_pad(&self) -> Self::Variable {
+        self.variable(KeccakColumn::Selector(Pad))
+    }
+    fn is_round(&self) -> Self::Variable {
+        self.variable(KeccakColumn::Selector(Round))
+    }
 }

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -147,10 +147,8 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
 
     /// Checks the constraint `tag` by checking that the input `x` is zero
     fn constrain(&mut self, tag: Constraint, if_true: Self::Variable, x: Self::Variable) {
-        if if_true == Self::Variable::one() {
-            if x != F::zero() {
-                self.errors.push(Error::Constraint(tag));
-            }
+        if if_true == Self::Variable::one() && x != F::zero() {
+            self.errors.push(Error::Constraint(tag));
         }
     }
 

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -8,7 +8,7 @@
 //! <https://keccak.team/keccak_specs_summary.html>
 use crate::{
     keccak::{
-        column::{Absorbs::*, Flags::*, KeccakWitness, Sponges::*},
+        column::{Absorbs::*, KeccakWitness, Sponges::*, Steps::*},
         interpreter::KeccakInterpreter,
         Constraint, Error, KeccakColumn,
         Selector::{self, *},
@@ -94,7 +94,7 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
         // BOOLEANITY CHECKS
         {
             // Round is either true or false
-            self.check(NotBoolean(Round), Self::is_boolean(self.mode_round()));
+            self.check(NotBoolean(Round(0)), Self::is_boolean(self.mode_round()));
             // Absorb is either true or false
             self.check(
                 NotBoolean(Sponge(Absorb(Middle))),
@@ -189,6 +189,8 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
         self.variable(KeccakColumn::Selector(Sponge(Absorb(Only))))
     }
     fn mode_round(&self) -> Self::Variable {
-        self.variable(KeccakColumn::Selector(Round))
+        // The actual round number in the selector carries no information for witness nor constraints
+        // because in the witness, any usize is mapped to the same index inside the mode flags
+        self.variable(KeccakColumn::Selector(Round(0)))
     }
 }

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -8,7 +8,7 @@
 //! <https://keccak.team/keccak_specs_summary.html>
 use crate::{
     keccak::{
-        column::{Absorb::*, Flag::*, KeccakWitness, Sponge::*},
+        column::{Absorbs::*, Flags::*, KeccakWitness, Sponges::*},
         interpreter::KeccakInterpreter,
         Constraint, Error, KeccakColumn,
         Selector::{self, *},
@@ -90,7 +90,7 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
         }
     }
 
-    fn checks(&self) {
+    fn checks(&mut self) {
         // BOOLEANITY CHECKS
         {
             // Round is either true or false

--- a/optimism/src/lookups.rs
+++ b/optimism/src/lookups.rs
@@ -20,7 +20,7 @@ pub enum LookupTableIDs {
     // randomization with the joint combiner is applied.
     /// All [1..136] values of possible padding lengths, the value 2^len, and the 5 corresponding pad suffixes with the 10*1 rule
     PadLookup = 0,
-    /// 24-row table with all possible values for round and their round constant in expanded form (in big endian)
+    /// 24-row table with all possible values for round and their round constant in expanded form (in big endian) [0..=23]
     RoundConstantsLookup = 1,
     /// All values that can be stored in a byte (amortized table, better than model as RangeCheck16 (x and scaled x)
     ByteLookup = 2,

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -111,7 +111,7 @@ pub fn main() -> ExitCode {
 
         if let Some(ref mut keccak_env) = env.keccak_env {
             // Run all steps of hash
-            while keccak_env.keccak_step.is_some() {
+            while keccak_env.constraints_env.step.is_some() {
                 keccak_env.step();
             }
 


### PR DESCRIPTION
This PR manages to split the all-purpose Keccak circuit into separate specialized steps so that each row can be made part of an independent instance for folding. In particular, it now has 6 different modes of operation: `Round`, `Sponge::Squeeze`, `Sponge::Absorb(First)`, `Sponge::Absorb(Middle)`, `Sponge::Absorb(Last)`, and `Sponge::Absorb(Only)` (they reuse the `Step` enum used previously).

Now, less constraints and actual columns are used in comparison with `master`. In particular, 2079 columns instead of 2219 (140 columns less), and the sub-circuit with more constraint is the `Sponge::Absorb(Only)`, which uses 474 constraints instead of 887. Also, constraints checking the correct composition of the flags are no longer needed, because now there will be a "public" selector for each of the variants independently. This means some constraints are removed (booleanity and mutual exclusivity), and they have been replaced with simple checks on the witness environment side, just to check that they were configured correctly. 

Now, for each step of the execution, one witness environment will be instantiated with a single selector set to 1 (and the rest are 0). Note that the folding column trait has been adapted so that `is_witness()` returns `false` for selector columns. Apart from this, constraints for specific sub-circuits can be generated upon a constraint environment which has the `.step` field set to the desired selector. These will be shared across the whole sub-circuit for that type.

The regression test has been adapted accordingly as well, to bring further visibility to the concrete changes that have occurred on the constraints side. Special mentioning that the degrees of the constraints have been reduced drastically by introducing these "fine-grain" selectors. In particular, most constraints are degree 1 and just a few are degree 2, whereas the old design had many degree 3 and 4 constraints (which would have resulted in a non-negligible increase of folding columns).

I recommend reviewing this PR in a per-commit basis, where I tried to keep the changes to a minimum. Do not try to compile each individual commit, because most changes done throughout the implementation of this PR were breaking other parts of the code. Compilation was fixed only at the very last few commits of the history. 

Closes https://github.com/MinaProtocol/mina/issues/15163 and https://github.com/o1-labs/proof-systems/issues/1751 as a side effect. 

NOTE: this still DOES NOT split lookups into sub-circuits. That means, in this PR all lookups are added, no matter the step type. I am addressing this in an upcoming PR because I didn't want this one to be that long. That was a non-breaking stop point, convenient for a PR switch.

TODO: I would like to treat the selector columns separately from the `Witness::cols` field, so we can address commitments to these columns in a special way (meaning, they might only become real columns in folding, so there are no duplicates.