### PR TITLE
Fixed Selectors: Introduce support for

### DIFF
--- a/ivc/src/ivc/columns.rs
+++ b/ivc/src/ivc/columns.rs
@@ -129,7 +129,7 @@ pub type IVCPoseidonColumn = PoseidonColumn<IVC_POSEIDON_STATE_SIZE, IVC_POSEIDO
 
 // NB: We can reuse hash constants.
 // TODO: Can we pass just one coordinate and sign (x, sign) instead of (x,y) for hashing?
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IVCColumn {
     /// 2*17 15-bit limbs (two base field points)
     Block1Input(usize),
@@ -160,9 +160,9 @@ pub enum IVCColumn {
 
 impl ColumnIndexer for IVCColumn {
     // This should be
-    //   const COL_N: usize = std::cmp::max(IVCPoseidonColumn::COL_N, FECColumn::COL_N);
+    //   const N_COL: usize = std::cmp::max(IVCPoseidonColumn::N_COL, FECColumn::N_COL);
     // which is runtime-only expression..?
-    const COL_N: usize = IVCPoseidonColumn::COL_N;
+    const N_COL: usize = IVCPoseidonColumn::N_COL;
 
     fn to_column(self) -> Column {
         match self {

--- a/ivc/src/ivc/mod.rs
+++ b/ivc/src/ivc/mod.rs
@@ -24,8 +24,15 @@ mod tests {
     #[derive(Clone)]
     pub struct PoseidonBN254Parameters;
 
-    type IVCWitnessBuilderEnv =
-        WitnessBuilderEnv<Fp, { <IVCColumn as ColumnIndexer>::COL_N }, IVCLookupTable<Ff1>>;
+    type IVCWitnessBuilderEnv = WitnessBuilderEnv<
+        Fp,
+        IVCColumn,
+        { <IVCColumn as ColumnIndexer>::N_COL },
+        { <IVCColumn as ColumnIndexer>::N_COL },
+        0,
+        0,
+        IVCLookupTable<Ff1>,
+    >;
 
     impl PoseidonParams<Fp, IVC_POSEIDON_STATE_SIZE, IVC_POSEIDON_NB_FULL_ROUND>
         for PoseidonBN254Parameters

--- a/ivc/src/poseidon/columns.rs
+++ b/ivc/src/poseidon/columns.rs
@@ -16,7 +16,7 @@
 // expression must be changed to support this.
 use kimchi_msm::columns::{Column, ColumnIndexer};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PoseidonColumn<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> {
     Input(usize),
     Round(usize, usize),
@@ -26,7 +26,7 @@ pub enum PoseidonColumn<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> {
 impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> ColumnIndexer
     for PoseidonColumn<STATE_SIZE, NB_FULL_ROUND>
 {
-    const COL_N: usize = STATE_SIZE + 2 * NB_FULL_ROUND * STATE_SIZE;
+    const N_COL: usize = STATE_SIZE + 2 * NB_FULL_ROUND * STATE_SIZE;
 
     fn to_column(self) -> Column {
         match self {

--- a/ivc/src/poseidon/interpreter.rs
+++ b/ivc/src/poseidon/interpreter.rs
@@ -151,7 +151,7 @@ where
     let state: Vec<Env::Variable> = elements
         .iter()
         .map(|x| {
-            let x_col = env.read_column(x.clone());
+            let x_col = env.read_column(*x);
             let x_square = x_col.clone() * x_col.clone();
             let x_four = x_square.clone() * x_square.clone();
             x_four.clone() * x_square.clone() * x_col.clone()

--- a/ivc/src/poseidon/mod.rs
+++ b/ivc/src/poseidon/mod.rs
@@ -28,8 +28,9 @@ mod tests {
 
     pub const STATE_SIZE: usize = 3;
     pub const NB_FULL_ROUND: usize = 55;
-    pub const N_COL: usize = PoseidonColumn::<STATE_SIZE, NB_FULL_ROUND>::COL_N;
-    pub const N_SEL: usize = 0;
+    type TestPoseidonColumn = PoseidonColumn<STATE_SIZE, NB_FULL_ROUND>;
+    pub const N_COL: usize = TestPoseidonColumn::N_COL;
+    pub const N_DSEL: usize = 0;
 
     impl PoseidonParams<Fp, STATE_SIZE, NB_FULL_ROUND> for PoseidonBN254Parameters {
         fn constants(&self) -> [[Fp; STATE_SIZE]; NB_FULL_ROUND] {
@@ -43,6 +44,16 @@ mod tests {
         }
     }
 
+    type PoseidonWitnessBuilderEnv = WitnessBuilderEnv<
+        Fp,
+        TestPoseidonColumn,
+        { <TestPoseidonColumn as ColumnIndexer>::N_COL },
+        { <TestPoseidonColumn as ColumnIndexer>::N_COL },
+        0,
+        0,
+        DummyLookupTable,
+    >;
+
     #[test]
     /// Tests that poseidon circuit is correctly formed (witness
     /// generation + constraints match) and matches the CPU
@@ -52,8 +63,7 @@ mod tests {
         let mut rng = o1_utils::tests::make_test_rng();
         let domain_size = 1 << 4;
 
-        let mut witness_env: WitnessBuilderEnv<Fp, N_COL, DummyLookupTable> =
-            WitnessBuilderEnv::create();
+        let mut witness_env: PoseidonWitnessBuilderEnv = WitnessBuilderEnv::create();
 
         // Generate random inputs at each row
         for _row in 0..domain_size {
@@ -101,8 +111,7 @@ mod tests {
 
         let empty_lookups = BTreeMap::new();
         let proof_inputs = {
-            let mut witness_env: WitnessBuilderEnv<Fp, N_COL, DummyLookupTable> =
-                WitnessBuilderEnv::create();
+            let mut witness_env: PoseidonWitnessBuilderEnv = WitnessBuilderEnv::create();
 
             // Generate random inputs at each row
             for _row in 0..domain.d1.size {
@@ -147,7 +156,8 @@ mod tests {
             _,
             N_COL,
             N_COL,
-            N_SEL,
+            N_DSEL,
+            0,
             DummyLookupTable,
         >(domain, &srs, &constraints, proof_inputs, &mut rng)
         .unwrap();
@@ -160,7 +170,8 @@ mod tests {
             ScalarSponge,
             N_COL,
             N_COL,
-            N_SEL,
+            N_DSEL,
+            0,
             0,
             DummyLookupTable,
         >(

--- a/msm/src/circuit_design/witness.rs
+++ b/msm/src/circuit_design/witness.rs
@@ -10,14 +10,24 @@ use crate::{
 use ark_ff::PrimeField;
 use kimchi::circuits::domains::EvaluationDomains;
 use log::debug;
-use std::{collections::BTreeMap, iter};
+use std::{collections::BTreeMap, iter, marker::PhantomData};
 
-/// Witness builder environment. Operates
-pub struct WitnessBuilderEnv<F: PrimeField, const CIX_COL_N: usize, LT: LookupTableID> {
+/// Witness builder environment. Operates on multiple rows at the same
+/// time. `CIx::N_COL` must be equal to `N_COL`; passing these two
+/// separately is due to a rust limitation.
+pub struct WitnessBuilderEnv<
+    F: PrimeField,
+    CIx: ColumnIndexer,
+    const N_COL: usize,
+    const N_REL: usize,
+    const N_DSEL: usize,
+    const N_FSEL: usize,
+    LT: LookupTableID,
+> {
     /// The witness columns that the environment is working with.
     /// Every element of the vector is a row, and the builder is
     /// always processing the last row.
-    pub witness: Vec<Witness<CIX_COL_N, F>>,
+    pub witness: Vec<Witness<N_COL, F>>,
 
     /// Lookup multiplicities, a vector of values `m_i` per lookup
     /// table, where `m_i` is how many times the lookup value number
@@ -28,10 +38,24 @@ pub struct WitnessBuilderEnv<F: PrimeField, const CIX_COL_N: usize, LT: LookupTa
     /// each row is a map from lookup type to a vector of concrete
     /// lookups requested.
     pub lookups: Vec<BTreeMap<LT, Vec<Logup<F, LT>>>>,
+
+    /// Fixed values for selector columns. `fixed_selectors[i][j]` is the
+    /// value for row #j of the selector #i.
+    pub fixed_selectors: Vec<Vec<F>>,
+
+    // Not strictly needed at this point, but likely will be used later.
+    pub phantom_cix: PhantomData<CIx>,
 }
 
-impl<F: PrimeField, CIx: ColumnIndexer, const CIX_COL_N: usize, LT: LookupTableID>
-    ColAccessCap<F, CIx> for WitnessBuilderEnv<F, CIX_COL_N, LT>
+impl<
+        F: PrimeField,
+        CIx: ColumnIndexer,
+        const N_COL: usize,
+        const N_REL: usize,
+        const N_DSEL: usize,
+        const N_FSEL: usize,
+        LT: LookupTableID,
+    > ColAccessCap<F, CIx> for WitnessBuilderEnv<F, CIx, N_COL, N_REL, N_DSEL, N_FSEL, LT>
 {
     // Requiring an F element as we would need to compute values up to 180 bits
     // in the 15 bits decomposition.
@@ -46,15 +70,23 @@ impl<F: PrimeField, CIx: ColumnIndexer, const CIX_COL_N: usize, LT: LookupTableI
     }
 
     fn read_column(&self, ix: CIx) -> Self::Variable {
-        let Column::Relation(i) = ix.to_column() else {
-            todo!()
-        };
-        self.witness.last().unwrap().cols[i]
+        match ix.to_column() {
+            Column::Relation(i) => self.witness.last().unwrap().cols[i],
+            Column::FixedSelector(i) => self.fixed_selectors[i][self.witness.len() - 1],
+            other => panic!("WitnessBuilderEnv::read_column does not support {other:?}"),
+        }
     }
 }
 
-impl<F: PrimeField, CIx: ColumnIndexer, const CIX_COL_N: usize, LT: LookupTableID>
-    ColWriteCap<F, CIx> for WitnessBuilderEnv<F, CIX_COL_N, LT>
+impl<
+        F: PrimeField,
+        CIx: ColumnIndexer,
+        const N_COL: usize,
+        const N_REL: usize,
+        const N_DSEL: usize,
+        const N_FSEL: usize,
+        LT: LookupTableID,
+    > ColWriteCap<F, CIx> for WitnessBuilderEnv<F, CIx, N_COL, N_REL, N_DSEL, N_FSEL, LT>
 {
     fn write_column(&mut self, ix: CIx, value: &Self::Variable) {
         let Column::Relation(i) = ix.to_column() else {
@@ -70,17 +102,33 @@ impl<F: PrimeField, CIx: ColumnIndexer, const CIX_COL_N: usize, LT: LookupTableI
 ///
 /// Sadly, rust does not allow "cover" instances to define this impl
 /// for every `T: ColWriteCap`.
-impl<F: PrimeField, CIx: ColumnIndexer, const CIX_COL_N: usize, LT: LookupTableID>
-    HybridCopyCap<F, CIx> for WitnessBuilderEnv<F, CIX_COL_N, LT>
+impl<
+        F: PrimeField,
+        CIx: ColumnIndexer,
+        const N_COL: usize,
+        const N_REL: usize,
+        const N_DSEL: usize,
+        const N_FSEL: usize,
+        LT: LookupTableID,
+    > HybridCopyCap<F, CIx> for WitnessBuilderEnv<F, CIx, N_COL, N_REL, N_DSEL, N_FSEL, LT>
 {
     fn hcopy(&mut self, value: &Self::Variable, ix: CIx) -> Self::Variable {
-        <WitnessBuilderEnv<F, CIX_COL_N, LT> as ColWriteCap<F, CIx>>::write_column(self, ix, value);
+        <WitnessBuilderEnv<F, CIx, N_COL, N_REL, N_DSEL, N_FSEL, LT> as ColWriteCap<F, CIx>>::write_column(
+            self, ix, value,
+        );
         *value
     }
 }
 
-impl<F: PrimeField, CIx: ColumnIndexer, const CIX_COL_N: usize, LT: LookupTableID>
-    MultiRowReadCap<F, CIx> for WitnessBuilderEnv<F, CIX_COL_N, LT>
+impl<
+        F: PrimeField,
+        CIx: ColumnIndexer,
+        const N_COL: usize,
+        const N_REL: usize,
+        const N_DSEL: usize,
+        const N_FSEL: usize,
+        LT: LookupTableID,
+    > MultiRowReadCap<F, CIx> for WitnessBuilderEnv<F, CIx, N_COL, N_REL, N_DSEL, N_FSEL, LT>
 {
     /// Read value from a (row,column) position.
     fn read_row_column(&mut self, row: usize, col: CIx) -> Self::Variable {
@@ -101,8 +149,15 @@ impl<F: PrimeField, CIx: ColumnIndexer, const CIX_COL_N: usize, LT: LookupTableI
     }
 }
 
-impl<F: PrimeField, CIx: ColumnIndexer, const CIX_COL_N: usize, LT: LookupTableID>
-    DirectWitnessCap<F, CIx> for WitnessBuilderEnv<F, CIX_COL_N, LT>
+impl<
+        F: PrimeField,
+        CIx: ColumnIndexer,
+        const N_COL: usize,
+        const N_REL: usize,
+        const N_DSEL: usize,
+        const N_FSEL: usize,
+        LT: LookupTableID,
+    > DirectWitnessCap<F, CIx> for WitnessBuilderEnv<F, CIx, N_COL, N_REL, N_DSEL, N_FSEL, LT>
 {
     /// Convert an abstract variable to a field element! Inverse of Env::constant().
     fn variable_to_field(value: Self::Variable) -> F {
@@ -110,8 +165,15 @@ impl<F: PrimeField, CIx: ColumnIndexer, const CIX_COL_N: usize, LT: LookupTableI
     }
 }
 
-impl<F: PrimeField, CIx: ColumnIndexer, const CIX_COL_N: usize, LT: LookupTableID>
-    LookupCap<F, CIx, LT> for WitnessBuilderEnv<F, CIX_COL_N, LT>
+impl<
+        F: PrimeField,
+        CIx: ColumnIndexer,
+        const N_COL: usize,
+        const N_REL: usize,
+        const N_DSEL: usize,
+        const N_FSEL: usize,
+        LT: LookupTableID,
+    > LookupCap<F, CIx, LT> for WitnessBuilderEnv<F, CIx, N_COL, N_REL, N_DSEL, N_FSEL, LT>
 {
     fn lookup(&mut self, table_id: LT, value: &<Self as ColAccessCap<F, CIx>>::Variable) {
         let value_ix = table_id.ix_by_value(*value);
@@ -129,10 +191,23 @@ impl<F: PrimeField, CIx: ColumnIndexer, const CIX_COL_N: usize, LT: LookupTableI
     }
 }
 
-impl<F: PrimeField, const CIX_COL_N: usize, LT: LookupTableID> WitnessBuilderEnv<F, CIX_COL_N, LT> {
+impl<
+        F: PrimeField,
+        CIx: ColumnIndexer,
+        const N_COL: usize,
+        const N_REL: usize,
+        const N_DSEL: usize,
+        const N_FSEL: usize,
+        LT: LookupTableID,
+    > WitnessBuilderEnv<F, CIx, N_COL, N_REL, N_DSEL, N_FSEL, LT>
+{
+    // TODO this function duplicates one from ColWriteCap
     pub fn write_column(&mut self, position: Column, value: F) {
         match position {
             Column::Relation(i) => self.witness.last_mut().unwrap().cols[i] = value,
+            Column::FixedSelector(_) => {
+                panic!("Witness environment can't write into fixed selector columns.");
+            }
             Column::DynamicSelector(_) => {
                 // TODO: Do we want to allow writing to dynamic selector columns only 1 or 0?
                 panic!(
@@ -170,7 +245,7 @@ impl<F: PrimeField, const CIX_COL_N: usize, LT: LookupTableID> WitnessBuilderEnv
     /// Progress to the computations on the next row.
     pub fn next_row(&mut self) {
         self.witness.push(Witness {
-            cols: Box::new([F::zero(); CIX_COL_N]),
+            cols: Box::new([F::zero(); N_COL]),
         });
         let mut lookups_row = BTreeMap::new();
         for table_id in LT::all_variants().into_iter() {
@@ -196,11 +271,21 @@ impl<F: PrimeField, const CIX_COL_N: usize, LT: LookupTableID> WitnessBuilderEnv
     }
 }
 
-impl<F: PrimeField, const CIX_COL_N: usize, LT: LookupTableID> WitnessBuilderEnv<F, CIX_COL_N, LT> {
+impl<
+        F: PrimeField,
+        CIx: ColumnIndexer,
+        const N_COL: usize,
+        const N_REL: usize,
+        const N_DSEL: usize,
+        const N_FSEL: usize,
+        LT: LookupTableID,
+    > WitnessBuilderEnv<F, CIx, N_COL, N_REL, N_DSEL, N_FSEL, LT>
+{
     /// Create a new empty-state witness builder.
     pub fn create() -> Self {
         let mut lookups_row = BTreeMap::new();
         let mut lookup_multiplicities = BTreeMap::new();
+        let fixed_selectors = vec![vec![]; N_FSEL];
         for table_id in LT::all_variants().into_iter() {
             lookups_row.insert(table_id, Vec::new());
             lookup_multiplicities.insert(table_id, vec![F::zero(); table_id.length()]);
@@ -208,11 +293,23 @@ impl<F: PrimeField, const CIX_COL_N: usize, LT: LookupTableID> WitnessBuilderEnv
 
         Self {
             witness: vec![Witness {
-                cols: Box::new([F::zero(); CIX_COL_N]),
+                cols: Box::new([F::zero(); N_COL]),
             }],
 
             lookup_multiplicities,
             lookups: vec![lookups_row],
+            fixed_selectors,
+            phantom_cix: PhantomData,
+        }
+    }
+
+    /// Sets a fixed selector, the vector of length equal to the
+    /// domain size (circuit height).
+    pub fn set_fixed_selector(&mut self, sel: CIx, sel_values: Vec<F>) {
+        if let Column::FixedSelector(i) = sel.to_column() {
+            self.fixed_selectors[i] = sel_values;
+        } else {
+            panic!("Tried to assign values to non-fixed-selector typed column {sel:?}");
         }
     }
 
@@ -221,25 +318,37 @@ impl<F: PrimeField, const CIX_COL_N: usize, LT: LookupTableID> WitnessBuilderEnv
         &self,
         domain: EvaluationDomains<F>,
         lookup_tables_data: BTreeMap<LT, Vec<F>>,
-    ) -> ProofInputs<CIX_COL_N, F, LT> {
+    ) -> ProofInputs<N_COL, F, LT> {
         let domain_size: usize = domain.d1.size as usize;
         // Boxing to avoid stack overflow
-        let mut witness: Box<Witness<CIX_COL_N, Vec<F>>> = Box::new(Witness {
+        let mut witness: Box<Witness<N_COL, Vec<F>>> = Box::new(Witness {
             cols: Box::new(std::array::from_fn(|_| Vec::with_capacity(domain_size))),
         });
 
         // Filling actually used rows first
         for witness_row in self.witness.iter().take(domain_size) {
-            for j in 0..CIX_COL_N {
+            for j in 0..N_REL {
                 witness.cols[j].push(witness_row.cols[j]);
             }
         }
+
         // Then filling witness rows up with zeroes to the domain size
         // FIXME: Maybe this is not always wise, as default instance can be non-zero.
         if self.witness.len() < domain_size {
-            for i in 0..CIX_COL_N {
+            for i in 0..N_REL {
                 witness.cols[i].extend(vec![F::zero(); domain_size - self.witness.len()]);
             }
+        }
+
+        // Fill out dynamic selectors.
+        for i in 0..N_DSEL {
+            // TODO FIXME Fill out dynamic selectors!
+            witness.cols[N_REL + i] = vec![F::zero(); domain_size];
+        }
+
+        // Fill out fixed selectors.
+        for i in 0..N_FSEL {
+            witness.cols[N_REL + N_DSEL + i] = self.fixed_selectors[i].clone();
         }
 
         // Building lookup values

--- a/msm/src/columns.rs
+++ b/msm/src/columns.rs
@@ -10,6 +10,8 @@ pub enum Column {
     Relation(usize),
     /// Columns related to dynamic selectors to indicate gate type
     DynamicSelector(usize),
+    /// Constant column that is /always/ fixed for a given circuit.
+    FixedSelector(usize),
     // Columns related to the lookup protocol
     /// Partial sums. This corresponds to the `h_i`.
     /// It is first indexed by the table ID, and after that internal index.
@@ -22,11 +24,20 @@ pub enum Column {
     LookupFixedTable(u32),
 }
 
+impl Column {
+    /// Adds offset if the column is `Relation`. Fails otherwise.
+    pub fn add_rel_offset(self, offset: usize) -> Column {
+        let Column::Relation(i) = self else { todo!() };
+        Column::Relation(offset + i)
+    }
+}
+
 impl FormattedOutput for Column {
     fn latex(&self, _cache: &mut HashMap<CacheId, Self>) -> String {
         match self {
             Column::Relation(i) => format!("x_{{{i}}}"),
-            Column::DynamicSelector(i) => format!("s_{{{i}}}"),
+            Column::FixedSelector(i) => format!("fs_{{{i}}}"),
+            Column::DynamicSelector(i) => format!("ds_{{{i}}}"),
             Column::LookupPartialSum((table_id, i)) => format!("h_{{{table_id}, {i}}}"),
             Column::LookupMultiplicity(i) => format!("m_{{{i}}}"),
             Column::LookupFixedTable(i) => format!("t_{{{i}}}"),
@@ -37,7 +48,8 @@ impl FormattedOutput for Column {
     fn text(&self, _cache: &mut HashMap<CacheId, Self>) -> String {
         match self {
             Column::Relation(i) => format!("x[{i}]"),
-            Column::DynamicSelector(i) => format!("s[{i}]"),
+            Column::FixedSelector(i) => format!("fs[{i}]"),
+            Column::DynamicSelector(i) => format!("ds[{i}]"),
             Column::LookupPartialSum((table_id, i)) => format!("h[{table_id}, {i}]"),
             Column::LookupMultiplicity(i) => format!("m[{i}]"),
             Column::LookupFixedTable(i) => format!("t[{i}]"),
@@ -58,9 +70,10 @@ impl FormattedOutput for Column {
 
 /// A datatype expressing a generalized column, but with potentially
 /// more convenient interface than a bare column.
-pub trait ColumnIndexer {
+pub trait ColumnIndexer: core::fmt::Debug + Copy + Eq + Ord {
+    // TODO rename into N_COL for consistency
     /// Total number of columns in this index.
-    const COL_N: usize;
+    const N_COL: usize;
 
     /// Flatten the column "alias" into the integer-like column.
     fn to_column(self) -> Column;

--- a/msm/src/fec/columns.rs
+++ b/msm/src/fec/columns.rs
@@ -7,7 +7,7 @@ use crate::{
 pub const FEC_N_COLUMNS: usize = 5 * N_LIMBS_LARGE + 12 * N_LIMBS_SMALL + 9;
 
 /// Columns used by the serialization subcircuit.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FECColumn {
     XP(usize),     // 4
     YP(usize),     // 4
@@ -29,7 +29,7 @@ pub enum FECColumn {
 }
 
 impl ColumnIndexer for FECColumn {
-    const COL_N: usize = FEC_N_COLUMNS;
+    const N_COL: usize = FEC_N_COLUMNS;
     fn to_column(self) -> Column {
         match self {
             FECColumn::XP(i) => {

--- a/msm/src/fec/mod.rs
+++ b/msm/src/fec/mod.rs
@@ -25,10 +25,20 @@ mod tests {
     use rand::{CryptoRng, RngCore};
     use std::collections::BTreeMap;
 
+    type FECWitnessBuilderEnv = WitnessBuilderEnv<
+        Fp,
+        FECColumn,
+        { <FECColumn as ColumnIndexer>::N_COL },
+        { <FECColumn as ColumnIndexer>::N_COL },
+        0,
+        0,
+        LookupTable<Ff1>,
+    >;
+
     fn build_fec_addition_circuit<RNG: RngCore + CryptoRng>(
         rng: &mut RNG,
         domain_size: usize,
-    ) -> WitnessBuilderEnv<Fp, { <FECColumn as ColumnIndexer>::COL_N }, LookupTable<Ff1>> {
+    ) -> FECWitnessBuilderEnv {
         let mut witness_env = WitnessBuilderEnv::create();
 
         // To support less rows than domain_size we need to have selectors.
@@ -91,6 +101,7 @@ mod tests {
             FEC_N_COLUMNS,
             FEC_N_COLUMNS,
             0,
+            0,
             _,
         >(domain, &srs, &constraints, proof_inputs, &mut rng)
         .unwrap();
@@ -103,6 +114,7 @@ mod tests {
             ScalarSponge,
             FEC_N_COLUMNS,
             FEC_N_COLUMNS,
+            0,
             0,
             0,
             _,

--- a/msm/src/ffa/columns.rs
+++ b/msm/src/ffa/columns.rs
@@ -6,11 +6,11 @@ use crate::N_LIMBS;
 pub const FFA_N_COLUMNS: usize = 5 * N_LIMBS;
 pub const FFA_NPUB_COLUMNS: usize = N_LIMBS;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
 /// Column indexer for MSM columns.
 ///
 /// They represent the equation
 ///   `InputA(i) + InputB(i) = ModulusF(i) * Quotient + Carry(i) * 2^LIMB_SIZE - Carry(i-1)`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FFAColumn {
     InputA(usize),
     InputB(usize),
@@ -21,7 +21,7 @@ pub enum FFAColumn {
 }
 
 impl ColumnIndexer for FFAColumn {
-    const COL_N: usize = FFA_N_COLUMNS;
+    const N_COL: usize = FFA_N_COLUMNS;
     fn to_column(self) -> Column {
         let to_column_inner = |offset, i| {
             assert!(i < N_LIMBS);

--- a/msm/src/ffa/mod.rs
+++ b/msm/src/ffa/mod.rs
@@ -26,15 +26,24 @@ mod tests {
     use rand::{CryptoRng, RngCore};
     use std::collections::BTreeMap;
 
+    type FFAWitnessBuilderEnv = WitnessBuilderEnv<
+        Fp,
+        FFAColumn,
+        { <FFAColumn as ColumnIndexer>::N_COL },
+        { <FFAColumn as ColumnIndexer>::N_COL },
+        0,
+        0,
+        LookupTable,
+    >;
+
     /// Builds the FF addition circuit with random values. The witness
     /// environment enforces the constraints internally, so it is
     /// enough to just build the circuit to ensure it is satisfied.
     fn build_ffa_circuit<RNG: RngCore + CryptoRng>(
         rng: &mut RNG,
         domain_size: usize,
-    ) -> WitnessBuilderEnv<Fp, { <FFAColumn as ColumnIndexer>::COL_N }, LookupTable> {
-        let mut witness_env =
-            WitnessBuilderEnv::<Fp, { <FFAColumn as ColumnIndexer>::COL_N }, LookupTable>::create();
+    ) -> FFAWitnessBuilderEnv {
+        let mut witness_env = FFAWitnessBuilderEnv::create();
 
         for _row_i in 0..domain_size {
             let a: Ff1 = <Ff1 as UniformRand>::rand(rng);
@@ -88,6 +97,7 @@ mod tests {
             FFA_N_COLUMNS,
             FFA_N_COLUMNS,
             0,
+            0,
             _,
         >(domain, &srs, &constraints, proof_inputs, &mut rng)
         .unwrap();
@@ -100,6 +110,7 @@ mod tests {
             ScalarSponge,
             FFA_N_COLUMNS,
             FFA_N_COLUMNS,
+            0,
             0,
             0,
             _,

--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -54,7 +54,8 @@ pub fn prove<
     RNG,
     const N: usize,
     const N_REL: usize,
-    const N_SEL: usize,
+    const N_DSEL: usize,
+    const N_FSEL: usize,
     ID: LookupTableID,
 >(
     domain: EvaluationDomains<G::ScalarField>,
@@ -62,7 +63,7 @@ pub fn prove<
     constraints: &Vec<E<G::ScalarField>>,
     inputs: ProofInputs<N, G::ScalarField, ID>,
     rng: &mut RNG,
-) -> Result<Proof<N, N_REL, N_SEL, G, OpeningProof, ID>, ProverError>
+) -> Result<Proof<N, N_REL, N_DSEL, N_FSEL, G, OpeningProof, ID>, ProverError>
 where
     OpeningProof::SRS: Sync,
     RNG: RngCore + CryptoRng,
@@ -182,7 +183,7 @@ where
     let alpha: G::ScalarField = fq_sponge.challenge();
 
     let zk_rows = 0;
-    let column_env: ColumnEnvironment<'_, N, N_REL, N_SEL, _, _> = {
+    let column_env: ColumnEnvironment<'_, N, N_REL, N_DSEL, N_FSEL, _, _> = {
         let challenges = Challenges {
             alpha,
             // NB: as there is on permutation argument, we do use the beta
@@ -464,7 +465,7 @@ where
         rng,
     );
 
-    let proof_evals: ProofEvaluations<N, N_REL, N_SEL, G::ScalarField, ID> = {
+    let proof_evals: ProofEvaluations<N, N_REL, N_DSEL, N_FSEL, G::ScalarField, ID> = {
         ProofEvaluations {
             witness_evals,
             logup_evals,

--- a/msm/src/serialization/column.rs
+++ b/msm/src/serialization/column.rs
@@ -8,6 +8,7 @@ use crate::{
 pub const SER_N_COLUMNS: usize = 6 * N_LIMBS + N_INTERMEDIATE_LIMBS + 9;
 
 /// Columns used by the serialization subcircuit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SerializationColumn {
     /// 3 88-bit inputs. For the row #i this represents the IPA challenge xi_{log(i)}.
     ChalKimchi(usize),
@@ -29,7 +30,7 @@ pub enum SerializationColumn {
 }
 
 impl ColumnIndexer for SerializationColumn {
-    const COL_N: usize = SER_N_COLUMNS;
+    const N_COL: usize = SER_N_COLUMNS;
     fn to_column(self) -> Column {
         match self {
             Self::ChalKimchi(j) => {

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -31,6 +31,16 @@ mod tests {
         BaseSponge, Ff1, Fp, OpeningProof, ScalarSponge, BN254,
     };
 
+    type SerializationWitnessBuilderEnv = WitnessBuilderEnv<
+        Fp,
+        SerializationColumn,
+        { <SerializationColumn as ColumnIndexer>::N_COL },
+        { <SerializationColumn as ColumnIndexer>::N_COL },
+        0,
+        0,
+        LookupTable<Ff1>,
+    >;
+
     #[test]
     fn test_completeness() {
         let mut rng = o1_utils::tests::make_test_rng();
@@ -41,11 +51,7 @@ mod tests {
 
         let srs: PairingSRS<BN254> = get_bn254_srs(domain);
 
-        let mut witness_env = WitnessBuilderEnv::<
-            Fp,
-            { <SerializationColumn as ColumnIndexer>::COL_N },
-            LookupTable<Ff1>,
-        >::create();
+        let mut witness_env = SerializationWitnessBuilderEnv::create();
 
         // Boxing to avoid stack overflow
         let mut field_elements = vec![];
@@ -106,6 +112,7 @@ mod tests {
             SER_N_COLUMNS,
             SER_N_COLUMNS,
             0,
+            0,
             LookupTable<Ff1>,
         >(domain, &srs, &constraints, proof_inputs, &mut rng)
         .unwrap();
@@ -117,6 +124,7 @@ mod tests {
             ScalarSponge,
             SER_N_COLUMNS,
             SER_N_COLUMNS,
+            0,
             0,
             0,
             LookupTable<Ff1>,

--- a/msm/src/test/columns.rs
+++ b/msm/src/test/columns.rs
@@ -4,24 +4,25 @@ use crate::{
 };
 
 /// Number of columns in the test circuits.
-pub const TEST_N_COLUMNS: usize = 4 * N_LIMBS;
+pub const TEST_N_COLUMNS: usize = 4 * N_LIMBS + 1;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
 /// Column indexer for MSM columns.
 ///
 /// Columns A to D are used for testing right now, they are used for
 /// either of the two equations:
 ///   A + B - C = 0
 ///   A * B - D = 0
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TestColumn {
     A(usize),
     B(usize),
     C(usize),
     D(usize),
+    FixedE,
 }
 
 impl ColumnIndexer for TestColumn {
-    const COL_N: usize = TEST_N_COLUMNS;
+    const N_COL: usize = TEST_N_COLUMNS;
     fn to_column(self) -> Column {
         let to_column_inner = |offset, i| {
             assert!(i < N_LIMBS);
@@ -32,6 +33,7 @@ impl ColumnIndexer for TestColumn {
             TestColumn::B(i) => to_column_inner(1, i),
             TestColumn::C(i) => to_column_inner(2, i),
             TestColumn::D(i) => to_column_inner(3, i),
+            TestColumn::FixedE => Column::FixedSelector(0),
         }
     }
 }

--- a/msm/src/test/interpreter.rs
+++ b/msm/src/test/interpreter.rs
@@ -30,9 +30,7 @@ fn fill_limbs_a_b<
 
 /// A consraint function for A + B - C that reads values from limbs A
 /// and B, and additionally returns resulting value in C.
-pub fn constrain_addition<F: PrimeField, Ff: PrimeField, Env: ColAccessCap<F, TestColumn>>(
-    env: &mut Env,
-) {
+pub fn constrain_addition<F: PrimeField, Env: ColAccessCap<F, TestColumn>>(env: &mut Env) {
     let a_limbs: [Env::Variable; N_LIMBS] =
         core::array::from_fn(|i| Env::read_column(env, TestColumn::A(i)));
     let b_limbs: [Env::Variable; N_LIMBS] =
@@ -64,14 +62,12 @@ pub fn test_addition<
         env.write_column(TestColumn::D(i), &Env::constant(Zero::zero()));
     });
 
-    constrain_addition::<F, Ff, Env>(env);
+    constrain_addition(env);
 }
 
 /// A consraint function for A * B - D that reads values from limbs A
 /// and B, and multiplicationally returns resulting value in D.
-pub fn constrain_multiplication<F: PrimeField, Ff: PrimeField, Env: ColAccessCap<F, TestColumn>>(
-    env: &mut Env,
-) {
+pub fn constrain_multiplication<F: PrimeField, Env: ColAccessCap<F, TestColumn>>(env: &mut Env) {
     let a_limbs: [Env::Variable; N_LIMBS] =
         core::array::from_fn(|i| Env::read_column(env, TestColumn::A(i)));
     let b_limbs: [Env::Variable; N_LIMBS] =
@@ -86,7 +82,7 @@ pub fn constrain_multiplication<F: PrimeField, Ff: PrimeField, Env: ColAccessCap
     });
 }
 
-/// Circuit generator function for A + B - C, with D = 0.
+/// Circuit generator function for A * B - C, with D = 0.
 pub fn test_multiplication<
     F: PrimeField,
     Ff: PrimeField,
@@ -103,5 +99,54 @@ pub fn test_multiplication<
         env.write_column(TestColumn::C(i), &Env::constant(Zero::zero()));
     });
 
-    constrain_multiplication::<F, Ff, Env>(env);
+    constrain_multiplication(env);
+}
+
+/// A consraint function for A * B - D that reads values from limbs A
+/// and B, and multiplication_constally returns resulting value in D.
+pub fn constrain_test_const<F: PrimeField, Env: ColAccessCap<F, TestColumn>>(
+    env: &mut Env,
+    constant: F,
+) {
+    let a0 = Env::read_column(env, TestColumn::A(0));
+    let b0 = Env::read_column(env, TestColumn::B(0));
+    let equation = a0.clone() * b0.clone() - Env::constant(constant);
+    env.assert_zero(equation.clone());
+}
+
+/// Circuit generator function for A_0 * B_0 - const, with every other column = 0
+pub fn test_const<F: PrimeField, Env: ColAccessCap<F, TestColumn> + ColWriteCap<F, TestColumn>>(
+    env: &mut Env,
+    a: F,
+    b: F,
+    constant: F,
+) {
+    env.write_column(TestColumn::A(0), &Env::constant(a));
+    env.write_column(TestColumn::B(0), &Env::constant(b));
+
+    constrain_test_const(env, constant);
+}
+
+/// A consraint function for A_0 + B_0 - FIXED_E
+pub fn constrain_test_fixed_sel<F: PrimeField, Env: ColAccessCap<F, TestColumn>>(env: &mut Env) {
+    let a0 = Env::read_column(env, TestColumn::A(0));
+    let b0 = Env::read_column(env, TestColumn::B(0));
+    let fixed_e = Env::read_column(env, TestColumn::FixedE);
+    let equation = a0.clone() + b0.clone() - fixed_e;
+    env.assert_zero(equation.clone());
+}
+
+/// Circuit generator function for A_0 + B_0 - FIXED_E.
+pub fn test_fixed_sel<
+    F: PrimeField,
+    Env: ColAccessCap<F, TestColumn> + ColWriteCap<F, TestColumn>,
+>(
+    env: &mut Env,
+    a: F,
+) {
+    env.write_column(TestColumn::A(0), &Env::constant(a));
+    let fixed_e = env.read_column(TestColumn::FixedE);
+    env.write_column(TestColumn::B(0), &(fixed_e - Env::constant(a)));
+
+    constrain_test_fixed_sel(env);
 }

--- a/msm/src/test/mod.rs
+++ b/msm/src/test/mod.rs
@@ -12,7 +12,13 @@ use rand::{CryptoRng, RngCore};
 
 // Generic function to test with different circuits with the generic prover/verifier.
 // It doesn't use the interpreter to build the witness and compute the constraints.
-pub fn test_completeness_generic<const N: usize, const N_REL: usize, const N_SEL: usize, RNG>(
+pub fn test_completeness_generic<
+    const N: usize,
+    const N_REL: usize,
+    const N_DSEL: usize,
+    const N_FSEL: usize,
+    RNG,
+>(
     constraints: Vec<E<Fp>>,
     evaluations: Witness<N, Vec<Fp>>,
     domain_size: usize,
@@ -34,15 +40,19 @@ pub fn test_completeness_generic<const N: usize, const N_REL: usize, const N_SEL
         logups: vec![],
     };
 
-    let proof =
-        prove::<_, OpeningProof, BaseSponge, ScalarSponge, _, N, N_REL, N_SEL, LookupTableIDs>(
-            domain,
-            &srs,
-            &constraints,
-            proof_inputs,
-            rng,
-        )
-        .unwrap();
+    let proof = prove::<
+        _,
+        OpeningProof,
+        BaseSponge,
+        ScalarSponge,
+        _,
+        N,
+        N_REL,
+        N_DSEL,
+        N_FSEL,
+        LookupTableIDs,
+    >(domain, &srs, &constraints, proof_inputs, rng)
+    .unwrap();
 
     {
         // Checking the proof size. We should have:
@@ -80,14 +90,24 @@ pub fn test_completeness_generic<const N: usize, const N_REL: usize, const N_SEL
         }
     }
 
-    let verifies =
-        verify::<_, OpeningProof, BaseSponge, ScalarSponge, N, N_REL, N_SEL, 0, LookupTableIDs>(
-            domain,
-            &srs,
-            &constraints,
-            &proof,
-            Witness::zero_vec(domain_size),
-        );
+    let verifies = verify::<
+        _,
+        OpeningProof,
+        BaseSponge,
+        ScalarSponge,
+        N,
+        N_REL,
+        N_DSEL,
+        N_FSEL,
+        0,
+        LookupTableIDs,
+    >(
+        domain,
+        &srs,
+        &constraints,
+        &proof,
+        Witness::zero_vec(domain_size),
+    );
     assert!(verifies)
 }
 
@@ -173,7 +193,7 @@ mod tests {
             cols: Box::new([random_x0s, exp_x1]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic::<N, N, 0, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -209,7 +229,7 @@ mod tests {
             cols: Box::new([random_x0s, random_x1s, exp_x2]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic::<N, N, 0, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -254,7 +274,7 @@ mod tests {
             cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic::<N, N, 0, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -293,7 +313,7 @@ mod tests {
             cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic::<N, N, 0, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -326,7 +346,7 @@ mod tests {
             cols: Box::new([random_x0s, exp_x1]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic::<N, N, 0, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -369,7 +389,7 @@ mod tests {
             cols: Box::new([random_x0s, exp_x1, random_x2s, exp_x3]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic::<N, N, 0, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -424,7 +444,7 @@ mod tests {
             cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic::<N, N, 0, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -479,7 +499,7 @@ mod tests {
             cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic::<N, N, 0, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,

--- a/msm/src/verifier.rs
+++ b/msm/src/verifier.rs
@@ -31,14 +31,15 @@ pub fn verify<
     EFrSponge: FrSponge<G::ScalarField>,
     const N: usize,
     const N_REL: usize,
-    const N_SEL: usize,
+    const N_DSEL: usize,
+    const N_FSEL: usize,
     const NPUB: usize,
     ID: LookupTableID,
 >(
     domain: EvaluationDomains<G::ScalarField>,
     srs: &OpeningProof::SRS,
     constraints: &Vec<E<G::ScalarField>>,
-    proof: &Proof<N, N_REL, N_SEL, G, OpeningProof, ID>,
+    proof: &Proof<N, N_REL, N_DSEL, N_FSEL, G, OpeningProof, ID>,
     public_inputs: Witness<NPUB, Vec<G::ScalarField>>,
 ) -> bool
 where

--- a/o1vm/src/folding.rs
+++ b/o1vm/src/folding.rs
@@ -107,12 +107,12 @@ impl<const N: usize, G: CommitmentCurve> Witness<G> for FoldingWitness<N, G::Sca
 pub struct DecomposableFoldingEnvironment<
     const N: usize,
     const N_REL: usize,
-    const N_SEL: usize,
+    const N_DSEL: usize,
     C: FoldingConfig,
 > {
     /// Structure of the folded circuit (using [DecomposedTrace] for now, as
     /// it contains the domain size)
-    pub structure: DecomposedTrace<N, N_REL, N_SEL, C>,
+    pub structure: DecomposedTrace<N, N_REL, N_DSEL, C>,
     /// Commitments to the witness columns, for both sides
     pub instances: [FoldingInstance<N, C::Curve>; 2],
     /// Corresponds to the omega evaluations, for both sides
@@ -122,7 +122,7 @@ pub struct DecomposableFoldingEnvironment<
     pub next_witnesses: [FoldingWitness<N, ScalarField<C>>; 2],
 }
 
-impl<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig>
+impl<const N: usize, const N_REL: usize, const N_DSEL: usize, C: FoldingConfig>
     FoldingEnv<
         ScalarField<C>,
         FoldingInstance<N, C::Curve>,
@@ -130,7 +130,7 @@ impl<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig>
         C::Column,
         Challenge,
         C::Selector,
-    > for DecomposableFoldingEnvironment<N, N_REL, N_SEL, C>
+    > for DecomposableFoldingEnvironment<N, N_REL, N_DSEL, C>
 where
     // Used by col and selector
     FoldingWitness<N, ScalarField<C>>: Index<
@@ -142,7 +142,7 @@ where
         Output = Evaluations<ScalarField<C>, Radix2EvaluationDomain<ScalarField<C>>>,
     >,
 {
-    type Structure = DecomposedTrace<N, N_REL, N_SEL, C>;
+    type Structure = DecomposedTrace<N, N_REL, N_DSEL, C>;
 
     fn new(
         structure: &Self::Structure,

--- a/o1vm/src/keccak/column.rs
+++ b/o1vm/src/keccak/column.rs
@@ -70,7 +70,7 @@ pub(crate) const PAD_BYTES_LEN: usize = RATE_IN_BYTES;
 /// columns.
 /// Each alias will be mapped to a column index depending on the step kind
 /// (Sponge or Round) that is currently being executed.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ColumnAlias {
     /// Hash identifier to distinguish inside the syscalls communication channel
     HashIndex,
@@ -378,7 +378,7 @@ impl<T: Clone> IndexMut<ColumnAlias> for KeccakWitness<T> {
 }
 
 impl ColumnIndexer for ColumnAlias {
-    const COL_N: usize = N_ZKVM_KECCAK_REL_COLS + N_ZKVM_KECCAK_SEL_COLS;
+    const N_COL: usize = N_ZKVM_KECCAK_REL_COLS + N_ZKVM_KECCAK_SEL_COLS;
     fn to_column(self) -> Column {
         Column::Relation(self.ix())
     }
@@ -405,7 +405,7 @@ impl<T: Clone> IndexMut<Steps> for KeccakWitness<T> {
 }
 
 impl ColumnIndexer for Steps {
-    const COL_N: usize = N_ZKVM_KECCAK_REL_COLS + N_ZKVM_KECCAK_SEL_COLS;
+    const N_COL: usize = N_ZKVM_KECCAK_REL_COLS + N_ZKVM_KECCAK_SEL_COLS;
     fn to_column(self) -> Column {
         Column::DynamicSelector(self.ix())
     }

--- a/o1vm/src/keccak/tests.rs
+++ b/o1vm/src/keccak/tests.rs
@@ -529,6 +529,7 @@ fn test_keccak_prover_constraints() {
                     N_ZKVM_KECCAK_COLS,
                     N_ZKVM_KECCAK_REL_COLS,
                     N_ZKVM_KECCAK_SEL_COLS,
+                    0,
                     _,
                 >(
                     keccak_circuit.constraints[&step].clone(),

--- a/o1vm/src/main.rs
+++ b/o1vm/src/main.rs
@@ -241,6 +241,7 @@ pub fn main() -> ExitCode {
                     N_MIPS_COLS,
                     N_MIPS_REL_COLS,
                     N_MIPS_SEL_COLS,
+                    0,
                     LookupTableIDs,
                 >(
                     domain,
@@ -259,6 +260,7 @@ pub fn main() -> ExitCode {
                     N_MIPS_COLS,
                     N_MIPS_REL_COLS,
                     N_MIPS_SEL_COLS,
+                    0,
                     0,
                     LookupTableIDs,
                 >(
@@ -293,6 +295,7 @@ pub fn main() -> ExitCode {
                     N_ZKVM_KECCAK_COLS,
                     N_ZKVM_KECCAK_REL_COLS,
                     N_ZKVM_KECCAK_SEL_COLS,
+                    0,
                     LookupTableIDs,
                 >(
                     domain,
@@ -311,6 +314,7 @@ pub fn main() -> ExitCode {
                     N_ZKVM_KECCAK_COLS,
                     N_ZKVM_KECCAK_REL_COLS,
                     N_ZKVM_KECCAK_SEL_COLS,
+                    0,
                     0,
                     LookupTableIDs,
                 >(

--- a/o1vm/src/mips/column.rs
+++ b/o1vm/src/mips/column.rs
@@ -35,7 +35,7 @@ pub const N_MIPS_COLS: usize = N_MIPS_REL_COLS + N_MIPS_SEL_COLS;
 
 /// Abstract columns (or variables of our multi-variate polynomials) that will be used to
 /// describe our constraints.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ColumnAlias {
     // Can be seen as the abstract indexed variable X_{i}
     ScratchState(usize),
@@ -114,7 +114,7 @@ impl<T: Clone> IndexMut<ColumnAlias> for MIPSWitness<T> {
 }
 
 impl ColumnIndexer for ColumnAlias {
-    const COL_N: usize = N_MIPS_COLS;
+    const N_COL: usize = N_MIPS_COLS;
     fn to_column(self) -> Column {
         // TODO: what happens with error? It does not have a corresponding alias
         Column::Relation(self.ix())
@@ -139,7 +139,7 @@ impl<T: Clone> IndexMut<Instruction> for MIPSWitness<T> {
 }
 
 impl ColumnIndexer for Instruction {
-    const COL_N: usize = N_MIPS_COLS;
+    const N_COL: usize = N_MIPS_COLS;
     fn to_column(self) -> Column {
         // TODO: what happens with error? It does not have a corresponding alias
         Column::DynamicSelector(self.ix())

--- a/o1vm/src/trace.rs
+++ b/o1vm/src/trace.rs
@@ -57,19 +57,23 @@ impl<const N: usize, C: FoldingConfig> ProvableTrace for Trace<N, C> {
 /// Struct representing a circuit execution trace which is decomposable in
 /// individual sub-circuits sharing the same columns.
 /// It is parameterized by
-/// - `N`: the total number of columns (constant), it must equal `N_REL + N_SEL`
+/// - `N`: the total number of columns (constant), it must equal `N_REL + N_DSEL`
 /// - `N_REL`: the number of relation columns (constant),
-/// - `N_SEL`: the number of selector columns (constant),
+/// - `N_DSEL`: the number of dynamic selector columns (constant),
 /// - `Selector`: an enum representing the different gate behaviours,
 /// - `F`: the type of the witness data.
 #[allow(clippy::type_complexity)]
 #[derive(Clone)]
-pub struct DecomposedTrace<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig>
-{
+pub struct DecomposedTrace<
+    const N: usize,
+    const N_REL: usize,
+    const N_DSEL: usize,
+    C: FoldingConfig,
+> {
     /// The domain size of the circuit
     pub domain_size: usize,
     /// The witness for a given selector
-    /// - the last N_SEL columns represent the selector columns
+    /// - the last N_DSEL columns represent the selector columns
     ///   and only the one for `Selector` should be all ones (the rest of selector columns should be all zeros)
     pub witness: BTreeMap<C::Selector, Witness<N, Vec<ScalarField<C>>>>,
     /// The vector of constraints for a given selector
@@ -79,16 +83,16 @@ pub struct DecomposedTrace<const N: usize, const N_REL: usize, const N_SEL: usiz
 }
 
 // Any decomposable trace is provable.
-impl<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig> ProvableTrace
-    for DecomposedTrace<N, N_REL, N_SEL, C>
+impl<const N: usize, const N_REL: usize, const N_DSEL: usize, C: FoldingConfig> ProvableTrace
+    for DecomposedTrace<N, N_REL, N_DSEL, C>
 {
     fn domain_size(&self) -> usize {
         self.domain_size
     }
 }
 
-impl<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig>
-    DecomposedTrace<N, N_REL, N_SEL, C>
+impl<const N: usize, const N_REL: usize, const N_DSEL: usize, C: FoldingConfig>
+    DecomposedTrace<N, N_REL, N_DSEL, C>
 where
     C::Selector: Indexer,
 {
@@ -156,8 +160,8 @@ pub(crate) trait Foldable<const N: usize, C: FoldingConfig, Sponge> {
 }
 
 /// Implement the trait Foldable for the structure [DecomposedTrace]
-impl<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig, Sponge>
-    Foldable<N, C, Sponge> for DecomposedTrace<N, N_REL, N_SEL, C>
+impl<const N: usize, const N_REL: usize, const N_DSEL: usize, C: FoldingConfig, Sponge>
+    Foldable<N, C, Sponge> for DecomposedTrace<N, N_REL, N_DSEL, C>
 where
     C::Selector: Indexer,
     Sponge: FqSponge<BaseField<C>, C::Curve, ScalarField<C>>,
@@ -213,7 +217,7 @@ where
 /// can use per row.
 /// The constant type `N_REL` is defined as the maximum number of relation
 /// columns the trace can use per row.
-/// The constant type `N_SEL` is defined as the number of selector columns the
+/// The constant type `N_DSEL` is defined as the number of selector columns the
 /// trace can use per row.
 /// The type `Selector` encodes the information of the kind of information the
 /// trace encodes. Examples:
@@ -226,7 +230,7 @@ where
 pub trait DecomposableTracer<
     const N: usize,
     const N_REL: usize,
-    const N_SEL: usize,
+    const N_DSEL: usize,
     C: FoldingConfig,
     Env,
 >


### PR DESCRIPTION
Adding another column type, `FixedSelector`, to represent columns that are predefined for all instantiations of a given circuit.

Also:
* Added tests specifically for the fixed selector case
* Had to pass `N_FSEL` into MANY methods, but it's mostly boilerplate (we should generalise tests...). Similarly renamed `COL_N` into `N_COL` for consistency.


Addresses #2088 