### PR TITLE
[easy] MSM: remove one unnecessary intermediary step

### DIFF
--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -178,11 +178,8 @@ where
 
     let (_, endo_r) = G::endos();
 
-    //~ 1. Sample $\alpha'$ with the Fq-Sponge.
-    let alpha_chal = ScalarChallenge(fq_sponge.challenge());
-
-    //~ 1. Derive $\alpha$ from $\alpha'$ using the endomorphism (TODO: details)
-    let alpha: G::ScalarField = alpha_chal.to_field(endo_r);
+    // Sample α with the Fq-Sponge.
+    let alpha: G::ScalarField = fq_sponge.challenge();
 
     let zk_rows = 0;
     let column_env: ColumnEnvironment<'_, N, N_REL, N_SEL, _, _> = {

--- a/msm/src/verifier.rs
+++ b/msm/src/verifier.rs
@@ -135,10 +135,8 @@ where
         }
     };
 
-    //~ 1. Sample $\alpha'$ with the Fq-Sponge.
-    let alpha_chal = ScalarChallenge(fq_sponge.challenge());
-    let (_, endo_r) = G::endos();
-    let alpha: G::ScalarField = alpha_chal.to_field(endo_r);
+    // Sample α with the Fq-Sponge.
+    let alpha = fq_sponge.challenge();
 
     ////////////////////////////////////////////////////////////////////////////
     // Quotient polynomial


### PR DESCRIPTION
fq_sponge.challenge returns a correct scalar field element ScalarChallenge only wraps the scalar field element into a new structure to be passed to Caml/Pickles, apparently.