### PR TITLE
MSM: Use 15 bit carries in FEC/Serialization

### DIFF
--- a/msm/src/fec/interpreter.rs
+++ b/msm/src/fec/interpreter.rs
@@ -142,9 +142,10 @@ pub fn limbs_to_bigints<F: PrimeField, const N: usize>(input: [F; N]) -> Vec<Big
 /// bits * 6 carries = 36 chunks, and every 6th chunk is 4 bits only.
 /// This matches the 2*S+2 = 36, since S = 17.
 ///
-/// TODO: on avoiding 16bit lookups.
-/// Our current packing is we have 6 batches x 6 elements, each batch is
-/// [16 16 16 16 16 4] bits. We could do [15 15 15 15 15 9] and avoid 16-bit lookups.
+/// Note however since 79-bit carry is signed, we will store it as a list of
+/// [15 15 15 15 15 9]-bit limbs, where limbs are signed.
+/// E.g. 15-bit limbs are in [-2^14, 2^14-1]. This allows us to use
+/// 14abs range checks.
 ///
 /// === Ranges
 ///
@@ -264,10 +265,9 @@ pub fn constrain_ec_addition<
         if i % 6 == 5 {
             // This should be a diferent range check depending on which big-limb we're processing?
             // So instead of one type of lookup we will have 5 different ones?
-            env.lookup(LookupTable::RangeCheck4Abs, x);
+            env.lookup(LookupTable::RangeCheck9Abs, x);
         } else {
-            // TODO add this table back
-            // env.lookup(LookupTable::RangeCheck15Abs, x);
+            env.lookup(LookupTable::RangeCheck14Abs, x);
         }
     }
 
@@ -533,8 +533,11 @@ pub fn ec_add_circuit<
                 };
                 let newcarry_abs_bui = (newcarry * newcarry_sign).to_biguint();
                 // Our big carries are at most 79 bits, so we need 6 small limbs per each.
+                // But limbs are signed, so we split into 14-bit /signed/ limbs. + last chunk is signed 9 bit.
                 let newcarry_limbs: [F; 6] =
-                    limb_decompose_biguint::<F, LIMB_BITSIZE_SMALL, 6>(newcarry_abs_bui.clone());
+                    limb_decompose_biguint::<F, { LIMB_BITSIZE_SMALL - 1 }, 6>(
+                        newcarry_abs_bui.clone(),
+                    );
 
                 for (j, limb) in newcarry_limbs.iter().enumerate() {
                     write_column_const(env, column_mapper(6 * i + j), &(newcarry_sign * limb));

--- a/msm/src/serialization/interpreter.rs
+++ b/msm/src/serialization/interpreter.rs
@@ -364,7 +364,7 @@ pub fn combine_carry<F: PrimeField, CIx: ColumnIndexer, Env: ColAccessCap<F, CIx
     let constant_u128 = |x: u128| Env::constant(From::from(x));
     std::array::from_fn(|i| {
         (0..6)
-            .map(|j| x[6 * i + j].clone() * constant_u128(1u128 << (j * LIMB_BITSIZE_SMALL)))
+            .map(|j| x[6 * i + j].clone() * constant_u128(1u128 << (j * (LIMB_BITSIZE_SMALL - 1))))
             .fold(Env::Variable::from(0u64), |acc, v| acc + v)
     })
 }
@@ -418,10 +418,11 @@ pub fn constrain_multiplication<
         if i % 6 == 5 {
             // This should be a different range check depending on which big-limb we're processing?
             // So instead of one type of lookup we will have 5 different ones?
-            env.lookup(LookupTable::RangeCheck4Abs, x);
+            env.lookup(LookupTable::RangeCheck9Abs, x); // 4 + 5 ?
         } else {
             // TODO add actual lookup
-            // env.range_check_abs15bit(x);
+            env.lookup(LookupTable::RangeCheck14Abs, x);
+            //env.range_check_abs15(x);
             // assert!(x < F::from(1u64 << 15) || x >= F::zero() - F::from(1u64 << 15));
         }
     }
@@ -617,8 +618,13 @@ pub fn multiplication_circuit<
                 };
                 let newcarry_abs_bui = (newcarry * newcarry_sign).to_biguint();
                 // Our big carries are at most 79 bits, so we need 6 small limbs per each.
+                // However we split them into 14-bit chunks -- each chunk is signed, so in the end
+                // the layout is [14bitabs,14bitabs,14bitabs,14bitabs,14bitabs,9bitabs]
+                // altogether giving a 79bit number (signed).
                 let newcarry_limbs: [F; 6] =
