### PR TITLE
Unify alpha structures

### DIFF
--- a/folding/src/examples/example.rs
+++ b/folding/src/examples/example.rs
@@ -8,10 +8,10 @@
 /// ```
 use crate::{
     error_term::Side,
-    examples::generic::{Alphas, BaseSponge, Checker, Column, Curve, Fp, Provide},
+    examples::generic::{BaseSponge, Checker, Column, Curve, Fp, Provide},
     expressions::FoldingCompatibleExprInner,
-    ExpExtension, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance, RelaxedInstance,
-    RelaxedWitness, Witness,
+    Alphas, ExpExtension, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance,
+    RelaxedInstance, RelaxedWitness, Witness,
 };
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{One, UniformRand, Zero};
@@ -28,7 +28,7 @@ use rand::thread_rng;
 struct TestInstance {
     commitments: [Curve; 3],
     challenges: [Fp; 3],
-    alphas: Alphas,
+    alphas: Alphas<Fp>,
 }
 
 impl Instance<Curve> for TestInstance {

--- a/folding/src/examples/example_decomposable_folding.rs
+++ b/folding/src/examples/example_decomposable_folding.rs
@@ -1,9 +1,9 @@
 use crate::{
     error_term::Side,
-    examples::generic::{Alphas, BaseSponge, Checker, Curve, Fp, Provide},
+    examples::generic::{BaseSponge, Checker, Curve, Fp, Provide},
     expressions::{FoldingColumnTrait, FoldingCompatibleExprInner},
-    ExpExtension, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance, RelaxedInstance,
-    RelaxedWitness, Witness,
+    Alphas, ExpExtension, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance,
+    RelaxedInstance, RelaxedWitness, Witness,
 };
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{UniformRand, Zero};
@@ -47,7 +47,7 @@ pub struct TestInstance {
     // for ilustration only, no constraint in this example uses challenges
     challenges: [Fp; 3],
     // also challenges, but segregated as folding gives them special treatment
-    alphas: Alphas,
+    alphas: Alphas<Fp>,
 }
 
 impl Instance<Curve> for TestInstance {

--- a/folding/src/examples/example_quadriticization.rs
+++ b/folding/src/examples/example_quadriticization.rs
@@ -4,11 +4,11 @@ use crate::{
     error_term::Side,
     examples::{
         example_decomposable_folding::TestWitness,
-        generic::{Alphas, BaseSponge, Checker, Curve, Fp, Provide},
+        generic::{BaseSponge, Checker, Curve, Fp, Provide},
     },
     expressions::{FoldingColumnTrait, FoldingCompatibleExprInner},
-    ExpExtension, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance, RelaxedInstance,
-    RelaxedWitness,
+    Alphas, ExpExtension, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance,
+    RelaxedInstance, RelaxedWitness,
 };
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{UniformRand, Zero};
@@ -52,7 +52,7 @@ pub struct TestInstance {
     // for ilustration only, no constraint in this example uses challenges
     challenges: [Fp; 3],
     // also challenges, but segregated as folding gives them special treatment
-    alphas: Alphas,
+    alphas: Alphas<Fp>,
 }
 
 impl Instance<Curve> for TestInstance {

--- a/folding/src/lib.rs
+++ b/folding/src/lib.rs
@@ -18,7 +18,7 @@
 // TODO: the documentation above might need more descriptions.
 
 use ark_ec::AffineCurve;
-use ark_ff::Zero;
+use ark_ff::{Field, Zero};
 use ark_poly::{EvaluationDomain, Evaluations, Radix2EvaluationDomain};
 use error_term::{compute_error, ExtendedEnv};
 use expressions::{
@@ -28,7 +28,13 @@ use instance_witness::{RelaxableInstance, RelaxablePair};
 use kimchi::circuits::gate::CurrOrNext;
 use poly_commitment::{commitment::CommitmentCurve, PolyComm, SRS};
 use quadraticization::ExtendedWitnessGenerator;
-use std::{fmt::Debug, hash::Hash};
+use std::{
+    fmt::Debug,
+    hash::Hash,
+    iter::successors,
+    rc::Rc,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 // Make available outside the crate to avoid code duplication
 pub use error_term::Side;
@@ -385,5 +391,56 @@ impl<'a, CF: FoldingConfig> FoldingScheme<'a, CF> {
         let b: RelaxedInstance<CF::Curve, CF::Instance> = b.relax(self.zero_commitment.clone());
         let challenge = <CF::Sponge>::challenge(&error_commitments);
         RelaxedInstance::combine_and_sub_error(a, b, challenge, &error_commitments)
+    }
+}
+
+/// Combinators that will be used to fold the constraints,
+/// called the "alphas".
+/// The alphas are exceptional, their number cannot be known ahead of time as it
+/// will be defined by folding.
+/// The values will be computed as powers in new instances, but after folding
+/// each alpha will be a linear combination of other alphas, instand of a power
+/// of other element. This type represents that, allowing to also recognize
+/// which case is present.
+#[derive(Debug, Clone)]
+pub enum Alphas<F: Field> {
+    Powers(F, Rc<AtomicUsize>),
+    Combinations(Vec<F>),
+}
+
+impl<F: Field> Alphas<F> {
+    pub fn new(alpha: F) -> Self {
+        Self::Powers(alpha, Rc::new(AtomicUsize::from(0)))
+    }
+    pub fn get(&self, i: usize) -> Option<F> {
+        match self {
+            Alphas::Powers(alpha, count) => {
+                let _ = count.fetch_max(i + 1, Ordering::Relaxed);
+                let i = [i as u64];
+                Some(alpha.pow(i))
+            }
+            Alphas::Combinations(alphas) => alphas.get(i).cloned(),
+        }
+    }
+    pub fn powers(self) -> Vec<F> {
+        match self {
+            Alphas::Powers(alpha, count) => {
+                let n = count.load(Ordering::Relaxed);
+                let alphas = successors(Some(F::one()), |last| Some(*last * alpha));
+                alphas.take(n).collect()
+            }
+            Alphas::Combinations(c) => c,
+        }
+    }
+    pub fn combine(a: Self, b: Self, challenge: F) -> Self {
+        let a = a.powers();
+        let b = b.powers();
+        assert_eq!(a.len(), b.len());
+        let comb = a
+            .into_iter()
+            .zip(b)
+            .map(|(a, b)| a + b * challenge)
+            .collect();
+        Self::Combinations(comb)
     }
 }

--- a/optimism/src/folding.rs
+++ b/optimism/src/folding.rs
@@ -1,8 +1,7 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_ff::{Field, One, Zero};
+use ark_ff::Zero;
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
-use core::sync::atomic::Ordering;
-use folding::{FoldingEnv, Instance, Side, Sponge, Witness};
+use folding::{Alphas, FoldingEnv, Instance, Side, Sponge, Witness};
 use kimchi::{
     circuits::{expr::ChallengeTerm, gate::CurrOrNext},
     curve::KimchiCurve,
@@ -13,7 +12,7 @@ use mina_poseidon::{
     FqSponge,
 };
 use poly_commitment::PolyComm;
-use std::{array, iter::successors, ops::Index, rc::Rc, sync::atomic::AtomicUsize};
+use std::{array, ops::Index};
 use strum::EnumCount;
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 
@@ -47,54 +46,6 @@ pub enum Challenge {
     JointCombiner,
 }
 
-/// The alphas are exceptional, their number cannot be known ahead of time as it
-/// will be defined by folding. The values will be computed as powers in new
-/// instances, but after folding each alfa will be a linear combination of other
-/// alphas, instand of a power of other element. This type represents that,
-/// allowing to also recognize which case is present
-#[derive(Debug, Clone)]
-pub enum Alphas {
-    Powers(Fp, Rc<AtomicUsize>),
-    Combinations(Vec<Fp>),
-}
-
-impl Alphas {
-    pub fn new(alpha: Fp) -> Self {
-        Self::Powers(alpha, Rc::new(AtomicUsize::from(0)))
-    }
-    pub fn get(&self, i: usize) -> Option<Fp> {
-        match self {
-            Alphas::Powers(alpha, count) => {
-                let _ = count.fetch_max(i + 1, Ordering::Relaxed);
-                let i = [i as u64];
-                Some(alpha.pow(i))
-            }
-            Alphas::Combinations(alphas) => alphas.get(i).cloned(),
-        }
-    }
-    pub fn powers(self) -> Vec<Fp> {
-        match self {
-            Alphas::Powers(alpha, count) => {
-                let n = count.load(Ordering::Relaxed);
-                let alphas = successors(Some(Fp::one()), |last| Some(*last * alpha));
-                alphas.take(n).collect()
-            }
-            Alphas::Combinations(c) => c,
-        }
-    }
-    pub fn combine(a: Self, b: Self, challenge: Fp) -> Self {
-        let a = a.powers();
-        let b = b.powers();
-        assert_eq!(a.len(), b.len());
-        let comb = a
-            .into_iter()
-            .zip(b)
-            .map(|(a, b)| a + b * challenge)
-            .collect();
-        Self::Combinations(comb)
-    }
-}
-
 // Needed to transform from expressions to folding expressions
 impl From<ChallengeTerm> for Challenge {
     fn from(chal: ChallengeTerm) -> Self {
@@ -120,7 +71,7 @@ pub struct FoldingInstance<const N: usize> {
     /// - γ (set to 0 for now)
     pub challenges: [Fp; Challenge::COUNT],
     /// Reuses the Alphas defined in the example of folding
-    pub alphas: Alphas,
+    pub alphas: Alphas<Fp>,
 }
 
 impl<const N: usize> Instance<Curve> for FoldingInstance<N> {


### PR DESCRIPTION
There must be only one definition of alphas, up-to-now. We don't need to
duplicate code N times.