### PR TITLE
Lookups counterpart of PR 2051

### DIFF
--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -92,8 +92,10 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
     // LOOKUPS OPERATIONS //
     ////////////////////////
 
-    fn add_lookup(&mut self, lookup: Lookup<Self::Variable>) {
-        self.lookups.push(lookup);
+    fn add_lookup(&mut self, if_true: Self::Variable, lookup: Lookup<Self::Variable>) {
+        if if_true == Self::Variable::one() {
+            self.lookups.push(lookup);
+        }
     }
 
     /////////////////////////

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -465,16 +465,26 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     /// Adds a given Lookup to the environment if the condition holds
     fn add_lookup(&mut self, if_true: Self::Variable, lookup: Lookup<Self::Variable>);
 
-    /// Adds all 2481 lookups to the Keccak constraints environment:
-    /// - 2342 lookups for the step row
+    /// Creates all possible 2361 lookups to the Keccak constraints environment:
+    /// - 2222 lookups for the step row
     /// - 2 lookups for the inter-step channel
     /// - 136 lookups for the syscall channel (preimage bytes)
     /// - 1 lookups for the syscall channel (hash)
+    /// Of which:
+    /// - 1623 lookups if Step::Round          (1741 + 2)
+    /// - 737  lookups if Step::Absorb::First  (600 + 1 + 136)
+    /// - 738  lookups if Step::Absorb::Middle (600 + 2 + 136)
+    /// - 739  lookups if Step::Absorb::Last   (601 + 2 + 136)
+    /// - 738  lookups if Step::Absorb::Only   (601 + 1 + 136)
+    /// - 602 lookups if Step::Squeeze         (600 + 1 + 1)
     fn lookups(&mut self) {
         // SPONGE LOOKUPS
+        // -> adds 600 lookups if is_sponge
+        // -> adds 601 lookups if is_pad
         self.lookups_sponge();
 
         // ROUND LOOKUPS
+        // -> adds 1621 lookups if is_round
         {
             // THETA LOOKUPS
             self.lookups_round_theta();
@@ -488,16 +498,23 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
 
         // INTER-STEP CHANNEL
         // Write outputs for next step if not a squeeze and read inputs of curr step if not a root
+        // -> adds 1 lookup if is_root
+        // -> adds 1 lookup if is_squeeze
+        // -> adds 2 lookups otherwise
         self.lookup_steps();
 
         // COMMUNICATION CHANNEL: read bytes of current block
+        // -> adds 136 lookups if is_absorb
         self.lookup_syscall_preimage();
 
         // COMMUNICATION CHANNEL: Write hash output
+        // -> adds 1 lookup if is_squeeze
         self.lookup_syscall_hash();
     }
 
     /// When in Absorb mode, reads Lookups containing the 136 bytes of the block of the preimage
+    /// - if is_absorb, adds 136 lookups
+    /// - otherwise, adds 0 lookups
     // TODO: optimize this by using a single lookup reusing PadSuffix
     fn lookup_syscall_preimage(&mut self) {
         for i in 0..RATE_IN_BYTES {
@@ -517,6 +534,8 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     }
 
     /// When in Squeeze mode, writes a Lookup containing the 31byte output of the hash (excludes the MSB)
+    /// - if is_squeeze, adds 1 lookup
+    /// - otherwise, adds 0 lookups
     fn lookup_syscall_hash(&mut self) {
         let bytes31 = (1..32).fold(Self::zero(), |acc, i| {
             acc * Self::two_pow(8) + self.sponge_byte(i)
@@ -529,6 +548,9 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
 
     /// Reads a Lookup containing the input of a step
     /// and writes a Lookup containing the output of the next step
+    /// - if is_root, only adds 1 lookup
+    /// - if is_squeeze, only adds 1 lookup
+    /// - otherwise, adds 2 lookups
     fn lookup_steps(&mut self) {
         // (if not a root) Output of previous step is input of current step
         self.add_lookup(
@@ -578,6 +600,8 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     }
 
     /// Adds the 601 lookups required for the sponge
+    /// - 600 lookups if is_sponge()
+    /// - 1 extra lookup if is_pad()
     fn lookups_sponge(&mut self) {
         // PADDING LOOKUPS
         // Power of two corresponds to 2^pad_length
@@ -611,7 +635,7 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
         }
     }
 
-    /// Adds the 140 lookups required for Theta in the round
+    /// Adds the 120 lookups required for Theta in the round
     fn lookups_round_theta(&mut self) {
         for q in 0..QUARTERS {
             for x in 0..DIM {
@@ -633,7 +657,7 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
         }
     }
 
-    /// Adds the 800 lookups required for PiRho in the round
+    /// Adds the 700 lookups required for PiRho in the round
     fn lookups_round_pirho(&mut self) {
         for q in 0..QUARTERS {
             for x in 0..DIM {

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -462,8 +462,8 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     // LOOKUPS OPERATIONS //
     ////////////////////////
 
-    /// Adds a given Lookup to the environment
-    fn add_lookup(&mut self, lookup: Lookup<Self::Variable>);
+    /// Adds a given Lookup to the environment if the condition holds
+    fn add_lookup(&mut self, if_true: Self::Variable, lookup: Lookup<Self::Variable>);
 
     /// Adds all 2481 lookups to the Keccak constraints environment:
     /// - 2342 lookups for the step row
@@ -497,55 +497,54 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
         self.lookup_syscall_hash();
     }
 
-    /// Reads Lookups containing the 136 bytes of the block of the preimage
+    /// When in Absorb mode, reads Lookups containing the 136 bytes of the block of the preimage
     // TODO: optimize this by using a single lookup reusing PadSuffix
     fn lookup_syscall_preimage(&mut self) {
         for i in 0..RATE_IN_BYTES {
-            self.add_lookup(Lookup::read_if(
+            self.add_lookup(
                 self.is_absorb(),
-                SyscallLookup,
-                vec![
-                    self.hash_index(),
-                    self.block_index() * Self::constant(RATE_IN_BYTES as u64)
-                        + Self::constant(i as u64),
-                    self.sponge_byte(i),
-                ],
-            ));
+                Lookup::read_one(
+                    SyscallLookup,
+                    vec![
+                        self.hash_index(),
+                        self.block_index() * Self::constant(RATE_IN_BYTES as u64)
+                            + Self::constant(i as u64),
+                        self.sponge_byte(i),
+                    ],
+                ),
+            );
         }
     }
 
-    /// Writes a Lookup containing the 31byte output of the hash (excludes the MSB)
+    /// When in Squeeze mode, writes a Lookup containing the 31byte output of the hash (excludes the MSB)
     fn lookup_syscall_hash(&mut self) {
         let bytes31 = (1..32).fold(Self::zero(), |acc, i| {
             acc * Self::two_pow(8) + self.sponge_byte(i)
         });
-        self.add_lookup(Lookup::write_if(
+        self.add_lookup(
             self.is_squeeze(),
-            SyscallLookup,
-            vec![self.hash_index(), bytes31],
-        ));
+            Lookup::write_one(SyscallLookup, vec![self.hash_index(), bytes31]),
+        );
     }
 
     /// Reads a Lookup containing the input of a step
     /// and writes a Lookup containing the output of the next step
     fn lookup_steps(&mut self) {
         // (if not a root) Output of previous step is input of current step
-        self.add_lookup(Lookup::read_if(
+        self.add_lookup(
             Self::not(self.is_root()),
-            KeccakStepLookup,
-            self.input_of_step(),
-        ));
+            Lookup::read_one(KeccakStepLookup, self.input_of_step()),
+        );
         // (if not a squeeze) Input for next step is output of current step
-        self.add_lookup(Lookup::write_if(
+        self.add_lookup(
             Self::not(self.is_squeeze()),
-            KeccakStepLookup,
-            self.output_of_step(),
-        ));
+            Lookup::write_one(KeccakStepLookup, self.output_of_step()),
+        );
     }
 
     /// Adds a lookup to the RangeCheck16 table
     fn lookup_rc16(&mut self, flag: Self::Variable, value: Self::Variable) {
-        self.add_lookup(Lookup::read_if(flag, RangeCheck16Lookup, vec![value]));
+        self.add_lookup(flag, Lookup::read_one(RangeCheck16Lookup, vec![value]));
     }
 
     /// Adds a lookup to the Reset table
@@ -555,27 +554,27 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
         dense: Self::Variable,
         sparse: Self::Variable,
     ) {
-        self.add_lookup(Lookup::read_if(flag, ResetLookup, vec![dense, sparse]));
+        self.add_lookup(flag, Lookup::read_one(ResetLookup, vec![dense, sparse]));
     }
 
     /// Adds a lookup to the Shift table
     fn lookup_sparse(&mut self, flag: Self::Variable, value: Self::Variable) {
-        self.add_lookup(Lookup::read_if(flag, SparseLookup, vec![value]));
+        self.add_lookup(flag, Lookup::read_one(SparseLookup, vec![value]));
     }
 
     /// Adds a lookup to the Byte table
     fn lookup_byte(&mut self, flag: Self::Variable, value: Self::Variable) {
-        self.add_lookup(Lookup::read_if(flag, ByteLookup, vec![value]));
+        self.add_lookup(flag, Lookup::read_one(ByteLookup, vec![value]));
     }
 
     /// Adds a lookup to the Pad table
     fn lookup_pad(&mut self, flag: Self::Variable, value: Vec<Self::Variable>) {
-        self.add_lookup(Lookup::read_if(flag, PadLookup, value));
+        self.add_lookup(flag, Lookup::read_one(PadLookup, value));
     }
 
     /// Adds a lookup to the RoundConstants table
     fn lookup_round_constants(&mut self, flag: Self::Variable, value: Vec<Self::Variable>) {
-        self.add_lookup(Lookup::read_if(flag, RoundConstantsLookup, value));
+        self.add_lookup(flag, Lookup::read_one(RoundConstantsLookup, value));
     }
 
     /// Adds the 601 lookups required for the sponge

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -158,7 +158,7 @@ fn test_keccak_witness_satisfies_constraints() {
 }
 
 #[test]
-fn test_regression_number_of_constraints_and_degree() {
+fn test_regression_number_of_lookups_and_constraints_and_degree() {
     let mut rng = o1_utils::tests::make_test_rng();
 
     // Generate random bytelength and preimage for Keccak of 1, 2 or 3 blocks
@@ -168,90 +168,91 @@ fn test_regression_number_of_constraints_and_degree() {
 
     let mut keccak_env = KeccakEnv::<Fp>::new(0, &preimage);
 
-    // Checking lookup constraints (for now, all of them)
-    {
-        // Add the lookups (for now, all of them)
+    // Execute the interpreter to obtain constraints for each step
+    while keccak_env.constraints_env.step.is_some() {
+        // Current step to be executed
+        let step = keccak_env.constraints_env.step.unwrap();
+
+        // Push constraints for the current step
+        keccak_env.constraints_env.constraints();
+        // Push lookups for the current step
         keccak_env.constraints_env.lookups();
-        assert_eq!(keccak_env.constraints_env.lookups.len(), 2361);
-    }
 
-    // Checking relation constraints for each step selector
-    {
-        // Execute the interpreter to obtain constraints for each step
-        while keccak_env.constraints_env.step.is_some() {
-            // Current step to be executed
-            let step = keccak_env.constraints_env.step.unwrap();
-            // Push constraints for the current step
-            keccak_env.constraints_env.constraints();
-            println!("{:?}", step);
-            let mut constraint_degrees: HashMap<u64, u32> = HashMap::new();
-            keccak_env
-                .constraints_env
-                .constraints
-                .iter()
-                .for_each(|constraint| {
-                    let degree = constraint.degree(1, 0);
-                    let entry = constraint_degrees.entry(degree).or_insert(0);
-                    *entry += 1;
-                });
+        // Checking relation constraints for each step selector
+        let mut constraint_degrees: HashMap<u64, u32> = HashMap::new();
+        keccak_env
+            .constraints_env
+            .constraints
+            .iter()
+            .for_each(|constraint| {
+                let degree = constraint.degree(1, 0);
+                let entry = constraint_degrees.entry(degree).or_insert(0);
+                *entry += 1;
+            });
 
-            // Check that the number of constraints is correct for that step type
-            // Check that the degrees of the constraints are correct
+        // Check that the number of constraints is correct for that step type
+        // Check that the degrees of the constraints are correct
+        // Checking lookup constraints
 
-            match step {
-                Sponge(Absorb(First)) => {
-                    assert_eq!(keccak_env.constraints_env.constraints.len(), 332);
-                    // We have 1 different degrees of constraints in Absorbs::First
-                    assert_eq!(constraint_degrees.len(), 1);
-                    // 332 degree-1 constraints
-                    assert_eq!(constraint_degrees[&1], 332);
-                }
-                Sponge(Absorb(Middle)) => {
-                    assert_eq!(keccak_env.constraints_env.constraints.len(), 232);
-                    // We have 1 different degrees of constraints in Absorbs::Middle
-                    assert_eq!(constraint_degrees.len(), 1);
-                    // 232 degree-1 constraints
-                    assert_eq!(constraint_degrees[&1], 232);
-                }
-                Sponge(Absorb(Last)) => {
-                    assert_eq!(keccak_env.constraints_env.constraints.len(), 374);
-                    // We have 2 different degrees of constraints in Squeeze
-                    assert_eq!(constraint_degrees.len(), 2);
-                    // 232 degree-2 constraints
-                    assert_eq!(constraint_degrees[&1], 233);
-                    // 136 degree-2 constraints
-                    assert_eq!(constraint_degrees[&2], 141);
-                }
-                Sponge(Absorb(Only)) => {
-                    assert_eq!(keccak_env.constraints_env.constraints.len(), 474);
-                    // We have 2 different degrees of constraints in Squeeze
-                    assert_eq!(constraint_degrees.len(), 2);
-                    // 232 degree-2 constraints
-                    assert_eq!(constraint_degrees[&1], 333);
-                    // 136 degree-2 constraints
-                    assert_eq!(constraint_degrees[&2], 141);
-                }
-                Sponge(Squeeze) => {
-                    assert_eq!(keccak_env.constraints_env.constraints.len(), 16);
-                    // We have 1 different degrees of constraints in Squeeze
-                    assert_eq!(constraint_degrees.len(), 1);
-                    // 16 degree-1 constraints
-                    assert_eq!(constraint_degrees[&1], 16);
-                }
-                Round(_) => {
-                    assert_eq!(keccak_env.constraints_env.constraints.len(), 389);
-                    // We have 2 different degrees of constraints in Round
-                    assert_eq!(constraint_degrees.len(), 2);
-                    // 384 degree-1 constraints
-                    assert_eq!(constraint_degrees[&1], 384);
-                    // 5 degree-2 constraints
-                    assert_eq!(constraint_degrees[&2], 5);
-                }
+        match step {
+            Sponge(Absorb(First)) => {
+                assert_eq!(keccak_env.constraints_env.lookups.len(), 737);
+                assert_eq!(keccak_env.constraints_env.constraints.len(), 332);
+                // We have 1 different degrees of constraints in Absorbs::First
+                assert_eq!(constraint_degrees.len(), 1);
+                // 332 degree-1 constraints
+                assert_eq!(constraint_degrees[&1], 332);
             }
-            // Execute the step updating the witness
-            // (no need to happen before constraints if we are not checking the witness)
-            keccak_env.step(); // This updates the step for the next
+            Sponge(Absorb(Middle)) => {
+                assert_eq!(keccak_env.constraints_env.lookups.len(), 738);
+                assert_eq!(keccak_env.constraints_env.constraints.len(), 232);
+                // We have 1 different degrees of constraints in Absorbs::Middle
+                assert_eq!(constraint_degrees.len(), 1);
+                // 232 degree-1 constraints
+                assert_eq!(constraint_degrees[&1], 232);
+            }
+            Sponge(Absorb(Last)) => {
+                assert_eq!(keccak_env.constraints_env.lookups.len(), 739);
+                assert_eq!(keccak_env.constraints_env.constraints.len(), 374);
+                // We have 2 different degrees of constraints in Squeeze
+                assert_eq!(constraint_degrees.len(), 2);
+                // 232 degree-2 constraints
+                assert_eq!(constraint_degrees[&1], 233);
+                // 136 degree-2 constraints
+                assert_eq!(constraint_degrees[&2], 141);
+            }
+            Sponge(Absorb(Only)) => {
+                assert_eq!(keccak_env.constraints_env.lookups.len(), 738);
+                assert_eq!(keccak_env.constraints_env.constraints.len(), 474);
+                // We have 2 different degrees of constraints in Squeeze
+                assert_eq!(constraint_degrees.len(), 2);
+                // 232 degree-2 constraints
+                assert_eq!(constraint_degrees[&1], 333);
+                // 136 degree-2 constraints
+                assert_eq!(constraint_degrees[&2], 141);
+            }
+            Sponge(Squeeze) => {
+                assert_eq!(keccak_env.constraints_env.lookups.len(), 602);
+                assert_eq!(keccak_env.constraints_env.constraints.len(), 16);
+                // We have 1 different degrees of constraints in Squeeze
+                assert_eq!(constraint_degrees.len(), 1);
+                // 16 degree-1 constraints
+                assert_eq!(constraint_degrees[&1], 16);
+            }
+            Round(_) => {
+                assert_eq!(keccak_env.constraints_env.lookups.len(), 1623);
+                assert_eq!(keccak_env.constraints_env.constraints.len(), 389);
+                // We have 2 different degrees of constraints in Round
+                assert_eq!(constraint_degrees.len(), 2);
+                // 384 degree-1 constraints
+                assert_eq!(constraint_degrees[&1], 384);
+                // 5 degree-2 constraints
+                assert_eq!(constraint_degrees[&2], 5);
+            }
         }
+        // Execute the step updating the witness
+        // (no need to happen before constraints if we are not checking the witness)
+        keccak_env.step(); // This updates the step for the next
     }
 }
 

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -156,9 +156,9 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
     // LOOKUPS OPERATIONS //
     ////////////////////////
 
-    fn add_lookup(&mut self, lookup: Lookup<Self::Variable>) {
+    fn add_lookup(&mut self, if_true: Self::Variable, lookup: Lookup<Self::Variable>) {
         // Keep track of multiplicities for fixed lookups
-        if lookup.table_id.is_fixed() {
+        if if_true == Self::Variable::one() && lookup.table_id.is_fixed() {
             // Only when reading. We ignore the other values.
             if lookup.magnitude == Self::one() {
                 // Check that the lookup value is in the table


### PR DESCRIPTION
This PR builds on top of https://github.com/o1-labs/proof-systems/pull/2051 to bring splittability onto lookups. This way, each row of the circuit only adds the lookups that are specific to that step type. 

I modified the regression test accordingly.

Note that the maximum number of lookups per row corresponds to `Round` steps, with 1623 lookups (as opposed to 2361 that we had before, when all the lookups were run for all steps). 

Closes https://github.com/MinaProtocol/mina/issues/15163