### PR TITLE
Folding/o1VM: make structure unit

### DIFF
--- a/optimism/src/folding.rs
+++ b/optimism/src/folding.rs
@@ -154,10 +154,9 @@ impl<const N: usize> Witness<Curve> for FoldingWitness<N> {
 
 /// Environment for the folding protocol, for a given number of witness columns
 /// and structure
-pub struct FoldingEnvironment<const N: usize, Structure> {
+pub struct FoldingEnvironment<const N: usize> {
     /// Structure of the folded circuit (not used right now)
-    #[allow(dead_code)]
-    pub structure: Structure,
+    pub structure: (),
     /// Commitments to the witness columns, for both sides
     pub instances: [FoldingInstance<N>; 2],
     /// Corresponds to the omega evaluations, for both sides
@@ -167,17 +166,17 @@ pub struct FoldingEnvironment<const N: usize, Structure> {
     pub next_witnesses: [FoldingWitness<N>; 2],
 }
 
-impl<const N: usize, Col, Selector: Copy + Clone, Structure: Clone>
+impl<const N: usize, Col, Selector: Copy + Clone>
     FoldingEnv<Fp, FoldingInstance<N>, FoldingWitness<N>, Col, Challenge, Selector>
-    for FoldingEnvironment<N, Structure>
+    for FoldingEnvironment<N>
 where
     FoldingWitness<N>: Index<Col, Output = Evaluations<Fp, Radix2EvaluationDomain<Fp>>>,
     FoldingWitness<N>: Index<Selector, Output = Evaluations<Fp, Radix2EvaluationDomain<Fp>>>,
 {
-    type Structure = Structure;
+    type Structure = ();
 
     fn new(
-        structure: &Self::Structure,
+        _structure: &Self::Structure,
         instances: [&FoldingInstance<N>; 2],
         witnesses: [&FoldingWitness<N>; 2],
     ) -> Self {
@@ -189,7 +188,7 @@ where
             }
         }
         FoldingEnvironment {
-            structure: structure.clone(),
+            structure: (),
             instances: [instances[0].clone(), instances[1].clone()],
             curr_witnesses,
             next_witnesses,

--- a/optimism/src/keccak/folding.rs
+++ b/optimism/src/keccak/folding.rs
@@ -12,13 +12,15 @@ use crate::{
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 use folding::{expressions::FoldingColumnTrait, FoldingConfig};
 use kimchi_msm::columns::Column;
+use poly_commitment::srs::SRS;
 use std::ops::Index;
 
 use super::column::ZKVM_KECCAK_REL;
 
 pub type KeccakFoldingWitness = FoldingWitness<ZKVM_KECCAK_COLS>;
 pub type KeccakFoldingInstance = FoldingInstance<ZKVM_KECCAK_COLS>;
-pub type KeccakFoldingEnvironment = FoldingEnvironment<ZKVM_KECCAK_COLS, KeccakStructure>;
+
+pub type KeccakFoldingEnvironment = FoldingEnvironment<ZKVM_KECCAK_COLS>;
 
 impl Index<KeccakColumn> for KeccakFoldingWitness {
     type Output = Evaluations<Fp, Radix2EvaluationDomain<Fp>>;
@@ -52,11 +54,6 @@ impl Index<Column> for KeccakFoldingWitness {
     }
 }
 
-// TODO: will contain information about the circuit structure
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct KeccakStructure;
-
-// TODO
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct KeccakConfig;
 
@@ -72,11 +69,13 @@ impl FoldingConfig for KeccakConfig {
     type Selector = Steps;
     type Challenge = Challenge;
     type Curve = Curve;
-    type Srs = poly_commitment::srs::SRS<Curve>;
+    type Srs = SRS<Curve>;
     type Sponge = BaseSponge;
     type Instance = KeccakFoldingInstance;
     type Witness = KeccakFoldingWitness;
-    type Structure = KeccakStructure;
+    // The structure is empty as we don't need to store any additional
+    // information that is static for the relation
+    type Structure = ();
     type Env = KeccakFoldingEnvironment;
 
     fn rows() -> usize {

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -541,10 +541,7 @@ fn test_keccak_prover_constraints() {
 
 #[test]
 fn test_keccak_decomposable_folding() {
-    use crate::{
-        keccak::folding::{KeccakConfig, KeccakStructure},
-        Curve,
-    };
+    use crate::{keccak::folding::KeccakConfig, Curve};
     use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as D};
     use folding::{
         decomposable_folding::DecomposableFoldingScheme, expressions::FoldingCompatibleExpr,
@@ -610,11 +607,6 @@ fn test_keccak_decomposable_folding() {
     .into_iter()
     .collect();
 
-    let (_scheme, _final_constraint) = DecomposableFoldingScheme::<KeccakConfig>::new(
-        constraints,
-        vec![],
-        &srs,
-        domain,
-        KeccakStructure {},
-    );
+    let (_scheme, _final_constraint) =
+        DecomposableFoldingScheme::<KeccakConfig>::new(constraints, vec![], &srs, domain, ());
 }

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -16,7 +16,7 @@ use kimchi_optimism::{
     mips::{
         column::{MIPS_COLUMNS, MIPS_REL_COLS, MIPS_SEL_COLS},
         constraints as mips_constraints,
-        folding::{MIPSFoldingConfig, MIPSStructure},
+        folding::MIPSFoldingConfig,
         interpreter::Instruction,
         trace::MIPSTrace,
         witness::{self as mips_witness, SCRATCH_SIZE},
@@ -113,7 +113,7 @@ pub fn main() -> ExitCode {
             vec![],
             &srs.full_srs,
             domain.d1,
-            MIPSStructure,
+            (),
         )
     };
 

--- a/optimism/src/mips/folding.rs
+++ b/optimism/src/mips/folding.rs
@@ -18,10 +18,11 @@ use kimchi_msm::columns::Column;
 use std::ops::Index;
 
 use super::column::MIPS_REL_COLS;
+use poly_commitment::srs::SRS;
 
 pub type MIPSFoldingWitness = FoldingWitness<MIPS_COLUMNS>;
 pub type MIPSFoldingInstance = FoldingInstance<MIPS_COLUMNS>;
-pub type MIPSFoldingEnvironment = FoldingEnvironment<MIPS_COLUMNS, MIPSStructure>;
+pub type MIPSFoldingEnvironment = FoldingEnvironment<MIPS_COLUMNS>;
 
 impl Index<MIPSColumn> for MIPSFoldingWitness {
     type Output = Evaluations<Fp, Radix2EvaluationDomain<Fp>>;
@@ -55,11 +56,6 @@ impl Index<Column> for MIPSFoldingWitness {
     }
 }
 
-// TODO: will contain information about the circuit structure
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct MIPSStructure;
-
-// TODO
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct MIPSFoldingConfig;
 
@@ -75,11 +71,13 @@ impl FoldingConfig for MIPSFoldingConfig {
     type Selector = Instruction;
     type Challenge = Challenge;
     type Curve = Curve;
-    type Srs = poly_commitment::srs::SRS<Curve>;
+    type Srs = SRS<Curve>;
     type Sponge = BaseSponge;
     type Instance = MIPSFoldingInstance;
     type Witness = MIPSFoldingWitness;
-    type Structure = MIPSStructure;
+    // The structure is empty as we don't need to store any additional
+    // information that is static for the relation
+    type Structure = ();
     type Env = MIPSFoldingEnvironment;
 
     fn rows() -> usize {


### PR DESCRIPTION
Based on discussion with Fabrizio, it seems that structure must contain data that is the same for the whole relation, like the matrices when we use R1CS. However, here, we do have nothing for MIPS/Keccak for now.