### PR TITLE
Folding: reorganize examples + add explanation for the user

### DIFF
--- a/folding/src/examples/example_decomposable_folding.rs
+++ b/folding/src/examples/example_decomposable_folding.rs
@@ -1,24 +1,18 @@
 use crate::{
     error_term::Side,
-    examples::generic::{Alphas, BaseSponge, Curve, Fp},
+    examples::generic::{Alphas, BaseSponge, Checker, Curve, Fp, Provide},
     expressions::{FoldingColumnTrait, FoldingCompatibleExprInner},
     ExpExtension, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance, RelaxedInstance,
     RelaxedWitness, Witness,
 };
 use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_ff::{Field, UniformRand, Zero};
+use ark_ff::{UniformRand, Zero};
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 use itertools::Itertools;
 use kimchi::circuits::{expr::Variable, gate::CurrOrNext};
 use poly_commitment::SRS;
 use rand::thread_rng;
 use std::collections::BTreeMap;
-
-#[cfg(test)]
-use std::println as debug;
-
-#[cfg(not(test))]
-use log::debug;
 
 // the type representing our columns, in this case we have 3 witness columns
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -295,10 +289,7 @@ mod checker {
         }
     }
 
-    pub(super) trait Provide {
-        fn resolve(&self, inner: FoldingCompatibleExprInner<TestFoldingConfig>) -> Vec<Fp>;
-    }
-    impl Provide for Provider {
+    impl Provide<TestFoldingConfig> for Provider {
         fn resolve(&self, inner: FoldingCompatibleExprInner<TestFoldingConfig>) -> Vec<Fp> {
             match inner {
                 FoldingCompatibleExprInner::Constant(c) => {
@@ -334,6 +325,7 @@ mod checker {
             }
         }
     }
+
     pub struct ExtendedProvider {
         inner_provider: Provider,
         pub instance: RelaxedInstance<<TestFoldingConfig as FoldingConfig>::Curve, TestInstance>,
@@ -357,7 +349,8 @@ mod checker {
             }
         }
     }
-    impl Provide for ExtendedProvider {
+
+    impl Provide<TestFoldingConfig> for ExtendedProvider {
         fn resolve(&self, inner: FoldingCompatibleExprInner<TestFoldingConfig>) -> Vec<Fp> {
             match inner {
                 FoldingCompatibleExprInner::Extensions(ext) => match ext {
@@ -386,57 +379,7 @@ mod checker {
         }
     }
 
-    pub(super) trait Checker: Provide {
-        fn check_rec(&self, exp: FoldingCompatibleExpr<TestFoldingConfig>) -> Vec<Fp> {
-            let e2 = exp.clone();
-            let res = match exp {
-                FoldingCompatibleExpr::Atom(inner) => self.resolve(inner),
-                FoldingCompatibleExpr::Double(e) => {
-                    let v = self.check_rec(*e);
-                    v.into_iter().map(|x| x.double()).collect()
-                }
-                FoldingCompatibleExpr::Square(e) => {
-                    let v = self.check_rec(*e);
-                    v.into_iter().map(|x| x.square()).collect()
-                }
-                FoldingCompatibleExpr::Add(e1, e2) => {
-                    let v1 = self.check_rec(*e1);
-                    let v2 = self.check_rec(*e2);
-                    v1.into_iter().zip(v2).map(|(a, b)| a + b).collect()
-                }
-                FoldingCompatibleExpr::Sub(e1, e2) => {
-                    let v1 = self.check_rec(*e1);
-                    let v2 = self.check_rec(*e2);
-                    v1.into_iter().zip(v2).map(|(a, b)| a - b).collect()
-                }
-                FoldingCompatibleExpr::Mul(e1, e2) => {
-                    let v1 = self.check_rec(*e1);
-                    let v2 = self.check_rec(*e2);
-                    v1.into_iter().zip(v2).map(|(a, b)| a * b).collect()
-                }
-                FoldingCompatibleExpr::Pow(e, exp) => {
-                    let v = self.check_rec(*e);
-                    v.into_iter().map(|x| x.pow([exp])).collect()
-                }
-            };
-            debug!("exp: {:?}", e2);
-            debug!("res: [\n");
-            for e in res.iter() {
-                debug!("{e}\n");
-            }
-            debug!("]");
-            res
-        }
-        fn check(&self, exp: &FoldingCompatibleExpr<TestFoldingConfig>) {
-            let res = self.check_rec(exp.clone());
-            for (i, row) in res.iter().enumerate() {
-                if !row.is_zero() {
-                    panic!("check in row {i} failed, {row} != 0");
-                }
-            }
-        }
-    }
-    impl<T: Provide> Checker for T {}
+    impl Checker<TestFoldingConfig> for ExtendedProvider {}
 }
 
 #[cfg(test)]
@@ -444,7 +387,7 @@ mod tests {
     use super::*;
     // Trick to print debug message while testing, as we in the test config env
     use crate::decomposable_folding::DecomposableFoldingScheme;
-    use ark_poly::{EvaluationDomain, Evaluations};
+    use ark_poly::{EvaluationDomain, Evaluations, Radix2EvaluationDomain as D};
     use checker::ExtendedProvider;
     use std::println as debug;
 
@@ -474,9 +417,6 @@ mod tests {
     // and instead directly check the witness
     #[test]
     fn test_decomposable_folding() {
-        use ark_poly::Radix2EvaluationDomain as D;
-        use checker::Checker;
-
         let constraints = constraints();
         let domain = D::<Fp>::new(2).unwrap();
         let mut srs = poly_commitment::srs::SRS::<Curve>::create(2);

--- a/folding/src/examples/example_decomposable_folding.rs
+++ b/folding/src/examples/example_decomposable_folding.rs
@@ -1,6 +1,6 @@
 use crate::{
     error_term::Side,
-    examples::{BaseSponge, Curve, Fp},
+    examples::generic::{Alphas, BaseSponge, Curve, Fp},
     expressions::{FoldingColumnTrait, FoldingCompatibleExprInner},
     ExpExtension, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance, RelaxedInstance,
     RelaxedWitness, Witness,
@@ -13,8 +13,6 @@ use kimchi::circuits::{expr::Variable, gate::CurrOrNext};
 use poly_commitment::SRS;
 use rand::thread_rng;
 use std::collections::BTreeMap;
-
-use super::example::Alphas;
 
 #[cfg(test)]
 use std::println as debug;

--- a/folding/src/examples/example_quadriticization.rs
+++ b/folding/src/examples/example_quadriticization.rs
@@ -2,7 +2,10 @@
 // that triggers quadriticization
 use crate::{
     error_term::Side,
-    examples::{example_decomposable_folding::TestWitness, BaseSponge, Curve, Fp},
+    examples::{
+        example_decomposable_folding::TestWitness,
+        generic::{BaseSponge, Curve, Fp},
+    },
     expressions::{FoldingColumnTrait, FoldingCompatibleExprInner},
     ExpExtension, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance, RelaxedInstance,
     RelaxedWitness,
@@ -12,7 +15,7 @@ use ark_ff::{Field, One, UniformRand, Zero};
 use ark_poly::Radix2EvaluationDomain;
 use itertools::Itertools;
 use kimchi::circuits::{expr::Variable, gate::CurrOrNext};
-use poly_commitment::SRS;
+use poly_commitment::SRS as _;
 use rand::thread_rng;
 use std::{
     collections::BTreeMap,

--- a/folding/src/examples/generic.rs
+++ b/folding/src/examples/generic.rs
@@ -29,7 +29,7 @@ pub type Curve = ark_bn254::G1Affine;
 pub type SpongeParams = PlonkSpongeConstantsKimchi;
 pub type BaseSponge = DefaultFqSponge<ark_bn254::g1::Parameters, SpongeParams>;
 
-// 1. We start by defining a generic type of columns and selectors.
+// 1. We continue by defining a generic type of columns and selectors.
 // The selectors can be seen as additional (public) columns that are not part of
 // the witness.
 // The column must implement the trait [Hash] as it will be used by internal
@@ -105,7 +105,8 @@ impl Alphas {
     }
 }
 
-// 4. We define differen traits that can be used generically by the folding examples.
+// 4. We define different traits that can be used generically by the folding
+// examples.
 // It can be used by "pseudo-provers".
 pub(crate) trait Provide<C: FoldingConfig> {
     fn resolve(&self, inner: FoldingCompatibleExprInner<C>) -> Vec<Fp>;

--- a/folding/src/examples/generic.rs
+++ b/folding/src/examples/generic.rs
@@ -1,0 +1,113 @@
+use crate::{expressions::FoldingColumnTrait, Sponge};
+use ark_ff::{Field, One};
+use kimchi::curve::KimchiCurve;
+use mina_poseidon::{
+    constants::PlonkSpongeConstantsKimchi,
+    sponge::{DefaultFqSponge, ScalarChallenge},
+    FqSponge,
+};
+use poly_commitment::PolyComm;
+use std::{
+    iter::successors,
+    rc::Rc,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+// 0. We start by defining the field and the curve that will be used in the
+// constraint system, in addition to the sponge that will be used to generate
+// challenges.
+pub type Fp = ark_bn254::Fr;
+pub type Curve = ark_bn254::G1Affine;
+pub type SpongeParams = PlonkSpongeConstantsKimchi;
+pub type BaseSponge = DefaultFqSponge<ark_bn254::g1::Parameters, SpongeParams>;
+
+// 1. We start by defining a generic type of columns and selectors.
+// The selectors can be seen as additional (public) columns that are not part of
+// the witness.
+// The column must implement the trait [Hash] as it will be used by internal
+// structures of the library.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum Column {
+    X(usize),
+    Selector(usize),
+}
+
+// 2. We implement the trait [FoldingColumnTrait] that allows to distinguish
+// between the public and private inputs, often called the "instances" and the
+// "witnesses".
+// By default, we consider that the columns are all witness values and selectors
+// are public.
+impl FoldingColumnTrait for Column {
+    fn is_witness(&self) -> bool {
+        match self {
+            Column::X(_) => true,
+            Column::Selector(_) => false,
+        }
+    }
+}
+
+// 3. We define the combinators that will be used to fold the constraints,
+// called the "alphas".
+// The alphas are exceptional, their number cannot be known ahead of time as it
+// will be defined by folding.
+// The values will be computed as powers in new instances, but after folding
+// each alpha will be a linear combination of other alphas, instand of a power
+// of other element. This type represents that, allowing to also recognize
+// which case is present.
+#[derive(Debug, Clone)]
+pub enum Alphas {
+    Powers(Fp, Rc<AtomicUsize>),
+    Combinations(Vec<Fp>),
+}
+
+impl Alphas {
+    pub fn new(alpha: Fp) -> Self {
+        Self::Powers(alpha, Rc::new(AtomicUsize::from(0)))
+    }
+    pub fn get(&self, i: usize) -> Option<Fp> {
+        match self {
+            Alphas::Powers(alpha, count) => {
+                let _ = count.fetch_max(i + 1, Ordering::Relaxed);
+                let i = [i as u64];
+                Some(alpha.pow(i))
+            }
+            Alphas::Combinations(alphas) => alphas.get(i).cloned(),
+        }
+    }
+    pub fn powers(self) -> Vec<Fp> {
+        match self {
+            Alphas::Powers(alpha, count) => {
+                let n = count.load(Ordering::Relaxed);
+                let alphas = successors(Some(Fp::one()), |last| Some(*last * alpha));
+                alphas.take(n).collect()
+            }
+            Alphas::Combinations(c) => c,
+        }
+    }
+    pub fn combine(a: Self, b: Self, challenge: Fp) -> Self {
+        let a = a.powers();
+        let b = b.powers();
+        assert_eq!(a.len(), b.len());
+        let comb = a
+            .into_iter()
+            .zip(b)
+            .map(|(a, b)| a + b * challenge)
+            .collect();
+        Self::Combinations(comb)
+    }
+}
+
+// TODO: get rid of trait Sponge in folding, and use the one from kimchi
+impl Sponge<Curve> for BaseSponge {
+    fn challenge(absorb: &[PolyComm<Curve>; 2]) -> Fp {
+        // This function does not have a &self because it is meant to absorb and
+        // squeeze only once
+        let mut s = BaseSponge::new(Curve::other_curve_sponge_params());
+        s.absorb_g(&absorb[0].elems);
+        s.absorb_g(&absorb[1].elems);
+        // Squeeze sponge
+        let chal = ScalarChallenge(s.challenge());
+        let (_, endo_r) = Curve::endos();
+        chal.to_field(endo_r)
+    }
+}

--- a/folding/src/examples/mod.rs
+++ b/folding/src/examples/mod.rs
@@ -1,32 +1,17 @@
-use crate::Sponge;
-use kimchi::curve::KimchiCurve;
-use mina_poseidon::{
-    constants::PlonkSpongeConstantsKimchi,
-    sponge::{DefaultFqSponge, ScalarChallenge},
-    FqSponge,
-};
-use poly_commitment::PolyComm;
+//! This module provides examples on how to use the different submodules of the library.
+//! The examples are meant to be run with the `cargo nextest` command.
+//! The user is encouraged to read the code and understand the different steps of the protocol.
+//! The examples are built over a generic type of columns and selectors.
+//! The user is encouraged to start reading this module and then move to the
+//! modules specialised for the different folding implementations.
+//!
+//! The examples are generic enough to be reused externally. The users can copy the
+//! code and adapt it to their needs. The generic structures are defined in the
+//! `generic` module.
 
 mod example;
 mod example_decomposable_folding;
 mod example_quadriticization;
 
-type Fp = ark_bn254::Fr;
-type Curve = ark_bn254::G1Affine;
-type SpongeParams = PlonkSpongeConstantsKimchi;
-type BaseSponge = DefaultFqSponge<ark_bn254::g1::Parameters, SpongeParams>;
-
-// TODO: get rid of trait Sponge in folding, and use the one from kimchi
-impl Sponge<Curve> for BaseSponge {
-    fn challenge(absorb: &[PolyComm<Curve>; 2]) -> Fp {
-        // This function does not have a &self because it is meant to absorb and
-        // squeeze only once
-        let mut s = BaseSponge::new(Curve::other_curve_sponge_params());
-        s.absorb_g(&absorb[0].elems);
-        s.absorb_g(&absorb[1].elems);
-        // Squeeze sponge
-        let chal = ScalarChallenge(s.challenge());
-        let (_, endo_r) = Curve::endos();
-        chal.to_field(endo_r)
-    }
-}
+/// Define the different structures requires for the examples.
+mod generic;

--- a/folding/src/examples/mod.rs
+++ b/folding/src/examples/mod.rs
@@ -9,9 +9,9 @@
 //! code and adapt it to their needs. The generic structures are defined in the
 //! `generic` module.
 
-mod example;
-mod example_decomposable_folding;
-mod example_quadriticization;
+pub mod example;
+pub mod example_decomposable_folding;
+pub mod example_quadriticization;
 
 /// Define the different structures requires for the examples.
-mod generic;
+pub mod generic;


### PR DESCRIPTION
This can improved later. Maybe good already to merge a first iteration?

The initial idea was to get rid of duplicated code and improve my understanding of the implementation. If we want to expose the library later, it is good to have this kind of structure.
It can be mixed later with the generic interpreter/prover/verifier.