-                    limb_decompose_biguint::<F, LIMB_BITSIZE_SMALL, 6>(newcarry_abs_bui.clone());
+                    limb_decompose_biguint::<F, { LIMB_BITSIZE_SMALL - 1 }, 6>(
+                        newcarry_abs_bui.clone(),
+                    );
 
                 for (j, limb) in newcarry_limbs.iter().enumerate() {
                     env.copy(
@@ -658,8 +664,10 @@ mod tests {
         circuit_design::{ColAccessCap, WitnessBuilderEnv},
         columns::ColumnIndexer,
         serialization::{
-            column::SerializationColumn, interpreter::deserialize_field_element,
-            lookups::LookupTable, N_INTERMEDIATE_LIMBS,
+            column::SerializationColumn,
+            interpreter::{deserialize_field_element, multiplication_circuit},
+            lookups::LookupTable,
+            N_INTERMEDIATE_LIMBS,
         },
         Ff1, LIMB_BITSIZE, N_LIMBS,
     };
@@ -667,7 +675,7 @@ mod tests {
     use mina_curves::pasta::Fp;
     use num_bigint::BigUint;
     use o1_utils::{tests::make_test_rng, FieldHelpers};
-    use rand::Rng;
+    use rand::{CryptoRng, Rng, RngCore};
     use std::str::FromStr;
 
     fn test_decomposition_generic(x: Fp) {
@@ -814,5 +822,37 @@ mod tests {
             - BigUint::from_str("1").unwrap();
 
         test_decomposition_generic(Fp::from(x));
+    }
+
+    fn build_serialization_mul_circuit<RNG: RngCore + CryptoRng>(
+        rng: &mut RNG,
+        domain_size: usize,
+    ) -> WitnessBuilderEnv<Fp, { <SerializationColumn as ColumnIndexer>::COL_N }, LookupTable<Ff1>>
+    {
+        let mut witness_env = WitnessBuilderEnv::create();
+
+        // To support less rows than domain_size we need to have selectors.
+        //let row_num = rng.gen_range(0..domain_size);
+
+        for row_i in 0..domain_size {
+            let input_chal: Ff1 = <Ff1 as UniformRand>::rand(rng);
+            let coeff_input: Ff1 = <Ff1 as UniformRand>::rand(rng);
+            multiplication_circuit(&mut witness_env, input_chal, coeff_input, true);
+
+            if row_i < domain_size - 1 {
+                witness_env.next_row();
+            }
+        }
+
+        witness_env
+    }
+
+    #[test]
+    /// Builds the FF addition circuit with random values. The witness
+    /// environment enforces the constraints internally, so it is
+    /// enough to just build the circuit to ensure it is satisfied.
+    pub fn test_serialization_mul_circuit() {
+        let mut rng = o1_utils::tests::make_test_rng();
+        build_serialization_mul_circuit(&mut rng, 1 << 4);
     }
 }

--- a/msm/src/serialization/lookups.rs
+++ b/msm/src/serialization/lookups.rs
@@ -12,8 +12,10 @@ pub enum LookupTable<Ff> {
     RangeCheck15,
     /// x ∈ [0, 2^4]
     RangeCheck4,
+    /// x ∈ [-2^14, 2^14-1]
+    RangeCheck14Abs,
     /// x ∈ [-2^4, 2^4-1]
-    RangeCheck4Abs,
+    RangeCheck9Abs,
     /// x ∈ [0, ff_highest] where ff_highest is the highest 15-bit
     /// limb of the modulus of the foreign field `Ff`.
     RangeCheckFfHighest(PhantomData<Ff>),
@@ -24,8 +26,9 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
         match self {
             Self::RangeCheck15 => 1,
             Self::RangeCheck4 => 2,
-            Self::RangeCheck4Abs => 3,
-            Self::RangeCheckFfHighest(_) => 4,
+            Self::RangeCheck14Abs => 3,
+            Self::RangeCheck9Abs => 4,
+            Self::RangeCheckFfHighest(_) => 5,
         }
     }
 
@@ -33,8 +36,9 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
         match value {
             1 => Self::RangeCheck15,
             2 => Self::RangeCheck4,
-            3 => Self::RangeCheck4Abs,
-            4 => Self::RangeCheckFfHighest(PhantomData),
+            3 => Self::RangeCheck14Abs,
+            4 => Self::RangeCheck9Abs,
+            5 => Self::RangeCheckFfHighest(PhantomData),
             _ => panic!("Invalid lookup table id"),
         }
     }
@@ -48,7 +52,8 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
         match self {
             Self::RangeCheck15 => 1 << 15,
             Self::RangeCheck4 => 1 << 4,
-            Self::RangeCheck4Abs => 1 << 5,
+            Self::RangeCheck14Abs => 1 << 15,
+            Self::RangeCheck9Abs => 1 << 10,
             Self::RangeCheckFfHighest(_) => TryFrom::try_from(
                 crate::serialization::interpreter::ff_modulus_highest_limb::<Ff>(),
             )
@@ -58,16 +63,25 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
 
     /// Converts a value to its index in the fixed table.
     fn ix_by_value<F: PrimeField>(&self, value: F) -> usize {
+        assert!(self.is_member(value));
         match self {
             Self::RangeCheck15 => TryFrom::try_from(value.to_biguint()).unwrap(),
             Self::RangeCheck4 => TryFrom::try_from(value.to_biguint()).unwrap(),
-            Self::RangeCheck4Abs => {
-                if value < F::from(1u64 << 4) {
+            Self::RangeCheck14Abs => {
+                if value < F::from(1u64 << 14) {
                     TryFrom::try_from(value.to_biguint()).unwrap()
                 } else {
-                    TryFrom::try_from((value + F::from(2 * (1u64 << 4))).to_biguint()).unwrap()
+                    TryFrom::try_from((value + F::from(2 * (1u64 << 14))).to_biguint()).unwrap()
                 }
             }
+            Self::RangeCheck9Abs => {
+                if value < F::from(1u64 << 9) {
+                    TryFrom::try_from(value.to_biguint()).unwrap()
+                } else {
+                    TryFrom::try_from((value + F::from(2 * (1u64 << 9))).to_biguint()).unwrap()
+                }
+            }
+
             Self::RangeCheckFfHighest(_) => TryFrom::try_from(value.to_biguint()).unwrap(),
         }
     }
@@ -97,14 +111,28 @@ impl<Ff: PrimeField> LookupTable<Ff> {
             Self::RangeCheck4 => (0..domain_d1_size)
                 .map(|i| if i < (1 << 4) { F::from(i) } else { F::zero() })
                 .collect(),
-            Self::RangeCheck4Abs => (0..domain_d1_size)
+            Self::RangeCheck14Abs => (0..domain_d1_size)
                 .map(|i| {
-                    if i < (1 << 4) {
-                        // [0,1,2 ... (1<<4)-1]
+                    if i < (1 << 14) {
+                        // [0,1,2 ... (1<<14)-1]
                         F::from(i)
-                    } else if i < 2 * (1 << 4) {
-                        // [-(i<<4),...-2,-1]
-                        F::from(i) - F::from(2u64 * (1 << 4))
+                    } else if i < 2 * (1 << 14) {
+                        // [-(i<<14),...-2,-1]
+                        F::from(i) - F::from(2u64 * (1 << 14))
+                    } else {
+                        F::zero()
+                    }
+                })
+                .collect(),
+
+            Self::RangeCheck9Abs => (0..domain_d1_size)
+                .map(|i| {
+                    if i < (1 << 9) {
+                        // [0,1,2 ... (1<<9)-1]
+                        F::from(i)
+                    } else if i < 2 * (1 << 9) {
+                        // [-(i<<9),...-2,-1]
+                        F::from(i) - F::from(2u64 * (1 << 9))
                     } else {
                         F::zero()
                     }
@@ -119,8 +147,11 @@ impl<Ff: PrimeField> LookupTable<Ff> {
         match self {
             Self::RangeCheck15 => value.to_biguint() < BigUint::from(2u128.pow(15)),
             Self::RangeCheck4 => value.to_biguint() < BigUint::from(2u128.pow(4)),
-            Self::RangeCheck4Abs => {
-                value < F::from(1u64 << 4) || value >= F::zero() - F::from(1u64 << 4)
+            Self::RangeCheck14Abs => {
+                value < F::from(1u64 << 14) || value >= F::zero() - F::from(1u64 << 14)
+            }
+            Self::RangeCheck9Abs => {
+                value < F::from(1u64 << 9) || value >= F::zero() - F::from(1u64 << 9)
             }
             Self::RangeCheckFfHighest(_) => {
                 let f_bui: BigUint = TryFrom::try_from(Ff::Params::MODULUS).unwrap();

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -68,7 +68,7 @@ mod tests {
             // Sanity checks.
             assert!(constraints_env.lookups[&LookupTable::RangeCheck15].len() == (3 * 17 - 1));
             assert!(constraints_env.lookups[&LookupTable::RangeCheck4].len() == 20);
-            assert!(constraints_env.lookups[&LookupTable::RangeCheck4Abs].len() == 6);
+            assert!(constraints_env.lookups[&LookupTable::RangeCheck9Abs].len() == 6);
             assert!(
                 constraints_env.lookups
                     [&LookupTable::RangeCheckFfHighest(std::marker::PhantomData)]


### PR DESCRIPTION
Previously: I thought we need 16 bit range checks to implement MSM FEC & Serialization circuits.

Now: 
* Actually managed to repack carries a bit tighter -- they're 79 bits and they were packed `[16 16 16 16 16 4]` so I repacked them into `[15 15 15 15 15 9]`. 
* I also added the "14abs" lookup table, so now these circuits have /all the/ range check tables they need :tada: