### PR TITLE
Split MIPS and Keccak instances in `main` and proof with constraints

### DIFF
--- a/msm/src/mvlookup.rs
+++ b/msm/src/mvlookup.rs
@@ -83,7 +83,7 @@ pub struct LookupTable<F, ID: LookupTableID> {
 /// IMPROVEME: Possible to index by a generic const?
 // The parameter N is the number of functions/looked-up values per row. It is
 // used by the PlonK polynomial IOP to compute the number of partial sums.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MVLookupWitness<F, ID: LookupTableID> {
     /// A list of functions/looked-up values.
     /// Invariant: for fixed lookup tables, the last value of the vector is the

--- a/msm/src/proof.rs
+++ b/msm/src/proof.rs
@@ -16,7 +16,7 @@ use kimchi::{
 use poly_commitment::{commitment::PolyComm, OpenProof};
 use rand::thread_rng;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProofInputs<const N: usize, G: KimchiCurve, ID: LookupTableID> {
     /// Actual values w_i of the witness columns. "Evaluations" as in
     /// evaluations of polynomial P_w that interpolates w_i.

--- a/optimism/run-code.sh
+++ b/optimism/run-code.sh
@@ -11,8 +11,8 @@ set -u
 
 source $FILENAME
 
-./run-op-program.sh
+#./run-op-program.sh
 
-./run-cannon.sh
+#./run-cannon.sh
 
 ./run-vm.sh

--- a/optimism/run-code.sh
+++ b/optimism/run-code.sh
@@ -11,8 +11,8 @@ set -u
 
 source $FILENAME
 
-#./run-op-program.sh
+./run-op-program.sh
 
-#./run-cannon.sh
+./run-cannon.sh
 
 ./run-vm.sh

--- a/optimism/src/keccak/circuit.rs
+++ b/optimism/src/keccak/circuit.rs
@@ -1,0 +1,3 @@
+pub(crate) struct KeccakCircuit<F> {
+    pub(crate) circuit: KeccakWitness<Vec<F>>,
+}

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -85,8 +85,10 @@ impl<F: Field> KeccakEnv<F> {
     /// Starts a new Keccak environment for a given hash index and bytestring of preimage data
     pub fn new(hash_idx: u64, preimage: &[u8]) -> Self {
         // Must update the flag type at each step from the witness interpretation
-        let mut env = KeccakEnv::default();
-        env.hash_idx = hash_idx;
+        let mut env = KeccakEnv::<F> {
+            hash_idx,
+            ..Default::default()
+        };
 
         // Store hash index in the witness
         env.write_column(KeccakColumn::HashIndex, env.hash_idx);

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -134,6 +134,15 @@ impl<F: Field> KeccakEnv<F> {
         self.constraints_env.lookups = vec![];
     }
 
+    /// Returns the selector of the current step
+    pub fn selector(&self) -> Steps {
+        let mut step = self.constraints_env.step.unwrap();
+        if let Round(_) = step {
+            step = Round(0);
+        }
+        step
+    }
+
     /// Entrypoint for the interpreter. It executes one step of the Keccak circuit (one row),
     /// and updates the environment accordingly (including the witness and inter-step lookups).
     /// When it finishes, it updates the value of the current step, so that the next call to

--- a/optimism/src/keccak/environment.rs
+++ b/optimism/src/keccak/environment.rs
@@ -63,24 +63,30 @@ pub struct KeccakEnv<F> {
     pad_suffixes: [[F; PAD_SUFFIX_LEN]; RATE_IN_BYTES],
 }
 
-impl<F: Field> KeccakEnv<F> {
-    /// Starts a new Keccak environment for a given hash index and bytestring of preimage data
-    pub fn new(hash_idx: u64, preimage: &[u8]) -> Self {
-        let mut env = Self {
-            // Must update the flag type at each step from the witness interpretation
+impl<F: Field> Default for KeccakEnv<F> {
+    fn default() -> Self {
+        Self {
             constraints_env: ConstraintsEnv::default(),
             witness_env: WitnessEnv::default(),
-            hash_idx,
+            hash_idx: 0,
             step_idx: 0,
             block_idx: 0,
             prev_block: vec![],
             blocks_left_to_absorb: 0,
             padded: vec![],
             pad_len: 0,
-            // Add 1 to i so that 0 is not included
             two_to_pad: array::from_fn(|i| F::two_pow(1 + i as u64)),
             pad_suffixes: array::from_fn(|i| pad_blocks::<F>(1 + i)),
-        };
+        }
+    }
+}
+
+impl<F: Field> KeccakEnv<F> {
+    /// Starts a new Keccak environment for a given hash index and bytestring of preimage data
+    pub fn new(hash_idx: u64, preimage: &[u8]) -> Self {
+        // Must update the flag type at each step from the witness interpretation
+        let mut env = KeccakEnv::default();
+        env.hash_idx = hash_idx;
 
         // Store hash index in the witness
         env.write_column(KeccakColumn::HashIndex, env.hash_idx);

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -413,7 +413,7 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
                 for y in 0..DIM {
                     let not = Self::constant(0x1111111111111111u64)
                         - self.shifts_b(0, y, (x + 1) % DIM, q);
-                    let _sum = not + self.shifts_b(0, y, (x + 2) % DIM, q);
+                    let sum = not + self.shifts_b(0, y, (x + 2) % DIM, q);
                     let and = self.shifts_sum(1, y, x, q);
 
                     self.constrain(

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -413,7 +413,7 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
                 for y in 0..DIM {
                     let not = Self::constant(0x1111111111111111u64)
                         - self.shifts_b(0, y, (x + 1) % DIM, q);
-                    let sum = not + self.shifts_b(0, y, (x + 2) % DIM, q);
+                    let _sum = not + self.shifts_b(0, y, (x + 2) % DIM, q);
                     let and = self.shifts_sum(1, y, x, q);
 
                     self.constrain(

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -84,8 +84,8 @@ pub enum Constraint {
 pub(crate) type KeccakCircuit<F> = Circuit<ZKVM_KECCAK_COLS, Steps, F>;
 
 #[allow(dead_code)]
-impl<F: Field> CircuitTrait<ZKVM_KECCAK_COLS, Steps, F> for KeccakCircuit<F> {
-    fn new(domain_size: usize) -> Self {
+impl<F: Field> CircuitTrait<ZKVM_KECCAK_COLS, Steps, F, KeccakEnv<F>> for KeccakCircuit<F> {
+    fn new(domain_size: usize, _env: &mut KeccakEnv<F>) -> Self {
         let mut circuit = Self {
             witness: HashMap::new(),
             constraints: Default::default(),

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -83,6 +83,15 @@ pub enum Constraint {
 /// The Keccak circuit
 pub(crate) type KeccakCircuit<F> = Circuit<ZKVM_KECCAK_COLS, Steps, F>;
 
+const STEPS: [Steps; 6] = [
+    Round(0),
+    Sponge(Absorb(First)),
+    Sponge(Absorb(Middle)),
+    Sponge(Absorb(Last)),
+    Sponge(Absorb(Only)),
+    Sponge(Squeeze),
+];
+
 #[allow(dead_code)]
 impl<F: Field> CircuitTrait<ZKVM_KECCAK_COLS, Steps, F, KeccakEnv<F>> for KeccakCircuit<F> {
     fn new(domain_size: usize, _env: &mut KeccakEnv<F>) -> Self {
@@ -92,14 +101,7 @@ impl<F: Field> CircuitTrait<ZKVM_KECCAK_COLS, Steps, F, KeccakEnv<F>> for Keccak
             lookups: Default::default(),
         };
 
-        for step in [
-            Round(0),
-            Sponge(Absorb(First)),
-            Sponge(Absorb(Middle)),
-            Sponge(Absorb(Last)),
-            Sponge(Absorb(Only)),
-            Sponge(Squeeze),
-        ] {
+        for step in STEPS {
             circuit.witness.insert(
                 step,
                 Witness {
@@ -130,14 +132,7 @@ impl<F: Field> CircuitTrait<ZKVM_KECCAK_COLS, Steps, F, KeccakEnv<F>> for Keccak
     }
 
     fn pad_rows(&mut self) {
-        for step in [
-            Round(0),
-            Sponge(Absorb(First)),
-            Sponge(Absorb(Middle)),
-            Sponge(Absorb(Last)),
-            Sponge(Absorb(Only)),
-            Sponge(Squeeze),
-        ] {
+        for step in STEPS {
             let rows_left =
                 self.witness[&step].cols[0].capacity() - self.witness[&step].cols[0].len();
             for _ in 0..rows_left {

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -81,7 +81,7 @@ pub enum Constraint {
 
 #[allow(dead_code)]
 /// The Keccak circuit
-pub(crate) type KeccakCircuit<F> = Circuit<ZKVM_KECCAK_COLS, Steps, F>;
+pub type KeccakCircuit<F> = Circuit<ZKVM_KECCAK_COLS, Steps, F>;
 
 const STEPS: [Steps; 6] = [
     Round(0),

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -96,6 +96,7 @@ pub const STEPS: [Steps; 6] = [
 impl<F: Field> CircuitTrait<ZKVM_KECCAK_COLS, Steps, F, KeccakEnv<F>> for KeccakCircuit<F> {
     fn new(domain_size: usize, _env: &mut KeccakEnv<F>) -> Self {
         let mut circuit = Self {
+            domain_size,
             witness: HashMap::new(),
             constraints: Default::default(),
             lookups: Default::default(),
@@ -139,6 +140,17 @@ impl<F: Field> CircuitTrait<ZKVM_KECCAK_COLS, Steps, F, KeccakEnv<F>> for Keccak
                 self.push_row(step, &[F::zero(); ZKVM_KECCAK_COLS]);
             }
         }
+    }
+
+    fn reset(&mut self, step: Steps) {
+        self.witness.insert(
+            step,
+            Witness {
+                cols: Box::new(std::array::from_fn(|_| {
+                    Vec::with_capacity(self.domain_size)
+                })),
+            },
+        );
     }
 }
 

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         PAD_SUFFIX_LEN,
     },
     lookups::LookupTableIDs,
-    Circuit,
+    Circuit, CircuitTrait,
 };
 use ark_ff::Field;
 use kimchi::circuits::polynomials::keccak::constants::{
@@ -84,9 +84,8 @@ pub enum Constraint {
 pub(crate) type KeccakCircuit<F> = Circuit<ZKVM_KECCAK_COLS, Steps, F>;
 
 #[allow(dead_code)]
-impl<F: Field> KeccakCircuit<F> {
-    /// Create a new Keccak circuit
-    pub fn new(domain_size: usize) -> Self {
+impl<F: Field> CircuitTrait<ZKVM_KECCAK_COLS, Steps, F> for KeccakCircuit<F> {
+    fn new(domain_size: usize) -> Self {
         let mut circuit = Self {
             witness: HashMap::new(),
             constraints: Default::default(),
@@ -115,8 +114,7 @@ impl<F: Field> KeccakCircuit<F> {
         circuit
     }
 
-    /// Add a witness row to the circuit
-    pub(crate) fn push_row(&mut self, step: Steps, row: &[F; ZKVM_KECCAK_COLS]) {
+    fn push_row(&mut self, step: Steps, row: &[F; ZKVM_KECCAK_COLS]) {
         // Make sure we are using the same round number to refer to round steps
         let mut step = step;
         if let Round(_) = step {
@@ -131,8 +129,7 @@ impl<F: Field> KeccakCircuit<F> {
         });
     }
 
-    /// Pads the rows of the witnesses until reaching the domain size
-    pub(crate) fn pad_rows(&mut self) {
+    fn pad_rows(&mut self) {
         for step in [
             Round(0),
             Sponge(Absorb(First)),

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -83,7 +83,7 @@ pub enum Constraint {
 /// The Keccak circuit
 pub type KeccakCircuit<F> = Circuit<ZKVM_KECCAK_COLS, Steps, F>;
 
-const STEPS: [Steps; 6] = [
+pub const STEPS: [Steps; 6] = [
     Round(0),
     Sponge(Absorb(First)),
     Sponge(Absorb(Middle)),

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -132,13 +132,22 @@ impl<F: Field> CircuitTrait<ZKVM_KECCAK_COLS, Steps, F, KeccakEnv<F>> for Keccak
         });
     }
 
-    fn pad_rows(&mut self) {
-        for step in STEPS {
-            let rows_left =
-                self.witness[&step].cols[0].capacity() - self.witness[&step].cols[0].len();
-            for _ in 0..rows_left {
-                self.push_row(step, &[F::zero(); ZKVM_KECCAK_COLS]);
+    fn pad(&mut self, step: Steps) -> bool {
+        let rows_left = self.domain_size - self.witness[&step].cols[0].len();
+        if rows_left == 0 {
+            return false;
+        }
+        self.witness.entry(step).and_modify(|wit| {
+            for col in wit.cols.iter_mut() {
+                col.extend((0..rows_left).map(|_| F::zero()));
             }
+        });
+        true
+    }
+
+    fn pad_witnesses(&mut self) {
+        for step in STEPS {
+            self.pad(step);
         }
     }
 

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -507,7 +507,7 @@ fn test_keccak_prover() {
             // Add the witness row to the circuit
             keccak_circuit.push_row(step, &keccak_env.witness_env.witness.cols);
         }
-        keccak_circuit.pad_rows();
+        keccak_circuit.pad_witnesses();
 
         for step in [
             Round(0),

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -7,6 +7,7 @@ use crate::{
         Error, KeccakColumn,
     },
     lookups::{FixedLookupTables, LookupTable, LookupTableIDs::*},
+    CircuitTrait,
 };
 use ark_ff::{One, Zero};
 use kimchi::{

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -490,11 +490,11 @@ fn test_keccak_prover() {
         let bytelength = rng.gen_range(2 * RATE_IN_BYTES..RATE_IN_BYTES * 3);
         let preimage: Vec<u8> = (0..bytelength).map(|_| rng.gen()).collect();
 
-        // Keep track of the constraints and lookups of the sub-circuits
-        let mut keccak_circuit = KeccakCircuit::<Fp>::new(domain_size);
-
         // Initialize the environment and run the interpreter
         let mut keccak_env = KeccakEnv::<Fp>::new(0, &preimage);
+
+        // Keep track of the constraints and lookups of the sub-circuits
+        let mut keccak_circuit = KeccakCircuit::<Fp>::new(domain_size, &mut keccak_env);
 
         // We want to use domain_size rows, even if that is an incomplete Keccak execution
         while keccak_env.constraints_env.step.is_some() {

--- a/optimism/src/lib.rs
+++ b/optimism/src/lib.rs
@@ -58,3 +58,14 @@ pub(crate) struct Circuit<const N: usize, SELECTOR, F> {
     /// The vector of lookups for a given selector
     pub(crate) lookups: HashMap<SELECTOR, Vec<Lookup<E<F>>>>,
 }
+
+trait CircuitTrait<const N: usize, SELECTOR, F> {
+    /// Create a new Keccak circuit
+    fn new(domain_size: usize) -> Self;
+
+    /// Add a witness row to the circuit
+    fn push_row(&mut self, step: SELECTOR, row: &[F; N]);
+
+    /// Pads the rows of the witnesses until reaching the domain size
+    fn pad_rows(&mut self);
+}

--- a/optimism/src/lib.rs
+++ b/optimism/src/lib.rs
@@ -52,11 +52,11 @@ pub(crate) type E<F> = Expr<ConstantExpr<F>, Column>;
 
 pub struct Circuit<const N: usize, SELECTOR, F> {
     /// The witness for a given selector
-    pub(crate) witness: HashMap<SELECTOR, Witness<N, Vec<F>>>,
+    pub witness: HashMap<SELECTOR, Witness<N, Vec<F>>>,
     /// The vector of constraints for a given selector
-    pub(crate) constraints: HashMap<SELECTOR, Vec<E<F>>>,
+    pub constraints: HashMap<SELECTOR, Vec<E<F>>>,
     /// The vector of lookups for a given selector
-    pub(crate) lookups: HashMap<SELECTOR, Vec<Lookup<E<F>>>>,
+    pub lookups: HashMap<SELECTOR, Vec<Lookup<E<F>>>>,
 }
 
 pub trait CircuitTrait<const N: usize, SELECTOR, F, Env> {

--- a/optimism/src/lib.rs
+++ b/optimism/src/lib.rs
@@ -50,7 +50,7 @@ pub use ramlookup::{LookupMode as RAMLookupMode, RAMLookup};
 /// we would use 3 different columns.
 pub(crate) type E<F> = Expr<ConstantExpr<F>, Column>;
 
-pub(crate) struct Circuit<const N: usize, SELECTOR, F> {
+pub struct Circuit<const N: usize, SELECTOR, F> {
     /// The witness for a given selector
     pub(crate) witness: HashMap<SELECTOR, Witness<N, Vec<F>>>,
     /// The vector of constraints for a given selector
@@ -59,7 +59,7 @@ pub(crate) struct Circuit<const N: usize, SELECTOR, F> {
     pub(crate) lookups: HashMap<SELECTOR, Vec<Lookup<E<F>>>>,
 }
 
-trait CircuitTrait<const N: usize, SELECTOR, F, Env> {
+pub trait CircuitTrait<const N: usize, SELECTOR, F, Env> {
     /// Create a new circuit
     fn new(domain_size: usize, env: &mut Env) -> Self;
 

--- a/optimism/src/lib.rs
+++ b/optimism/src/lib.rs
@@ -68,8 +68,11 @@ pub trait CircuitTrait<const N: usize, SELECTOR, F, Env> {
     /// Add a witness row to the circuit
     fn push_row(&mut self, step: SELECTOR, row: &[F; N]);
 
+    /// Pads the rows of one selector until reaching the domain size
+    fn pad(&mut self, step: SELECTOR) -> bool;
+
     /// Pads the rows of the witnesses until reaching the domain size
-    fn pad_rows(&mut self);
+    fn pad_witnesses(&mut self);
 
     /// Resets the witness after folding
     fn reset(&mut self, step: SELECTOR);

--- a/optimism/src/lib.rs
+++ b/optimism/src/lib.rs
@@ -51,6 +51,8 @@ pub use ramlookup::{LookupMode as RAMLookupMode, RAMLookup};
 pub(crate) type E<F> = Expr<ConstantExpr<F>, Column>;
 
 pub struct Circuit<const N: usize, SELECTOR, F> {
+    /// The domain size of the circuit
+    pub domain_size: usize,
     /// The witness for a given selector
     pub witness: HashMap<SELECTOR, Witness<N, Vec<F>>>,
     /// The vector of constraints for a given selector
@@ -68,4 +70,7 @@ pub trait CircuitTrait<const N: usize, SELECTOR, F, Env> {
 
     /// Pads the rows of the witnesses until reaching the domain size
     fn pad_rows(&mut self);
+
+    /// Resets the witness after folding
+    fn reset(&mut self, step: SELECTOR);
 }

--- a/optimism/src/lib.rs
+++ b/optimism/src/lib.rs
@@ -59,9 +59,9 @@ pub(crate) struct Circuit<const N: usize, SELECTOR, F> {
     pub(crate) lookups: HashMap<SELECTOR, Vec<Lookup<E<F>>>>,
 }
 
-trait CircuitTrait<const N: usize, SELECTOR, F> {
-    /// Create a new Keccak circuit
-    fn new(domain_size: usize) -> Self;
+trait CircuitTrait<const N: usize, SELECTOR, F, Env> {
+    /// Create a new circuit
+    fn new(domain_size: usize, env: &mut Env) -> Self;
 
     /// Add a witness row to the circuit
     fn push_row(&mut self, step: SELECTOR, row: &[F; N]);

--- a/optimism/src/lib.rs
+++ b/optimism/src/lib.rs
@@ -68,7 +68,8 @@ pub trait CircuitTrait<const N: usize, SELECTOR, F, Env> {
     /// Add a witness row to the circuit
     fn push_row(&mut self, step: SELECTOR, row: &[F; N]);
 
-    /// Pads the rows of one selector until reaching the domain size
+    /// Pads the rows of one selector until reaching the domain size if needed.
+    /// Returns true if padding was performed, false otherwise.
     fn pad(&mut self, step: SELECTOR) -> bool;
 
     /// Pads the rows of the witnesses until reaching the domain size

--- a/optimism/src/lib.rs
+++ b/optimism/src/lib.rs
@@ -29,13 +29,10 @@ pub mod proof;
 /// The RAM lookup argument.
 pub mod ramlookup;
 
-use kimchi::{
-    circuits::expr::{ConstantExpr, Expr},
-    curve::KimchiCurve,
-};
-use kimchi_msm::{columns::Column, proof::ProofInputs, witness::Witness, LookupTableID};
+use kimchi::circuits::expr::{ConstantExpr, Expr};
+use kimchi_msm::{columns::Column, witness::Witness};
 use lookups::Lookup;
-use std::{collections::HashMap, hash::Hash};
+use std::collections::HashMap;
 
 pub use ramlookup::{LookupMode as RAMLookupMode, RAMLookup};
 
@@ -53,22 +50,21 @@ pub use ramlookup::{LookupMode as RAMLookupMode, RAMLookup};
 /// we would use 3 different columns.
 pub(crate) type E<F> = Expr<ConstantExpr<F>, Column>;
 
-pub struct Circuit<const N: usize, G: KimchiCurve, ID: LookupTableID, SELECTOR> {
-    /// The proof inputs for folding instances.
-    /// Includes witness evaluations and mvlookups.
-    pub(crate) proof_inputs: HashMap<SELECTOR, ProofInputs<N, G, ID>>,
+pub struct Circuit<const N: usize, SELECTOR, F> {
+    /// The witness for a given selector
+    pub(crate) witness: HashMap<SELECTOR, Witness<N, Vec<F>>>,
     /// The vector of constraints for a given selector
-    pub(crate) constraints: HashMap<SELECTOR, Vec<E<G::ScalarField>>>,
+    pub(crate) constraints: HashMap<SELECTOR, Vec<E<F>>>,
     /// The vector of lookups for a given selector
-    pub(crate) lookups: HashMap<SELECTOR, Vec<Lookup<E<G::ScalarField>>>>,
+    pub(crate) lookups: HashMap<SELECTOR, Vec<Lookup<E<F>>>>,
 }
 
-pub trait CircuitTrait<const N: usize, G: KimchiCurve, ID: LookupTableID, SELECTOR, Env> {
+pub trait CircuitTrait<const N: usize, SELECTOR, F, Env> {
     /// Create a new circuit
     fn new(domain_size: usize, env: &mut Env) -> Self;
 
     /// Add a witness row to the circuit
-    fn push_row(&mut self, step: SELECTOR, row: &[G::ScalarField; N]);
+    fn push_row(&mut self, step: SELECTOR, row: &[F; N]);
 
     /// Pads the rows of the witnesses until reaching the domain size
     fn pad_rows(&mut self);

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -140,7 +140,7 @@ pub fn main() -> ExitCode {
                     proof::fold::<ZKVM_KECCAK_COLS, _, OpeningProof, BaseSponge, ScalarSponge>(
                         domain,
                         &srs,
-                        &mut keccak_folded_instance[&step],
+                        &mut keccak_folded_instance.get_mut(&step).unwrap(),
                         &keccak_circuit.witness[&step],
                     );
                     keccak_circuit.reset(step);
@@ -153,13 +153,15 @@ pub fn main() -> ExitCode {
         // TODO: unify witness of MIPS to include the instruction and the error
         for i in 0..MIPS_COLUMNS {
             if i < SCRATCH_SIZE {
-                mips_circuit.witness[&instr].cols[i].push(mips_wit_env.scratch_state[i]);
+                mips_circuit.witness.get_mut(&instr).unwrap().cols[i]
+                    .push(mips_wit_env.scratch_state[i]);
             } else if i == MIPS_COLUMNS - 2 {
-                mips_circuit.witness[&instr].cols[i]
+                mips_circuit.witness.get_mut(&instr).unwrap().cols[i]
                     .push(Fp::from(mips_wit_env.instruction_counter));
             } else {
                 // TODO: error
-                mips_circuit.witness[&instr].cols[i].push(Fp::rand(&mut rand::rngs::OsRng));
+                mips_circuit.witness.get_mut(&instr).unwrap().cols[i]
+                    .push(Fp::rand(&mut rand::rngs::OsRng));
             }
         }
 
@@ -167,7 +169,7 @@ pub fn main() -> ExitCode {
             proof::fold::<MIPS_COLUMNS, _, OpeningProof, BaseSponge, ScalarSponge>(
                 domain,
                 &srs,
-                &mut mips_folded_instance[&instr],
+                &mut mips_folded_instance.get_mut(&instr).unwrap(),
                 &mips_circuit.witness[&instr],
             );
             mips_circuit.reset(instr);
@@ -181,7 +183,7 @@ pub fn main() -> ExitCode {
             proof::fold::<MIPS_COLUMNS, _, OpeningProof, BaseSponge, ScalarSponge>(
                 domain,
                 &srs,
-                &mut mips_folded_instance[&instr],
+                &mut mips_folded_instance.get_mut(&instr).unwrap(),
                 &mips_circuit.witness[&instr],
             );
         }
@@ -192,7 +194,7 @@ pub fn main() -> ExitCode {
             proof::fold::<ZKVM_KECCAK_COLS, _, OpeningProof, BaseSponge, ScalarSponge>(
                 domain,
                 &srs,
-                &mut keccak_folded_instance[&step],
+                &mut keccak_folded_instance.get_mut(&step).unwrap(),
                 &keccak_circuit.witness[&step],
             );
         }
@@ -214,7 +216,7 @@ pub fn main() -> ExitCode {
                 domain,
                 &srs,
                 &vec![],
-                mips_folded_instance[&instr],
+                mips_folded_instance[&instr].clone(),
                 &mut rng,
             );
             let mips_proof = mips_result.unwrap();
@@ -259,7 +261,7 @@ pub fn main() -> ExitCode {
                 domain,
                 &srs,
                 &vec![],
-                keccak_folded_instance[&step],
+                keccak_folded_instance[&step].clone(),
                 &mut rng,
             );
             let keccak_proof = keccak_result.unwrap();

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -10,7 +10,6 @@ use kimchi_optimism::{
     keccak::{self, column::ZKVM_KECCAK_COLS, environment::KeccakEnv, KeccakCircuit},
     lookups::LookupTableIDs,
     mips::{
-        self,
         column::{MIPSWitnessTrait, MIPS_COLUMNS},
         constraints as mips_constraints,
         interpreter::Instruction,

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -135,7 +135,7 @@ pub fn main() -> ExitCode {
                     proof::fold::<ZKVM_KECCAK_COLS, _, OpeningProof, BaseSponge, ScalarSponge>(
                         domain,
                         &srs,
-                        &mut keccak_folded_instance.get_mut(&step).unwrap(),
+                        keccak_folded_instance.get_mut(&step).unwrap(),
                         &keccak_circuit.witness[&step],
                     );
                     keccak_circuit.reset(step);
@@ -164,7 +164,7 @@ pub fn main() -> ExitCode {
             proof::fold::<MIPS_COLUMNS, _, OpeningProof, BaseSponge, ScalarSponge>(
                 domain,
                 &srs,
-                &mut mips_folded_instance.get_mut(&instr).unwrap(),
+                mips_folded_instance.get_mut(&instr).unwrap(),
                 &mips_circuit.witness[&instr],
             );
             mips_circuit.reset(instr);
@@ -178,7 +178,7 @@ pub fn main() -> ExitCode {
             proof::fold::<MIPS_COLUMNS, _, OpeningProof, BaseSponge, ScalarSponge>(
                 domain,
                 &srs,
-                &mut mips_folded_instance.get_mut(&instr).unwrap(),
+                mips_folded_instance.get_mut(&instr).unwrap(),
                 &mips_circuit.witness[&instr],
             );
         }
@@ -189,7 +189,7 @@ pub fn main() -> ExitCode {
             proof::fold::<ZKVM_KECCAK_COLS, _, OpeningProof, BaseSponge, ScalarSponge>(
                 domain,
                 &srs,
-                &mut keccak_folded_instance.get_mut(&step).unwrap(),
+                keccak_folded_instance.get_mut(&step).unwrap(),
                 &keccak_circuit.witness[&step],
             );
         }

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -200,71 +200,90 @@ pub fn main() -> ExitCode {
 
     {
         // MIPS
-        // TODO: use actual constraints, not just an empty vector
-        // FIXME: this means create separate MIPS witnesses and prove the corresponding constraints for each
-        let mips_result = prove::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            Column,
-            _,
-            MIPS_COLUMNS,
-            LookupTableIDs,
-        >(domain, &srs, &vec![], mips_folded_instance, &mut rng);
-        let mips_proof = mips_result.unwrap();
-        println!("Generated a MIPS proof:\n{:?}", mips_proof);
-        let mips_verifies =
-            verify::<_, OpeningProof, BaseSponge, ScalarSponge, MIPS_COLUMNS, 0, LookupTableIDs>(
+        for instr in mips::INSTRUCTIONS {
+            let mips_result = prove::<
+                _,
+                OpeningProof,
+                BaseSponge,
+                ScalarSponge,
+                Column,
+                _,
+                MIPS_COLUMNS,
+                LookupTableIDs,
+            >(
+                domain,
+                &srs,
+                &vec![],
+                mips_folded_instance[&instr],
+                &mut rng,
+            );
+            let mips_proof = mips_result.unwrap();
+            println!("Generated a MIPS {:?} proof:\n{:?}", instr, mips_proof);
+            let mips_verifies = verify::<
+                _,
+                OpeningProof,
+                BaseSponge,
+                ScalarSponge,
+                MIPS_COLUMNS,
+                0,
+                LookupTableIDs,
+            >(
                 domain,
                 &srs,
                 &vec![],
                 &mips_proof,
                 Witness::zero_vec(DOMAIN_SIZE),
             );
-        if mips_verifies {
-            println!("The MIPS proof verifies")
-        } else {
-            println!("The MIPS proof doesn't verify")
+            if mips_verifies {
+                println!("The MIPS {:?} proof verifies", instr)
+            } else {
+                println!("The MIPS {:?} proof doesn't verify", instr)
+            }
         }
     }
 
     {
         // KECCAK
-        // TODO: use actual constraints, not just an empty vector
-        // FIXME: this means create separate Keccak witnesses and prove the corresponding constraints for each
         // FIXME: when folding is applied, the error term will be created to satisfy the folded witness
-        let keccak_result = prove::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            Column,
-            _,
-            ZKVM_KECCAK_COLS,
-            LookupTableIDs,
-        >(domain, &srs, &vec![], keccak_folded_instance, &mut rng);
-        let keccak_proof = keccak_result.unwrap();
-        println!("Generated a proof:\n{:?}", keccak_proof);
-        let keccak_verifies = verify::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            ZKVM_KECCAK_COLS,
-            0,
-            LookupTableIDs,
-        >(
-            domain,
-            &srs,
-            &vec![],
-            &keccak_proof,
-            Witness::zero_vec(DOMAIN_SIZE),
-        );
-        if keccak_verifies {
-            println!("The Keccak proof verifies")
-        } else {
-            println!("The Keccak proof doesn't verify")
+        for step in keccak::STEPS {
+            let keccak_result = prove::<
+                _,
+                OpeningProof,
+                BaseSponge,
+                ScalarSponge,
+                Column,
+                _,
+                ZKVM_KECCAK_COLS,
+                LookupTableIDs,
+            >(
+                domain,
+                &srs,
+                &vec![],
+                keccak_folded_instance[&step],
+                &mut rng,
+            );
+            let keccak_proof = keccak_result.unwrap();
+            println!("Generated a Keccak {:?} proof:\n{:?}", step, keccak_proof);
+            let keccak_verifies = verify::<
+                _,
+                OpeningProof,
+                BaseSponge,
+                ScalarSponge,
+                ZKVM_KECCAK_COLS,
+                0,
+                LookupTableIDs,
+            >(
+                domain,
+                &srs,
+                &vec![],
+                &keccak_proof,
+                Witness::zero_vec(DOMAIN_SIZE),
+            );
+            if keccak_verifies {
+                println!("The Keccak {:?} proof verifies", step)
+            } else {
+                println!("The Keccak {:?} proof doesn't verify", step)
+            }
         }
     }
 

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -96,7 +96,7 @@ pub fn main() -> ExitCode {
 
     // Initialize folded instances of the sub circuits
     let mut mips_folded_instance = HashMap::new();
-    for instr in Instruction::iter() {
+    for instr in Instruction::iter().flat_map(|x| x.into_iter()) {
         mips_folded_instance.insert(
             instr,
             ProofInputs::<
@@ -175,7 +175,7 @@ pub fn main() -> ExitCode {
     }
 
     // Pad any possible remaining rows if the execution was not a multiple of the domain size
-    for instr in Instruction::iter() {
+    for instr in Instruction::iter().flat_map(|x| x.into_iter()) {
         let needs_folding = mips_circuit.pad(instr);
         if needs_folding {
             proof::fold::<MIPS_COLUMNS, _, OpeningProof, BaseSponge, ScalarSponge>(
@@ -200,7 +200,7 @@ pub fn main() -> ExitCode {
 
     {
         // MIPS
-        for instr in Instruction::iter() {
+        for instr in Instruction::iter().flat_map(|x| x.into_iter()) {
             let mips_result = prove::<
                 _,
                 OpeningProof,

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -32,9 +32,10 @@ pub enum Instruction {
     IType(ITypeInstruction),
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Hash, Default)]
 pub enum RTypeInstruction {
-    ShiftLeftLogical,             // sll
+    #[default]
+    ShiftLeftLogical, // sll
     ShiftRightLogical,            // srl
     ShiftRightArithmetic,         // sra
     ShiftLeftLogicalVariable,     // sllv
@@ -78,15 +79,17 @@ pub enum RTypeInstruction {
     CountLeadingZeros,            // clz
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Hash, Default)]
 pub enum JTypeInstruction {
-    Jump,        // j
+    #[default]
+    Jump, // j
     JumpAndLink, // jal
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Hash, Default)]
 pub enum ITypeInstruction {
-    BranchEq,                     // beq
+    #[default]
+    BranchEq, // beq
     BranchNeq,                    // bne
     BranchLeqZero,                // blez
     BranchGtZero,                 // bgtz
@@ -113,22 +116,6 @@ pub enum ITypeInstruction {
     Store32Conditional,           // sc
     StoreWordLeft,                // swl
     StoreWordRight,               // swr
-}
-
-impl Default for RTypeInstruction {
-    fn default() -> Self {
-        RTypeInstruction::ShiftLeftLogical
-    }
-}
-impl Default for JTypeInstruction {
-    fn default() -> Self {
-        JTypeInstruction::Jump
-    }
-}
-impl Default for ITypeInstruction {
-    fn default() -> Self {
-        ITypeInstruction::BranchEq
-    }
 }
 
 pub trait InterpreterEnv {

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -25,7 +25,7 @@ pub const SYSCALL_READ: u32 = 4003;
 pub const SYSCALL_WRITE: u32 = 4004;
 pub const SYSCALL_FCNTL: u32 = 4055;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Hash)]
 pub enum Instruction {
     RType(RTypeInstruction),
     JType(JTypeInstruction),
@@ -113,6 +113,22 @@ pub enum ITypeInstruction {
     Store32Conditional,           // sc
     StoreWordLeft,                // swl
     StoreWordRight,               // swr
+}
+
+impl Default for RTypeInstruction {
+    fn default() -> Self {
+        RTypeInstruction::ShiftLeftLogical
+    }
+}
+impl Default for JTypeInstruction {
+    fn default() -> Self {
+        JTypeInstruction::Jump
+    }
+}
+impl Default for ITypeInstruction {
+    fn default() -> Self {
+        ITypeInstruction::BranchEq
+    }
 }
 
 pub trait InterpreterEnv {

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -25,14 +25,14 @@ pub const SYSCALL_READ: u32 = 4003;
 pub const SYSCALL_WRITE: u32 = 4004;
 pub const SYSCALL_FCNTL: u32 = 4055;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Instruction {
     RType(RTypeInstruction),
     JType(JTypeInstruction),
     IType(ITypeInstruction),
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Hash)]
 pub enum RTypeInstruction {
     ShiftLeftLogical,             // sll
     ShiftRightLogical,            // srl
@@ -78,13 +78,13 @@ pub enum RTypeInstruction {
     CountLeadingZeros,            // clz
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Hash)]
 pub enum JTypeInstruction {
     Jump,        // j
     JumpAndLink, // jal
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Hash)]
 pub enum ITypeInstruction {
     BranchEq,                     // beq
     BranchNeq,                    // bne

--- a/optimism/src/mips/interpreter.rs
+++ b/optimism/src/mips/interpreter.rs
@@ -7,6 +7,7 @@ use crate::{
     },
 };
 use ark_ff::{One, Zero};
+use strum::{EnumCount, IntoEnumIterator};
 use strum_macros::{EnumCount, EnumIter};
 
 pub const FD_STDIN: u32 = 0;
@@ -32,7 +33,7 @@ pub enum Instruction {
     IType(ITypeInstruction),
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Hash, Default)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Default, Hash)]
 pub enum RTypeInstruction {
     #[default]
     ShiftLeftLogical, // sll
@@ -79,14 +80,14 @@ pub enum RTypeInstruction {
     CountLeadingZeros,            // clz
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Hash, Default)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Default, Hash)]
 pub enum JTypeInstruction {
     #[default]
     Jump, // j
     JumpAndLink, // jal
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Hash, Default)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumCount, EnumIter, Default, Hash)]
 pub enum ITypeInstruction {
     #[default]
     BranchEq, // beq
@@ -116,6 +117,38 @@ pub enum ITypeInstruction {
     Store32Conditional,           // sc
     StoreWordLeft,                // swl
     StoreWordRight,               // swr
+}
+
+impl IntoIterator for Instruction {
+    type Item = Instruction;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    /// Iterate over the instruction variants
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Instruction::RType(_) => {
+                let mut iter_contents = Vec::with_capacity(RTypeInstruction::COUNT);
+                for rtype in RTypeInstruction::iter() {
+                    iter_contents.push(Instruction::RType(rtype));
+                }
+                iter_contents.into_iter()
+            }
+            Instruction::JType(_) => {
+                let mut iter_contents = Vec::with_capacity(JTypeInstruction::COUNT);
+                for jtype in JTypeInstruction::iter() {
+                    iter_contents.push(Instruction::JType(jtype));
+                }
+                iter_contents.into_iter()
+            }
+            Instruction::IType(_) => {
+                let mut iter_contents = Vec::with_capacity(ITypeInstruction::COUNT);
+                for itype in ITypeInstruction::iter() {
+                    iter_contents.push(Instruction::IType(itype));
+                }
+                iter_contents.into_iter()
+            }
+        }
+    }
 }
 
 pub trait InterpreterEnv {

--- a/optimism/src/mips/mod.rs
+++ b/optimism/src/mips/mod.rs
@@ -158,13 +158,22 @@ impl<F: Field> CircuitTrait<MIPS_COLUMNS, Instruction, F, Env<F>> for MIPSCircui
         });
     }
 
-    fn pad_rows(&mut self) {
-        for step in INSTRUCTIONS {
-            let rows_left =
-                self.witness[&step].cols[0].capacity() - self.witness[&step].cols[0].len();
-            for _ in 0..rows_left {
-                self.push_row(step, &[F::zero(); MIPS_COLUMNS]);
+    fn pad(&mut self, instr: Instruction) -> bool {
+        let rows_left = self.domain_size - self.witness[&instr].cols[0].len();
+        if rows_left == 0 {
+            return false;
+        }
+        self.witness.entry(instr).and_modify(|wit| {
+            for col in wit.cols.iter_mut() {
+                col.extend((0..rows_left).map(|_| F::zero()));
             }
+        });
+        true
+    }
+
+    fn pad_witnesses(&mut self) {
+        for instr in INSTRUCTIONS {
+            self.pad(instr);
         }
     }
 

--- a/optimism/src/mips/mod.rs
+++ b/optimism/src/mips/mod.rs
@@ -37,6 +37,8 @@ pub mod constraints;
 pub mod folding;
 pub mod interpreter;
 pub mod registers;
+#[cfg(test)]
+pub mod tests;
 pub mod witness;
 
 #[allow(dead_code)]
@@ -52,7 +54,7 @@ impl<F: Field> CircuitTrait<MIPS_COLUMNS, Instruction, F, Env<F>> for MIPSCircui
             lookups: Default::default(),
         };
 
-        for instr in Instruction::iter() {
+        for instr in Instruction::iter().flat_map(|x| x.into_iter()) {
             circuit.witness.insert(
                 instr,
                 Witness {
@@ -92,7 +94,7 @@ impl<F: Field> CircuitTrait<MIPS_COLUMNS, Instruction, F, Env<F>> for MIPSCircui
     }
 
     fn pad_witnesses(&mut self) {
-        for instr in Instruction::iter() {
+        for instr in Instruction::iter().flat_map(|x| x.into_iter()) {
             self.pad(instr);
         }
     }

--- a/optimism/src/mips/mod.rs
+++ b/optimism/src/mips/mod.rs
@@ -19,23 +19,18 @@ use std::collections::HashMap;
 
 use ark_ff::Field;
 use kimchi_msm::witness::Witness;
-use strum::{EnumCount, IntoEnumIterator};
+use strum::IntoEnumIterator;
 
 use crate::{
     mips::{
         column::MIPS_COLUMNS,
         constraints::Env,
-        interpreter::Instruction::{self, *},
+        interpreter::Instruction::{self},
     },
     Circuit, CircuitTrait,
 };
 
-use self::interpreter::{
-    interpret_instruction,
-    ITypeInstruction::{self, *},
-    JTypeInstruction::{self, *},
-    RTypeInstruction::{self, *},
-};
+use self::interpreter::interpret_instruction;
 
 pub mod column;
 pub mod constraints;

--- a/optimism/src/mips/mod.rs
+++ b/optimism/src/mips/mod.rs
@@ -46,7 +46,7 @@ pub mod witness;
 
 #[allow(dead_code)]
 /// The Keccak circuit
-pub(crate) type MIPSCircuit<F> = Circuit<MIPS_COLUMNS, Instruction, F>;
+pub type MIPSCircuit<F> = Circuit<MIPS_COLUMNS, Instruction, F>;
 
 const INSTRUCTIONS: [Instruction;
     RTypeInstruction::COUNT + JTypeInstruction::COUNT + ITypeInstruction::COUNT] = [
@@ -123,7 +123,6 @@ const INSTRUCTIONS: [Instruction;
     IType(StoreWordRight),
 ];
 
-#[allow(dead_code)]
 impl<F: Field> CircuitTrait<MIPS_COLUMNS, Instruction, F, Env<F>> for MIPSCircuit<F> {
     fn new(domain_size: usize, env: &mut Env<F>) -> Self {
         let mut circuit = Self {

--- a/optimism/src/mips/mod.rs
+++ b/optimism/src/mips/mod.rs
@@ -48,7 +48,7 @@ pub mod witness;
 /// The Keccak circuit
 pub type MIPSCircuit<F> = Circuit<MIPS_COLUMNS, Instruction, F>;
 
-const INSTRUCTIONS: [Instruction;
+pub const INSTRUCTIONS: [Instruction;
     RTypeInstruction::COUNT + JTypeInstruction::COUNT + ITypeInstruction::COUNT] = [
     RType(ShiftLeftLogical),
     RType(ShiftRightLogical),

--- a/optimism/src/mips/mod.rs
+++ b/optimism/src/mips/mod.rs
@@ -126,6 +126,7 @@ pub const INSTRUCTIONS: [Instruction;
 impl<F: Field> CircuitTrait<MIPS_COLUMNS, Instruction, F, Env<F>> for MIPSCircuit<F> {
     fn new(domain_size: usize, env: &mut Env<F>) -> Self {
         let mut circuit = Self {
+            domain_size,
             witness: HashMap::new(),
             constraints: Default::default(),
             lookups: Default::default(),
@@ -165,5 +166,16 @@ impl<F: Field> CircuitTrait<MIPS_COLUMNS, Instruction, F, Env<F>> for MIPSCircui
                 self.push_row(step, &[F::zero(); MIPS_COLUMNS]);
             }
         }
+    }
+
+    fn reset(&mut self, instr: Instruction) {
+        self.witness.insert(
+            instr,
+            Witness {
+                cols: Box::new(std::array::from_fn(|_| {
+                    Vec::with_capacity(self.domain_size)
+                })),
+            },
+        );
     }
 }

--- a/optimism/src/mips/mod.rs
+++ b/optimism/src/mips/mod.rs
@@ -15,9 +15,156 @@
 //! [crate::mips::interpreter], and the evaluations will be kept in the
 //! structure ProofInputs.
 
+use std::collections::HashMap;
+
+use ark_ff::Field;
+use kimchi_msm::witness::Witness;
+use strum::EnumCount;
+
+use crate::{
+    mips::{
+        column::MIPS_COLUMNS,
+        constraints::Env,
+        interpreter::Instruction::{self, *},
+    },
+    Circuit, CircuitTrait,
+};
+
+use self::interpreter::{
+    interpret_instruction,
+    ITypeInstruction::{self, *},
+    JTypeInstruction::{self, *},
+    RTypeInstruction::{self, *},
+};
+
 pub mod column;
 pub mod constraints;
 pub mod folding;
 pub mod interpreter;
 pub mod registers;
 pub mod witness;
+
+#[allow(dead_code)]
+/// The Keccak circuit
+pub(crate) type MIPSCircuit<F> = Circuit<MIPS_COLUMNS, Instruction, F>;
+
+const INSTRUCTIONS: [Instruction;
+    RTypeInstruction::COUNT + JTypeInstruction::COUNT + ITypeInstruction::COUNT] = [
+    RType(ShiftLeftLogical),
+    RType(ShiftRightLogical),
+    RType(ShiftRightArithmetic),
+    RType(ShiftLeftLogicalVariable),
+    RType(ShiftRightLogicalVariable),
+    RType(ShiftRightArithmeticVariable),
+    RType(JumpRegister),
+    RType(JumpAndLinkRegister),
+    RType(SyscallMmap),
+    RType(SyscallExitGroup),
+    RType(SyscallReadHint),
+    RType(SyscallReadPreimage),
+    RType(SyscallReadOther),
+    RType(SyscallWriteHint),
+    RType(SyscallWritePreimage),
+    RType(SyscallWriteOther),
+    RType(SyscallFcntl),
+    RType(SyscallOther),
+    RType(MoveZero),
+    RType(MoveNonZero),
+    RType(Sync),
+    RType(MoveFromHi),
+    RType(MoveToHi),
+    RType(MoveFromLo),
+    RType(MoveToLo),
+    RType(Multiply),
+    RType(MultiplyUnsigned),
+    RType(Div),
+    RType(DivUnsigned),
+    RType(Add),
+    RType(AddUnsigned),
+    RType(Sub),
+    RType(SubUnsigned),
+    RType(And),
+    RType(Or),
+    RType(Xor),
+    RType(Nor),
+    RType(SetLessThan),
+    RType(SetLessThanUnsigned),
+    RType(MultiplyToRegister),
+    RType(CountLeadingOnes),
+    RType(CountLeadingZeros),
+    JType(Jump),
+    JType(JumpAndLink),
+    IType(BranchEq),
+    IType(BranchNeq),
+    IType(BranchLeqZero),
+    IType(BranchGtZero),
+    IType(BranchLtZero),
+    IType(BranchGeqZero),
+    IType(AddImmediate),
+    IType(AddImmediateUnsigned),
+    IType(SetLessThanImmediate),
+    IType(SetLessThanImmediateUnsigned),
+    IType(AndImmediate),
+    IType(OrImmediate),
+    IType(XorImmediate),
+    IType(LoadUpperImmediate),
+    IType(Load8),
+    IType(Load16),
+    IType(Load32),
+    IType(Load8Unsigned),
+    IType(Load16Unsigned),
+    IType(LoadWordLeft),
+    IType(LoadWordRight),
+    IType(Store8),
+    IType(Store16),
+    IType(Store32),
+    IType(Store32Conditional),
+    IType(StoreWordLeft),
+    IType(StoreWordRight),
+];
+
+#[allow(dead_code)]
+impl<F: Field> CircuitTrait<MIPS_COLUMNS, Instruction, F, Env<F>> for MIPSCircuit<F> {
+    fn new(domain_size: usize, env: &mut Env<F>) -> Self {
+        let mut circuit = Self {
+            witness: HashMap::new(),
+            constraints: Default::default(),
+            lookups: Default::default(),
+        };
+
+        for instr in INSTRUCTIONS {
+            circuit.witness.insert(
+                instr,
+                Witness {
+                    cols: Box::new(std::array::from_fn(|_| Vec::with_capacity(domain_size))),
+                },
+            );
+            interpret_instruction(env, instr);
+            circuit.constraints.insert(instr, env.constraints.clone());
+            circuit.lookups.insert(instr, env.lookups.clone());
+            env.constraints = vec![]; // Clear the constraints for the next instruction
+            env.lookups = vec![]; // Clear the lookups for the next instruction
+        }
+        circuit
+    }
+
+    fn push_row(&mut self, instr: Instruction, row: &[F; MIPS_COLUMNS]) {
+        self.witness.entry(instr).and_modify(|wit| {
+            for (i, value) in row.iter().enumerate() {
+                if wit.cols[i].len() < wit.cols[i].capacity() {
+                    wit.cols[i].push(*value);
+                }
+            }
+        });
+    }
+
+    fn pad_rows(&mut self) {
+        for step in INSTRUCTIONS {
+            let rows_left =
+                self.witness[&step].cols[0].capacity() - self.witness[&step].cols[0].len();
+            for _ in 0..rows_left {
+                self.push_row(step, &[F::zero(); MIPS_COLUMNS]);
+            }
+        }
+    }
+}

--- a/optimism/src/mips/mod.rs
+++ b/optimism/src/mips/mod.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 
 use ark_ff::Field;
 use kimchi_msm::witness::Witness;
-use strum::EnumCount;
+use strum::{EnumCount, IntoEnumIterator};
 
 use crate::{
     mips::{
@@ -48,81 +48,6 @@ pub mod witness;
 /// The Keccak circuit
 pub type MIPSCircuit<F> = Circuit<MIPS_COLUMNS, Instruction, F>;
 
-pub const INSTRUCTIONS: [Instruction;
-    RTypeInstruction::COUNT + JTypeInstruction::COUNT + ITypeInstruction::COUNT] = [
-    RType(ShiftLeftLogical),
-    RType(ShiftRightLogical),
-    RType(ShiftRightArithmetic),
-    RType(ShiftLeftLogicalVariable),
-    RType(ShiftRightLogicalVariable),
-    RType(ShiftRightArithmeticVariable),
-    RType(JumpRegister),
-    RType(JumpAndLinkRegister),
-    RType(SyscallMmap),
-    RType(SyscallExitGroup),
-    RType(SyscallReadHint),
-    RType(SyscallReadPreimage),
-    RType(SyscallReadOther),
-    RType(SyscallWriteHint),
-    RType(SyscallWritePreimage),
-    RType(SyscallWriteOther),
-    RType(SyscallFcntl),
-    RType(SyscallOther),
-    RType(MoveZero),
-    RType(MoveNonZero),
-    RType(Sync),
-    RType(MoveFromHi),
-    RType(MoveToHi),
-    RType(MoveFromLo),
-    RType(MoveToLo),
-    RType(Multiply),
-    RType(MultiplyUnsigned),
-    RType(Div),
-    RType(DivUnsigned),
-    RType(Add),
-    RType(AddUnsigned),
-    RType(Sub),
-    RType(SubUnsigned),
-    RType(And),
-    RType(Or),
-    RType(Xor),
-    RType(Nor),
-    RType(SetLessThan),
-    RType(SetLessThanUnsigned),
-    RType(MultiplyToRegister),
-    RType(CountLeadingOnes),
-    RType(CountLeadingZeros),
-    JType(Jump),
-    JType(JumpAndLink),
-    IType(BranchEq),
-    IType(BranchNeq),
-    IType(BranchLeqZero),
-    IType(BranchGtZero),
-    IType(BranchLtZero),
-    IType(BranchGeqZero),
-    IType(AddImmediate),
-    IType(AddImmediateUnsigned),
-    IType(SetLessThanImmediate),
-    IType(SetLessThanImmediateUnsigned),
-    IType(AndImmediate),
-    IType(OrImmediate),
-    IType(XorImmediate),
-    IType(LoadUpperImmediate),
-    IType(Load8),
-    IType(Load16),
-    IType(Load32),
-    IType(Load8Unsigned),
-    IType(Load16Unsigned),
-    IType(LoadWordLeft),
-    IType(LoadWordRight),
-    IType(Store8),
-    IType(Store16),
-    IType(Store32),
-    IType(Store32Conditional),
-    IType(StoreWordLeft),
-    IType(StoreWordRight),
-];
-
 impl<F: Field> CircuitTrait<MIPS_COLUMNS, Instruction, F, Env<F>> for MIPSCircuit<F> {
     fn new(domain_size: usize, env: &mut Env<F>) -> Self {
         let mut circuit = Self {
@@ -132,7 +57,7 @@ impl<F: Field> CircuitTrait<MIPS_COLUMNS, Instruction, F, Env<F>> for MIPSCircui
             lookups: Default::default(),
         };
 
-        for instr in INSTRUCTIONS {
+        for instr in Instruction::iter() {
             circuit.witness.insert(
                 instr,
                 Witness {
@@ -172,7 +97,7 @@ impl<F: Field> CircuitTrait<MIPS_COLUMNS, Instruction, F, Env<F>> for MIPSCircui
     }
 
     fn pad_witnesses(&mut self) {
-        for instr in INSTRUCTIONS {
+        for instr in Instruction::iter() {
             self.pad(instr);
         }
     }

--- a/optimism/src/mips/tests.rs
+++ b/optimism/src/mips/tests.rs
@@ -1,0 +1,108 @@
+use strum::{EnumCount, IntoEnumIterator};
+
+use crate::{
+    mips::interpreter::{ITypeInstruction, JTypeInstruction, RTypeInstruction},
+    CircuitTrait,
+};
+
+use super::{
+    constraints::Env,
+    interpreter::{ITypeInstruction::*, JTypeInstruction::*, RTypeInstruction::*},
+    MIPSCircuit,
+};
+use crate::mips::Instruction::{self, *};
+
+type Fp = ark_bn254::Fr;
+
+// Manually change the number of constraints if they are modififed in the interpreter
+#[test]
+fn test_mips_number_constraints() {
+    let domain_size = 1 << 8;
+
+    // Initialize the environment and run the interpreter
+    let mut constraints_env = Env::<Fp> {
+        scratch_state_idx: 0,
+        constraints: Vec::new(),
+        lookups: Vec::new(),
+    };
+
+    // Keep track of the constraints and lookups of the sub-circuits
+    let mips_circuit = MIPSCircuit::<Fp>::new(domain_size, &mut constraints_env);
+
+    let assert_num_constraints = |instr: &Instruction, num: usize| {
+        assert_eq!(mips_circuit.constraints.get(instr).unwrap().len(), num)
+    };
+
+    let mut i = 0;
+    for instr in Instruction::iter().flat_map(|x| x.into_iter()) {
+        match instr {
+            RType(rtype) => match rtype {
+                JumpRegister | SyscallExitGroup | Sync | MoveToHi | CountLeadingOnes => {
+                    assert_num_constraints(&instr, 0)
+                }
+                ShiftLeftLogical
+                | ShiftRightLogical
+                | ShiftRightArithmetic
+                | ShiftLeftLogicalVariable
+                | ShiftRightLogicalVariable
+                | ShiftRightArithmeticVariable
+                | JumpAndLinkRegister
+                | SyscallReadHint
+                | MoveFromHi
+                | MoveFromLo
+                | MoveToLo
+                | Add
+                | AddUnsigned
+                | Sub
+                | SubUnsigned
+                | And
+                | Or
+                | Xor
+                | Nor
+                | SetLessThan
+                | SetLessThanUnsigned
+                | MultiplyToRegister
+                | CountLeadingZeros => assert_num_constraints(&instr, 3),
+                MoveZero | MoveNonZero => assert_num_constraints(&instr, 5),
+                SyscallReadOther | SyscallWriteHint | SyscallWriteOther | Multiply
+                | MultiplyUnsigned | Div | DivUnsigned => assert_num_constraints(&instr, 6),
+                SyscallOther => assert_num_constraints(&instr, 10),
+                SyscallMmap => assert_num_constraints(&instr, 11),
+                SyscallReadPreimage => assert_num_constraints(&instr, 21),
+                SyscallFcntl => assert_num_constraints(&instr, 22),
+                SyscallWritePreimage => assert_num_constraints(&instr, 30),
+            },
+            JType(jtype) => match jtype {
+                Jump => assert_num_constraints(&instr, 0),
+                JumpAndLink => assert_num_constraints(&instr, 3),
+            },
+            IType(itype) => match itype {
+                BranchLeqZero | BranchGtZero | BranchLtZero | BranchGeqZero | Store8 | Store16
+                | Store32 => assert_num_constraints(&instr, 0),
+                BranchEq | BranchNeq => assert_num_constraints(&instr, 2),
+                AddImmediate
+                | AddImmediateUnsigned
+                | SetLessThanImmediate
+                | SetLessThanImmediateUnsigned
+                | AndImmediate
+                | OrImmediate
+                | XorImmediate
+                | LoadUpperImmediate
+                | Load8
+                | Load16
+                | Load32
+                | Load8Unsigned
+                | Load16Unsigned
+                | Store32Conditional => assert_num_constraints(&instr, 3),
+                LoadWordLeft | LoadWordRight | StoreWordLeft | StoreWordRight => {
+                    assert_num_constraints(&instr, 12)
+                }
+            },
+        }
+        i += 1;
+    }
+    assert_eq!(
+        i,
+        RTypeInstruction::COUNT + JTypeInstruction::COUNT + ITypeInstruction::COUNT
+    );
+}

--- a/optimism/src/mips/witness.rs
+++ b/optimism/src/mips/witness.rs
@@ -1032,7 +1032,14 @@ impl<Fp: Field> Env<Fp> {
         (opcode, instruction)
     }
 
-    pub fn step(&mut self, config: &VmConfiguration, metadata: &Meta, start: &Start) {
+    /// Execute a single step of the MIPS program.
+    /// Returns the instruction that was executed.
+    pub fn step(
+        &mut self,
+        config: &VmConfiguration,
+        metadata: &Meta,
+        start: &Start,
+    ) -> Instruction {
         self.reset_scratch_state();
         let (opcode, _instruction) = self.decode_instruction();
 
@@ -1046,7 +1053,7 @@ impl<Fp: Field> Env<Fp> {
                 "Halted as requested at step={} instruction={:?}",
                 self.instruction_counter, opcode
             );
-            return;
+            return opcode;
         }
 
         interpreter::interpret_instruction(self, opcode);
@@ -1059,6 +1066,7 @@ impl<Fp: Field> Env<Fp> {
                 self.instruction_counter, opcode
             );
         }
+        opcode
     }
 
     fn should_trigger_at(&self, at: &StepFrequency) -> bool {

--- a/optimism/src/proof.rs
+++ b/optimism/src/proof.rs
@@ -8,14 +8,61 @@ use rayon::iter::{
     IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
 };
 
-/// This function folds the witness of the current circuit with the accumulated Keccak instance
-/// with a random combination using a scaling challenge
+/// FIXME: DUMMY FOLD FUNCTION THAT ONLY KEEPS THE LAST INSTANCE
 pub fn fold<
     const N: usize,
     G: KimchiCurve,
     OpeningProof: OpenProof<G>,
     EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
     EFrSponge: FrSponge<G::ScalarField>,
+>(
+    domain: EvaluationDomains<G::ScalarField>,
+    srs: &OpeningProof::SRS,
+    accumulator: &mut ProofInputs<N, G, LookupTableIDs>,
+    inputs: &Witness<N, Vec<G::ScalarField>>,
+) where
+    <OpeningProof as poly_commitment::OpenProof<G>>::SRS: std::marker::Sync,
+{
+    let commitments = {
+        inputs
+            .par_iter()
+            .map(|evals: &Vec<G::ScalarField>| {
+                let evals = Evaluations::<G::ScalarField, D<G::ScalarField>>::from_vec_and_domain(
+                    evals.clone(),
+                    domain.d1,
+                );
+                srs.commit_evaluations_non_hiding(domain.d1, &evals)
+            })
+            .collect::<Witness<N, _>>()
+    };
+    let mut fq_sponge = EFqSponge::new(G::other_curve_sponge_params());
+
+    commitments.into_iter().for_each(|comm| {
+        absorb_commitment(&mut fq_sponge, &comm);
+    });
+
+    // TODO: fold mvlookups as well
+    accumulator
+        .evaluations
+        .par_iter_mut()
+        .zip(inputs.par_iter())
+        .for_each(|(accumulator, inputs)| {
+            accumulator
+                .par_iter_mut()
+                .zip(inputs.par_iter())
+                .for_each(|(accumulator, input)| *accumulator = *input);
+        });
+}
+
+#[allow(dead_code)]
+/// This function folds the witness of the current circuit with the accumulated Keccak instance
+/// with a random combination using a scaling challenge
+// FIXME: This will have to be adapted when the folding library is available
+fn old_fold<
+    const N: usize,
+    G: KimchiCurve,
+    OpeningProof: OpenProof<G>,
+    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
 >(
     domain: EvaluationDomains<G::ScalarField>,
     srs: &OpeningProof::SRS,


### PR DESCRIPTION
This PR updates the `main.rs` file (and thus the zkvm demo) to split the instructions/steps into separate instances for MIPS and Keccak, as a prior step to folding. On top of that, the generic prover is being used with the actual constraints for both MIPS and Keccak. In order for this to work, I am creating a dummier folding algorithm which does not aggregate instances as a linear combination of the witnesses, but instead just keeps the last witness chunk. This for sure, will need to be modified when the folding library is fully in place, so that folded instances contain information about all the previous witnesses. The reason for this tweak now is that if I randomly aggregated witnesses without actually obtaining the corresponding error terms, the constraints would not be satisfied on the randomized witnesses.

TODO: Lookups are still not being proven in this PR. Only witness constraints.

Closes: https://github.com/MinaProtocol/mina/issues/15166 https://github.com/MinaProtocol/mina/issues/15164

NOTE: while testing this I realized that some MIPS constraints are not passing. Will investigate more.