### PR TITLE
Extended folding Keccak test

### DIFF
--- a/folding/src/examples/example_decomposable_folding.rs
+++ b/folding/src/examples/example_decomposable_folding.rs
@@ -3,10 +3,10 @@ use crate::{
     error_term::Side,
     examples::{Curve, Fp},
     expressions::{FoldingColumnTrait, FoldingCompatibleExprInner},
-    Alphas, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance, Witness,
+    Alphas, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance, ScalarField, Witness,
 };
 use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_ff::UniformRand;
+use ark_ff::{One, UniformRand};
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 use itertools::Itertools;
 use kimchi::circuits::{expr::Variable, gate::CurrOrNext};
@@ -194,6 +194,13 @@ fn constraints() -> BTreeMap<DynamicSelector, Vec<FoldingCompatibleExpr<TestFold
 
     let add = FoldingCompatibleExpr::Add(a.clone(), b.clone());
     let add = FoldingCompatibleExpr::Sub(add.into(), c.clone());
+    let add = FoldingCompatibleExpr::Sub(
+        add.into(),
+        Box::new(FoldingCompatibleExpr::Atom(
+            FoldingCompatibleExprInner::Constant(ScalarField::<TestFoldingConfig>::one()),
+        )),
+    );
+    // a + b + c + 1 = 0
 
     let sub = FoldingCompatibleExpr::Sub(a.clone(), b.clone());
     let sub = FoldingCompatibleExpr::Sub(sub.into(), c.clone());
@@ -311,9 +318,10 @@ mod tests {
     fn add_witness(a: [u32; 2], b: [u32; 2]) -> [[u32; 2]; 5] {
         let [a1, a2] = a;
         let [b1, b2] = b;
-        let c = [a1 + b1, a2 + b2];
+        let c = [a1 + b1 - 1, a2 + b2 - 1];
         [a, b, c, [1, 1], [0, 0]]
     }
+
     fn sub_witness(a: [u32; 2], b: [u32; 2]) -> [[u32; 2]; 5] {
         let [a1, a2] = a;
         let [b1, b2] = b;

--- a/optimism/src/keccak/folding.rs
+++ b/optimism/src/keccak/folding.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 use folding::{
-    checker::{Checker, ExtendedProvider},
+    checker::{Checker, ExtendedProvider, Provider},
     expressions::FoldingColumnTrait,
     FoldingConfig,
 };
@@ -80,3 +80,4 @@ impl FoldingConfig for KeccakConfig {
 // IMPLEMENT CHECKER TRAITS
 
 impl Checker<KeccakConfig> for ExtendedProvider<KeccakConfig> {}
+impl Checker<KeccakConfig> for Provider<KeccakConfig> {}


### PR DESCRIPTION
This PR extends the test proposed in https://github.com/o1-labs/proof-systems/pull/2182 to better observe the behavior of the folding when applied to individual Keccak steps. 

This is WIP.

For now, one can see that individual steps satisfy their respective constraints, and also when folded with circuits of the same type.

It remains to understand why when using decomposable folding scheme (using selectors), only `Sponge(Absorb(Only))` is satisfied.