### PR TITLE
Folding: replace binop by mul/add/sub in FoldingCompatibleExpr

### DIFF
--- a/folding/src/decomposable_folding.rs
+++ b/folding/src/decomposable_folding.rs
@@ -11,7 +11,6 @@ use crate::{
     FoldingConfig, FoldingScheme, ScalarField, Sponge,
 };
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
-use kimchi::circuits::expr::Op2;
 use poly_commitment::{PolyComm, SRS};
 use std::collections::BTreeMap;
 
@@ -36,7 +35,7 @@ impl<CF: FoldingConfig> DecomposableFoldingScheme<CF> {
                     let s =
                         FoldingCompatibleExprInner::Extensions(ExpExtension::Selector(s.clone()));
                     let s = Box::new(FoldingCompatibleExpr::Atom(s));
-                    FoldingCompatibleExpr::BinOp(Op2::Mul, s, Box::new(exp))
+                    FoldingCompatibleExpr::Mul(s, Box::new(exp))
                 })
             })
             .chain(common_constraints)

--- a/folding/src/examples/example_decomposable_folding.rs
+++ b/folding/src/examples/example_decomposable_folding.rs
@@ -9,10 +9,7 @@ use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{Field, UniformRand, Zero};
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 use itertools::Itertools;
-use kimchi::circuits::{
-    expr::{Op2, Variable},
-    gate::CurrOrNext,
-};
+use kimchi::circuits::{expr::Variable, gate::CurrOrNext};
 use poly_commitment::SRS;
 use rand::thread_rng;
 use std::collections::BTreeMap;
@@ -209,18 +206,15 @@ fn constraints() -> BTreeMap<DynamicSelector, Vec<FoldingCompatibleExpr<TestFold
     let b = Box::new(get_col(TestColumn::B));
     let c = Box::new(get_col(TestColumn::C));
 
-    type E = Box<FoldingCompatibleExpr<TestFoldingConfig>>;
-    let op = |a: E, b: E, op| Box::new(FoldingCompatibleExpr::BinOp(op, a, b));
+    let add = FoldingCompatibleExpr::Add(a.clone(), b.clone());
+    let add = FoldingCompatibleExpr::Sub(add.into(), c.clone());
 
-    let add = op(a.clone(), b.clone(), Op2::Add);
-    let add = op(add, c.clone(), Op2::Sub);
-
-    let sub = op(a, b, Op2::Sub);
-    let sub = op(sub, c, Op2::Sub);
+    let sub = FoldingCompatibleExpr::Sub(a.clone(), b.clone());
+    let sub = FoldingCompatibleExpr::Sub(sub.into(), c.clone());
 
     [
-        (DynamicSelector::SelecAdd, vec![*add]),
-        (DynamicSelector::SelecSub, vec![*sub]),
+        (DynamicSelector::SelecAdd, vec![add]),
+        (DynamicSelector::SelecSub, vec![sub]),
     ]
     .into_iter()
     .collect()
@@ -409,15 +403,20 @@ mod checker {
                     let v = self.check_rec(*e);
                     v.into_iter().map(|x| x.square()).collect()
                 }
-                FoldingCompatibleExpr::BinOp(op, e1, e2) => {
+                FoldingCompatibleExpr::Add(e1, e2) => {
                     let v1 = self.check_rec(*e1);
                     let v2 = self.check_rec(*e2);
-                    let op = match op {
-                        Op2::Add => |(a, b)| a + b,
-                        Op2::Mul => |(a, b)| a * b,
-                        Op2::Sub => |(a, b)| a - b,
-                    };
-                    v1.into_iter().zip(v2).map(op).collect()
+                    v1.into_iter().zip(v2).map(|(a, b)| a + b).collect()
+                }
+                FoldingCompatibleExpr::Sub(e1, e2) => {
+                    let v1 = self.check_rec(*e1);
+                    let v2 = self.check_rec(*e2);
+                    v1.into_iter().zip(v2).map(|(a, b)| a - b).collect()
+                }
+                FoldingCompatibleExpr::Mul(e1, e2) => {
+                    let v1 = self.check_rec(*e1);
+                    let v2 = self.check_rec(*e2);
+                    v1.into_iter().zip(v2).map(|(a, b)| a * b).collect()
                 }
                 FoldingCompatibleExpr::Pow(e, exp) => {
                     let v = self.check_rec(*e);


### PR DESCRIPTION
`BinOp` was used in the previous version of the expression framework. It eases the translation between the new expression framework and the folding compatible one.