### PR TITLE
Keccak tests: remove unecessary cfg(feature=bn254)

### DIFF
--- a/folding/src/checker.rs
+++ b/folding/src/checker.rs
@@ -10,21 +10,12 @@ use ark_ec::AffineCurve;
 use ark_ff::{Field, Zero};
 use ark_poly::Evaluations;
 use kimchi::circuits::{expr::Variable, gate::CurrOrNext};
-use mina_poseidon::{constants::PlonkSpongeConstantsKimchi, sponge::DefaultFqSponge};
 use std::ops::Index;
 
 #[cfg(not(test))]
 use log::debug;
 #[cfg(test)]
 use std::println as debug;
-
-// 0. We start by defining the field and the curve that will be used in the
-// constraint system, in addition to the sponge that will be used to generate
-// challenges.
-pub type Fp = ark_bn254::Fr;
-pub type Curve = ark_bn254::G1Affine;
-pub type SpongeParams = PlonkSpongeConstantsKimchi;
-pub type BaseSponge = DefaultFqSponge<ark_bn254::g1::Parameters, SpongeParams>;
 
 // 1. We continue by defining a generic type of columns and selectors.
 // The selectors can be seen as additional (public) columns that are not part of

--- a/folding/src/examples/example.rs
+++ b/folding/src/examples/example.rs
@@ -7,8 +7,9 @@
 /// cargo nextest run examples::example::tests::test_folding_instance --release --all-features
 /// ```
 use crate::{
-    checker::{BaseSponge, Checker, Column, Curve, Fp, Provide},
+    checker::{Checker, Column, Provide},
     error_term::Side,
+    examples::{Curve, Fp, BaseSponge},
     expressions::FoldingCompatibleExprInner,
     Alphas, ExpExtension, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance,
     RelaxedInstance, RelaxedWitness, Witness,

--- a/folding/src/examples/example.rs
+++ b/folding/src/examples/example.rs
@@ -9,7 +9,7 @@
 use crate::{
     checker::{Checker, Column, Provide},
     error_term::Side,
-    examples::{Curve, Fp, BaseSponge},
+    examples::{BaseSponge, Curve, Fp},
     expressions::FoldingCompatibleExprInner,
     Alphas, ExpExtension, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance,
     RelaxedInstance, RelaxedWitness, Witness,

--- a/folding/src/examples/example_decomposable_folding.rs
+++ b/folding/src/examples/example_decomposable_folding.rs
@@ -1,6 +1,7 @@
 use crate::{
-    checker::{BaseSponge, Checker, Curve, ExtendedProvider, Fp},
+    checker::{Checker, ExtendedProvider},
     error_term::Side,
+    examples::{Curve, Fp},
     expressions::{FoldingColumnTrait, FoldingCompatibleExprInner},
     Alphas, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance, Witness,
 };
@@ -303,7 +304,10 @@ impl Index<DynamicSelector> for TestWitness {
 mod tests {
     use super::*;
     // Trick to print debug message while testing, as we in the test config env
-    use crate::{checker::ExtendedProvider, decomposable_folding::DecomposableFoldingScheme};
+    use crate::{
+        checker::ExtendedProvider, decomposable_folding::DecomposableFoldingScheme,
+        examples::BaseSponge,
+    };
     use ark_poly::{EvaluationDomain, Evaluations, Radix2EvaluationDomain as D};
     use kimchi::curve::KimchiCurve;
     use mina_poseidon::FqSponge;

--- a/folding/src/examples/example_quadriticization.rs
+++ b/folding/src/examples/example_quadriticization.rs
@@ -1,9 +1,9 @@
 // this example is a copy of the decomposable folding one, but with a degree 3 gate
 // that triggers quadriticization
 use crate::{
-    checker::{BaseSponge, Checker, Curve, ExtendedProvider, Fp},
+    checker::{Checker, ExtendedProvider},
     error_term::Side,
-    examples::example_decomposable_folding::TestWitness,
+    examples::{example_decomposable_folding::TestWitness, BaseSponge, Curve, Fp},
     expressions::{FoldingColumnTrait, FoldingCompatibleExprInner},
     Alphas, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance,
 };

--- a/folding/src/examples/mod.rs
+++ b/folding/src/examples/mod.rs
@@ -9,6 +9,16 @@
 //! code and adapt it to their needs. The generic structures are defined in the
 //! `checker` module.
 
+use mina_poseidon::{constants::PlonkSpongeConstantsKimchi, sponge::DefaultFqSponge};
+
+// 0. We start by defining the field and the curve that will be used in the
+// constraint system, in addition to the sponge that will be used to generate
+// challenges.
+pub type Fp = ark_bn254::Fr;
+pub type Curve = ark_bn254::G1Affine;
+pub type SpongeParams = PlonkSpongeConstantsKimchi;
+pub type BaseSponge = DefaultFqSponge<ark_bn254::g1::Parameters, SpongeParams>;
+
 pub mod example;
 pub mod example_decomposable_folding;
 pub mod example_quadriticization;

--- a/folding/src/lib.rs
+++ b/folding/src/lib.rs
@@ -58,8 +58,8 @@ pub mod quadraticization;
 #[cfg(feature = "bn254")]
 mod examples;
 
-/// Define the different structures required for the examples (both internal and external)
-#[cfg(feature = "bn254")]
+/// Define the different structures required for the examples (both internal and
+/// external)
 pub mod checker;
 
 // Simple type alias as ScalarField/BaseField is often used. Reduce type

--- a/optimism/src/keccak/mod.rs
+++ b/optimism/src/keccak/mod.rs
@@ -10,7 +10,6 @@ use kimchi::circuits::polynomials::keccak::constants::{
 pub mod column;
 pub mod constraints;
 pub mod environment;
-#[cfg(feature = "bn254")]
 pub mod folding;
 pub mod helpers;
 pub mod interpreter;

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -539,7 +539,6 @@ fn test_keccak_prover_constraints() {
     });
 }
 
-#[cfg(feature = "bn254")]
 #[test]
 fn test_keccak_decomposable_folding() {
     use crate::{keccak::folding::KeccakConfig, Curve};

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -541,7 +541,7 @@ fn test_keccak_prover_constraints() {
 
 #[test]
 fn test_keccak_decomposable_folding() {
-    use crate::{keccak::folding::KeccakConfig, Curve};
+    use crate::{keccak::folding::KeccakConfig, trace::Folder, Curve};
     use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as D};
     use folding::{
         decomposable_folding::DecomposableFoldingScheme, expressions::FoldingCompatibleExpr,


### PR DESCRIPTION
bn254 is always included.
If we only want to activate this test with a feature flag, we do have to use a different flag name than an optional feature flag used by another dependency and included by default in this crate.