### PR TITLE
IVC Circuit (Part 6): Error computation in ECADDs

### DIFF
--- a/ivc/src/ivc/interpreter.rs
+++ b/ivc/src/ivc/interpreter.rs
@@ -18,7 +18,7 @@ use kimchi_msm::{
     },
     columns::ColumnIndexer,
     fec::{
-        columns::FECColumn,
+        columns::FECColumnOutput,
         interpreter::{constrain_ec_addition, ec_add_circuit},
     },
     serialization::{
@@ -439,7 +439,12 @@ where
     env.assert_zero(phi_pow_r_expected - phi_i_r);
 }
 
-pub fn write_scalars_row<F, Env>(env: &mut Env, r_f: F, phi_f: F, phi_prev_power_f: F) -> F
+pub fn write_scalars_row<F, Env>(
+    env: &mut Env,
+    r_f: F,
+    phi_f: F,
+    phi_prev_power_f: F,
+) -> (F, [F; N_LIMBS_SMALL], [F; N_LIMBS_SMALL])
 where
     F: PrimeField,
     Env: ColWriteCap<F, IVCColumn>,
@@ -453,34 +458,75 @@ where
     env.write_column(IVCColumn::Block3PhiPowR, &Env::constant(phi_cur_power_r_f));
 
     // TODO check that limb_decompose_ff works with <F,F,_,_>
-    write_column_array_const(
-        env,
-        &limb_decompose_ff::<F, F, LIMB_BITSIZE_SMALL, N_LIMBS_SMALL>(&phi_cur_power_f),
-        IVCColumn::Block3PhiPowLimbs,
-    );
-    write_column_array_const(
-        env,
-        &limb_decompose_ff::<F, F, LIMB_BITSIZE_SMALL, N_LIMBS_SMALL>(&phi_cur_power_r_f),
-        IVCColumn::Block3PhiPowRLimbs,
-    );
+    let phi_cur_power_f_limbs =
+        limb_decompose_ff::<F, F, LIMB_BITSIZE_SMALL, N_LIMBS_SMALL>(&phi_cur_power_f);
+    write_column_array_const(env, &phi_cur_power_f_limbs, IVCColumn::Block3PhiPowLimbs);
 
-    phi_cur_power_f
+    let phi_cur_power_r_f_limbs =
+        limb_decompose_ff::<F, F, LIMB_BITSIZE_SMALL, N_LIMBS_SMALL>(&phi_cur_power_r_f);
+    write_column_array_const(env, &phi_cur_power_r_f_limbs, IVCColumn::Block3PhiPowRLimbs);
+
+    (
+        phi_cur_power_f,
+        phi_cur_power_f_limbs,
+        phi_cur_power_r_f_limbs,
+    )
 }
 
