### PR TITLE
Folding: remove zkrows and lagrange basis variants from folding expre…

### DIFF
--- a/folding/src/columns.rs
+++ b/folding/src/columns.rs
@@ -17,7 +17,6 @@ pub enum ExtendedFoldingColumn<C: FoldingConfig> {
     WitnessExtended(usize),
     /// The error term introduced in the "relaxed" instance.
     Error,
-    UnnormalizedLagrangeBasis(usize),
     Constant(<C::Curve as AffineCurve>::ScalarField),
     /// A challenge used by the PIOP or the folding scheme.
     Challenge(C::Challenge),

--- a/folding/src/error_term.rs
+++ b/folding/src/error_term.rs
@@ -313,7 +313,6 @@ impl<CF: FoldingConfig> ExtendedEnv<CF> {
                 .expect("extended column not present")
                 .evals),
             Error => panic!("shouldn't happen"),
-            UnnormalizedLagrangeBasis(i) => Col(self.inner().lagrange_basis(*i)),
             Constant(c) => EvalLeaf::Const(*c),
             Challenge(chall) => EvalLeaf::Const(self.inner().challenge(*chall, side)),
             Alpha(i) => EvalLeaf::Const(self.inner().alpha(*i, side)),
@@ -330,12 +329,7 @@ impl<CF: FoldingConfig> ExtendedEnv<CF> {
         match col {
             WitnessExtended(i) => witness.inner().extended.get(i).is_some(),
             Error => panic!("shouldn't happen"),
-            Inner(_)
-            | UnnormalizedLagrangeBasis(_)
-            | Constant(_)
-            | Challenge(_)
-            | Alpha(_)
-            | Selector(_) => true,
+            Inner(_) | Constant(_) | Challenge(_) | Alpha(_) | Selector(_) => true,
         }
     }
 

--- a/folding/src/examples/example.rs
+++ b/folding/src/examples/example.rs
@@ -379,8 +379,6 @@ mod checker {
                     }
                     col
                 }
-                FoldingCompatibleExprInner::VanishesOnZeroKnowledgeAndPreviousRows => todo!(),
-                FoldingCompatibleExprInner::UnnormalizedLagrangeBasis(_) => todo!(),
                 FoldingCompatibleExprInner::Extensions(_) => {
                     panic!("not handled")
                 }

--- a/folding/src/examples/example_decomposable_folding.rs
+++ b/folding/src/examples/example_decomposable_folding.rs
@@ -330,8 +330,6 @@ mod checker {
                     }
                     col
                 }
-                FoldingCompatibleExprInner::VanishesOnZeroKnowledgeAndPreviousRows => todo!(),
-                FoldingCompatibleExprInner::UnnormalizedLagrangeBasis(_) => todo!(),
                 FoldingCompatibleExprInner::Extensions(_) => {
                     panic!("not handled here");
                 }

--- a/folding/src/examples/example_quadriticization.rs
+++ b/folding/src/examples/example_quadriticization.rs
@@ -366,8 +366,6 @@ mod checker {
                     }
                     col
                 }
-                FoldingCompatibleExprInner::VanishesOnZeroKnowledgeAndPreviousRows => todo!(),
-                FoldingCompatibleExprInner::UnnormalizedLagrangeBasis(_) => todo!(),
                 FoldingCompatibleExprInner::Extensions(_) => {
                     panic!("not handled here");
                 }


### PR DESCRIPTION
…ssions

We do not need them at the moment. We might want to add them later, but it is not used now, and it adds noise to the code.
The folding expression framework should only handle multivariate polynomials describing relation constraints for now. We can add lookup and others later, when needed.