### PR TITLE
Finish decompsable folding Keccak test

### DIFF
--- a/folding/src/decomposable_folding.rs
+++ b/folding/src/decomposable_folding.rs
@@ -27,7 +27,7 @@ impl<'a, CF: FoldingConfig> DecomposableFoldingScheme<'a, CF> {
         common_constraints: Vec<FoldingCompatibleExpr<CF>>,
         srs: &'a CF::Srs,
         domain: Radix2EvaluationDomain<ScalarField<CF>>,
-        structure: CF::Structure,
+        structure: &CF::Structure,
     ) -> (Self, FoldingCompatibleExpr<CF>) {
         let constraints = constraints
             .into_iter()

--- a/folding/src/examples/example_decomposable_folding.rs
+++ b/folding/src/examples/example_decomposable_folding.rs
@@ -6,7 +6,7 @@ use crate::{
     Alphas, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance, Witness,
 };
 use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_ff::{UniformRand, Zero};
+use ark_ff::UniformRand;
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 use itertools::Itertools;
 use kimchi::circuits::{expr::Variable, gate::CurrOrNext};

--- a/folding/src/examples/example_decomposable_folding.rs
+++ b/folding/src/examples/example_decomposable_folding.rs
@@ -81,6 +81,10 @@ impl Witness<Curve> for TestWitness {
         }
         a
     }
+
+    fn rows(&self) -> usize {
+        self[0].evals.len()
+    }
 }
 
 // our environment, the way in which we provide access to the actual values in the
@@ -125,10 +129,10 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, TestColumn, TestChallenge, Dynami
         }
     }
 
-    fn zero_vec(&self) -> Vec<Fp> {
+    fn domain_size(&self) -> usize {
         // this works in the example but is not the best way as the envionment
         // could get circuits of any size
-        vec![Fp::zero(); 2]
+        2
     }
 
     // provide access to columns, here side refers to one of the two pairs you
@@ -230,10 +234,6 @@ impl FoldingConfig for TestFoldingConfig {
     type Instance = TestInstance;
     type Witness = TestWitness;
     type Env = TestFoldingEnv;
-
-    fn rows() -> usize {
-        2
-    }
 }
 
 //creates an instance from its witness
@@ -353,7 +353,7 @@ mod tests {
             vec![],
             &srs,
             domain,
-            (),
+            &(),
         );
 
         // some inputs to be used by both add and sub

--- a/folding/src/examples/example_quadriticization.rs
+++ b/folding/src/examples/example_quadriticization.rs
@@ -8,7 +8,7 @@ use crate::{
     Alphas, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance,
 };
 use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_ff::{UniformRand, Zero};
+use ark_ff::UniformRand;
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 use itertools::Itertools;
 use kimchi::circuits::{expr::Variable, gate::CurrOrNext};

--- a/folding/src/examples/example_quadriticization.rs
+++ b/folding/src/examples/example_quadriticization.rs
@@ -112,10 +112,10 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, TestColumn, TestChallenge, Dynami
         }
     }
 