-pub fn process_scalars<F, Ff, Env, const N_COL_TOTAL: usize>(env: &mut Env, r: F, phi: F)
+/// Contains vectors of of scalars in small limb representations.
+/// Generic consts don't allow +1 so vectors not arrays. `N` is
+/// `N_COL_TOTAL`.
+pub struct ScalarLimbs<F> {
+    /// ϕ^i,   i ∈ [N+1]
+    pub phi_limbs: Vec<[F; N_LIMBS_SMALL]>,
+    /// r·ϕ^i, i ∈ [N+1]
+    pub phi_r_limbs: Vec<[F; N_LIMBS_SMALL]>,
+    /// r^2·ϕ^{N+1}
+    pub phi_np1_r2_limbs: [F; N_LIMBS_SMALL],
+    /// r^3·ϕ^{N+1}
+    pub phi_np1_r3_limbs: [F; N_LIMBS_SMALL],
+}
+
+/// Processes scalars. Returns a vector of limbs of (powers of) scalars produced.
+pub fn process_scalars<F, Ff, Env, const N_COL_TOTAL: usize>(
+    env: &mut Env,
+    r: F,
+    phi: F,
+) -> ScalarLimbs<F>
 where
     F: PrimeField,
     Ff: PrimeField,
     Env: DirectWitnessCap<F, IVCColumn> + LookupCap<F, IVCColumn, IVCLookupTable<Ff>>,
 {
     let mut phi_prev_power_f = F::one();
-    for _block_row_i in 0..N_COL_TOTAL {
-        phi_prev_power_f = write_scalars_row(env, r, phi, phi_prev_power_f);
+    let mut phi_limbs = vec![];
+    let mut phi_r_limbs = vec![];
+    for _block_row_i in 0..N_COL_TOTAL + 1 {
+        let (phi_prev_power_f_new, phi_cur_power_f_limbs, phi_cur_power_r_f_limbs) =
+            write_scalars_row(env, r, phi, phi_prev_power_f);
+
+        phi_prev_power_f = phi_prev_power_f_new;
+        phi_limbs.push(phi_cur_power_f_limbs);
+        phi_r_limbs.push(phi_cur_power_r_f_limbs);
 
         // Checking our constraints
         constrain_scalars(env);
 
         env.next_row();
+    }
+
+    // FIXME constrain these two, they are not in circuit yet
+    let phi_np1_r2_limbs =
+        limb_decompose_ff::<F, F, LIMB_BITSIZE_SMALL, N_LIMBS_SMALL>(&(r * r * phi_prev_power_f));
+    let phi_np1_r3_limbs = limb_decompose_ff::<F, F, LIMB_BITSIZE_SMALL, N_LIMBS_SMALL>(
+        &(r * r * r * phi_prev_power_f),
+    );
+
+    ScalarLimbs {
+        phi_limbs,
+        phi_r_limbs,
+        phi_np1_r2_limbs,
+        phi_np1_r3_limbs,
     }
 }
 
@@ -494,13 +540,41 @@ where
         &mut SubEnvColumn::new(env, IVCFECLens {}),
         IVCFECLookupLens(PhantomData),
     ));
+
+    // Repacking to 75 bits
+
+    let output_limbs_small_x: [_; N_LIMBS_SMALL] =
+        read_column_array(env, |i| IVCColumn::Block4OutputRaw(FECColumnOutput::XR(i)));
+    let output_limbs_small_y: [_; N_LIMBS_SMALL] =
+        read_column_array(env, |i| IVCColumn::Block4OutputRaw(FECColumnOutput::YR(i)));
+
+    let output_limbs_large_x: [_; N_LIMBS_LARGE] =
+        read_column_array(env, IVCColumn::Block4OutputRepacked);
+    let output_limbs_large_y: [_; N_LIMBS_LARGE] =
+        read_column_array(env, |i| IVCColumn::Block4OutputRepacked(N_LIMBS_LARGE + i));
+
+    {
+        let output_limbs_large_x_expected =
+            combine_small_to_large::<_, _, Env>(output_limbs_small_x);
+        let output_limbs_large_y_expected =
+            combine_small_to_large::<_, _, Env>(output_limbs_small_y);
+        output_limbs_large_x_expected
+            .into_iter()
+            .zip(output_limbs_large_x.clone())
+            .for_each(|(e1, e2)| env.assert_zero(e1 - e2));
+        output_limbs_large_y_expected
+            .into_iter()
+            .zip(output_limbs_large_y.clone())
+            .for_each(|(e1, e2)| env.assert_zero(e1 - e2));
+    }
 }
 
 pub fn process_ecadds<F, Ff, Env, const N_COL_TOTAL: usize>(
     env: &mut Env,
-    _r: F,
-    _phi: F,
+    scalar_limbs: ScalarLimbs<F>,
     comms_large: &[[[F; 2 * N_LIMBS_LARGE]; N_COL_TOTAL]; 3],
+    error_terms: [(Ff, Ff); 3], // E_L, E_R, E_O
+    t_terms: [(Ff, Ff); 2],     // T_0, T_1
 ) where
     F: PrimeField,
     Ff: PrimeField,
