### PR TITLE
Separate functionalities of Keccak interpreter

### DIFF
--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -6,7 +6,7 @@ use crate::{
             Sponges::*,
             Steps::{self, *},
         },
-        helpers::{ArithHelpers, BoolHelpers, LookupHelpers},
+        helpers::{ArithHelpers, BoolHelpers, LogupHelpers},
         interpreter::{Interpreter, KeccakInterpreter},
         Constraint, KeccakColumn, Selector,
     },
@@ -52,7 +52,7 @@ impl<F: Field> ArithHelpers<F> for Env<F> {
 
 impl<F: Field> BoolHelpers<F> for Env<F> {}
 
-impl<F: Field> LookupHelpers<F> for Env<F> {}
+impl<F: Field> LogupHelpers<F> for Env<F> {}
 
 impl<F: Field> Interpreter<F> for Env<F> {
     type Variable = E<F>;

--- a/optimism/src/keccak/constraints.rs
+++ b/optimism/src/keccak/constraints.rs
@@ -6,6 +6,8 @@ use crate::{
             Sponges::*,
             Steps::{self, *},
         },
+        helpers::{ArithHelpers, BoolHelpers, LookupHelpers},
+        interpreter::{Interpreter, KeccakInterpreter},
         Constraint, KeccakColumn, Selector,
     },
     lookups::Lookup,
@@ -20,8 +22,6 @@ use kimchi::{
     o1_utils::Two,
 };
 use kimchi_msm::columns::ColumnIndexer;
-
-use super::interpreter::KeccakInterpreter;
 
 /// This struct contains all that needs to be kept track of during the execution of the Keccak step interpreter
 #[derive(Clone, Debug)]
@@ -44,12 +44,18 @@ impl<F: Field> Default for Env<F> {
     }
 }
 
-impl<F: Field> KeccakInterpreter<F> for Env<F> {
-    type Variable = E<F>;
+impl<F: Field> ArithHelpers<F> for Env<F> {
+    fn two_pow(x: u64) -> Self::Variable {
+        Self::constant_field(F::two_pow(x))
+    }
+}
 
-    ///////////////////////////
-    // ARITHMETIC OPERATIONS //
-    ///////////////////////////
+impl<F: Field> BoolHelpers<F> for Env<F> {}
+
+impl<F: Field> LookupHelpers<F> for Env<F> {}
+
+impl<F: Field> Interpreter<F> for Env<F> {
+    type Variable = E<F>;
 
     fn constant(x: u64) -> Self::Variable {
         Self::constant_field(F::from(x))
@@ -58,14 +64,6 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
     fn constant_field(x: F) -> Self::Variable {
         Self::Variable::constant(Operations::from(Literal(x)))
     }
-
-    fn two_pow(x: u64) -> Self::Variable {
-        Self::constant_field(F::two_pow(x))
-    }
-
-    ////////////////////////////
-    // CONSTRAINTS OPERATIONS //
-    ////////////////////////////
 
     fn variable(&self, column: KeccakColumn) -> Self::Variable {
         // Despite `KeccakWitness` containing both `curr` and `next` fields,
@@ -76,7 +74,21 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
         }))
     }
 
