### PR TITLE
MDBook: Fix compilation + add CI check

### DIFF
--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -8,7 +8,7 @@ env:
   OCAML_VERSION: "4.14.0"
   # This version has been chosen randomly. It seems that with 2023-11-16, it is
   # broken. The compiler crashes. Feel free to pick any newer working version.
-  RUST_TOOLCHAIN_VERSION: "nightly-2024-01-16"
+  RUST_TOOLCHAIN_VERSION: "1.72"
 
 jobs:
   release:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,34 @@ env:
   # 30 MB of stack for Keccak tests
 
 jobs:
+  run_mdbook:
+    name: Building MDBook
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust_toolchain_version: ["1.72"]
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Rust toolchain ${{ matrix.rust_toolchain_version }}
+        run:
+          |
+            curl --proto '=https' --tlsv1.2 -sSf -o rustup-init \
+            https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init
+            chmod +x ./rustup-init
+            ./rustup-init -y --default-toolchain "${{ matrix.rust_toolchain_version }}" --profile default
+            rm ./rustup-init
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+            # overwriting default rust-toolchain
+            echo ${{ matrix.rust_toolchain_version }} > rust-toolchain
+
+      - name: Build the mdbook
+        run: |
+          cd book
+          make deps
+          make build
+
   run_formatting:
     name: Formatting
     runs-on: ubuntu-latest

--- a/book/Makefile
+++ b/book/Makefile
@@ -17,12 +17,12 @@ all: deps check build serve
 #
 
 deps:
-	cargo install "mdbook@$(MDBOOK_VERSION)"
-	cargo install "mdbook-admonish@$(MDBOOK_ADMONISH_VERSION)"
-	cargo install "mdbook-katex@$(MDBOOK_KATEX_VERSION)"
-	cargo install --git https://github.com/o1-labs/mdbook-linkcheck --rev 8cccfc8fee397092ecdf1236a42871c5c980672e --locked mdbook-linkcheck
-	cargo install "mdbook-mermaid@$(MDBOOK_MERMAID_VERSION)"
-	cargo install "mdbook-toc@$(MDBOOK_TOC_VERSION)"
+	cargo install --locked "mdbook@$(MDBOOK_VERSION)"
+	cargo install --locked "mdbook-admonish@$(MDBOOK_ADMONISH_VERSION)"
+	cargo install --locked "mdbook-katex@$(MDBOOK_KATEX_VERSION)"
+	cargo install --locked --git https://github.com/o1-labs/mdbook-linkcheck --rev 8cccfc8fee397092ecdf1236a42871c5c980672e mdbook-linkcheck
+	cargo install --locked "mdbook-mermaid@$(MDBOOK_MERMAID_VERSION)"
+	cargo install --locked "mdbook-toc@$(MDBOOK_TOC_VERSION)"
 
 #
 # Checks if your installed dependencies match what we've listed above


### PR DESCRIPTION
Problem: 
* (recently added) mdbook linkcheck does not build with nightly.
* Checking that MDBook is not broken was not part of the build script, 

Solution:
* Now we check MDBook in CI (because we want to make sure contributions to the book are not buggy..?)
* Downgraded the book deployment version from `nightly` to `1.72` to be in line with the rust script/our main `rust-toolchain` version. 


Question:
* Why does our CI check the project builds with `1.74` but `rust-toolchain` is `1.72`? If we can upgrade it to `1.74` I can remove `--fixed` from the script, which is a way to make `mdbook` work on `1.72` which is our default version. Because lot of dependencies want `1.74` actually.