### PR TITLE
[easy] Iterate over Keccak steps enum instead of static array of steps

### DIFF
--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -16,6 +16,7 @@ use kimchi::circuits::polynomials::keccak::constants::{
     DIM, KECCAK_COLS, QUARTERS, RATE_IN_BYTES, STATE_LEN,
 };
 use kimchi_msm::witness::Witness;
+use strum::IntoEnumIterator;
 
 use self::{column::ZKVM_KECCAK_COLS, environment::KeccakEnv};
 
@@ -85,15 +86,6 @@ pub enum Constraint {
 /// The Keccak circuit
 pub type KeccakCircuit<F> = Circuit<ZKVM_KECCAK_COLS, Steps, F>;
 
-pub const STEPS: [Steps; 6] = [
-    Round(0),
-    Sponge(Absorb(First)),
-    Sponge(Absorb(Middle)),
-    Sponge(Absorb(Last)),
-    Sponge(Absorb(Only)),
-    Sponge(Squeeze),
-];
-
 #[allow(dead_code)]
 impl<F: Field> CircuitTrait<ZKVM_KECCAK_COLS, Steps, F, KeccakEnv<F>> for KeccakCircuit<F> {
     fn new(domain_size: usize, _env: &mut KeccakEnv<F>) -> Self {
@@ -104,7 +96,7 @@ impl<F: Field> CircuitTrait<ZKVM_KECCAK_COLS, Steps, F, KeccakEnv<F>> for Keccak
             lookups: Default::default(),
         };
 
-        for step in STEPS {
+        for step in Steps::iter().flat_map(|x| x.into_iter()) {
             circuit.witness.insert(
                 step,
                 Witness {
@@ -148,7 +140,7 @@ impl<F: Field> CircuitTrait<ZKVM_KECCAK_COLS, Steps, F, KeccakEnv<F>> for Keccak
     }
 
     fn pad_witnesses(&mut self) {
-        for step in STEPS {
+        for step in Steps::iter().flat_map(|x| x.into_iter()) {
             self.pad(step);
         }
     }

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -18,8 +18,9 @@ use kimchi_msm::test::test_completeness_generic;
 use rand::Rng;
 use sha3::{Digest, Keccak256};
 use std::collections::HashMap;
+use strum::IntoEnumIterator;
 
-use super::KeccakCircuit;
+use super::{column::Steps, KeccakCircuit};
 
 pub type Fp = ark_bn254::Fr;
 
@@ -509,14 +510,7 @@ fn test_keccak_prover() {
         }
         keccak_circuit.pad_witnesses();
 
-        for step in [
-            Round(0),
-            Sponge(Absorb(First)),
-            Sponge(Absorb(Middle)),
-            Sponge(Absorb(Last)),
-            Sponge(Absorb(Only)),
-            Sponge(Squeeze),
-        ] {
+        for step in Steps::iter().flat_map(|x| x.into_iter()) {
             test_completeness_generic::<ZKVM_KECCAK_COLS, _>(
                 keccak_circuit.constraints[&step].clone(),
                 keccak_circuit.witness[&step].clone(),

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -7,7 +7,11 @@ use kimchi_msm::{
 use kimchi_optimism::{
     cannon::{self, Meta, Start, State},
     cannon_cli,
-    keccak::{self, column::ZKVM_KECCAK_COLS, environment::KeccakEnv, KeccakCircuit},
+    keccak::{
+        column::{Steps, ZKVM_KECCAK_COLS},
+        environment::KeccakEnv,
+        KeccakCircuit,
+    },
     lookups::LookupTableIDs,
     mips::{
         column::{MIPSWitnessTrait, MIPS_COLUMNS},
@@ -108,7 +112,7 @@ pub fn main() -> ExitCode {
         );
     }
     let mut keccak_folded_instance = HashMap::new();
-    for step in keccak::STEPS {
+    for step in Steps::iter().flat_map(|x| x.into_iter()) {
         keccak_folded_instance.insert(
             step,
             ProofInputs::<
@@ -185,7 +189,7 @@ pub fn main() -> ExitCode {
             );
         }
     }
-    for step in keccak::STEPS {
+    for step in Steps::iter().flat_map(|x| x.into_iter()) {
         let needs_folding = keccak_circuit.pad(step);
         if needs_folding {
             proof::fold::<ZKVM_KECCAK_COLS, _, OpeningProof, BaseSponge, ScalarSponge>(
@@ -245,7 +249,7 @@ pub fn main() -> ExitCode {
     {
         // KECCAK
         // FIXME: when folding is applied, the error term will be created to satisfy the folded witness
-        for step in keccak::STEPS {
+        for step in Steps::iter().flat_map(|x| x.into_iter()) {
             debug!("Checking Keccak circuit {:?}", step);
             let keccak_result = prove::<
                 _,


### PR DESCRIPTION
This is to prevent having to manually create 
```
pub const STEPS = [ Round(0), Sponge(Absorb(First)), Sponge(Absorb(Middle)), Sponge(Absorb(Last)), Sponge(Absorb(Only)), Sponge(Squeeze)];
```
to iterate over all Keccak steps available.