### PR TITLE
Optimism: uniformising the imported/defined types

### DIFF
--- a/optimism/src/folding.rs
+++ b/optimism/src/folding.rs
@@ -1,4 +1,3 @@
-use ark_bn254;
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{Field, One, Zero};
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
@@ -10,21 +9,17 @@ use kimchi::{
 };
 use kimchi_msm::witness::Witness as GenericWitness;
 use mina_poseidon::{
-    constants::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, ScalarChallenge},
     FqSponge,
 };
 use poly_commitment::PolyComm;
 use std::{array, iter::successors, ops::Index, rc::Rc, sync::atomic::AtomicUsize};
 
-use crate::DOMAIN_SIZE;
+use crate::{BaseSponge as BaseSpongeT, Curve, Fp, DOMAIN_SIZE};
 
-// Instantiate it with the desired group and field
-pub type Fp = ark_bn254::Fr;
-pub type Curve = ark_bn254::G1Affine;
-pub type SpongeParams = PlonkSpongeConstantsKimchi;
-
-pub struct BaseSponge(DefaultFqSponge<ark_bn254::g1::Parameters, SpongeParams>);
+// FIXME: Using a struct as Rust asks for it, but we should change how folding
+// uses the sponge.
+pub struct BaseSponge(BaseSpongeT);
 
 // TODO: get rid of trait Sponge in folding, and use the one from kimchi
 impl Sponge<Curve> for BaseSponge {

--- a/optimism/src/keccak/folding.rs
+++ b/optimism/src/keccak/folding.rs
@@ -1,9 +1,12 @@
 use crate::{
-    folding::{
-        BaseSponge, Challenge, Curve, FoldingEnvironment, FoldingInstance, FoldingWitness, Fp,
-    },
+    // FIXME: using BaseSponge from folding as it does require a struct, but we
+    // should simply have a type by modifying how folding uses the sponge
+    folding::BaseSponge,
+    folding::{Challenge, FoldingEnvironment, FoldingInstance, FoldingWitness},
     keccak::{column::ZKVM_KECCAK_COLS, KeccakColumn, Steps},
     trace::Indexer,
+    Curve,
+    Fp,
     DOMAIN_SIZE,
 };
 use ark_poly::{Evaluations, Radix2EvaluationDomain};

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -542,8 +542,8 @@ fn test_keccak_prover_constraints() {
 #[test]
 fn test_keccak_decomposable_folding() {
     use crate::{
-        folding::Curve,
         keccak::folding::{KeccakConfig, KeccakStructure},
+        Curve,
     };
     use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as D};
     use folding::{

--- a/optimism/src/lib.rs
+++ b/optimism/src/lib.rs
@@ -33,9 +33,15 @@ pub mod ramlookup;
 /// Defines a trace struct used for testing / demo purposes
 pub mod trace;
 
+use ark_ec::bn::Bn;
 use kimchi::circuits::expr::{ConstantExpr, Expr};
 use kimchi_msm::columns::Column;
 
+use mina_poseidon::{
+    constants::PlonkSpongeConstantsKimchi,
+    sponge::{DefaultFqSponge, DefaultFrSponge},
+};
+use poly_commitment::pairing_proof::PairingProof;
 pub use ramlookup::{LookupMode as RAMLookupMode, RAMLookup};
 
 /// Type to represent a constraint on the individual columns of the execution
@@ -51,3 +57,11 @@ pub use ramlookup::{LookupMode as RAMLookupMode, RAMLookup};
 /// To represent this multi-variate polynomial using the expression framework,
 /// we would use 3 different columns.
 pub(crate) type E<F> = Expr<ConstantExpr<F>, Column>;
+
+// Instantiate it with the desired group and field
+pub type Fp = ark_bn254::Fr;
+pub type Curve = ark_bn254::G1Affine;
+pub type BaseSponge = DefaultFqSponge<ark_bn254::g1::Parameters, SpongeParams>;
+pub type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
+pub type SpongeParams = PlonkSpongeConstantsKimchi;
+pub type OpeningProof = PairingProof<Bn<ark_bn254::Parameters>>;

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -1,4 +1,4 @@
-use ark_ec::{bn::Bn, AffineCurve};
+use ark_ec::AffineCurve;
 use ark_ff::UniformRand;
 use kimchi::o1_utils;
 use kimchi_msm::{proof::ProofInputs, prover::prove, verifier::verify, witness::Witness};
@@ -21,22 +21,11 @@ use kimchi_optimism::{
     preimage_oracle::PreImageOracle,
     proof,
     trace::Tracer,
-    DOMAIN_SIZE,
+    BaseSponge, Fp, OpeningProof, ScalarSponge, DOMAIN_SIZE,
 };
 use log::debug;
-use mina_poseidon::{
-    constants::PlonkSpongeConstantsKimchi,
-    sponge::{DefaultFqSponge, DefaultFrSponge},
-};
-use poly_commitment::pairing_proof::PairingProof;
 use std::{cmp::Ordering, collections::HashMap, fs::File, io::BufReader, process::ExitCode};
 use strum::IntoEnumIterator;
-
-type Fp = ark_bn254::Fr;
-type SpongeParams = PlonkSpongeConstantsKimchi;
-type BaseSponge = DefaultFqSponge<ark_bn254::g1::Parameters, SpongeParams>;
-type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
-type OpeningProof = PairingProof<Bn<ark_bn254::Parameters>>;
 
 pub fn main() -> ExitCode {
     let cli = cannon_cli::main_cli();

--- a/optimism/src/mips/folding.rs
+++ b/optimism/src/mips/folding.rs
@@ -1,12 +1,15 @@
 use crate::{
-    folding::{
-        BaseSponge, Challenge, Curve, FoldingEnvironment, FoldingInstance, FoldingWitness, Fp,
-    },
+    // FIXME: using BaseSponge from folding as it does require a struct, but we
+    // should simply have a type by modifying how folding uses the sponge
+    folding::BaseSponge,
+    folding::{Challenge, FoldingEnvironment, FoldingInstance, FoldingWitness},
     mips::{
         column::{ColumnAlias as MIPSColumn, MIPS_COLUMNS},
         Instruction,
     },
     trace::Indexer,
+    Curve,
+    Fp,
     DOMAIN_SIZE,
 };
 use ark_poly::{Evaluations, Radix2EvaluationDomain};


### PR DESCRIPTION
It seems we do redefine at multiple place the same types/structures. Uniformising it in this commit