### PR TITLE
Kimchi: remove Op2 enum

### DIFF
--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -566,14 +566,6 @@ impl Cache {
     }
 }
 
-/// A binary operation
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Op2 {
-    Add,
-    Mul,
-    Sub,
-}
-
 /// The feature flags that can be used to enable or disable parts of constraints.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[cfg_attr(


### PR DESCRIPTION
It was only used by the FoldingCompatibleExpr enum, but it has been removed recently