-    fn zero_vec(&self) -> Vec<Fp> {
+    fn domain_size(&self) -> usize {
         // this works in the example but is not the best way as the envionment
         // could get circuits of any size
-        vec![Fp::zero(); 2]
+        2
     }
 
     // provide access to columns, here side refers to one of the two pairs you
@@ -220,10 +220,6 @@ impl FoldingConfig for TestFoldingConfig {
     type Instance = TestInstance;
     type Witness = TestWitness;
     type Env = TestFoldingEnv;
-
-    fn rows() -> usize {
-        2
-    }
 }
 
 //creates an instance from its witness
@@ -338,7 +334,7 @@ mod tests {
             vec![],
             &srs,
             domain,
-            (),
+            &(),
         );
 
         // some inputs to be used by both add and mul

--- a/folding/src/instance_witness.rs
+++ b/folding/src/instance_witness.rs
@@ -26,6 +26,9 @@ pub trait Witness<G: CommitmentCurve>: Sized {
     /// Should return a linear combination
     fn combine(a: Self, b: Self, challenge: G::ScalarField) -> Self;
 
+    /// Returns the number of rows in the witness
+    fn rows(&self) -> usize;
+
     fn relax(self, zero_poly: &Evals<G::ScalarField>) -> RelaxedWitness<G, Self> {
         let witness = ExtendedWitness::extend(self);
         RelaxedWitness {
@@ -145,6 +148,10 @@ impl<G: CommitmentCurve, W: Witness<G>> Witness<G> for ExtendedWitness<G, W> {
             })
             .collect();
         Self { inner, extended }
+    }
+
+    fn rows(&self) -> usize {
+        self.inner.rows()
     }
 }
 

--- a/folding/src/lib.rs
+++ b/folding/src/lib.rs
@@ -74,7 +74,7 @@ pub trait FoldingConfig: Clone + Debug + Eq + Hash + 'static {
     type Column: FoldingColumnTrait + Debug + Eq + Hash;
 
     // in case of using docomposable folding, if not it can be just ()
-    type Selector: Clone + Debug + Eq + Hash + Copy;
+    type Selector: Clone + Debug + Eq + Hash + Copy + Ord + PartialOrd;
 
     /// The type of an abstract challenge that can be found in the expressions
     /// provided as constraints.

--- a/optimism/src/folding.rs
+++ b/optimism/src/folding.rs
@@ -1,4 +1,4 @@
-use crate::DOMAIN_SIZE;
+use crate::trace::Trace;
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{FftField, Zero};
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
@@ -96,45 +96,56 @@ impl<const N: usize, G: CommitmentCurve> Witness<G> for FoldingWitness<N, G::Sca
         }
         a
     }
+
+    fn rows(&self) -> usize {
+        self.witness.cols[0].evals.len()
+    }
 }
 
 /// Environment for the folding protocol, for a given number of witness columns
 /// and structure
-pub struct FoldingEnvironment<const N: usize, G: CommitmentCurve> {
-    /// Structure of the folded circuit (not used right now)
-    pub structure: (),
+pub struct FoldingEnvironment<
+    const N: usize,
+    const N_REL: usize,
+    const N_SEL: usize,
+    C: FoldingConfig,
+> {
+    /// Structure of the folded circuit (using Trace for now, as it contains the domain size)
+    pub structure: Trace<N, N_REL, N_SEL, C>,
     /// Commitments to the witness columns, for both sides
-    pub instances: [FoldingInstance<N, G>; 2],
+    pub instances: [FoldingInstance<N, C::Curve>; 2],
     /// Corresponds to the omega evaluations, for both sides
-    pub curr_witnesses: [FoldingWitness<N, G::ScalarField>; 2],
+    pub curr_witnesses: [FoldingWitness<N, ScalarField<C>>; 2],
     /// Corresponds to the zeta*omega evaluations, for both sides
     /// This is curr_witness but left shifted by 1
-    pub next_witnesses: [FoldingWitness<N, G::ScalarField>; 2],
+    pub next_witnesses: [FoldingWitness<N, ScalarField<C>>; 2],
 }
 
-impl<const N: usize, G: CommitmentCurve, Col, Selector: Copy + Clone>
+impl<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig>
     FoldingEnv<
-        G::ScalarField,
-        FoldingInstance<N, G>,
-        FoldingWitness<N, G::ScalarField>,
-        Col,
+        ScalarField<C>,
+        FoldingInstance<N, C::Curve>,
+        FoldingWitness<N, ScalarField<C>>,
+        C::Column,
         Challenge,
-        Selector,
-    > for FoldingEnvironment<N, G>
+        C::Selector,
+    > for FoldingEnvironment<N, N_REL, N_SEL, C>
 where
-    FoldingWitness<N, G::ScalarField>:
-        Index<Col, Output = Evaluations<G::ScalarField, Radix2EvaluationDomain<G::ScalarField>>>,
-    FoldingWitness<N, G::ScalarField>: Index<
-        Selector,
-        Output = Evaluations<G::ScalarField, Radix2EvaluationDomain<G::ScalarField>>,
+    FoldingWitness<N, ScalarField<C>>: Index<
+        C::Column,
+        Output = Evaluations<ScalarField<C>, Radix2EvaluationDomain<ScalarField<C>>>,
+    >,
+    FoldingWitness<N, ScalarField<C>>: Index<
+        C::Selector,
+        Output = Evaluations<ScalarField<C>, Radix2EvaluationDomain<ScalarField<C>>>,
     >,
 {
-    type Structure = ();
+    type Structure = Trace<N, N_REL, N_SEL, C>;
 
     fn new(
-        _structure: &Self::Structure,
-        instances: [&FoldingInstance<N, G>; 2],
-        witnesses: [&FoldingWitness<N, G::ScalarField>; 2],
+        structure: &Self::Structure,
+        instances: [&FoldingInstance<N, C::Curve>; 2],
+        witnesses: [&FoldingWitness<N, ScalarField<C>>; 2],
     ) -> Self {
         let curr_witnesses = [witnesses[0].clone(), witnesses[1].clone()];
         let mut next_witnesses = curr_witnesses.clone();
@@ -144,18 +155,22 @@ where
             }
         }
         FoldingEnvironment {
-            structure: (),
+            structure: structure.clone(),
             instances: [instances[0].clone(), instances[1].clone()],
             curr_witnesses,
             next_witnesses,
         }
     }
 