@@ -509,33 +583,150 @@ pub fn process_ecadds<F, Ff, Env, const N_COL_TOTAL: usize>(
     // TODO FIXME multiply by r. For now these are just C_{R,i}, they must be {r * C_{R,i}}
     let r_hat_large: Box<[[F; 2 * N_LIMBS_LARGE]; N_COL_TOTAL]> = Box::new(comms_large[1]);
 
-    for block_row_i in 0..35 * N_COL_TOTAL {
-        // Number of the commitment we're processing
-        let com_i = block_row_i % N_COL_TOTAL;
-        let (xp_limbs, yp_limbs) =
-            if block_row_i < 17 * N_COL_TOTAL || block_row_i >= 34 * N_COL_TOTAL {
-                // Our main commitment input
-                (
-                    comms_large[1][com_i][..N_LIMBS_LARGE].try_into().unwrap(),
-                    comms_large[1][com_i][N_LIMBS_LARGE..].try_into().unwrap(),
-                )
-            } else {
-                (
-                    r_hat_large[com_i][..N_LIMBS_LARGE].try_into().unwrap(),
-                    r_hat_large[com_i][N_LIMBS_LARGE..].try_into().unwrap(),
-                )
-            };
-        write_column_array_const(env, &xp_limbs, |i| IVCColumn::Block4ECAdd(FECColumn::XP(i)));
-        write_column_array_const(env, &yp_limbs, |i| IVCColumn::Block4ECAdd(FECColumn::YP(i)));
+    // Compute error and t terms limbs.
+    let error_terms_large: [[F; 2 * N_LIMBS_LARGE]; 3] = error_terms
+        .iter()
+        .map(|(x, y)| {
+            limb_decompose_ff::<F, Ff, LIMB_BITSIZE_LARGE, N_LIMBS_LARGE>(x)
+                .into_iter()
+                .chain(limb_decompose_ff::<F, Ff, LIMB_BITSIZE_LARGE, N_LIMBS_LARGE>(y))
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap()
+        })
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
+    let t_terms_large: [[F; 2 * N_LIMBS_LARGE]; 2] = t_terms
+        .iter()
+        .map(|(x, y)| {
+            limb_decompose_ff::<F, Ff, LIMB_BITSIZE_LARGE, N_LIMBS_LARGE>(x)
+                .into_iter()
+                .chain(limb_decompose_ff::<F, Ff, LIMB_BITSIZE_LARGE, N_LIMBS_LARGE>(y))
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap()
+        })
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
 
-        // FIXME This is a STUB right now it uses C_{L,i} commitments.
+    // E_R' = r·T_0 + r^2·T_1 + r^3·E_R
+    // FIXME for now stubbed and just equal to E_L
+    let error_term_rprime_large: [F; 2 * N_LIMBS_LARGE] = error_terms_large[0];
+
+    for block_row_i in 0..(35 * N_COL_TOTAL + 5) {
+        // Number of the commitment we're processing, ∈ [N]
+        let com_i = block_row_i % N_COL_TOTAL;
+        // Coefficient limb we're processing for C_L/C_R/C_O, ∈ [k = 17]
+        let coeff_num_1 = (block_row_i / N_COL_TOTAL) % N_LIMBS_SMALL;
+        // Coefficient limb we're processing for error terms, ∈ [k = 17]
+        let coeff_num_2 = if block_row_i >= 35 * N_COL_TOTAL {
+            (block_row_i - 35 * N_COL_TOTAL) % N_LIMBS_SMALL
+        } else {
+            0
+        };
+
+        // First FEC input point, P.
+        let (xp_limbs, yp_limbs, coeff) = if block_row_i < 17 * N_COL_TOTAL {
+            // R hat, with ϕ^i
+            (
+                r_hat_large[com_i][..N_LIMBS_LARGE].try_into().unwrap(),
+                r_hat_large[com_i][N_LIMBS_LARGE..].try_into().unwrap(),
+                scalar_limbs.phi_limbs[com_i][coeff_num_1],
+            )
+        } else if block_row_i < 34 * N_COL_TOTAL {
+            // Our main C_R commitment input, with r·ϕ^i
+            (
+                comms_large[1][com_i][..N_LIMBS_LARGE].try_into().unwrap(),
+                comms_large[1][com_i][N_LIMBS_LARGE..].try_into().unwrap(),
+                scalar_limbs.phi_r_limbs[com_i][coeff_num_1],
+            )
+        } else if block_row_i < 35 * N_COL_TOTAL {
+            // FIXME add a minus!
+            // no bucketing, no coeffient, no RAM. Only -R hat
+            (
+                r_hat_large[com_i][..N_LIMBS_LARGE].try_into().unwrap(),
+                r_hat_large[com_i][N_LIMBS_LARGE..].try_into().unwrap(),
+                F::zero(),
+            )
+        } else if block_row_i < 35 * N_COL_TOTAL + 17 {
+            // FIXME add a minus
+            // -E_R', with coeff ϕ^{n+1}
+            (
+                error_term_rprime_large[..N_LIMBS_LARGE].try_into().unwrap(),
+                error_term_rprime_large[N_LIMBS_LARGE..].try_into().unwrap(),
+                scalar_limbs.phi_limbs[N_COL_TOTAL][coeff_num_2],
+            )
+        } else if block_row_i < 35 * N_COL_TOTAL + 2 * 17 {
+            // T_0, with coeff r · ϕ^{n+1}
+            (
+                t_terms_large[0][..N_LIMBS_LARGE].try_into().unwrap(),
+                t_terms_large[0][N_LIMBS_LARGE..].try_into().unwrap(),
+                scalar_limbs.phi_r_limbs[N_COL_TOTAL][coeff_num_2],
+            )
+        } else if block_row_i < 35 * N_COL_TOTAL + 3 * 17 {
+            // T_1, with coeff r^2 · ϕ^{n+1}
+            (
+                t_terms_large[1][..N_LIMBS_LARGE].try_into().unwrap(),
+                t_terms_large[1][N_LIMBS_LARGE..].try_into().unwrap(),
+                scalar_limbs.phi_np1_r2_limbs[coeff_num_2],
+            )
+        } else if block_row_i < 35 * N_COL_TOTAL + 4 * 17 {
+            // E_R, with coeff r^3 · ϕ^{n+1}
+            (
+                error_terms_large[1][..N_LIMBS_LARGE].try_into().unwrap(),
+                error_terms_large[1][N_LIMBS_LARGE..].try_into().unwrap(),
+                scalar_limbs.phi_np1_r3_limbs[coeff_num_2],
+            )
+        } else if block_row_i == 35 * N_COL_TOTAL + 4 * 17 {
+            // E_L, no bucketing, no coeff
+            (
+                error_terms_large[0][..N_LIMBS_LARGE].try_into().unwrap(),
+                error_terms_large[0][N_LIMBS_LARGE..].try_into().unwrap(),
+                F::zero(),
+            )
+        } else {
+            panic!("Dead case");
+        };
+
+        // FIXME This is a STUB right now it uses C_{O,i} commitments.
         // Must use bucket input which is looked up.
-        let xq_limbs: [F; N_LIMBS_LARGE] =
-            comms_large[0][com_i][..N_LIMBS_LARGE].try_into().unwrap();
-        let yq_limbs: [F; N_LIMBS_LARGE] =
-            comms_large[0][com_i][..N_LIMBS_LARGE].try_into().unwrap();
-        write_column_array_const(env, &xq_limbs, |i| IVCColumn::Block4ECAdd(FECColumn::XQ(i)));
-        write_column_array_const(env, &yq_limbs, |i| IVCColumn::Block4ECAdd(FECColumn::YQ(i)));
+        let stub_bucket = (
+            comms_large[2][com_i][..N_LIMBS_LARGE].try_into().unwrap(),
+            comms_large[2][com_i][N_LIMBS_LARGE..].try_into().unwrap(),
+        );
+
+        // Second FEC input point, Q.
+        let (xq_limbs, yq_limbs) = if block_row_i < 34 * N_COL_TOTAL {
+            stub_bucket
+        } else if block_row_i < 35 * N_COL_TOTAL {
+            // C_{L,i} commitments
+            (
+                comms_large[0][com_i][..N_LIMBS_LARGE].try_into().unwrap(),
+                comms_large[0][com_i][N_LIMBS_LARGE..].try_into().unwrap(),
+            )
+        } else if block_row_i < 35 * N_COL_TOTAL + 4 * 17 {
+            stub_bucket
+        } else if block_row_i == 35 * N_COL_TOTAL + 4 * 17 {
+            // E_R'
+            (
+                error_term_rprime_large[..N_LIMBS_LARGE].try_into().unwrap(),
+                error_term_rprime_large[N_LIMBS_LARGE..].try_into().unwrap(),
+            )
+        } else {
+            panic!("Dead case");
+        };
+
+        env.write_column(IVCColumn::Block4Coeff, &Env::constant(coeff));
+        write_column_array_const(env, &xp_limbs, IVCColumn::Block4Input1);
+        write_column_array_const(env, &yp_limbs, |i| IVCColumn::Block4Input1(i + 4));
+        write_column_array_const(env, &xq_limbs, IVCColumn::Block4Input2);
+        write_column_array_const(env, &yq_limbs, |i| IVCColumn::Block4Input2(i + 4));
+
+        // TODO These two should be used when RAMLookups are enabled.
+        env.write_column(IVCColumn::Block4Input2AccessTime, &Env::constant(F::zero()));
+        env.write_column(IVCColumn::Block4OutputAccessTime, &Env::constant(F::zero()));
 
         let limbs_f_to_ff = |limbs: &[F; N_LIMBS_LARGE]| {
             limbs
@@ -555,7 +746,7 @@ pub fn process_ecadds<F, Ff, Env, const N_COL_TOTAL: usize>(
         let yp = combine_large_to_full_field(yp_limbs_ff);
         let yq = combine_large_to_full_field(yq_limbs_ff);
 
-        ec_add_circuit(
+        let (xr, yr) = ec_add_circuit(
             &mut SubEnvLookup::new(
                 &mut SubEnvColumn::new(env, IVCFECLens {}),
                 IVCFECLookupLens(PhantomData),
@@ -565,6 +756,17 @@ pub fn process_ecadds<F, Ff, Env, const N_COL_TOTAL: usize>(
             xq,
             yq,
         );
+
+        // repacking results into 75 bits.
+        let xr_limbs_large: [F; N_LIMBS_LARGE] =
+            limb_decompose_ff::<F, Ff, LIMB_BITSIZE_LARGE, N_LIMBS_LARGE>(&xr);
+        let yr_limbs_large: [F; N_LIMBS_LARGE] =
+            limb_decompose_ff::<F, Ff, LIMB_BITSIZE_LARGE, N_LIMBS_LARGE>(&yr);
+
+        write_column_array_const(env, &xr_limbs_large, IVCColumn::Block4OutputRepacked);
+        write_column_array_const(env, &yr_limbs_large, |i| {
+            IVCColumn::Block4OutputRepacked(4 + i)
+        });
 
         constrain_ecadds::<F, Ff, Env>(env);
     }
@@ -578,11 +780,14 @@ where
 }
 
 /// Instantiates the IVC circuit for folding. N is the total number of columns
+#[allow(clippy::too_many_arguments)]
 pub fn ivc_circuit<F, Ff, Env, PParams, const N_COL_TOTAL: usize>(
     env: &mut Env,
     comms_left: [(Ff, Ff); N_COL_TOTAL],
     comms_right: [(Ff, Ff); N_COL_TOTAL],
     comms_out: [(Ff, Ff); N_COL_TOTAL],
+    error_terms: [(Ff, Ff); 3], // E_L, E_R, E_O
+    t_terms: [(Ff, Ff); 2],     // T_0, T_1
     poseidon_params: &PParams,
     domain_size: usize,
 ) where
@@ -602,7 +807,7 @@ pub fn ivc_circuit<F, Ff, Env, PParams, const N_COL_TOTAL: usize>(
         process_hashes::<_, _, _, N_COL_TOTAL>(env, poseidon_params, &comms_xlarge);
     let r: F = Env::variable_to_field(r_var);
     let phi: F = Env::variable_to_field(phi_var);
-    process_scalars::<_, Ff, _, N_COL_TOTAL>(env, r, phi);
-    process_ecadds::<_, Ff, _, N_COL_TOTAL>(env, r, phi, &comms_large);
+    let scalar_limbs = process_scalars::<_, Ff, _, N_COL_TOTAL>(env, r, phi);
+    process_ecadds::<_, Ff, _, N_COL_TOTAL>(env, scalar_limbs, &comms_large, error_terms, t_terms);
     process_misc::<_, _, N_COL_TOTAL>(env);
 }

--- a/ivc/src/ivc/mod.rs
+++ b/ivc/src/ivc/mod.rs
@@ -13,7 +13,7 @@ mod tests {
         },
         poseidon::{interpreter::PoseidonParams, params::static_params},
     };
-    use ark_ff::UniformRand;
+    use ark_ff::{UniformRand, Zero};
     use kimchi_msm::{circuit_design::WitnessBuilderEnv, columns::ColumnIndexer, Ff1, Fp};
     use rand::{CryptoRng, RngCore};
 
@@ -73,11 +73,14 @@ mod tests {
             )
         });
 
+        // TODO add nonzero E/T values.
         ivc_circuit::<_, _, _, _, TEST_N_COL_TOTAL>(
             &mut witness_env,
             comms_left,
             comms_right,
             comms_output,
+            [(Ff1::zero(), Ff1::zero()); 3],
+            [(Ff1::zero(), Ff1::zero()); 2],
             &PoseidonBN254Parameters,
             TEST_DOMAIN_SIZE,
         );

--- a/msm/src/fec/columns.rs
+++ b/msm/src/fec/columns.rs
@@ -6,16 +6,27 @@ use crate::{
 /// Number of columns in the FEC circuits.
 pub const FEC_N_COLUMNS: usize = 5 * N_LIMBS_LARGE + 12 * N_LIMBS_SMALL + 9;
 
-/// Columns used by the serialization subcircuit.
+/// FEC ADD inputs: two points = four coordinates, and each in 4
+/// "large format" limbs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum FECColumn {
-    XP(usize),     // 4
-    YP(usize),     // 4
-    XQ(usize),     // 4
-    YQ(usize),     // 4
+pub enum FECColumnInput {
+    XP(usize), // 4
+    YP(usize), // 4
+    XQ(usize), // 4
+    YQ(usize), // 4
+}
+
+/// FEC ADD outputs: one point, each in 17 limb output format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FECColumnOutput {
+    XR(usize), // 17
+    YR(usize), // 17
+}
+
+/// FEC ADD intermediate (work) columns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FECColumnInter {
     F(usize),      // 4
-    XR(usize),     // 17
-    YR(usize),     // 17
     S(usize),      // 17
     Q1(usize),     // 17
     Q2(usize),     // 17
@@ -28,69 +39,106 @@ pub enum FECColumn {
     Carry3(usize), // 36
 }
 
+/// Columns used by the FEC Addition subcircuit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FECColumn {
+    Input(FECColumnInput),
+    Output(FECColumnOutput),
+    Inter(FECColumnInter),
+}
+
+impl ColumnIndexer for FECColumnInput {
+    const N_COL: usize = 4 * N_LIMBS_LARGE;
+    fn to_column(self) -> Column {
+        match self {
+            FECColumnInput::XP(i) => {
+                assert!(i < N_LIMBS_LARGE);
+                Column::Relation(i)
+            }
+            FECColumnInput::YP(i) => {
+                assert!(i < N_LIMBS_LARGE);
+                Column::Relation(N_LIMBS_LARGE + i)
+            }
+            FECColumnInput::XQ(i) => {
+                assert!(i < N_LIMBS_LARGE);
+                Column::Relation(2 * N_LIMBS_LARGE + i)
+            }
+            FECColumnInput::YQ(i) => {
+                assert!(i < N_LIMBS_LARGE);
+                Column::Relation(3 * N_LIMBS_LARGE + i)
+            }
+        }
+    }
+}
+
+impl ColumnIndexer for FECColumnOutput {
+    const N_COL: usize = 2 * N_LIMBS_SMALL;
+    fn to_column(self) -> Column {
+        match self {
+            FECColumnOutput::XR(i) => {
+                assert!(i < N_LIMBS_SMALL);
+                Column::Relation(i)
+            }
+            FECColumnOutput::YR(i) => {
+                assert!(i < N_LIMBS_SMALL);
+                Column::Relation(N_LIMBS_SMALL + i)
+            }
+        }
+    }
+}
+
+impl ColumnIndexer for FECColumnInter {
+    const N_COL: usize = N_LIMBS_LARGE + 10 * N_LIMBS_SMALL + 9;
+    fn to_column(self) -> Column {
+        match self {
+            FECColumnInter::F(i) => {
+                assert!(i < N_LIMBS_LARGE);
+                Column::Relation(i)
+            }
+            FECColumnInter::S(i) => {
+                assert!(i < N_LIMBS_SMALL);
+                Column::Relation(N_LIMBS_LARGE + i)
+            }
+            FECColumnInter::Q1(i) => {
+                assert!(i < N_LIMBS_SMALL);
+                Column::Relation(N_LIMBS_LARGE + N_LIMBS_SMALL + i)
+            }
+            FECColumnInter::Q2(i) => {
+                assert!(i < N_LIMBS_SMALL);
+                Column::Relation(N_LIMBS_LARGE + 2 * N_LIMBS_SMALL + i)
+            }
+            FECColumnInter::Q3(i) => {
+                assert!(i < N_LIMBS_SMALL);
+                Column::Relation(N_LIMBS_LARGE + 3 * N_LIMBS_SMALL + i)
+            }
+            FECColumnInter::Q1Sign => Column::Relation(N_LIMBS_LARGE + 4 * N_LIMBS_SMALL),
+            FECColumnInter::Q2Sign => Column::Relation(N_LIMBS_LARGE + 4 * N_LIMBS_SMALL + 1),
+            FECColumnInter::Q3Sign => Column::Relation(N_LIMBS_LARGE + 4 * N_LIMBS_SMALL + 2),
+            FECColumnInter::Carry1(i) => {
+                assert!(i < 2 * N_LIMBS_SMALL + 2);
+                Column::Relation(N_LIMBS_LARGE + 4 * N_LIMBS_SMALL + 3 + i)
+            }
+            FECColumnInter::Carry2(i) => {
+                assert!(i < 2 * N_LIMBS_SMALL + 2);
+                Column::Relation(N_LIMBS_LARGE + 6 * N_LIMBS_SMALL + 5 + i)
+            }
+            FECColumnInter::Carry3(i) => {
+                assert!(i < 2 * N_LIMBS_SMALL + 2);
+                Column::Relation(N_LIMBS_LARGE + 8 * N_LIMBS_SMALL + 7 + i)
+            }
+        }
+    }
+}
+
 impl ColumnIndexer for FECColumn {
     const N_COL: usize = FEC_N_COLUMNS;
     fn to_column(self) -> Column {
         match self {
-            FECColumn::XP(i) => {
-                assert!(i < N_LIMBS_LARGE);
-                Column::Relation(i)
-            }
-            FECColumn::YP(i) => {
-                assert!(i < N_LIMBS_LARGE);
-                Column::Relation(N_LIMBS_LARGE + i)
-            }
-            FECColumn::XQ(i) => {
-                assert!(i < N_LIMBS_LARGE);
-                Column::Relation(2 * N_LIMBS_LARGE + i)
-            }
-            FECColumn::YQ(i) => {
-                assert!(i < N_LIMBS_LARGE);
-                Column::Relation(3 * N_LIMBS_LARGE + i)
-            }
-            FECColumn::F(i) => {
-                assert!(i < N_LIMBS_LARGE);
-                Column::Relation(4 * N_LIMBS_LARGE + i)
-            }
-            FECColumn::XR(i) => {
-                assert!(i < N_LIMBS_SMALL);
-                Column::Relation(5 * N_LIMBS_LARGE + i)
-            }
-            FECColumn::YR(i) => {
-                assert!(i < N_LIMBS_SMALL);
-                Column::Relation(5 * N_LIMBS_LARGE + N_LIMBS_SMALL + i)
-            }
-            FECColumn::S(i) => {
-                assert!(i < N_LIMBS_SMALL);
-                Column::Relation(5 * N_LIMBS_LARGE + 2 * N_LIMBS_SMALL + i)
-            }
-            FECColumn::Q1(i) => {
-                assert!(i < N_LIMBS_SMALL);
-                Column::Relation(5 * N_LIMBS_LARGE + 3 * N_LIMBS_SMALL + i)
-            }
-            FECColumn::Q2(i) => {
-                assert!(i < N_LIMBS_SMALL);
-                Column::Relation(5 * N_LIMBS_LARGE + 4 * N_LIMBS_SMALL + i)
-            }
-            FECColumn::Q3(i) => {
-                assert!(i < N_LIMBS_SMALL);
-                Column::Relation(5 * N_LIMBS_LARGE + 5 * N_LIMBS_SMALL + i)
-            }
-            FECColumn::Q1Sign => Column::Relation(5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL),
-            FECColumn::Q2Sign => Column::Relation(5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL + 1),
-            FECColumn::Q3Sign => Column::Relation(5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL + 2),
-            FECColumn::Carry1(i) => {
-                assert!(i < 2 * N_LIMBS_SMALL + 2);
-                Column::Relation(5 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL + 3 + i)
-            }
-            FECColumn::Carry2(i) => {
-                assert!(i < 2 * N_LIMBS_SMALL + 2);
-                Column::Relation(5 * N_LIMBS_LARGE + 8 * N_LIMBS_SMALL + 5 + i)
-            }
-            FECColumn::Carry3(i) => {
-                assert!(i < 2 * N_LIMBS_SMALL + 2);
-                Column::Relation(5 * N_LIMBS_LARGE + 10 * N_LIMBS_SMALL + 7 + i)
-            }
+            FECColumn::Input(input) => input.to_column(),
+            FECColumn::Inter(inter) => inter.to_column().add_rel_offset(FECColumnInput::N_COL),
+            FECColumn::Output(output) => output
+                .to_column()
+                .add_rel_offset(FECColumnInput::N_COL + FECColumnInter::N_COL),
         }
     }
 }


### PR DESCRIPTION
This PR:
* Adds IVC circuit design stubs related to one-off error computation & other misc parts (indices).
* Updates the diagram correspondingly.
* Modularises the FEC/Column structure for composing.

Previous PRs:
3. https://github.com/o1-labs/proof-systems/pull/2141
4. https://github.com/o1-labs/proof-systems/pull/2144
5. https://github.com/o1-labs/proof-systems/pull/2151