### PR TITLE
[easy] Ignore instructions with no constraints in main

### DIFF
--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -208,7 +208,7 @@ pub fn main() -> ExitCode {
         for instr in Instruction::iter().flat_map(|x| x.into_iter()) {
             // Prove only if the instruction was executed
             // and if the number of constraints is nonzero (otherwise quotient polynomial cannot be created)
-            if mips_trace.in_circuit(instr) && mips_trace.constraints[&instr].len() > 0 {
+            if mips_trace.in_circuit(instr) && !mips_trace.constraints[&instr].is_empty() {
                 debug!("Checking MIPS circuit {:?}", instr);
                 let mips_result = prove::<
                     _,

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -207,7 +207,8 @@ pub fn main() -> ExitCode {
         // MIPS
         for instr in Instruction::iter().flat_map(|x| x.into_iter()) {
             // Prove only if the instruction was executed
-            if mips_trace.in_circuit(instr) {
+            // and if the number of constraints is nonzero (otherwise quotient polynomial cannot be created)
+            if mips_trace.in_circuit(instr) && mips_trace.constraints[&instr].len() > 0 {
                 debug!("Checking MIPS circuit {:?}", instr);
                 let mips_result = prove::<
                     _,
@@ -226,7 +227,7 @@ pub fn main() -> ExitCode {
                     &mut rng,
                 );
                 let mips_proof = mips_result.unwrap();
-                debug!("Generated a MIPS {:?} proof:\n{:?}", instr, mips_proof);
+                debug!("Generated a MIPS {:?} proof:", instr);
                 let mips_verifies = verify::<
                     _,
                     OpeningProof,
@@ -243,9 +244,9 @@ pub fn main() -> ExitCode {
                     Witness::zero_vec(DOMAIN_SIZE),
                 );
                 if mips_verifies {
-                    debug!("The MIPS {:?} proof verifies", instr)
+                    debug!("The MIPS {:?} proof verifies\n", instr)
                 } else {
-                    debug!("The MIPS {:?} proof doesn't verify", instr)
+                    debug!("The MIPS {:?} proof doesn't verify\n", instr)
                 }
             }
         }
@@ -275,7 +276,7 @@ pub fn main() -> ExitCode {
                     &mut rng,
                 );
                 let keccak_proof = keccak_result.unwrap();
-                debug!("Generated a Keccak {:?} proof:\n{:?}", step, keccak_proof);
+                debug!("Generated a Keccak {:?} proof:", step);
                 let keccak_verifies = verify::<
                     _,
                     OpeningProof,
@@ -292,9 +293,9 @@ pub fn main() -> ExitCode {
                     Witness::zero_vec(DOMAIN_SIZE),
                 );
                 if keccak_verifies {
-                    debug!("The Keccak {:?} proof verifies", step)
+                    debug!("The Keccak {:?} proof verifies\n", step)
                 } else {
-                    debug!("The Keccak {:?} proof doesn't verify", step)
+                    debug!("The Keccak {:?} proof doesn't verify\n", step)
                 }
             }
         }

--- a/optimism/src/mips/constraints.rs
+++ b/optimism/src/mips/constraints.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use ark_ff::Field;
 use kimchi::circuits::{
-    expr::{ConstantExpr, Expr, ExprInner, Variable},
+    expr::{ConstantExpr, ConstantTerm::Literal, Expr, ExprInner, Operations, Variable},
     gate::CurrOrNext,
 };
 use kimchi_msm::columns::{Column, ColumnIndexer as _};
@@ -139,7 +139,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
     }
 
     fn constant(x: u32) -> Self::Variable {
-        Expr::from(x as u64)
+        Self::Variable::constant(Operations::from(Literal(Fp::from(x))))
     }
 
     unsafe fn bitmask(


### PR DESCRIPTION
As pointed out in https://github.com/o1-labs/proof-systems/issues/2075#issuecomment-2072062084, some instructions were getting the prover process killed with memory overflow. Met with Danny, and confirmed that they are the ones with no constraints so creation of the quotient polynomial cannot be performed. Until the generic prover supports this corner case, this PR just ignores the instructions with zero constraints in the proving scope of the demo. 

NOTE: Even if they don't have any constraints, they will have lookups. So when lookups are added to the demo to compute the quotient polynomial, we should be able to generate proofs for them as well.

Partially addresses https://github.com/o1-labs/proof-systems/issues/2075

TODO: there are still a few instructions with failing constraints (they involve constants, but not all constraints with constants fail). 
- SyscallReadPreimage,
- SyscallWritePreimage,
- SyscallFcntl,
- BranchEq, 
- BranchNeq,
- LoadWordLeft,
- LoadWordRight,
- StoreWordLeft,
- StoreWordRight,