### PR TITLE
Using generic prover inside zkVM

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,8 @@ env:
   CARGO_INCREMENTAL: 1
   # https://nexte.st/book/pre-built-binaries.html#using-nextest-in-github-actions
   CARGO_TERM_COLOR: always
+  RUST_MIN_STACK: 31457280
+  # 30 MB of stack for Keccak tests
 
 jobs:
   run_formatting:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,6 +1480,7 @@ dependencies = [
  "serde_json",
  "serde_with 3.6.0",
  "sha3",
+ "stacker",
  "strum",
  "strum_macros",
 ]
@@ -2214,6 +2215,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,6 +2620,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "psm",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/msm/src/proof.rs
+++ b/msm/src/proof.rs
@@ -2,12 +2,9 @@ use crate::{
     lookups::{LookupTableIDs, LookupWitness},
     mvlookup::{LookupProof, LookupTableID},
     witness::Witness,
-    MVLookupWitness,
+    MVLookupWitness, DOMAIN_SIZE,
 };
-
-use ark_ff::UniformRand;
-use rand::thread_rng;
-
+use ark_ff::{UniformRand, Zero};
 use kimchi::{
     circuits::{
         domains::EvaluationDomains,
@@ -17,6 +14,7 @@ use kimchi::{
     proof::PointEvaluations,
 };
 use poly_commitment::{commitment::PolyComm, OpenProof};
+use rand::thread_rng;
 
 #[derive(Debug)]
 pub struct ProofInputs<const N: usize, G: KimchiCurve, ID: LookupTableID> {
@@ -26,11 +24,11 @@ pub struct ProofInputs<const N: usize, G: KimchiCurve, ID: LookupTableID> {
     pub mvlookups: Vec<MVLookupWitness<G::ScalarField, ID>>,
 }
 
-// This should be used only for testing purposes.
-// It is not only in the test API because it is used at the moment in the
-// main.rs. It should be moved to the test API when main.rs is replaced with
-// real production code.
 impl<const N: usize, G: KimchiCurve> ProofInputs<N, G, LookupTableIDs> {
+    // This should be used only for testing purposes.
+    // It is not only in the test API because it is used at the moment in the
+    // main.rs. It should be moved to the test API when main.rs is replaced with
+    // real production code.
     pub fn random(domain: EvaluationDomains<G::ScalarField>) -> Self {
         let mut rng = thread_rng();
         let cols: Box<[Vec<G::ScalarField>; N]> = Box::new(std::array::from_fn(|_| {
@@ -41,6 +39,19 @@ impl<const N: usize, G: KimchiCurve> ProofInputs<N, G, LookupTableIDs> {
         ProofInputs {
             evaluations: Witness { cols },
             mvlookups: vec![LookupWitness::<G::ScalarField>::random(domain)],
+        }
+    }
+}
+
+impl<const N: usize, G: KimchiCurve, ID: LookupTableID> Default for ProofInputs<N, G, ID> {
+    fn default() -> Self {
+        ProofInputs {
+            evaluations: Witness {
+                cols: Box::new(std::array::from_fn(|_| {
+                    (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect()
+                })),
+            },
+            mvlookups: vec![],
         }
     }
 }

--- a/msm/src/test/mod.rs
+++ b/msm/src/test/mod.rs
@@ -3,109 +3,107 @@ pub mod constraint;
 pub mod interpreter;
 pub mod witness;
 
+use crate::{
+    columns::Column, expr::E, lookups::LookupTableIDs, proof::ProofInputs, prover::prove,
+    verifier::verify, witness::Witness, BaseSponge, Fp, OpeningProof, ScalarSponge, BN254,
+};
+use ark_ff::{UniformRand, Zero};
+use kimchi::circuits::domains::EvaluationDomains;
+use poly_commitment::pairing_proof::PairingSRS;
+use rand::{CryptoRng, RngCore};
+
+// Generic function to test with different circuits with the generic prover/verifier.
+// It doesn't use the interpreter to build the witness and compute the constraints.
+pub fn test_completeness_generic<const N: usize, RNG>(
+    constraints: Vec<E<Fp>>,
+    evaluations: Witness<N, Vec<Fp>>,
+    domain_size: usize,
+    rng: &mut RNG,
+) where
+    RNG: RngCore + CryptoRng,
+{
+    let domain = EvaluationDomains::<Fp>::create(domain_size).unwrap();
+
+    let mut srs: PairingSRS<BN254> = {
+        // Trusted setup toxic waste
+        let x = Fp::rand(rng);
+        PairingSRS::create(x, domain.d1.size as usize)
+    };
+    srs.full_srs.add_lagrange_basis(domain.d1);
+
+    let proof_inputs = ProofInputs {
+        evaluations,
+        mvlookups: vec![],
+    };
+
+    let proof = prove::<_, OpeningProof, BaseSponge, ScalarSponge, Column, _, N, LookupTableIDs>(
+        domain,
+        &srs,
+        &constraints,
+        proof_inputs,
+        rng,
+    )
+    .unwrap();
+
+    {
+        // Checking the proof size. We should have:
+        // - N commitments for the columns
+        // - N evaluations for the columns
+        // - MAX_DEGREE - 1 commitments for the constraints (quotient polynomial)
+        // TODO: add lookups
+
+        // We check there is always only one commitment chunk
+        (&proof.proof_comms.witness_comms)
+            .into_iter()
+            .for_each(|x| assert_eq!(x.len(), 1));
+        // This equality is therefore trivial, but still doing it.
+        assert!(
+            (&proof.proof_comms.witness_comms)
+                .into_iter()
+                .fold(0, |acc, x| acc + x.len())
+                == N
+        );
+        // Checking that none of the commitments are zero
+        (&proof.proof_comms.witness_comms)
+            .into_iter()
+            .for_each(|v| v.elems.iter().for_each(|x| assert!(!x.is_zero())));
+
+        // Checking the number of chunks of the quotient polynomial
+        let max_degree = constraints
+            .iter()
+            .map(|c| c.degree(1, 0) as usize)
+            .max()
+            .unwrap();
+        if max_degree == 1 {
+            assert_eq!(proof.proof_comms.t_comm.len(), 1);
+        } else {
+            assert_eq!(proof.proof_comms.t_comm.len(), max_degree - 1);
+        }
+    }
+
+    let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, N, 0, LookupTableIDs>(
+        domain,
+        &srs,
+        &constraints,
+        &proof,
+        Witness::zero_vec(domain_size),
+    );
+    assert!(verifies)
+}
+
 // TODO: move tests from src/lib.rs into this file
 // TODO: use interpreter/witness/constraint files to define witness/cosntraints
 
 #[cfg(test)]
-mod tests {
-    use ark_ff::{Field, One, UniformRand, Zero};
-    use kimchi::circuits::{
-        domains::EvaluationDomains,
-        expr::{ConstantExpr, ConstantTerm},
-    };
-    use poly_commitment::pairing_proof::PairingSRS;
-    use rand::{CryptoRng, RngCore};
+pub mod tests {
 
+    use super::*;
     use crate::{
         columns::Column,
         expr::{self, E},
-        lookups::LookupTableIDs,
-        proof::ProofInputs,
-        prover::prove,
-        verifier::verify,
-        witness::Witness,
-        BaseSponge, Fp, OpeningProof, ScalarSponge, BN254,
     };
-
-    // Generic function to test with different circuits with the generic prover/verifier.
-    // It doesn't use the interpreter to build the witness and compute the constraints.
-    pub fn test_completeness_generic<const N: usize, RNG>(
-        constraints: Vec<E<Fp>>,
-        evaluations: Witness<N, Vec<Fp>>,
-        domain_size: usize,
-        rng: &mut RNG,
-    ) where
-        RNG: RngCore + CryptoRng,
-    {
-        let domain = EvaluationDomains::<Fp>::create(domain_size).unwrap();
-
-        let mut srs: PairingSRS<BN254> = {
-            // Trusted setup toxic waste
-            let x = Fp::rand(rng);
-            PairingSRS::create(x, domain.d1.size as usize)
-        };
-        srs.full_srs.add_lagrange_basis(domain.d1);
-
-        let proof_inputs = ProofInputs {
-            evaluations,
-            mvlookups: vec![],
-        };
-
-        let proof =
-            prove::<_, OpeningProof, BaseSponge, ScalarSponge, Column, _, N, LookupTableIDs>(
-                domain,
-                &srs,
-                &constraints,
-                proof_inputs,
-                rng,
-            )
-            .unwrap();
-
-        {
-            // Checking the proof size. We should have:
-            // - N commitments for the columns
-            // - N evaluations for the columns
-            // - MAX_DEGREE - 1 commitments for the constraints (quotient polynomial)
-            // TODO: add lookups
-
-            // We check there is always only one commitment chunk
-            (&proof.proof_comms.witness_comms)
-                .into_iter()
-                .for_each(|x| assert_eq!(x.len(), 1));
-            // This equality is therefore trivial, but still doing it.
-            assert!(
-                (&proof.proof_comms.witness_comms)
-                    .into_iter()
-                    .fold(0, |acc, x| acc + x.len())
-                    == N
-            );
-            // Checking that none of the commitments are zero
-            (&proof.proof_comms.witness_comms)
-                .into_iter()
-                .for_each(|v| v.elems.iter().for_each(|x| assert!(!x.is_zero())));
-
-            // Checking the number of chunks of the quotient polynomial
-            let max_degree = constraints
-                .iter()
-                .map(|c| c.degree(1, 0) as usize)
-                .max()
-                .unwrap();
-            if max_degree == 1 {
-                assert_eq!(proof.proof_comms.t_comm.len(), 1);
-            } else {
-                assert_eq!(proof.proof_comms.t_comm.len(), max_degree - 1);
-            }
-        }
-
-        let verifies = verify::<_, OpeningProof, BaseSponge, ScalarSponge, N, 0, LookupTableIDs>(
-            domain,
-            &srs,
-            &constraints,
-            &proof,
-            Witness::zero_vec(domain_size),
-        );
-        assert!(verifies)
-    }
+    use ark_ff::{Field, One, UniformRand};
+    use kimchi::circuits::expr::{ConstantExpr, ConstantTerm};
 
     #[cfg(dead_code)]
     fn test_soundness_generic<const N: usize, RNG>(

--- a/msm/src/verifier.rs
+++ b/msm/src/verifier.rs
@@ -35,7 +35,7 @@ pub fn verify<
 >(
     domain: EvaluationDomains<G::ScalarField>,
     srs: &OpeningProof::SRS,
-    constraint_exprs: &Vec<E<G::ScalarField>>,
+    constraints: &Vec<E<G::ScalarField>>,
     proof: &Proof<N, G, OpeningProof, ID>,
     public_inputs: Witness<NPUB, Vec<G::ScalarField>>,
 ) -> bool
@@ -212,7 +212,7 @@ where
     };
 
     let combined_expr =
-        Expr::combine_constraints(0..(constraint_exprs.len() as u32), constraint_exprs.clone());
+        Expr::combine_constraints(0..(constraints.len() as u32), constraints.clone());
     let ft_eval0 = -PolishToken::evaluate(
         combined_expr.to_polish().as_slice(),
         domain.d1,

--- a/optimism/Cargo.toml
+++ b/optimism/Cargo.toml
@@ -29,6 +29,7 @@ rmp-serde.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 serde_with.workspace = true
+stacker = "0.1"
 ark-poly.workspace = true
 ark-ff.workspace = true
 ark-ec.workspace = true

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -1,7 +1,8 @@
 //! This module contains the constraints for one Keccak step.
 use crate::{
-    keccak::{Constraint, KeccakColumn, E},
+    keccak::{Constraint, KeccakColumn},
     lookups::Lookup,
+    E,
 };
 use ark_ff::Field;
 use kimchi::{

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -11,6 +11,7 @@ use kimchi::{
     },
     o1_utils::Two,
 };
+use kimchi_msm::columns::ColumnIndexer;
 
 use super::interpreter::KeccakInterpreter;
 
@@ -59,7 +60,7 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
         // Despite `KeccakWitness` containing both `curr` and `next` fields,
         // the Keccak step spans across one row only.
         Expr::Atom(ExprInner::Cell(Variable {
-            col: column,
+            col: column.to_column(),
             row: CurrOrNext::Curr,
         }))
     }

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -31,8 +31,6 @@ pub(crate) const ZKVM_KECCAK_COLS_NEXT: usize = STATE_LEN;
 /// Number of words that fit in the hash digest
 pub(crate) const WORDS_IN_HASH: usize = HASH_BITLENGTH / WORD_LENGTH_IN_BITS;
 
-pub(crate) type E<F> = Expr<ConstantExpr<F>, Column>;
-
 /// Errors that can occur during the check of the witness
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -7,6 +7,7 @@ use kimchi::circuits::{
     expr::{ConstantExpr, Expr},
     polynomials::keccak::constants::{DIM, KECCAK_COLS, QUARTERS, RATE_IN_BYTES, STATE_LEN},
 };
+use kimchi_msm::columns::Column;
 
 pub mod column;
 pub mod constraints;
@@ -30,7 +31,7 @@ pub(crate) const ZKVM_KECCAK_COLS_NEXT: usize = STATE_LEN;
 /// Number of words that fit in the hash digest
 pub(crate) const WORDS_IN_HASH: usize = HASH_BITLENGTH / WORD_LENGTH_IN_BITS;
 
-pub(crate) type E<F> = Expr<ConstantExpr<F>, KeccakColumn>;
+pub(crate) type E<F> = Expr<ConstantExpr<F>, Column>;
 
 /// Errors that can occur during the check of the witness
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -3,11 +3,9 @@ use crate::{
     lookups::LookupTableIDs,
 };
 use ark_ff::Field;
-use kimchi::circuits::{
-    expr::{ConstantExpr, Expr},
-    polynomials::keccak::constants::{DIM, KECCAK_COLS, QUARTERS, RATE_IN_BYTES, STATE_LEN},
+use kimchi::circuits::polynomials::keccak::constants::{
+    DIM, KECCAK_COLS, QUARTERS, RATE_IN_BYTES, STATE_LEN,
 };
-use kimchi_msm::columns::Column;
 
 pub mod column;
 pub mod constraints;

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -1,18 +1,24 @@
 use crate::{
     keccak::{
-        environment::KeccakEnv, interpreter::KeccakInterpreter, Constraint::*, Error, KeccakColumn,
+        column::{KeccakWitness, ZKVM_KECCAK_COLS},
+        environment::KeccakEnv,
+        interpreter::KeccakInterpreter,
+        Constraint::*,
+        Error, KeccakColumn,
     },
     lookups::{FixedLookupTables, LookupTable, LookupTableIDs::*},
 };
 use ark_ff::{One, Zero};
 use kimchi::{
-    circuits::polynomials::keccak::Keccak,
+    circuits::polynomials::keccak::{constants::RATE_IN_BYTES, Keccak},
     o1_utils::{self, FieldHelpers, Two},
 };
-use mina_curves::pasta::Fp;
+use kimchi_msm::test::test_completeness_generic;
 use rand::Rng;
 use sha3::{Digest, Keccak256};
 use std::collections::HashMap;
+
+pub type Fp = ark_bn254::Fr;
 
 #[test]
 fn test_pad_blocks() {
@@ -434,4 +440,60 @@ fn test_keccak_multiplicities() {
         witness_env[26].multiplicities[RoundConstantsLookup as usize][0],
         2
     );
+}
+
+// Prover/Verifier test includidng the Keccak constraints
+#[test]
+fn test_keccak_prover() {
+    // guaranteed to have at least 30MB of stack
+    stacker::grow(30 * 1024 * 1024, || {
+        let mut rng = o1_utils::tests::make_test_rng();
+        let domain_size = 1 << 6;
+
+        // Generate 3 blocks of preimage data to fill the domain length
+        let bytelength = rng.gen_range(RATE_IN_BYTES * 2..RATE_IN_BYTES * 3);
+        let preimage: Vec<u8> = (0..bytelength).map(|_| rng.gen()).collect();
+
+        // Initialize the environment and run the interpreter
+        let mut keccak_env = KeccakEnv::<Fp>::new(0, &preimage);
+
+        // Keep track of the constraints of the circuit.
+        // All rows run all the constraints.
+        // TODO: adapt this test when the witness is split into subcircuits.
+        keccak_env.constraints_env.constraints();
+
+        // No MVLookups for now
+
+        // Initialize the witness
+        let mut witness = KeccakWitness {
+            cols: Box::new(std::array::from_fn(|_| Vec::with_capacity(domain_size))),
+        };
+
+        let mut row = 0;
+        // We want to use domain_size rows, even if that is an incomplete Keccak execution
+        while row < domain_size {
+            assert!(keccak_env.keccak_step.is_some());
+            // Run the interpreter, which sets the witness columns
+            keccak_env.step();
+            // Check witness satisfies constraints
+            keccak_env.witness_env.constraints();
+
+            // Push this row of the witness to the full circuit witness
+            witness
+                .cols
+                .iter_mut()
+                .zip(keccak_env.witness_env.witness.cols.iter())
+                .for_each(|(wit_col, step_col)| {
+                    wit_col.push(*step_col);
+                });
+            row += 1;
+        }
+
+        test_completeness_generic::<ZKVM_KECCAK_COLS, _>(
+            keccak_env.constraints_env.constraints.clone(),
+            witness.clone(),
+            domain_size,
+            &mut rng,
+        );
+    });
 }

--- a/optimism/src/lib.rs
+++ b/optimism/src/lib.rs
@@ -29,4 +29,20 @@ pub mod proof;
 /// The RAM lookup argument.
 pub mod ramlookup;
 
+use kimchi::circuits::expr::{ConstantExpr, Expr};
+use kimchi_msm::columns::Column;
 pub use ramlookup::{LookupMode as RAMLookupMode, RAMLookup};
+
+/// Type to represent a constraint on the individual columns of the execution
+/// trace.
+/// As a reminder, a constraint can be formally defined as a multi-variate
+/// polynomial over a finite field. The variables of the polynomial are defined
+/// as `kimchi_msm::columns::Column``.
+/// The `expression` framework defined in `kimchi::circuits::expr` is used to
+/// describe the multi-variate polynomials.
+/// For instance, a vanilla 3-wires PlonK constraint can be defined using the
+/// multi-variate polynomial of degree 2
+/// `P(X, Y, Z) = q_x X + q_y Y + q_m X Y + q_o Z + q_c`
+/// To represent this multi-variate polynomial using the expression framework,
+/// we would use 3 different columns.
+pub(crate) type E<F> = Expr<ConstantExpr<F>, Column>;

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -1,10 +1,12 @@
 use ark_bn254::FrParameters;
 use ark_ec::bn::Bn;
 use ark_ff::{Fp256, UniformRand, Zero};
+use kimchi_msm::proof::ProofInputs;
 use kimchi_optimism::{
     cannon::{self, Meta, Start, State},
     cannon_cli,
     keccak::column::{KeccakWitness, ZKVM_KECCAK_COLS},
+    lookups::LookupTableIDs,
     mips::{
         column::{MIPSWitness, MIPSWitnessTrait, MIPS_COLUMNS},
         witness::{self as mips_witness, SCRATCH_SIZE},
@@ -73,9 +75,10 @@ pub fn main() -> ExitCode {
 
     let mut env = mips_witness::Env::<ark_bn254::Fr>::create(cannon::PAGE_SIZE as usize, state, po);
 
-    let mut mips_folded_witness = proof::ProofInputs::<
+    let mut mips_folded_witness = ProofInputs::<
         MIPS_COLUMNS,
         ark_ec::short_weierstrass_jacobian::GroupAffine<ark_bn254::g1::Parameters>,
+        LookupTableIDs,
     >::default();
 
     let mips_reset_pre_folding_witness = |witness_columns: &mut MIPSWitness<Vec<_>>| {
@@ -90,9 +93,10 @@ pub fn main() -> ExitCode {
 
     // The keccak environment is extracted inside the loop
 
-    let mut keccak_folded_witness = proof::ProofInputs::<
+    let mut keccak_folded_witness = ProofInputs::<
         ZKVM_KECCAK_COLS,
         ark_ec::short_weierstrass_jacobian::GroupAffine<ark_bn254::g1::Parameters>,
+        LookupTableIDs,
     >::default();
 
     let keccak_reset_pre_folding_witness =
@@ -182,7 +186,7 @@ pub fn main() -> ExitCode {
             &mips_current_pre_folding_witness,
         );
     }
-
+    /*
     {
         // MIPS
         let mips_proof = proof::prove::<MIPS_COLUMNS, _, OpeningProof, BaseSponge, ScalarSponge>(
@@ -224,6 +228,7 @@ pub fn main() -> ExitCode {
         }
     }
 
+    */
     // TODO: Logic
     ExitCode::SUCCESS
 }

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -254,9 +254,9 @@ pub fn main() -> ExitCode {
             Witness::zero_vec(DOMAIN_SIZE),
         );
         if keccak_verifies {
-            println!("The MIPS proof verifies")
+            println!("The Keccak proof verifies")
         } else {
-            println!("The MIPS proof doesn't verify")
+            println!("The Keccak proof doesn't verify")
         }
     }
 

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -221,29 +221,45 @@ pub fn main() -> ExitCode {
             println!("The MIPS proof doesn't verify")
         }
     }
-    /*
+
     {
         // KECCAK
-        let keccak_proof =
-            proof::prove::<ZKVM_KECCAK_COLS, _, OpeningProof, BaseSponge, ScalarSponge>(
-                domain,
-                &srs,
-                keccak_folded_witness,
-            );
+        // TODO: use actual constraints, not just an empty vector
+        // FIXME: when folding is applied, the list of constraints will be adapated to satisfy the folded witness
+        let keccak_result = prove::<
+            _,
+            OpeningProof,
+            BaseSponge,
+            ScalarSponge,
+            Column,
+            _,
+            ZKVM_KECCAK_COLS,
+            LookupTableIDs,
+        >(domain, &srs, &vec![], keccak_folded_witness, &mut rng);
+        let keccak_proof = keccak_result.unwrap();
         println!("Generated a proof:\n{:?}", keccak_proof);
-        let verifies = proof::verify::<ZKVM_KECCAK_COLS, _, OpeningProof, BaseSponge, ScalarSponge>(
+        let keccak_verifies = verify::<
+            _,
+            OpeningProof,
+            BaseSponge,
+            ScalarSponge,
+            ZKVM_KECCAK_COLS,
+            0,
+            LookupTableIDs,
+        >(
             domain,
             &srs,
+            &vec![],
             &keccak_proof,
+            Witness::zero_vec(DOMAIN_SIZE),
         );
-        if verifies {
-            println!("The KECCAK proof verifies")
+        if keccak_verifies {
+            println!("The MIPS proof verifies")
         } else {
-            println!("The KECCAK proof doesn't verify")
+            println!("The MIPS proof doesn't verify")
         }
     }
 
-    */
     // TODO: Logic
     ExitCode::SUCCESS
 }

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -195,6 +195,7 @@ pub fn main() -> ExitCode {
     {
         // MIPS
         // TODO: use actual constraints, not just an empty vector
+        // FIXME: this means create separate MIPS witnesses and prove the corresponding constraints for each
         let mips_result = prove::<
             _,
             OpeningProof,
@@ -225,7 +226,8 @@ pub fn main() -> ExitCode {
     {
         // KECCAK
         // TODO: use actual constraints, not just an empty vector
-        // FIXME: when folding is applied, the list of constraints will be adapated to satisfy the folded witness
+        // FIXME: this means create separate Keccak witnesses and prove the corresponding constraints for each
+        // FIXME: when folding is applied, the error term will be created to satisfy the folded witness
         let keccak_result = prove::<
             _,
             OpeningProof,

--- a/optimism/src/mips/mod.rs
+++ b/optimism/src/mips/mod.rs
@@ -16,7 +16,6 @@
 //! structure [crate::proof::ProofInputs].
 
 use self::column::ColumnAlias;
-use kimchi::circuits::expr::{ConstantExpr, Expr};
 
 pub mod column;
 pub mod constraints;

--- a/optimism/src/mips/mod.rs
+++ b/optimism/src/mips/mod.rs
@@ -24,17 +24,3 @@ pub mod folding;
 pub mod interpreter;
 pub mod registers;
 pub mod witness;
-
-/// Type to represent a constraint on the individual columns of the execution
-/// trace.
-/// As a reminder, a constraint can be formally defined as a multi-variate
-/// polynomial over a finite field. The variables of the polynomial are defined
-/// as `crate::column::MIPSColumn`.
-/// The `expression` framework defined in `kimchi::circuits::expr` is used to
-/// describe the multi-variate polynomials.
-/// For instance, a vanilla 3-wires PlonK constraint can be defined using the
-/// multi-variate polynomial of degree 2
-/// `P(X, Y, Z) = q_x X + q_y Y + q_m X Y + q_o Z + q_c`
-/// To represent this multi-variate polynomial using the expression framework,
-/// we would use 3 different columns.
-pub(crate) type E<F> = Expr<ConstantExpr<F>, ColumnAlias>;

--- a/optimism/src/proof.rs
+++ b/optimism/src/proof.rs
@@ -1,23 +1,11 @@
-use crate::{lookups::LookupTableIDs, DOMAIN_SIZE};
-use ark_ff::Zero;
-use ark_poly::{univariate::DensePolynomial, Evaluations, Polynomial, Radix2EvaluationDomain as D};
-use kimchi::{
-    circuits::domains::EvaluationDomains, curve::KimchiCurve, groupmap::GroupMap,
-    plonk_sponge::FrSponge,
-};
+use crate::lookups::LookupTableIDs;
+use ark_poly::{Evaluations, Radix2EvaluationDomain as D};
+use kimchi::{circuits::domains::EvaluationDomains, curve::KimchiCurve, plonk_sponge::FrSponge};
 use kimchi_msm::{proof::ProofInputs, witness::Witness};
 use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
-use poly_commitment::{
-    commitment::{
-        absorb_commitment, combined_inner_product, BatchEvaluationProof, Evaluation, PolyComm,
-    },
-    evaluation_proof::DensePolynomialOrEvaluations,
-    OpenProof, SRS as _,
-};
-use rand::thread_rng;
+use poly_commitment::{commitment::absorb_commitment, OpenProof, SRS as _};
 use rayon::iter::{
-    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator,
-    IntoParallelRefMutIterator, ParallelIterator,
+    IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
 };
 
 /// This function folds the witness of the current circuit with the accumulated Keccak instance

--- a/optimism/src/proof.rs
+++ b/optimism/src/proof.rs
@@ -1,11 +1,11 @@
-use crate::DOMAIN_SIZE;
+use crate::{lookups::LookupTableIDs, DOMAIN_SIZE};
 use ark_ff::Zero;
 use ark_poly::{univariate::DensePolynomial, Evaluations, Polynomial, Radix2EvaluationDomain as D};
 use kimchi::{
     circuits::domains::EvaluationDomains, curve::KimchiCurve, groupmap::GroupMap,
     plonk_sponge::FrSponge,
 };
-use kimchi_msm::witness::Witness;
+use kimchi_msm::{proof::ProofInputs, witness::Witness};
 use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
 use poly_commitment::{
     commitment::{
@@ -20,37 +20,6 @@ use rayon::iter::{
     IntoParallelRefMutIterator, ParallelIterator,
 };
 
-/// This struct contains the evaluations of the Witness columns across the whole domain of the circuit
-#[derive(Debug)]
-pub struct ProofInputs<const N: usize, G: KimchiCurve> {
-    evaluations: Witness<N, Vec<G::ScalarField>>,
-}
-
-impl<const N: usize, G: KimchiCurve> Default for ProofInputs<N, G> {
-    fn default() -> Self {
-        ProofInputs {
-            evaluations: Witness {
-                cols: Box::new(std::array::from_fn(|_| {
-                    (0..DOMAIN_SIZE).map(|_| G::ScalarField::zero()).collect()
-                })),
-            },
-        }
-    }
-}
-
-/// This struct contains the proof of the Keccak circuit
-#[derive(Debug)]
-pub struct Proof<const N: usize, G: KimchiCurve, OpeningProof: OpenProof<G>> {
-    /// Polynomial commitments to the witness columns
-    commitments: Witness<N, PolyComm<G>>,
-    /// Evaluations of witness polynomials at current rows on random evaluation point `zeta`
-    zeta_evaluations: Witness<N, G::ScalarField>,
-    /// Evaluations of witness polynomials at next rows (where `* omega` comes from) on random evaluation point `zeta`
-    zeta_omega_evaluations: Witness<N, G::ScalarField>,
-    /// Proof of opening for the evaluations with respect to the polynomial commitments
-    opening_proof: OpeningProof,
-}
-
 /// This function folds the witness of the current circuit with the accumulated Keccak instance
 /// with a random combination using a scaling challenge
 pub fn fold<
@@ -62,7 +31,7 @@ pub fn fold<
 >(
     domain: EvaluationDomains<G::ScalarField>,
     srs: &OpeningProof::SRS,
-    accumulator: &mut ProofInputs<N, G>,
+    accumulator: &mut ProofInputs<N, G, LookupTableIDs>,
     inputs: &Witness<N, Vec<G::ScalarField>>,
 ) where
     <OpeningProof as poly_commitment::OpenProof<G>>::SRS: std::marker::Sync,
@@ -88,6 +57,7 @@ pub fn fold<
     let scaling_challenge = ScalarChallenge(fq_sponge.challenge());
     let (_, endo_r) = G::endos();
     let scaling_challenge = scaling_challenge.to_field(endo_r);
+    // TODO: fold mvlookups as well
     accumulator
         .evaluations
         .par_iter_mut()
@@ -100,323 +70,4 @@ pub fn fold<
                     *accumulator = *input + scaling_challenge * *accumulator
                 });
         });
-}
-
-/// This function provides a proof for a Keccak instance.
-// TODO: this proof does not contain information about the constraints nor lookups yet
-pub fn prove<
-    const N: usize,
-    G: KimchiCurve,
-    OpeningProof: OpenProof<G>,
-    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
-    EFrSponge: FrSponge<G::ScalarField>,
->(
-    domain: EvaluationDomains<G::ScalarField>,
-    srs: &OpeningProof::SRS,
-    inputs: ProofInputs<N, G>,
-) -> Proof<N, G, OpeningProof>
-where
-    OpeningProof::SRS: Sync,
-{
-    let ProofInputs { evaluations } = inputs;
-    let polys: Witness<N, _> = {
-        let eval_col = |evals: Vec<G::ScalarField>| {
-            Evaluations::<G::ScalarField, D<G::ScalarField>>::from_vec_and_domain(evals, domain.d1)
-                .interpolate()
-        };
-        let eval_array_col = |evals: &[Vec<G::ScalarField>]| {
-            evals
-                .into_par_iter()
-                .map(|e| eval_col(e.to_vec()))
-                .collect::<Vec<_>>()
-        };
-        Witness {
-            cols: Box::new(eval_array_col(&(*evaluations.cols)).try_into().unwrap()),
-        }
-    };
-    let commitments = {
-        let comm = |poly: &DensePolynomial<G::ScalarField>| srs.commit_non_hiding(poly, 1);
-        let comm_array = |polys: &[DensePolynomial<G::ScalarField>]| {
-            polys.into_par_iter().map(comm).collect::<Vec<_>>()
-        };
-        Witness {
-            cols: Box::new(comm_array(&(*polys.cols)).try_into().unwrap()),
-        }
-    };
-
-    let mut fq_sponge = EFqSponge::new(G::other_curve_sponge_params());
-
-    for column in commitments.clone().into_iter() {
-        absorb_commitment(&mut fq_sponge, &column);
-    }
-    let zeta_chal = ScalarChallenge(fq_sponge.challenge());
-    let (_, endo_r) = G::endos();
-    let zeta = zeta_chal.to_field(endo_r);
-    let omega = domain.d1.group_gen;
-    let zeta_omega = zeta * omega;
-
-    let evals = |point| {
-        let comm = |poly: &DensePolynomial<G::ScalarField>| poly.evaluate(point);
-        let comm_array = |polys: &[DensePolynomial<G::ScalarField>]| {
-            polys.par_iter().map(comm).collect::<Vec<_>>()
-        };
-        Witness {
-            cols: Box::new(comm_array(&(*polys.cols)).try_into().unwrap()),
-        }
-    };
-    let zeta_evaluations = evals(&zeta);
-    let zeta_omega_evaluations = evals(&zeta_omega);
-    let group_map = G::Map::setup();
-    let polynomials = polys.into_iter().collect::<Vec<_>>();
-    let polynomials: Vec<_> = polynomials
-        .iter()
-        .map(|poly| {
-            (
-                DensePolynomialOrEvaluations::DensePolynomial(poly),
-                PolyComm {
-                    elems: vec![G::ScalarField::zero()],
-                },
-            )
-        })
-        .collect();
-    let fq_sponge_before_evaluations = fq_sponge.clone();
-    let mut fr_sponge = EFrSponge::new(G::sponge_params());
-    fr_sponge.absorb(&fq_sponge.digest());
-
-    for (zeta_eval, zeta_omega_eval) in zeta_evaluations
-        .clone()
-        .into_iter()
-        .zip(zeta_omega_evaluations.clone().into_iter())
-    {
-        fr_sponge.absorb(&zeta_eval);
-        fr_sponge.absorb(&zeta_omega_eval);
-    }
-
-    let v_chal = fr_sponge.challenge();
-    let v = v_chal.to_field(endo_r);
-    let u_chal = fr_sponge.challenge();
-    let u = u_chal.to_field(endo_r);
-
-    let opening_proof = OpenProof::open::<_, _, D<G::ScalarField>>(
-        srs,
-        &group_map,
-        polynomials.as_slice(),
-        &[zeta, zeta_omega],
-        v,
-        u,
-        fq_sponge_before_evaluations,
-        &mut rand::rngs::OsRng,
-    );
-
-    Proof {
-        commitments,
-        zeta_evaluations,
-        zeta_omega_evaluations,
-        opening_proof,
-    }
-}
-
-/// This function verifies the proof of a Keccak instance.
-// TODO: this still does not verify the constraints nor lookups
-pub fn verify<
-    const N: usize,
-    G: KimchiCurve,
-    OpeningProof: OpenProof<G>,
-    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
-    EFrSponge: FrSponge<G::ScalarField>,
->(
-    domain: EvaluationDomains<G::ScalarField>,
-    srs: &OpeningProof::SRS,
-    proof: &Proof<N, G, OpeningProof>,
-) -> bool {
-    let Proof {
-        commitments,
-        zeta_evaluations,
-        zeta_omega_evaluations,
-        opening_proof,
-    } = proof;
-
-    let mut fq_sponge = EFqSponge::new(G::other_curve_sponge_params());
-    commitments.into_iter().for_each(|comm| {
-        absorb_commitment(&mut fq_sponge, comm);
-    });
-    let zeta_chal = ScalarChallenge(fq_sponge.challenge());
-    let (_, endo_r) = G::endos();
-    let zeta: G::ScalarField = zeta_chal.to_field(endo_r);
-    let omega = domain.d1.group_gen;
-    let zeta_omega = zeta * omega;
-
-    let fq_sponge_before_evaluations = fq_sponge.clone();
-    let mut fr_sponge = EFrSponge::new(G::sponge_params());
-    fr_sponge.absorb(&fq_sponge.digest());
-
-    let es: Vec<_> = {
-        let mut evals = vec![];
-        for (zeta, zeta_omega) in zeta_evaluations
-            .clone()
-            .into_iter()
-            .zip(zeta_omega_evaluations.clone().into_iter())
-        {
-            evals.push(vec![vec![zeta], vec![zeta_omega]]);
-        }
-        evals
-    };
-
-    let evaluations: Vec<_> = {
-        let mut evals = vec![];
-        for (commitment, (zeta_eval, zeta_omega_eval)) in commitments.clone().into_iter().zip(
-            zeta_evaluations
-                .clone()
-                .into_iter()
-                .zip(zeta_omega_evaluations.clone().into_iter()),
-        ) {
-            evals.push(Evaluation {
-                commitment: commitment.clone(),
-                evaluations: vec![vec![zeta_eval], vec![zeta_omega_eval]],
-            });
-        }
-        evals
-    };
-
-    for (zeta_eval, zeta_omega_eval) in zeta_evaluations
-        .clone()
-        .into_iter()
-        .zip(zeta_omega_evaluations.clone().into_iter())
-    {
-        fr_sponge.absorb(&zeta_eval);
-        fr_sponge.absorb(&zeta_omega_eval);
-    }
-
-    let v_chal = fr_sponge.challenge();
-    let v = v_chal.to_field(endo_r);
-    let u_chal = fr_sponge.challenge();
-    let u = u_chal.to_field(endo_r);
-
-    let combined_inner_product = combined_inner_product(&v, &u, es.as_slice());
-
-    let batch = BatchEvaluationProof {
-        sponge: fq_sponge_before_evaluations,
-        evaluations,
-        evaluation_points: vec![zeta, zeta_omega],
-        polyscale: v,
-        evalscale: u,
-        opening: opening_proof,
-        combined_inner_product,
-    };
-
-    let group_map = G::Map::setup();
-    OpeningProof::verify(srs, &group_map, &mut [batch], &mut thread_rng())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{
-        keccak::column::{KeccakWitness, ZKVM_KECCAK_COLS},
-        mips::column::{MIPSWitness, MIPS_COLUMNS},
-    };
-
-    #[test]
-    fn test_mips_prover() {
-        use ark_ff::UniformRand;
-        use mina_poseidon::{
-            constants::PlonkSpongeConstantsKimchi,
-            sponge::{DefaultFqSponge, DefaultFrSponge},
-        };
-        use poly_commitment::pairing_proof::{PairingProof, PairingSRS};
-
-        type Fp = ark_bn254::Fr;
-        type BN254Parameters = ark_ec::bn::Bn<ark_bn254::Parameters>;
-        type SpongeParams = PlonkSpongeConstantsKimchi;
-        type BaseSponge = DefaultFqSponge<ark_bn254::g1::Parameters, SpongeParams>;
-        type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
-
-        let rng = &mut rand::rngs::OsRng;
-
-        let proof_inputs = {
-            let cols = std::array::from_fn(|_| {
-                (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>()
-            });
-            ProofInputs {
-                evaluations: MIPSWitness {
-                    cols: Box::new(cols),
-                },
-            }
-        };
-        let domain = EvaluationDomains::<Fp>::create(DOMAIN_SIZE).unwrap();
-
-        // Trusted setup toxic waste
-        let x = Fp::rand(rng);
-
-        let mut srs = PairingSRS::create(x, DOMAIN_SIZE);
-        srs.full_srs.add_lagrange_basis(domain.d1);
-
-        let proof = prove::<MIPS_COLUMNS, _, PairingProof<BN254Parameters>, BaseSponge, ScalarSponge>(
-            domain,
-            &srs,
-            proof_inputs,
-        );
-
-        assert!(verify::<
-            MIPS_COLUMNS,
-            _,
-            PairingProof<BN254Parameters>,
-            BaseSponge,
-            ScalarSponge,
-        >(domain, &srs, &proof));
-    }
-
-    // Dummy test with random witness that verifies because the proof still does not include constraints nor lookups
-    #[test]
-    fn test_keccak_prover() {
-        use ark_ff::UniformRand;
-        use mina_poseidon::{
-            constants::PlonkSpongeConstantsKimchi,
-            sponge::{DefaultFqSponge, DefaultFrSponge},
-        };
-        use poly_commitment::pairing_proof::{PairingProof, PairingSRS};
-
-        type Fp = ark_bn254::Fr;
-        type BN254Parameters = ark_ec::bn::Bn<ark_bn254::Parameters>;
-        type SpongeParams = PlonkSpongeConstantsKimchi;
-        type BaseSponge = DefaultFqSponge<ark_bn254::g1::Parameters, SpongeParams>;
-        type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
-
-        let rng = &mut rand::rngs::OsRng;
-
-        let proof_inputs = {
-            ProofInputs {
-                evaluations: KeccakWitness {
-                    cols: Box::new(std::array::from_fn(|_| {
-                        (0..DOMAIN_SIZE).map(|_| Fp::rand(rng)).collect::<Vec<_>>()
-                    })),
-                },
-            }
-        };
-        let domain = EvaluationDomains::<Fp>::create(DOMAIN_SIZE).unwrap();
-
-        // Trusted setup toxic waste
-        let x = Fp::rand(rng);
-
-        let mut srs = PairingSRS::create(x, DOMAIN_SIZE);
-        srs.full_srs.add_lagrange_basis(domain.d1);
-
-        let proof: Proof<
-            ZKVM_KECCAK_COLS,
-            ark_ec::short_weierstrass_jacobian::GroupAffine<ark_bn254::g1::Parameters>,
-            PairingProof<ark_ec::bn::Bn<ark_bn254::Parameters>>,
-        > = prove::<ZKVM_KECCAK_COLS, _, PairingProof<BN254Parameters>, BaseSponge, ScalarSponge>(
-            domain,
-            &srs,
-            proof_inputs,
-        );
-
-        assert!(verify::<
-            ZKVM_KECCAK_COLS,
-            _,
-            PairingProof<BN254Parameters>,
-            BaseSponge,
-            ScalarSponge,
-        >(domain, &srs, &proof));
-    }
 }


### PR DESCRIPTION
This PR removes the old prove/verify algorithms inside the zkVM project and instead uses the types and functions in the generic proof inside the MSM project. This means the proofs generated in `main()` use that prover/verifier pair instead. But because inside the loop the circuits are being folded in a dummy way, and creating no error terms whatsoever, running the actual constraints on the folded witnesses would not be satisfiable. For that reason, the proof is just being created with empty vector of constraints for now, and no lookups.

It also adds one test in the Keccak folder that does use the constraints in a non-folded circuit run. I had to increase the stack size for now, given the long witness. But the test is still failing and I am working to figure out why, given that the witness satisfies constraints individually. Will keep this description updated.