### PR TITLE
IVC Circuit (Part 5): Add EC Addition Stubs

### DIFF
--- a/ivc/src/ivc/columns.rs
+++ b/ivc/src/ivc/columns.rs
@@ -86,15 +86,15 @@ pub type IVCPoseidonColumn = PoseidonColumn<IVC_POSEIDON_STATE_SIZE, IVC_POSEIDO
 ///
 ///          input#1    input#2          FEC ADD computation          output
 ///   1   |------------------------------------------------------|-------------|
-///       |  C_{R'_i} | bucket[ϕ^i]_k   |      ϕ^i·C_{R'_i}      |  newbucket  |
+///       |  C_{R',i} | bucket[ϕ^i]_k   |      ϕ^i·C_{R',i}      |  newbucket  |
 ///       |           |                 |                        |             |
 ///       |           |                 |                        |             |
 ///  17*N |------------------------------------------------------|-------------|
-///       |  C_{R_i}  | bucket[r·ϕ^i]_k |   r·ϕ^i·C_{R_i}        |  newbucket  |
+///       |  C_{R,i}  | bucket[r·ϕ^i]_k |   r·ϕ^i·C_{R,i}        |  newbucket  |
 ///       |           |                 |                        |             |
 ///       |           |                 |                        |             |
 ///  34*N |------------------------------------------------------|-------------|
-///       |  C_{L}    |  C_{R}          |    C_{L} + C_{R}'      |    C_{O}'   | // assert that C_O' == C_O
+///       |  C_{R,i}  |  C_{L,i}        |  C_{L,i} + C_{R,i}'    |    C_{O}'   | // assert that C_O' == C_O
 /// 35*N  |------------------------------------------------------|-------------|
 ///
 ///
@@ -211,5 +211,23 @@ impl MPrism for IVCHashLens {
 
     fn re_get(&self, target: Self::Target) -> Self::Source {
         IVCColumn::Block2Hash(target)
+    }
+}
+
+pub struct IVCFECLens {}
+
+impl MPrism for IVCFECLens {
+    type Source = IVCColumn;
+    type Target = FECColumn;
+
+    fn traverse(&self, source: Self::Source) -> Option<Self::Target> {
+        match source {
+            IVCColumn::Block4ECAdd(col) => Some(col),
+            _ => None,
+        }
+    }
+
+    fn re_get(&self, target: Self::Target) -> Self::Source {
+        IVCColumn::Block4ECAdd(target)
     }
 }

--- a/ivc/src/ivc/mod.rs
+++ b/ivc/src/ivc/mod.rs
@@ -79,10 +79,8 @@ mod tests {
     }
 
     #[test]
-    /// Builds the FF addition circuit with random values. The witness
-    /// environment enforces the constraints internally, so it is
-    /// enough to just build the circuit to ensure it is satisfied.
-    pub fn test_ivc_addition_circuit() {
+    /// Tests if building the IVC circuit succeeds.
+    pub fn test_ivc_circuit() {
         let mut rng = o1_utils::tests::make_test_rng();
         build_ivc_circuit(&mut rng);
     }

--- a/msm/src/circuit_design/capabilities.rs
+++ b/msm/src/circuit_design/capabilities.rs
@@ -147,7 +147,7 @@ pub fn write_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer, ColMap
 /// Write an array of /field/ values simultaneously.
 pub fn write_column_array_const<F, Env, const ARR_N: usize, CIx: ColumnIndexer, ColMap>(
     env: &mut Env,
-    input: [F; ARR_N],
+    input: &[F; ARR_N],
     column_map: ColMap,
 ) where
     F: PrimeField,

--- a/msm/src/fec/interpreter.rs
+++ b/msm/src/fec/interpreter.rs
@@ -252,7 +252,7 @@ pub fn constrain_ec_addition<
 
     // Signs must be -1 or 1.
     for x in [&q1_sign, &q2_sign, &q3_sign] {
-        env.lookup(LookupTable::RangeCheck1Abs, x);
+        env.assert_zero(x.clone() * x.clone() - Env::constant(F::one()));
     }
 
     // Carry limbs need to be in particular ranges.
@@ -417,14 +417,14 @@ pub fn ec_add_circuit<
     let slope_limbs_large: [F; N_LIMBS_LARGE] =
         limb_decompose_ff::<F, Ff, LIMB_BITSIZE_LARGE, N_LIMBS_LARGE>(&slope);
 
-    write_column_array_const(env, xp_limbs_large, FECColumn::XP);
-    write_column_array_const(env, yp_limbs_large, FECColumn::YP);
-    write_column_array_const(env, xq_limbs_large, FECColumn::XQ);
-    write_column_array_const(env, yq_limbs_large, FECColumn::YQ);
-    write_column_array_const(env, f_limbs_large, FECColumn::F);
-    write_column_array_const(env, xr_limbs_small, FECColumn::XR);
-    write_column_array_const(env, yr_limbs_small, FECColumn::YR);
-    write_column_array_const(env, slope_limbs_small, FECColumn::S);
+    write_column_array_const(env, &xp_limbs_large, FECColumn::XP);
+    write_column_array_const(env, &yp_limbs_large, FECColumn::YP);
+    write_column_array_const(env, &xq_limbs_large, FECColumn::XQ);
+    write_column_array_const(env, &yq_limbs_large, FECColumn::YQ);
+    write_column_array_const(env, &f_limbs_large, FECColumn::F);
+    write_column_array_const(env, &xr_limbs_small, FECColumn::XR);
+    write_column_array_const(env, &yr_limbs_small, FECColumn::YR);
+    write_column_array_const(env, &slope_limbs_small, FECColumn::S);
 
     let xp_bi: BigInt = FieldHelpers::to_bigint_positive(&xp);
     let yp_bi: BigInt = FieldHelpers::to_bigint_positive(&yp);
@@ -478,9 +478,9 @@ pub fn ec_add_circuit<
     let q3_limbs_small: [F; N_LIMBS_SMALL] =
         limb_decompose_biguint::<F, LIMB_BITSIZE_SMALL, N_LIMBS_SMALL>(q3_bi.to_biguint().unwrap());
 
-    write_column_array_const(env, q1_limbs_small, FECColumn::Q1);
-    write_column_array_const(env, q2_limbs_small, FECColumn::Q2);
-    write_column_array_const(env, q3_limbs_small, FECColumn::Q3);
+    write_column_array_const(env, &q1_limbs_small, FECColumn::Q1);
+    write_column_array_const(env, &q2_limbs_small, FECColumn::Q2);
+    write_column_array_const(env, &q3_limbs_small, FECColumn::Q3);
     write_column_const(env, FECColumn::Q1Sign, &q1_sign);
     write_column_const(env, FECColumn::Q2Sign, &q2_sign);
     write_column_const(env, FECColumn::Q3Sign, &q3_sign);

--- a/msm/src/fec/lookups.rs
+++ b/msm/src/fec/lookups.rs
@@ -17,8 +17,6 @@ pub enum LookupTable<Ff> {
     /// x ∈ [0, ff_highest] where ff_highest is the highest 15-bit
     /// limb of the modulus of the foreign field `Ff`.
     RangeCheckFfHighest(PhantomData<Ff>),
-    /// x ∈ [-1, 1]
-    RangeCheck1Abs,
 }
 
 impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
@@ -28,7 +26,6 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
             Self::RangeCheck14Abs => 2,
             Self::RangeCheck9Abs => 3,
             Self::RangeCheckFfHighest(_) => 4,
-            Self::RangeCheck1Abs => 5,
         }
     }
 
