### PR TITLE
Optimism: folding - always activate bn254 feature

### DIFF
--- a/optimism/Cargo.toml
+++ b/optimism/Cargo.toml
@@ -18,7 +18,9 @@ path = "src/test_preimage_read.rs"
 
 [dependencies]
 ark-bn254.workspace = true
-folding.workspace = true
+# We activate the feature bn254 of folding as we do use some structures of
+# folding in tests that are only activated by this flag
+folding = { workspace = true, features = [ "bn254" ] }
 kimchi = { workspace = true, features = [ "bn254" ] }
 kimchi-msm.workspace = true
 poly-commitment.workspace = true


### PR DESCRIPTION
We do use ark-bn254 by default in optimism