### PR TITLE
MSM FEC: Use labelled columns (easy)

### DIFF
--- a/msm/src/circuit_design/capabilities.rs
+++ b/msm/src/circuit_design/capabilities.rs
@@ -51,16 +51,16 @@ where
 ////////////////////////////////////////////////////////////////////////////
 
 /// Write an array of values simultaneously.
-pub fn read_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer, Func>(
+pub fn read_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer, ColMap>(
     env: &mut Env,
-    column_foo: Func,
+    column_map: ColMap,
 ) -> [Env::Variable; ARR_N]
 where
     F: PrimeField,
     Env: ColAccessCap<F, CIx>,
-    Func: Fn(usize) -> CIx,
+    ColMap: Fn(usize) -> CIx,
 {
-    core::array::from_fn(|i| env.read_column(column_foo(i)))
+    core::array::from_fn(|i| env.read_column(column_map(i)))
 }
 
 /// Write a field element directly as a constant.
@@ -73,31 +73,31 @@ where
 }
 
 /// Write an array of values simultaneously.
-pub fn write_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer, Func>(
+pub fn write_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer, ColMap>(
     env: &mut Env,
     input: [Env::Variable; ARR_N],
-    column_foo: Func,
+    column_map: ColMap,
 ) where
     F: PrimeField,
     Env: ColWriteCap<F, CIx>,
-    Func: Fn(usize) -> CIx,
+    ColMap: Fn(usize) -> CIx,
 {
     input.iter().enumerate().for_each(|(i, var)| {
-        env.write_column(column_foo(i), var);
+        env.write_column(column_map(i), var);
     })
 }
 
 /// Write an array of /field/ values simultaneously.
-pub fn write_column_array_const<F, Env, const ARR_N: usize, CIx: ColumnIndexer, Func>(
+pub fn write_column_array_const<F, Env, const ARR_N: usize, CIx: ColumnIndexer, ColMap>(
     env: &mut Env,
     input: [F; ARR_N],
-    column_foo: Func,
+    column_map: ColMap,
 ) where
     F: PrimeField,
     Env: ColWriteCap<F, CIx>,
-    Func: Fn(usize) -> CIx,
+    ColMap: Fn(usize) -> CIx,
 {
     input.iter().enumerate().for_each(|(i, var)| {
-        env.write_column(column_foo(i), &Env::constant(*var));
+        env.write_column(column_map(i), &Env::constant(*var));
     })
 }

--- a/msm/src/circuit_design/capabilities.rs
+++ b/msm/src/circuit_design/capabilities.rs
@@ -45,3 +45,59 @@ where
 {
     fn lookup(&mut self, lookup_id: LT, value: &Self::Variable);
 }
+
+////////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////////
+
+/// Write an array of values simultaneously.
+pub fn read_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer, Func>(
+    env: &mut Env,
+    column_foo: Func,
+) -> [Env::Variable; ARR_N]
+where
+    F: PrimeField,
+    Env: ColAccessCap<F, CIx>,
+    Func: Fn(usize) -> CIx,
+{
+    core::array::from_fn(|i| env.read_column(column_foo(i)))
+}
+
+/// Write a field element directly as a constant.
+pub fn write_column_const<F, Env, CIx: ColumnIndexer>(env: &mut Env, col: CIx, var: &F)
+where
+    F: PrimeField,
+    Env: ColWriteCap<F, CIx>,
+{
+    env.write_column(col, &Env::constant(*var));
+}
+
+/// Write an array of values simultaneously.
+pub fn write_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer, Func>(
+    env: &mut Env,
+    input: [Env::Variable; ARR_N],
+    column_foo: Func,
+) where
+    F: PrimeField,
+    Env: ColWriteCap<F, CIx>,
+    Func: Fn(usize) -> CIx,
+{
+    input.iter().enumerate().for_each(|(i, var)| {
+        env.write_column(column_foo(i), var);
+    })
+}
+
+/// Write an array of /field/ values simultaneously.
+pub fn write_column_array_const<F, Env, const ARR_N: usize, CIx: ColumnIndexer, Func>(
+    env: &mut Env,
+    input: [F; ARR_N],
+    column_foo: Func,
+) where
+    F: PrimeField,
+    Env: ColWriteCap<F, CIx>,
+    Func: Fn(usize) -> CIx,
+{
+    input.iter().enumerate().for_each(|(i, var)| {
+        env.write_column(column_foo(i), &Env::constant(*var));
+    })
+}

--- a/msm/src/fec/columns.rs
+++ b/msm/src/fec/columns.rs
@@ -1,19 +1,95 @@
 use crate::{
     columns::{Column, ColumnIndexer},
-    N_LIMBS,
+    serialization::interpreter::{N_LIMBS_LARGE, N_LIMBS_SMALL},
 };
 
 /// Number of columns in the FEC circuits.
-pub const FEC_N_COLUMNS: usize = 12 * N_LIMBS + 29;
+pub const FEC_N_COLUMNS: usize = 5 * N_LIMBS_LARGE + 12 * N_LIMBS_SMALL + 9;
 
 /// Columns used by the serialization subcircuit.
-pub struct FECColumn(pub usize);
+pub enum FECColumn {
+    XP(usize),
+    YP(usize),
+    XQ(usize),
+    YQ(usize),
+    F(usize),
+    XR(usize),
+    YR(usize),
+    S(usize),
+    Q1(usize),
+    Q2(usize),
+    Q3(usize),
+    Q1Sign,
+    Q2Sign,
+    Q3Sign,
+    Carry1(usize),
+    Carry2(usize),
+    Carry3(usize),
+}
 
 impl ColumnIndexer for FECColumn {
     const COL_N: usize = FEC_N_COLUMNS;
     fn to_column(self) -> Column {
         match self {
-            FECColumn(j) => Column::X(j),
+            FECColumn::XP(i) => {
+                assert!(i < N_LIMBS_LARGE);
+                Column::X(i)
+            }
+            FECColumn::YP(i) => {
+                assert!(i < N_LIMBS_LARGE);
+                Column::X(N_LIMBS_LARGE + i)
+            }
+            FECColumn::XQ(i) => {
+                assert!(i < N_LIMBS_LARGE);
+                Column::X(2 * N_LIMBS_LARGE + i)
+            }
+            FECColumn::YQ(i) => {
+                assert!(i < N_LIMBS_LARGE);
+                Column::X(3 * N_LIMBS_LARGE + i)
+            }
+            FECColumn::F(i) => {
+                assert!(i < N_LIMBS_LARGE);
+                Column::X(4 * N_LIMBS_LARGE + i)
+            }
+            FECColumn::XR(i) => {
+                assert!(i < N_LIMBS_SMALL);
+                Column::X(5 * N_LIMBS_LARGE + i)
+            }
+            FECColumn::YR(i) => {
+                assert!(i < N_LIMBS_SMALL);
+                Column::X(5 * N_LIMBS_LARGE + N_LIMBS_SMALL + i)
+            }
+            FECColumn::S(i) => {
+                assert!(i < N_LIMBS_SMALL);
+                Column::X(5 * N_LIMBS_LARGE + 2 * N_LIMBS_SMALL + i)
+            }
+            FECColumn::Q1(i) => {
+                assert!(i < N_LIMBS_SMALL);
+                Column::X(5 * N_LIMBS_LARGE + 3 * N_LIMBS_SMALL + i)
+            }
+            FECColumn::Q2(i) => {
+                assert!(i < N_LIMBS_SMALL);
+                Column::X(5 * N_LIMBS_LARGE + 4 * N_LIMBS_SMALL + i)
+            }
+            FECColumn::Q3(i) => {
+                assert!(i < N_LIMBS_SMALL);
+                Column::X(5 * N_LIMBS_LARGE + 5 * N_LIMBS_SMALL + i)
+            }
+            FECColumn::Q1Sign => Column::X(5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL),
+            FECColumn::Q2Sign => Column::X(5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL + 1),
+            FECColumn::Q3Sign => Column::X(5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL + 2),
+            FECColumn::Carry1(i) => {
+                assert!(i < 2 * N_LIMBS_SMALL + 2);
+                Column::X(5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL + 3 + i)
+            }
+            FECColumn::Carry2(i) => {
+                assert!(i < 2 * N_LIMBS_SMALL + 2);
+                Column::X(5 * N_LIMBS_LARGE + 8 * N_LIMBS_SMALL + 5 + i)
+            }
+            FECColumn::Carry3(i) => {
+                assert!(i < 2 * N_LIMBS_SMALL + 2);
+                Column::X(5 * N_LIMBS_LARGE + 10 * N_LIMBS_SMALL + 7 + i)
+            }
         }
     }
 }

--- a/msm/src/fec/interpreter.rs
+++ b/msm/src/fec/interpreter.rs
@@ -511,17 +511,17 @@ pub fn ec_add_circuit<
             F::from_biguint(&carry_f).unwrap()
         };
 
-        fn assign_carry<F, Env, Foo>(
+        fn assign_carry<F, Env, ColMap>(
             env: &mut Env,
             n_half_bi: &BigInt,
             i: usize,
             newcarry: F,
             carryvar: &mut F,
-            column_foo: Foo,
+            column_mapper: ColMap,
         ) where
             F: PrimeField,
             Env: ColWriteCap<F, FECColumn>,
-            Foo: Fn(usize) -> FECColumn,
+            ColMap: Fn(usize) -> FECColumn,
         {
             // Last carry should be zero, otherwise we record it
             if i < N_LIMBS_LARGE * 2 - 2 {
@@ -537,7 +537,7 @@ pub fn ec_add_circuit<
                     limb_decompose_biguint::<F, LIMB_BITSIZE_SMALL, 6>(newcarry_abs_bui.clone());
 
                 for (j, limb) in newcarry_limbs.iter().enumerate() {
-                    write_column_const(env, column_foo(6 * i + j), &(newcarry_sign * limb));
+                    write_column_const(env, column_mapper(6 * i + j), &(newcarry_sign * limb));
                 }
 
                 *carryvar = newcarry;

--- a/msm/src/fec/interpreter.rs
+++ b/msm/src/fec/interpreter.rs
@@ -1,5 +1,8 @@
 use crate::{
-    circuit_design::{ColAccessCap, ColWriteCap, LookupCap},
+    circuit_design::{
+        capabilities::{read_column_array, write_column_array_const, write_column_const},
+        ColAccessCap, ColWriteCap, LookupCap,
+    },
     fec::{columns::FECColumn, lookups::LookupTable},
     serialization::interpreter::{
         bigint_to_biguint_f, combine_carry, combine_small_to_large, fold_choice2,
@@ -196,57 +199,26 @@ pub fn constrain_ec_addition<
     Env: ColAccessCap<F, FECColumn> + LookupCap<F, FECColumn, LookupTable<Ff>>,
 >(
     env: &mut Env,
-    mem_offset: usize,
 ) {
-    let read_array_small = |env: &mut Env, extra_offset: usize| -> [Env::Variable; N_LIMBS_SMALL] {
-        core::array::from_fn(|i| env.read_column(FECColumn(mem_offset + extra_offset + i)))
-    };
-    let read_array_large = |env: &mut Env, extra_offset: usize| -> [Env::Variable; N_LIMBS_LARGE] {
-        core::array::from_fn(|i| env.read_column(FECColumn(mem_offset + extra_offset + i)))
-    };
+    let xp_limbs_large: [_; N_LIMBS_LARGE] = read_column_array(env, FECColumn::XP);
+    let yp_limbs_large: [_; N_LIMBS_LARGE] = read_column_array(env, FECColumn::YP);
+    let xq_limbs_large: [_; N_LIMBS_LARGE] = read_column_array(env, FECColumn::XQ);
+    let yq_limbs_large: [_; N_LIMBS_LARGE] = read_column_array(env, FECColumn::YQ);
+    let f_limbs_large: [_; N_LIMBS_LARGE] = read_column_array(env, FECColumn::F);
+    let xr_limbs_small: [_; N_LIMBS_SMALL] = read_column_array(env, FECColumn::XR);
+    let yr_limbs_small: [_; N_LIMBS_SMALL] = read_column_array(env, FECColumn::YR);
+    let s_limbs_small: [_; N_LIMBS_SMALL] = read_column_array(env, FECColumn::S);
 
-    let xp_limbs_large: [_; N_LIMBS_LARGE] = read_array_large(env, 0);
-    let yp_limbs_large: [_; N_LIMBS_LARGE] = read_array_large(env, N_LIMBS_LARGE);
-    let xq_limbs_large: [_; N_LIMBS_LARGE] = read_array_large(env, 2 * N_LIMBS_LARGE);
-    let yq_limbs_large: [_; N_LIMBS_LARGE] = read_array_large(env, 3 * N_LIMBS_LARGE);
-    let f_limbs_large: [_; N_LIMBS_LARGE] = read_array_large(env, 4 * N_LIMBS_LARGE);
-    let xr_limbs_small: [_; N_LIMBS_SMALL] = read_array_small(env, 5 * N_LIMBS_LARGE);
-    let yr_limbs_small: [_; N_LIMBS_SMALL] =
-        read_array_small(env, 5 * N_LIMBS_LARGE + N_LIMBS_SMALL);
-    let s_limbs_small: [_; N_LIMBS_SMALL] =
-        read_array_small(env, 5 * N_LIMBS_LARGE + 2 * N_LIMBS_SMALL);
+    let q1_limbs_small: [_; N_LIMBS_SMALL] = read_column_array(env, FECColumn::Q1);
+    let q2_limbs_small: [_; N_LIMBS_SMALL] = read_column_array(env, FECColumn::Q2);
+    let q3_limbs_small: [_; N_LIMBS_SMALL] = read_column_array(env, FECColumn::Q3);
+    let q1_sign = env.read_column(FECColumn::Q1Sign);
+    let q2_sign = env.read_column(FECColumn::Q2Sign);
+    let q3_sign = env.read_column(FECColumn::Q3Sign);
 
-    let q1_limbs_small: [_; N_LIMBS_SMALL] =
-        read_array_small(env, 5 * N_LIMBS_LARGE + 3 * N_LIMBS_SMALL);
-    let q2_limbs_small: [_; N_LIMBS_SMALL] =
-        read_array_small(env, 5 * N_LIMBS_LARGE + 4 * N_LIMBS_SMALL);
-    let q3_limbs_small: [_; N_LIMBS_SMALL] =
-        read_array_small(env, 5 * N_LIMBS_LARGE + 5 * N_LIMBS_SMALL);
-    let q1_sign = env.read_column(FECColumn(
-        mem_offset + 5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL,
-    ));
-    let q2_sign = env.read_column(FECColumn(
-        mem_offset + 5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL + 1,
-    ));
-    let q3_sign = env.read_column(FECColumn(
-        mem_offset + 5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL + 2,
-    ));
-
-    let carry1_limbs_small: [_; 2 * N_LIMBS_SMALL + 2] = core::array::from_fn(|i| {
-        env.read_column(FECColumn(
-            mem_offset + 5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL + 3 + i,
-        ))
-    });
-    let carry2_limbs_small: [_; 2 * N_LIMBS_SMALL + 2] = core::array::from_fn(|i| {
-        env.read_column(FECColumn(
-            mem_offset + 5 * N_LIMBS_LARGE + 8 * N_LIMBS_SMALL + 5 + i,
-        ))
-    });
-    let carry3_limbs_small: [_; 2 * N_LIMBS_SMALL + 2] = core::array::from_fn(|i| {
-        env.read_column(FECColumn(
-            mem_offset + 5 * N_LIMBS_LARGE + 10 * N_LIMBS_SMALL + 7 + i,
-        ))
-    });
+    let carry1_limbs_small: [_; 2 * N_LIMBS_SMALL + 2] = read_column_array(env, FECColumn::Carry1);
+    let carry2_limbs_small: [_; 2 * N_LIMBS_SMALL + 2] = read_column_array(env, FECColumn::Carry2);
+    let carry3_limbs_small: [_; 2 * N_LIMBS_SMALL + 2] = read_column_array(env, FECColumn::Carry3);
 
     // FIXME get rid of cloning
 
@@ -405,7 +377,6 @@ pub fn ec_add_circuit<
     Env: ColWriteCap<F, FECColumn> + LookupCap<F, FECColumn, LookupTable<Ff>>,
 >(
     env: &mut Env,
-    mem_offset: usize,
     xp: Ff,
     yp: Ff,
     xq: Ff,
@@ -452,36 +423,14 @@ pub fn ec_add_circuit<
     let slope_limbs_large: [F; N_LIMBS_LARGE] =
         limb_decompose_ff::<F, Ff, LIMB_BITSIZE_LARGE, N_LIMBS_LARGE>(&slope);
 
-    let write_array = |env: &mut Env, input: [F; N_LIMBS_SMALL], extra_offset: usize| {
-        input.iter().enumerate().for_each(|(i, var)| {
-            env.write_column(
-                FECColumn(mem_offset + extra_offset + i),
-                &Env::constant(*var),
-            );
-        })
-    };
-
-    let write_array_large = |env: &mut Env, input: [F; N_LIMBS_LARGE], extra_offset: usize| {
-        input.iter().enumerate().for_each(|(i, var)| {
-            env.write_column(
-                FECColumn(mem_offset + extra_offset + i),
-                &Env::constant(*var),
-            );
-        })
-    };
-
-    write_array_large(env, xp_limbs_large, 0);
-    write_array_large(env, yp_limbs_large, N_LIMBS_LARGE);
-    write_array_large(env, xq_limbs_large, 2 * N_LIMBS_LARGE);
-    write_array_large(env, yq_limbs_large, 3 * N_LIMBS_LARGE);
-    write_array_large(env, f_limbs_large, 4 * N_LIMBS_LARGE);
-    write_array(env, xr_limbs_small, 5 * N_LIMBS_LARGE);
-    write_array(env, yr_limbs_small, 5 * N_LIMBS_LARGE + N_LIMBS_SMALL);
-    write_array(
-        env,
-        slope_limbs_small,
-        5 * N_LIMBS_LARGE + 2 * N_LIMBS_SMALL,
-    );
+    write_column_array_const(env, xp_limbs_large, FECColumn::XP);
+    write_column_array_const(env, yp_limbs_large, FECColumn::YP);
+    write_column_array_const(env, xq_limbs_large, FECColumn::XQ);
+    write_column_array_const(env, yq_limbs_large, FECColumn::YQ);
+    write_column_array_const(env, f_limbs_large, FECColumn::F);
+    write_column_array_const(env, xr_limbs_small, FECColumn::XR);
+    write_column_array_const(env, yr_limbs_small, FECColumn::YR);
+    write_column_array_const(env, slope_limbs_small, FECColumn::S);
 
     let xp_bi: BigInt = FieldHelpers::to_bigint_positive(&xp);
     let yp_bi: BigInt = FieldHelpers::to_bigint_positive(&yp);
@@ -535,33 +484,12 @@ pub fn ec_add_circuit<
     let q3_limbs_small: [F; N_LIMBS_SMALL] =
         limb_decompose_biguint::<F, LIMB_BITSIZE_SMALL, N_LIMBS_SMALL>(q3_bi.to_biguint().unwrap());
 
-    write_array(
-        env,
-        q1_limbs_small,
-        mem_offset + 5 * N_LIMBS_LARGE + 3 * N_LIMBS_SMALL,
-    );
-    write_array(
-        env,
-        q2_limbs_small,
-        mem_offset + 5 * N_LIMBS_LARGE + 4 * N_LIMBS_SMALL,
-    );
-    write_array(
-        env,
-        q3_limbs_small,
-        mem_offset + 5 * N_LIMBS_LARGE + 5 * N_LIMBS_SMALL,
-    );
-    env.write_column(
-        FECColumn(mem_offset + 5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL),
-        &Env::constant(q1_sign),
-    );
-    env.write_column(
-        FECColumn(mem_offset + 5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL + 1),
-        &Env::constant(q2_sign),
-    );
-    env.write_column(
-        FECColumn(mem_offset + 5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL + 2),
-        &Env::constant(q3_sign),
-    );
+    write_column_array_const(env, q1_limbs_small, FECColumn::Q1);
+    write_column_array_const(env, q2_limbs_small, FECColumn::Q2);
+    write_column_array_const(env, q3_limbs_small, FECColumn::Q3);
+    write_column_const(env, FECColumn::Q1Sign, &q1_sign);
+    write_column_const(env, FECColumn::Q2Sign, &q2_sign);
+    write_column_const(env, FECColumn::Q3Sign, &q3_sign);
 
     let mut carry1: F = From::from(0u64);
     let mut carry2: F = From::from(0u64);
@@ -583,11 +511,22 @@ pub fn ec_add_circuit<
             F::from_biguint(&carry_f).unwrap()
         };
 
-        let assign_carry = |env: &mut Env, newcarry: F, carryvar: &mut F, extra_offset: usize| {
+        fn assign_carry<F, Env, Foo>(
+            env: &mut Env,
+            n_half_bi: &BigInt,
+            i: usize,
+            newcarry: F,
+            carryvar: &mut F,
+            column_foo: Foo,
+        ) where
+            F: PrimeField,
+            Env: ColWriteCap<F, FECColumn>,
+            Foo: Fn(usize) -> FECColumn,
+        {
             // Last carry should be zero, otherwise we record it
             if i < N_LIMBS_LARGE * 2 - 2 {
                 // Carries will often not fit into 5 limbs, but they /should/ fit in 6 limbs I think.
-                let newcarry_sign = if newcarry.to_bigint_positive() > n_half_bi {
+                let newcarry_sign = if &newcarry.to_bigint_positive() > n_half_bi {
                     F::zero() - F::one()
                 } else {
                     F::one()
@@ -598,10 +537,7 @@ pub fn ec_add_circuit<
                     limb_decompose_biguint::<F, LIMB_BITSIZE_SMALL, 6>(newcarry_abs_bui.clone());
 
                 for (j, limb) in newcarry_limbs.iter().enumerate() {
-                    env.write_column(
-                        FECColumn(mem_offset + extra_offset + 6 * i + j),
-                        &Env::constant(newcarry_sign * limb),
-                    );
+                    write_column_const(env, column_foo(6 * i + j), &(newcarry_sign * limb));
                 }
 
                 *carryvar = newcarry;
@@ -609,7 +545,7 @@ pub fn ec_add_circuit<
                 // should this be in circiut?
                 assert!(newcarry.is_zero(), "Last carry is non-zero");
             }
-        };
+        }
 
         // Equation 1: s (xP - xQ) - (yP - yQ) - q_1 f =  0
         let mut res1 = fold_choice2(N_LIMBS_LARGE, i, |j, k| {
@@ -626,9 +562,11 @@ pub fn ec_add_circuit<
         let newcarry1 = compute_carry(res1);
         assign_carry(
             env,
+            &n_half_bi,
+            i,
             newcarry1,
             &mut carry1,
-            5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL + 3,
+            FECColumn::Carry1,
         );
 
         // Equation 2: xR - s^2 + xP + xQ - q_2 f = 0
@@ -647,9 +585,11 @@ pub fn ec_add_circuit<
         let newcarry2 = compute_carry(res2);
         assign_carry(
             env,
+            &n_half_bi,
+            i,
             newcarry2,
             &mut carry2,
-            5 * N_LIMBS_LARGE + 8 * N_LIMBS_SMALL + 5,
+            FECColumn::Carry2,
         );
 
         // Equation 3: yR + yP - s (xP - xR) - q_3 f = 0
@@ -668,11 +608,13 @@ pub fn ec_add_circuit<
         let newcarry3 = compute_carry(res3);
         assign_carry(
             env,
+            &n_half_bi,
+            i,
             newcarry3,
             &mut carry3,
-            5 * N_LIMBS_LARGE + 10 * N_LIMBS_SMALL + 7,
+            FECColumn::Carry3,
         );
     }
 
-    constrain_ec_addition::<F, Ff, Env>(env, mem_offset);
+    constrain_ec_addition::<F, Ff, Env>(env);
 }

--- a/msm/src/fec/mod.rs
+++ b/msm/src/fec/mod.rs
@@ -40,7 +40,7 @@ mod tests {
             let xq: Ff1 = <Ff1 as UniformRand>::rand(rng);
             let yq: Ff1 = <Ff1 as UniformRand>::rand(rng);
 
-            ec_add_circuit(&mut witness_env, 0, xp, yp, xq, yq);
+            ec_add_circuit(&mut witness_env, xp, yp, xq, yq);
             if row_i < domain_size - 1 {
                 witness_env.next_row();
             }
@@ -69,7 +69,7 @@ mod tests {
         srs.full_srs.add_lagrange_basis(domain.d1);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, LookupTable<Ff1>>::create();
-        constrain_ec_addition::<Fp, Ff1, _>(&mut constraint_env, 0);
+        constrain_ec_addition::<Fp, Ff1, _>(&mut constraint_env);
         let constraints = constraint_env.get_constraints();
 
         let witness_env = build_fec_addition_circuit(&mut rng, domain_size);


### PR DESCRIPTION
Before (for experimentation reasons) the columns in the FEC module were integer-based, so direct memory access by i:usize. Now the alias FECColumn explicitly names each column, which improves readability and safety.

+ it adds some helpers for convenience.