@@ -38,7 +35,6 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
             2 => Self::RangeCheck14Abs,
             3 => Self::RangeCheck9Abs,
             4 => Self::RangeCheckFfHighest(PhantomData),
-            5 => Self::RangeCheck1Abs,
             _ => panic!("Invalid lookup table id"),
         }
     }
@@ -57,7 +53,6 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
                 crate::serialization::interpreter::ff_modulus_highest_limb::<Ff>(),
             )
             .unwrap(),
-            Self::RangeCheck1Abs => 2,
         }
     }
 
@@ -81,15 +76,6 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
                 }
             }
             Self::RangeCheckFfHighest(_) => TryFrom::try_from(value.to_biguint()).unwrap(),
-            Self::RangeCheck1Abs => {
-                if value == F::one() {
-                    0
-                } else if value == F::zero() - F::one() {
-                    1
-                } else {
-                    panic!("Invalid value for rangecheck1abs")
-                }
-            }
         }
     }
 
@@ -98,7 +84,6 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
             Self::RangeCheck15,
             Self::RangeCheck14Abs,
             Self::RangeCheck9Abs,
-            Self::RangeCheck1Abs,
             Self::RangeCheckFfHighest(PhantomData),
         ]
     }
@@ -150,10 +135,6 @@ impl<Ff: PrimeField> LookupTable<Ff> {
                 })
                 .collect(),
             Self::RangeCheckFfHighest(_) => Self::entries_ff_highest::<F>(domain_d1_size),
-            Self::RangeCheck1Abs => [F::one(), F::zero() - F::one()]
-                .into_iter()
-                .chain((2..domain_d1_size).map(|_| F::one())) // dummies are 1s
-                .collect(),
         }
     }
 
@@ -173,7 +154,6 @@ impl<Ff: PrimeField> LookupTable<Ff> {
                     F::from_biguint(&(f_bui >> ((N_LIMBS - 1) * LIMB_BITSIZE))).unwrap();
                 value < top_modulus_f
             }
-            Self::RangeCheck1Abs => value == F::one() || value == F::zero() - F::one(),
         }
     }
 }


### PR DESCRIPTION
This PR:
* Adds EC Addition stubs: wires are properly populated (but partially with dummy values, since we don't have buckets)
    * Makes two types of lookups work together. See the `IVCFECLookupLens`. 
    * Replaced `Abs1` lookup with `x^2 - 1` constraint. So much cheaper.
    * Had to generalise/restructure some code along the way for readability.

Previous PRs:
1. https://github.com/o1-labs/proof-systems/pull/2139
2. https://github.com/o1-labs/proof-systems/pull/2140
3. https://github.com/o1-labs/proof-systems/pull/2141
4. https://github.com/o1-labs/proof-systems/pull/2144