-    fn zero_vec(&self) -> Vec<G::ScalarField> {
-        vec![G::ScalarField::zero(); DOMAIN_SIZE]
+    fn domain_size(&self) -> usize {
+        self.structure.domain_size
     }
 
-    fn col(&self, col: Col, curr_or_next: CurrOrNext, side: Side) -> &Vec<G::ScalarField> {
+    fn zero_vec(&self) -> Vec<ScalarField<C>> {
+        vec![ScalarField::<C>::zero(); self.domain_size()]
+    }
+
+    fn col(&self, col: C::Column, curr_or_next: CurrOrNext, side: Side) -> &Vec<ScalarField<C>> {
         let wit = match curr_or_next {
             CurrOrNext::Curr => &self.curr_witnesses[side as usize],
             CurrOrNext::Next => &self.next_witnesses[side as usize],
@@ -164,7 +179,7 @@ where
         &wit[col].evals
     }
 
-    fn challenge(&self, challenge: Challenge, side: Side) -> G::ScalarField {
+    fn challenge(&self, challenge: Challenge, side: Side) -> ScalarField<C> {
         match challenge {
             Challenge::Beta => self.instances[side as usize].challenges[0],
             Challenge::Gamma => self.instances[side as usize].challenges[1],
@@ -172,16 +187,16 @@ where
         }
     }
 
-    fn lagrange_basis(&self, _i: usize) -> &Vec<G::ScalarField> {
+    fn lagrange_basis(&self, _i: usize) -> &Vec<ScalarField<C>> {
         todo!()
     }
 
-    fn alpha(&self, i: usize, side: Side) -> G::ScalarField {
+    fn alpha(&self, i: usize, side: Side) -> ScalarField<C> {
         let instance = &self.instances[side as usize];
         instance.alphas.get(i).unwrap()
     }
 
-    fn selector(&self, s: &Selector, side: Side) -> &Vec<G::ScalarField> {
+    fn selector(&self, s: &C::Selector, side: Side) -> &Vec<ScalarField<C>> {
         let witness = &self.curr_witnesses[side as usize];
         &witness[*s].evals
     }

--- a/optimism/src/keccak/folding.rs
+++ b/optimism/src/keccak/folding.rs
@@ -1,8 +1,11 @@
 use crate::{
     folding::{Challenge, FoldingEnvironment, FoldingInstance, FoldingWitness},
-    keccak::{column::ZKVM_KECCAK_COLS, KeccakColumn, Steps},
-    trace::Indexer,
-    Curve, Fp, DOMAIN_SIZE,
+    keccak::{
+        column::{ZKVM_KECCAK_COLS, ZKVM_KECCAK_REL, ZKVM_KECCAK_SEL},
+        KeccakColumn, Steps,
+    },
+    trace::{Indexer, Trace},
+    Curve, Fp,
 };
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 use folding::{
@@ -14,12 +17,11 @@ use kimchi_msm::columns::Column;
 use poly_commitment::srs::SRS;
 use std::ops::Index;
 
-use super::column::ZKVM_KECCAK_REL;
-
 pub type KeccakFoldingWitness = FoldingWitness<ZKVM_KECCAK_COLS, Fp>;
 pub type KeccakFoldingInstance = FoldingInstance<ZKVM_KECCAK_COLS, Curve>;
 
-pub type KeccakFoldingEnvironment = FoldingEnvironment<ZKVM_KECCAK_COLS, Curve>;
+pub type KeccakFoldingEnvironment =
+    FoldingEnvironment<ZKVM_KECCAK_COLS, ZKVM_KECCAK_REL, ZKVM_KECCAK_SEL, KeccakConfig>;
 
 impl Index<KeccakColumn> for KeccakFoldingWitness {
     type Output = Evaluations<Fp, Radix2EvaluationDomain<Fp>>;
@@ -73,12 +75,8 @@ impl FoldingConfig for KeccakConfig {
     type Witness = KeccakFoldingWitness;
     // The structure is empty as we don't need to store any additional
     // information that is static for the relation
-    type Structure = ();
+    type Structure = Trace<ZKVM_KECCAK_COLS, ZKVM_KECCAK_REL, ZKVM_KECCAK_SEL, KeccakConfig>;
     type Env = KeccakFoldingEnvironment;
-
-    fn rows() -> usize {
-        DOMAIN_SIZE
-    }
 }
 
 // IMPLEMENT CHECKER TRAITS

--- a/optimism/src/keccak/folding.rs
+++ b/optimism/src/keccak/folding.rs
@@ -73,8 +73,6 @@ impl FoldingConfig for KeccakConfig {
     type Srs = SRS<Curve>;
     type Instance = KeccakFoldingInstance;
     type Witness = KeccakFoldingWitness;
-    // The structure is empty as we don't need to store any additional
-    // information that is static for the relation
     type Structure = Trace<ZKVM_KECCAK_COLS, ZKVM_KECCAK_REL, ZKVM_KECCAK_SEL, KeccakConfig>;
     type Env = KeccakFoldingEnvironment;
 }

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -592,14 +592,9 @@ fn test_keccak_decomposable_folding() {
                 while keccak_env.step.is_some() {
                     let step = keccak_env.step.unwrap(); // Either Absorb(Only) or Round(0)
                     keccak_env.step(); // Create the relation witness columns
-                    match step {
-                        Sponge(Absorb(Only)) => {
-                            // Add the witness row to the circuit
-                            trace.push_row(step, &keccak_env.witness_env.witness.cols);
-                        }
-                        _ => {
-                            // Don't push the other steps
-                        }
+                    if let Sponge(Absorb(Only)) = step {
+                        // Add the witness row to the circuit
+                        trace.push_row(step, &keccak_env.witness_env.witness.cols);
                     }
                 }
             }

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -90,8 +90,8 @@ pub fn main() -> ExitCode {
     // The keccak environment is extracted inside the loop
 
     // Initialize the circuits. Includes pre-folding witnesses.
-    let mut mips_trace = MIPSTrace::<Fp>::new(DOMAIN_SIZE, &mut mips_con_env);
-    let mut keccak_trace = KeccakTrace::<Fp>::new(DOMAIN_SIZE, &mut KeccakEnv::<Fp>::default());
+    let mut mips_trace = MIPSTrace::new(DOMAIN_SIZE, &mut mips_con_env);
+    let mut keccak_trace = KeccakTrace::new(DOMAIN_SIZE, &mut KeccakEnv::<Fp>::default());
 
     let _mips_folding = {
         let constraints: BTreeMap<Instruction, Vec<FoldingCompatibleExpr<MIPSFoldingConfig>>> =

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -113,7 +113,7 @@ pub fn main() -> ExitCode {
             vec![],
             &srs.full_srs,
             domain.d1,
-            (),
+            &mips_trace,
         )
     };
 

--- a/optimism/src/mips/folding.rs
+++ b/optimism/src/mips/folding.rs
@@ -70,8 +70,6 @@ impl FoldingConfig for MIPSFoldingConfig {
     type Srs = SRS<Curve>;
     type Instance = MIPSFoldingInstance;
     type Witness = MIPSFoldingWitness;
-    // The structure is empty as we don't need to store any additional
-    // information that is static for the relation
     type Structure = Trace<MIPS_COLUMNS, MIPS_REL_COLS, MIPS_SEL_COLS, MIPSFoldingConfig>;
     type Env = MIPSFoldingEnvironment;
 }

--- a/optimism/src/mips/folding.rs
+++ b/optimism/src/mips/folding.rs
@@ -4,20 +4,21 @@ use crate::{
         column::{ColumnAlias as MIPSColumn, MIPS_COLUMNS},
         Instruction,
     },
-    trace::Indexer,
-    Curve, Fp, DOMAIN_SIZE,
+    trace::{Indexer, Trace},
+    Curve, Fp,
 };
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 use folding::{expressions::FoldingColumnTrait, FoldingConfig};
 use kimchi_msm::columns::Column;
 use std::ops::Index;
 
-use super::column::MIPS_REL_COLS;
+use super::column::{MIPS_REL_COLS, MIPS_SEL_COLS};
 use poly_commitment::srs::SRS;
 
 pub type MIPSFoldingWitness = FoldingWitness<MIPS_COLUMNS, Fp>;
 pub type MIPSFoldingInstance = FoldingInstance<MIPS_COLUMNS, Curve>;
-pub type MIPSFoldingEnvironment = FoldingEnvironment<MIPS_COLUMNS, Curve>;
+pub type MIPSFoldingEnvironment =
+    FoldingEnvironment<MIPS_COLUMNS, MIPS_REL_COLS, MIPS_SEL_COLS, MIPSFoldingConfig>;
 
 impl Index<MIPSColumn> for MIPSFoldingWitness {
     type Output = Evaluations<Fp, Radix2EvaluationDomain<Fp>>;
@@ -71,10 +72,6 @@ impl FoldingConfig for MIPSFoldingConfig {
     type Witness = MIPSFoldingWitness;
     // The structure is empty as we don't need to store any additional
     // information that is static for the relation
-    type Structure = ();
+    type Structure = Trace<MIPS_COLUMNS, MIPS_REL_COLS, MIPS_SEL_COLS, MIPSFoldingConfig>;
     type Env = MIPSFoldingEnvironment;
-
-    fn rows() -> usize {
-        DOMAIN_SIZE
-    }
 }

--- a/optimism/src/mips/tests.rs
+++ b/optimism/src/mips/tests.rs
@@ -28,7 +28,7 @@ fn test_mips_number_constraints() {
     };
 
     // Keep track of the constraints and lookups of the sub-circuits
-    let mips_circuit = MIPSTrace::<Fp>::new(domain_size, &mut constraints_env);
+    let mips_circuit = MIPSTrace::new(domain_size, &mut constraints_env);
 
     let assert_num_constraints = |instr: &Instruction, num: usize| {
         assert_eq!(mips_circuit.constraints.get(instr).unwrap().len(), num)

--- a/optimism/src/trace.rs
+++ b/optimism/src/trace.rs
@@ -27,6 +27,7 @@ pub trait Indexer {
 /// - Selector: an enum representing the different gate behaviours,
 /// - F: the type of the witness data.
 #[allow(clippy::type_complexity)]
+#[derive(Clone)]
 pub struct Trace<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig> {
     /// The domain size of the circuit
     pub domain_size: usize,

--- a/optimism/src/trace.rs
+++ b/optimism/src/trace.rs
@@ -3,8 +3,7 @@ use crate::{
     lookups::Lookup,
     E,
 };
-use ark_ec::AffineCurve;
-use ark_ff::{FftField, One, Zero};
+use ark_ff::{One, Zero};
 use ark_poly::{EvaluationDomain, Evaluations, Radix2EvaluationDomain};
 use folding::{Alphas, FoldingConfig};
 use itertools::Itertools;
@@ -12,7 +11,7 @@ use kimchi_msm::witness::Witness;
 use mina_poseidon::sponge::FqSponge;
 use poly_commitment::{PolyComm, SRS as _};
 use rayon::{iter::ParallelIterator, prelude::IntoParallelIterator};
-use std::{collections::BTreeMap, hash::Hash};
+use std::collections::BTreeMap;
 
 /// Returns the index of the witness column in the trace.
 pub trait Indexer {
@@ -27,66 +26,64 @@ pub trait Indexer {
 /// - N_SEL: the number of selector columns (constant),
 /// - Selector: an enum representing the different gate behaviours,
 /// - F: the type of the witness data.
-pub struct Trace<const N: usize, const N_REL: usize, const N_SEL: usize, Selector, F> {
+#[allow(clippy::type_complexity)]
+pub struct Trace<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig> {
     /// The domain size of the circuit
     pub domain_size: usize,
     /// The witness for a given selector
     /// - the last N_SEL columns represent the selector columns
     ///   and only the one for `Selector` should be all ones (the rest of selector columns should be all zeros)
-    pub witness: BTreeMap<Selector, Witness<N, Vec<F>>>,
+    pub witness: BTreeMap<C::Selector, Witness<N, Vec<ScalarField<C>>>>,
     /// The vector of constraints for a given selector
-    pub constraints: BTreeMap<Selector, Vec<E<F>>>,
+    pub constraints: BTreeMap<C::Selector, Vec<E<ScalarField<C>>>>,
     /// The vector of lookups for a given selector
-    pub lookups: BTreeMap<Selector, Vec<Lookup<E<F>>>>,
+    pub lookups: BTreeMap<C::Selector, Vec<Lookup<E<ScalarField<C>>>>>,
 }
 
-impl<
-        const N: usize,
-        const N_REL: usize,
-        const N_SEL: usize,
-        Selector: Eq + Hash + Indexer + Copy + Ord + PartialOrd,
-        F: One + Zero,
-    > Trace<N, N_REL, N_SEL, Selector, F>
+impl<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig>
+    Trace<N, N_REL, N_SEL, C>
+where
+    C::Selector: Ord + PartialOrd + Indexer,
 {
     /// Returns the number of rows that have been instantiated for the given selector.
     /// It is important that the column used is a relation column because selector columns
     /// are only instantiated at the very end, so their length could be zero most times.
-    pub fn number_of_rows(&self, opcode: Selector) -> usize {
+    pub fn number_of_rows(&self, opcode: C::Selector) -> usize {
         self.witness[&opcode].cols[0].len()
     }
 
     /// Returns a boolean indicating whether the witness for the given selector was ever found in the cirucit or not.
-    pub fn in_circuit(&self, opcode: Selector) -> bool {
+    pub fn in_circuit(&self, opcode: C::Selector) -> bool {
         self.number_of_rows(opcode) != 0
     }
 
     /// Returns whether the witness for the given selector has achieved a number of rows that is equal to the domain size.
-    pub fn is_full(&self, opcode: Selector) -> bool {
+    pub fn is_full(&self, opcode: C::Selector) -> bool {
         self.domain_size == self.number_of_rows(opcode)
     }
 
     /// Resets the witness after folding
-    pub fn reset(&mut self, opcode: Selector) {
+    pub fn reset(&mut self, opcode: C::Selector) {
         (self.witness.get_mut(&opcode).unwrap().cols.as_mut())
             .iter_mut()
             .for_each(Vec::clear);
     }
 
     /// Sets the selector column to all ones, and the rest to all zeros
-    pub fn set_selector_column(&mut self, selector: Selector, number_of_rows: usize) {
+    pub fn set_selector_column(&mut self, selector: C::Selector, number_of_rows: usize) {
         (N_REL..N).for_each(|i| {
             if i == selector.ix() {
                 self.witness.get_mut(&selector).unwrap().cols[i]
-                    .extend((0..number_of_rows).map(|_| F::one()))
+                    .extend((0..number_of_rows).map(|_| ScalarField::<C>::one()))
             } else {
                 self.witness.get_mut(&selector).unwrap().cols[i]
-                    .extend((0..number_of_rows).map(|_| F::zero()))
+                    .extend((0..number_of_rows).map(|_| ScalarField::<C>::zero()))
             }
         });
     }
 }
 
-pub(crate) trait Folder<const N: usize, C: FoldingConfig, Sponge, F: FftField> {
+pub(crate) trait Folder<const N: usize, C: FoldingConfig, Sponge> {
     /// Returns the witness for the given selector as a folding witness and
     /// folding instance pair.
     /// Note that this function will also absorb all commitments to the columns
@@ -98,12 +95,12 @@ pub(crate) trait Folder<const N: usize, C: FoldingConfig, Sponge, F: FftField> {
         sponge: &mut Sponge,
     ) -> (
         FoldingInstance<N, C::Curve>,
-        FoldingWitness<N, <<C as FoldingConfig>::Curve as AffineCurve>::ScalarField>,
+        FoldingWitness<N, ScalarField<C>>,
     );
 }
 
 impl<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig, Sponge>
-    Folder<N, C, Sponge, ScalarField<C>> for Trace<N, N_REL, N_SEL, C::Selector, ScalarField<C>>
+    Folder<N, C, Sponge> for Trace<N, N_REL, N_SEL, C>
 where
     C::Selector: Ord + PartialOrd + Indexer,
     Sponge: FqSponge<BaseField<C>, C::Curve, ScalarField<C>>,
@@ -117,7 +114,6 @@ where
         FoldingInstance<N, C::Curve>,
         FoldingWitness<N, ScalarField<C>>,
     ) {
-        println!("domain size in tracer {}", self.domain_size);
         let domain = Radix2EvaluationDomain::<ScalarField<C>>::new(self.domain_size).unwrap();
         let folding_witness = FoldingWitness {
             witness: (&self.witness[&selector])
@@ -163,31 +159,31 @@ where
 /// - For Keccak, `Step` encodes the row being performed at a time: round, squeeze, padding, etc...
 /// - For MIPS, `Instruction` encodes the CPU instruction being executed: add, sub, load, store, etc...
 /// The type parameter `F` is the type the data points in the trace are encoded into. It can be a field or a native type (u64).
-pub trait Tracer<const N: usize, const N_REL: usize, const N_SEL: usize, Selector, F: Zero, Env> {
+pub trait Tracer<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig, Env> {
     /// Create a new circuit
     fn new(domain_size: usize, env: &mut Env) -> Self;
 
     /// Add a witness row to the circuit (only for relation columns)
-    fn push_row(&mut self, opcode: Selector, row: &[F; N_REL]);
+    fn push_row(&mut self, opcode: C::Selector, row: &[ScalarField<C>; N_REL]);
 
     /// Pad the rows of one opcode with the given row until
     /// reaching the domain size if needed.
     /// Returns the number of rows that were added.
     /// It does not add selector columns.
-    fn pad_with_row(&mut self, opcode: Selector, row: &[F; N_REL]) -> usize;
+    fn pad_with_row(&mut self, opcode: C::Selector, row: &[ScalarField<C>; N_REL]) -> usize;
 
     /// Pads the rows of one opcode with zero rows until
     /// reaching the domain size if needed.
     /// Returns the number of rows that were added.
     /// It does not add selector columns.
-    fn pad_with_zeros(&mut self, opcode: Selector) -> usize;
+    fn pad_with_zeros(&mut self, opcode: C::Selector) -> usize;
 
     /// Pad the rows of one opcode with the first row until
     /// reaching the domain size if needed.
     /// It only tries to pad witnesses which are non empty.
     /// Returns the number of rows that were added.
     /// It does not add selector columns.
-    fn pad_dummy(&mut self, opcode: Selector) -> usize;
+    fn pad_dummy(&mut self, opcode: C::Selector) -> usize;
 
     /// Pads the rows of the witnesses until reaching the domain size using the first
     /// row repeatedly. It does not add selector columns.

--- a/optimism/src/trace.rs
+++ b/optimism/src/trace.rs
@@ -43,7 +43,7 @@ pub struct Trace<const N: usize, const N_REL: usize, const N_SEL: usize, C: Fold
 impl<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig>
     Trace<N, N_REL, N_SEL, C>
 where
-    C::Selector: Ord + PartialOrd + Indexer,
+    C::Selector: Indexer,
 {
     /// Returns the number of rows that have been instantiated for the given selector.
     /// It is important that the column used is a relation column because selector columns
@@ -102,7 +102,7 @@ pub(crate) trait Folder<const N: usize, C: FoldingConfig, Sponge> {
 impl<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig, Sponge>
     Folder<N, C, Sponge> for Trace<N, N_REL, N_SEL, C>
 where
-    C::Selector: Ord + PartialOrd + Indexer,
+    C::Selector: Indexer,
     Sponge: FqSponge<BaseField<C>, C::Curve, ScalarField<C>>,
 {
     fn to_folding_pair(


### PR DESCRIPTION
The goal of this PR is to fold one Keccak instruction in a test. In particular, it is folding `Sponge(Absorb(Only))` circuits together. For this to work, I had to make the following changes to the codebase, which are mostly collateral:
- For the domain size to be correctly spread out to the folding library, the `zero_vec()` vector inside `FoldingEnv` needed to be dynamically configurable. Otherwise, it was taking $2^{15}$ by default as the number of rows. 
  - In particular, I realized that the `rows()` function inside `FoldingConfig` does not talk at all to the `zero_vec()` function, which was producing this mismatch. 
  - Moreover, the `rows()` function was only being used by the examples, and never inside the actual code of folding. Thus, it looked quite superficial and I proceeded to remove it.
  - Instead, I created a `domain_size()` inside `FoldingEnv` that can be used to obtain the number of rows in `zero_vec()`. 
  - This new function works thanks to the use of the structure. It used to be just `()` as we were not using it before. But after talking to @dannywillems, it made sense that we could use the `Trace` inside the optimism folding types. Thanks to that, we can just access the domain size that was used in the first place when initializing the trace used in the tests.
  - Apart from this, I created a `rows()` function inside the `Provider` trait that simply looks at the length of the witness to obtain this value (before, it was hardcoded in the type).
- In order to avoid some clones in the user-facing functions, I made the `Structure` clonable and it is passed as a reference instead in the inner functions of folding.
- I made the `FoldingEnvironment` optimism type to be generic over the folding configuration. That way, I can define the instances and witnesses linking them to the ones associated to that configuration.
  - Consequently, there's a bit of refactors in the types inside the `FoldingEnv` implementation for that type. 