-    fn check(&mut self, _tag: Selector, _x: Self::Variable) {
+    fn constrain(&mut self, _tag: Constraint, if_true: Self::Variable, x: Self::Variable) {
+        if if_true == Self::Variable::one() {
+            self.constraints.push(x);
+        }
+    }
+
+    fn add_lookup(&mut self, if_true: Self::Variable, lookup: Lookup<Self::Variable>) {
+        if if_true == Self::Variable::one() {
+            self.lookups.push(lookup);
+        }
+    }
+}
+
+impl<F: Field> KeccakInterpreter<F> for Env<F> {
+    fn check(&mut self, _tag: Selector, _x: <Env<F> as Interpreter<F>>::Variable) {
         // No-op in constraint side
     }
 
@@ -84,57 +96,37 @@ impl<F: Field> KeccakInterpreter<F> for Env<F> {
         // No-op in constraint side
     }
 
-    fn constrain(&mut self, _tag: Constraint, if_true: Self::Variable, x: Self::Variable) {
-        if if_true == Self::Variable::one() {
-            self.constraints.push(x);
-        }
-    }
-
-    ////////////////////////
-    // LOOKUPS OPERATIONS //
-    ////////////////////////
-
-    fn add_lookup(&mut self, if_true: Self::Variable, lookup: Lookup<Self::Variable>) {
-        if if_true == Self::Variable::one() {
-            self.lookups.push(lookup);
-        }
-    }
-
-    /////////////////////////
-    // SELECTOR OPERATIONS //
-    /////////////////////////
-
-    fn mode_absorb(&self) -> Self::Variable {
+    fn mode_absorb(&self) -> <Env<F> as Interpreter<F>>::Variable {
         match self.step {
             Some(Sponge(Absorb(Middle))) => Self::Variable::one(),
             _ => Self::Variable::zero(),
         }
     }
-    fn mode_squeeze(&self) -> Self::Variable {
+    fn mode_squeeze(&self) -> <Env<F> as Interpreter<F>>::Variable {
         match self.step {
             Some(Sponge(Squeeze)) => Self::Variable::one(),
             _ => Self::Variable::zero(),
         }
     }
-    fn mode_root(&self) -> Self::Variable {
+    fn mode_root(&self) -> <Env<F> as Interpreter<F>>::Variable {
         match self.step {
             Some(Sponge(Absorb(First))) => Self::Variable::one(),
             _ => Self::Variable::zero(),
         }
     }
-    fn mode_pad(&self) -> Self::Variable {
+    fn mode_pad(&self) -> <Env<F> as Interpreter<F>>::Variable {
         match self.step {
             Some(Sponge(Absorb(Last))) => Self::Variable::one(),
             _ => Self::Variable::zero(),
         }
     }
-    fn mode_rootpad(&self) -> Self::Variable {
+    fn mode_rootpad(&self) -> <Env<F> as Interpreter<F>>::Variable {
         match self.step {
             Some(Sponge(Absorb(Only))) => Self::Variable::one(),
             _ => Self::Variable::zero(),
         }
     }
-    fn mode_round(&self) -> Self::Variable {
+    fn mode_round(&self) -> <Env<F> as Interpreter<F>>::Variable {
         // The actual round number in the selector carries no information for witness nor constraints
         // because in the witness, any usize is mapped to the same index inside the mode flags
         match self.step {

--- a/optimism/src/keccak/helpers.rs
+++ b/optimism/src/keccak/helpers.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 
 /// This trait contains helper functions for the lookups used in the Keccak circuit
 /// using the zkVM lookup tables
-pub trait LookupHelpers<F: One + Debug + Zero>
+pub trait LogupHelpers<F: One + Debug + Zero>
 where
     Self: Interpreter<F>,
 {
@@ -44,6 +44,14 @@ where
     /// Adds a lookup to the RoundConstants table
     fn lookup_round_constants(&mut self, flag: Self::Variable, value: Vec<Self::Variable>) {
         self.add_lookup(flag, Lookup::read_one(RoundConstantsLookup, value));
+    }
+
+    fn read_syscall(&mut self, flag: Self::Variable, value: Vec<Self::Variable>) {
+        self.add_lookup(flag, Lookup::read_one(SyscallLookup, value));
+    }
+
+    fn write_syscall(&mut self, flag: Self::Variable, value: Vec<Self::Variable>) {
+        self.add_lookup(flag, Lookup::write_one(SyscallLookup, value));
     }
 }
 

--- a/optimism/src/keccak/helpers.rs
+++ b/optimism/src/keccak/helpers.rs
@@ -1,0 +1,114 @@
+use crate::{
+    keccak::interpreter::Interpreter,
+    lookups::{Lookup, LookupTableIDs::*},
+};
+use ark_ff::{One, Zero};
+use std::fmt::Debug;
+
+/// This trait contains helper functions for the lookups used in the Keccak circuit
+/// using the zkVM lookup tables
+pub trait LookupHelpers<F: One + Debug + Zero>
+where
+    Self: Interpreter<F>,
+{
+    /// Adds a lookup to the RangeCheck16 table
+    fn lookup_rc16(&mut self, flag: Self::Variable, value: Self::Variable) {
+        self.add_lookup(flag, Lookup::read_one(RangeCheck16Lookup, vec![value]));
+    }
+
+    /// Adds a lookup to the Reset table
+    fn lookup_reset(
+        &mut self,
+        flag: Self::Variable,
+        dense: Self::Variable,
+        sparse: Self::Variable,
+    ) {
+        self.add_lookup(flag, Lookup::read_one(ResetLookup, vec![dense, sparse]));
+    }
+
+    /// Adds a lookup to the Shift table
+    fn lookup_sparse(&mut self, flag: Self::Variable, value: Self::Variable) {
+        self.add_lookup(flag, Lookup::read_one(SparseLookup, vec![value]));
+    }
+
+    /// Adds a lookup to the Byte table
+    fn lookup_byte(&mut self, flag: Self::Variable, value: Self::Variable) {
+        self.add_lookup(flag, Lookup::read_one(ByteLookup, vec![value]));
+    }
+
+    /// Adds a lookup to the Pad table
+    fn lookup_pad(&mut self, flag: Self::Variable, value: Vec<Self::Variable>) {
+        self.add_lookup(flag, Lookup::read_one(PadLookup, value));
+    }
+
+    /// Adds a lookup to the RoundConstants table
+    fn lookup_round_constants(&mut self, flag: Self::Variable, value: Vec<Self::Variable>) {
+        self.add_lookup(flag, Lookup::read_one(RoundConstantsLookup, value));
+    }
+}
+
+/// This trait contains helper functions for boolean operations used in the Keccak circuit
+pub trait BoolHelpers<F: One + Debug + Zero>
+where
+    Self: Interpreter<F>,
+{
+    /// Degree-2 variable encoding whether the input is a boolean value (0 = yes)
+    fn is_boolean(x: Self::Variable) -> Self::Variable {
+        x.clone() * (x - Self::Variable::one())
+    }
+
+    /// Degree-1 variable encoding the negation of the input
+    /// Note: it only works as expected if the input is a boolean value
+    fn not(x: Self::Variable) -> Self::Variable {
+        Self::Variable::one() - x
+    }
+
+    /// Degree-1 variable encoding whether the input is the value one (0 = yes)
+    fn is_one(x: Self::Variable) -> Self::Variable {
+        Self::not(x)
+    }
+
+    /// Degree-2 variable encoding whether the first input is nonzero (0 = yes).
+    /// It requires the second input to be the multiplicative inverse of the first.
+    /// Note: if the first input is zero, there is no multiplicative inverse.
+    fn is_nonzero(x: Self::Variable, x_inv: Self::Variable) -> Self::Variable {
+        Self::is_one(x * x_inv)
+    }
+
+    /// Degree-2 variable encoding the XOR of two variables which should be boolean (1 = true)
+    fn xor(x: Self::Variable, y: Self::Variable) -> Self::Variable {
+        x.clone() + y.clone() - Self::constant(2) * x * y
+    }
+
+    /// Degree-2 variable encoding the OR of two variables, which should be boolean (1 = true)
+    fn or(x: Self::Variable, y: Self::Variable) -> Self::Variable {
+        x.clone() + y.clone() - x * y
+    }
+
+    /// Degree-2 variable encoding whether at least one of the two inputs is zero (0 = yes)
+    fn either_zero(x: Self::Variable, y: Self::Variable) -> Self::Variable {
+        x * y
+    }
+}
+
+/// This trait contains helper functions for arithmetic operations used in the Keccak circuit
+pub trait ArithHelpers<F: One + Debug + Zero>
+where
+    Self: Interpreter<F>,
+{
+    /// Returns a variable representing the value zero
+    fn zero() -> Self::Variable {
+        Self::constant(0)
+    }
+    /// Returns a variable representing the value one
+    fn one() -> Self::Variable {
+        Self::constant(1)
+    }
+    /// Returns a variable representing the value two
+    fn two() -> Self::Variable {
+        Self::constant(2)
+    }
+
+    /// Returns a variable representing the value 2^x
+    fn two_pow(x: u64) -> Self::Variable;
+}

--- a/optimism/src/keccak/interpreter.rs
+++ b/optimism/src/keccak/interpreter.rs
@@ -1,5 +1,10 @@
 //! This module defines the Keccak interpreter in charge of triggering the Keccak workflow
 
+use super::{
+    column::PAD_SUFFIX_LEN,
+    helpers::{ArithHelpers, BoolHelpers, LookupHelpers},
+    WORDS_IN_HASH,
+};
 use crate::{
     keccak::{
         column::{PAD_BYTES_LEN, ROUND_CONST_LEN},
@@ -27,10 +32,8 @@ use kimchi::{
 };
 use std::{array, fmt::Debug};
 
-use super::{column::PAD_SUFFIX_LEN, WORDS_IN_HASH};
-
 /// This trait includes functionalities needed to obtain the variables of the Keccak circuit needed for constraints and witness
-pub trait KeccakInterpreter<F: One + Debug + Zero> {
+pub trait Interpreter<F: One + Debug + Zero> {
     type Variable: std::ops::Mul<Self::Variable, Output = Self::Variable>
         + std::ops::Add<Self::Variable, Output = Self::Variable>
         + std::ops::Sub<Self::Variable, Output = Self::Variable>
@@ -39,89 +42,35 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
         + One
         + Zero;
 
-    ////////////////////////
-    // BOOLEAN OPERATIONS //
-    ////////////////////////
-
-    /// Degree-2 variable encoding whether the input is a boolean value (0 = yes)
-    fn is_boolean(x: Self::Variable) -> Self::Variable {
-        x.clone() * (x - Self::Variable::one())
-    }
-
-    /// Degree-1 variable encoding the negation of the input
-    /// Note: it only works as expected if the input is a boolean value
-    fn not(x: Self::Variable) -> Self::Variable {
-        Self::Variable::one() - x
-    }
-
-    /// Degree-1 variable encoding whether the input is the value one (0 = yes)
-    fn is_one(x: Self::Variable) -> Self::Variable {
-        Self::not(x)
-    }
-
-    /// Degree-2 variable encoding whether the first input is nonzero (0 = yes).
-    /// It requires the second input to be the multiplicative inverse of the first.
-    /// Note: if the first input is zero, there is no multiplicative inverse.
-    fn is_nonzero(x: Self::Variable, x_inv: Self::Variable) -> Self::Variable {
-        Self::is_one(x * x_inv)
-    }
-
-    /// Degree-2 variable encoding the XOR of two variables which should be boolean (1 = true)
-    fn xor(x: Self::Variable, y: Self::Variable) -> Self::Variable {
-        x.clone() + y.clone() - Self::constant(2) * x * y
-    }
-
-    /// Degree-2 variable encoding the OR of two variables, which should be boolean (1 = true)
-    fn or(x: Self::Variable, y: Self::Variable) -> Self::Variable {
-        x.clone() + y.clone() - x * y
-    }
-
-    /// Degree-2 variable encoding whether at least one of the two inputs is zero (0 = yes)
-    fn either_zero(x: Self::Variable, y: Self::Variable) -> Self::Variable {
-        x * y
-    }
-
-    //////////////////////////
-    // ARITHMETIC OPERATIONS //
-    ///////////////////////////
-
     /// Creates a variable from a constant integer
     fn constant(x: u64) -> Self::Variable;
 
     /// Creates a variable from a constant field element
     fn constant_field(x: F) -> Self::Variable;
 
-    /// Returns a variable representing the value zero
-    fn zero() -> Self::Variable {
-        Self::constant(0)
-    }
-    /// Returns a variable representing the value one
-    fn one() -> Self::Variable {
-        Self::constant(1)
-    }
-    /// Returns a variable representing the value two
-    fn two() -> Self::Variable {
-        Self::constant(2)
-    }
+    /// Returns the variable corresponding to a given column alias.
+    fn variable(&self, column: KeccakColumn) -> Self::Variable;
 
-    /// Returns a variable representing the value 2^x
-    fn two_pow(x: u64) -> Self::Variable;
+    /// Adds one KeccakConstraint to the environment if the selector holds
+    fn constrain(&mut self, tag: Constraint, if_true: Self::Variable, x: Self::Variable);
 
+    /// Adds a given Lookup to the environment if the condition holds
+    fn add_lookup(&mut self, if_true: Self::Variable, lookup: Lookup<Self::Variable>);
+}
+
+pub trait KeccakInterpreter<F: One + Debug + Zero>
+where
+    Self: Interpreter<F> + LookupHelpers<F> + BoolHelpers<F> + ArithHelpers<F>,
+{
     ////////////////////////////
     // CONSTRAINTS OPERATIONS //
     ////////////////////////////
-
-    /// Returns the variable corresponding to a given column alias.
-    fn variable(&self, column: KeccakColumn) -> Self::Variable;
 
     /// Check one condition on the selectors
     fn check(&mut self, tag: Selector, x: Self::Variable);
 
     /// Checks that the selectors are set correctly
     fn checks(&mut self);
-
-    /// Adds one KeccakConstraint to the environment if the selector holds
-    fn constrain(&mut self, tag: Constraint, if_true: Self::Variable, x: Self::Variable);
 
     /// Creates all 879 constraints/checks to the environment:
     /// - 733 constraints of degree 1
@@ -166,7 +115,10 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     /// - 136 constraints of degree 2
     /// Of which:
     /// - 136 constraints are added only if is_pad() holds
-    fn constrain_flags(&mut self) {
+    fn constrain_flags(&mut self)
+    where
+        Self: Interpreter<F>,
+    {
         // Booleanity of sponge flags:
         // - 136 constraints of degree 2
         self.constrain_booleanity();
@@ -176,7 +128,10 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     /// - 136 constraints of degree 2
     /// Of which,
     /// - 136 constraints are added only if is_pad() holds
-    fn constrain_booleanity(&mut self) {
+    fn constrain_booleanity(&mut self)
+    where
+        Self: Interpreter<F>,
+    {
         for i in 0..RATE_IN_BYTES {
             // Bytes are either involved on padding or not
             self.constrain(
@@ -462,9 +417,6 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
     // LOOKUPS OPERATIONS //
     ////////////////////////
 
-    /// Adds a given Lookup to the environment if the condition holds
-    fn add_lookup(&mut self, if_true: Self::Variable, lookup: Lookup<Self::Variable>);
-
     /// Creates all possible 2361 lookups to the Keccak constraints environment:
     /// - 2222 lookups for the step row
     /// - 2 lookups for the inter-step channel
@@ -562,41 +514,6 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
             Self::not(self.is_squeeze()),
             Lookup::write_one(KeccakStepLookup, self.output_of_step()),
         );
-    }
-
-    /// Adds a lookup to the RangeCheck16 table
-    fn lookup_rc16(&mut self, flag: Self::Variable, value: Self::Variable) {
-        self.add_lookup(flag, Lookup::read_one(RangeCheck16Lookup, vec![value]));
-    }
-
-    /// Adds a lookup to the Reset table
-    fn lookup_reset(
-        &mut self,
-        flag: Self::Variable,
-        dense: Self::Variable,
-        sparse: Self::Variable,
-    ) {
-        self.add_lookup(flag, Lookup::read_one(ResetLookup, vec![dense, sparse]));
-    }
-
-    /// Adds a lookup to the Shift table
-    fn lookup_sparse(&mut self, flag: Self::Variable, value: Self::Variable) {
-        self.add_lookup(flag, Lookup::read_one(SparseLookup, vec![value]));
-    }
-
-    /// Adds a lookup to the Byte table
-    fn lookup_byte(&mut self, flag: Self::Variable, value: Self::Variable) {
-        self.add_lookup(flag, Lookup::read_one(ByteLookup, vec![value]));
-    }
-
-    /// Adds a lookup to the Pad table
-    fn lookup_pad(&mut self, flag: Self::Variable, value: Vec<Self::Variable>) {
-        self.add_lookup(flag, Lookup::read_one(PadLookup, value));
-    }
-
-    /// Adds a lookup to the RoundConstants table
-    fn lookup_round_constants(&mut self, flag: Self::Variable, value: Vec<Self::Variable>) {
-        self.add_lookup(flag, Lookup::read_one(RoundConstantsLookup, value));
     }
 
     /// Adds the 601 lookups required for the sponge
@@ -1022,7 +939,7 @@ pub trait KeccakInterpreter<F: One + Debug + Zero> {
 
     /// Returns the 100 variables corresponding to PiRhoDenseE
     fn vec_dense_e(&self) -> [Self::Variable; PIRHO_DENSE_E_LEN] {
-        array::from_fn(|idx| self.variable(KeccakColumn::PiRhoDenseE(idx)))
+        array::from_fn(|idx: usize| self.variable(KeccakColumn::PiRhoDenseE(idx)))
     }
     /// Returns the (y,x,q)-th variable of PiRhoDenseE
     fn dense_e(&self, y: usize, x: usize, q: usize) -> Self::Variable {

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -24,6 +24,7 @@ pub mod constraints;
 pub mod environment;
 #[cfg(feature = "bn254")]
 pub mod folding;
+pub mod helpers;
 pub mod interpreter;
 #[cfg(test)]
 pub mod tests;

--- a/optimism/src/keccak/witness.rs
+++ b/optimism/src/keccak/witness.rs
@@ -9,7 +9,7 @@
 use crate::{
     keccak::{
         column::{Absorbs::*, KeccakWitness, Sponges::*, Steps::*},
-        helpers::{ArithHelpers, BoolHelpers, LookupHelpers},
+        helpers::{ArithHelpers, BoolHelpers, LogupHelpers},
         interpreter::{Interpreter, KeccakInterpreter},
         Constraint, Error, KeccakColumn,
         Selector::{self, *},
@@ -70,7 +70,7 @@ impl<F: Field> ArithHelpers<F> for Env<F> {
 
 impl<F: Field> BoolHelpers<F> for Env<F> {}
 
-impl<F: Field> LookupHelpers<F> for Env<F> {}
+impl<F: Field> LogupHelpers<F> for Env<F> {}
 
 impl<F: Field> Interpreter<F> for Env<F> {
     type Variable = F;


### PR DESCRIPTION
After our chat about a general-purpose interpreter, I worked on this PR aiming to split the functionalities in the Keccak interpreter across different traits with separate scopes. In particular, I have split the old `KeccakInterpreter` into 5 traits: `Interpreter` (the most general type of interpreter I could think of for now), `KeccakInterpreter` (which contains Keccak-related functionalities for both witness and constraints environments), `ArithHelpers` (containing arithmetic operations), `BoolHelpers` (containing boolean operations), and `LookupHelpers` (containing lookup helpers for the tables used in the zkvm project).

Note that there is no need to parameterize these traits with any generic `Env` in particular. But instead, the use of the clause `where Self: Interpreter<F> + ArithHelpers<F> + BoolHelpers<F> + LookupHelpers<F>` makes the diff super small (no need to change the `self.fun()` invocations nor change the type of `Self::Variable`) in comparison. And of course, it is still possible to instantiate it for a witness or constraint environment, just setting the `Self` to be either of them.