### PR TITLE
o1VM: rename `Trace(r)` into `DecomposableTrace(r)` + add docs

### DIFF
--- a/optimism/src/folding.rs
+++ b/optimism/src/folding.rs
@@ -1,4 +1,4 @@
-use crate::trace::Trace;
+use crate::trace::DecomposableTrace;
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{FftField, Zero};
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
@@ -110,8 +110,9 @@ pub struct FoldingEnvironment<
     const N_SEL: usize,
     C: FoldingConfig,
 > {
-    /// Structure of the folded circuit (using Trace for now, as it contains the domain size)
-    pub structure: Trace<N, N_REL, N_SEL, C>,
+    /// Structure of the folded circuit (using [DecomposableTrace] for now, as
+    /// it contains the domain size)
+    pub structure: DecomposableTrace<N, N_REL, N_SEL, C>,
     /// Commitments to the witness columns, for both sides
     pub instances: [FoldingInstance<N, C::Curve>; 2],
     /// Corresponds to the omega evaluations, for both sides
@@ -140,7 +141,7 @@ where
         Output = Evaluations<ScalarField<C>, Radix2EvaluationDomain<ScalarField<C>>>,
     >,
 {
-    type Structure = Trace<N, N_REL, N_SEL, C>;
+    type Structure = DecomposableTrace<N, N_REL, N_SEL, C>;
 
     fn new(
         structure: &Self::Structure,

--- a/optimism/src/keccak/folding.rs
+++ b/optimism/src/keccak/folding.rs
@@ -4,7 +4,7 @@ use crate::{
         column::{ZKVM_KECCAK_COLS, ZKVM_KECCAK_REL, ZKVM_KECCAK_SEL},
         KeccakColumn, Steps,
     },
-    trace::{Indexer, Trace},
+    trace::{DecomposableTrace, Indexer},
     Curve, Fp,
 };
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
@@ -73,7 +73,8 @@ impl FoldingConfig for KeccakConfig {
     type Srs = SRS<Curve>;
     type Instance = KeccakFoldingInstance;
     type Witness = KeccakFoldingWitness;
-    type Structure = Trace<ZKVM_KECCAK_COLS, ZKVM_KECCAK_REL, ZKVM_KECCAK_SEL, KeccakConfig>;
+    type Structure =
+        DecomposableTrace<ZKVM_KECCAK_COLS, ZKVM_KECCAK_REL, ZKVM_KECCAK_SEL, KeccakConfig>;
     type Env = KeccakFoldingEnvironment;
 }
 

--- a/optimism/src/keccak/tests.rs
+++ b/optimism/src/keccak/tests.rs
@@ -13,7 +13,7 @@ use crate::{
         Error, KeccakColumn,
     },
     lookups::{FixedLookupTables, LookupTable, LookupTableIDs::*},
-    trace::Tracer,
+    trace::DecomposableTracer,
     BaseSponge, Fp,
 };
 use ark_ff::{One, Zero};
@@ -540,7 +540,7 @@ fn test_keccak_prover_constraints() {
 fn test_keccak_decomposable_folding() {
     use crate::{
         keccak::folding::KeccakConfig,
-        trace::{Foldable, Trace},
+        trace::{DecomposableTrace, Foldable},
         Curve,
     };
     use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as D};
@@ -567,7 +567,7 @@ fn test_keccak_decomposable_folding() {
         let mut fq_sponge = BaseSponge::new(Curve::other_curve_sponge_params());
 
         // Create two instances for each selector to be folded
-        let mut keccak_trace: [Trace<
+        let mut keccak_trace: [DecomposableTrace<
             ZKVM_KECCAK_COLS,
             ZKVM_KECCAK_REL,
             ZKVM_KECCAK_SEL,

--- a/optimism/src/keccak/trace.rs
+++ b/optimism/src/keccak/trace.rs
@@ -11,16 +11,17 @@ use crate::{
         environment::KeccakEnv,
         standardize,
     },
-    trace::{Trace, Tracer},
+    trace::{DecomposableTrace, DecomposableTracer},
 };
 
 use super::folding::KeccakConfig;
 
 /// The Keccak circuit trace
-pub type KeccakTrace = Trace<ZKVM_KECCAK_COLS, ZKVM_KECCAK_REL, ZKVM_KECCAK_SEL, KeccakConfig>;
+pub type KeccakTrace =
+    DecomposableTrace<ZKVM_KECCAK_COLS, ZKVM_KECCAK_REL, ZKVM_KECCAK_SEL, KeccakConfig>;
 
 impl
-    Tracer<
+    DecomposableTracer<
         ZKVM_KECCAK_COLS,
         ZKVM_KECCAK_REL,
         ZKVM_KECCAK_SEL,

--- a/optimism/src/lib.rs
+++ b/optimism/src/lib.rs
@@ -30,7 +30,8 @@ pub mod proof;
 /// The RAM lookup argument.
 pub mod ramlookup;
 
-/// Defines a trace struct used for testing / demo purposes
+/// Abstract execution traces, possible long, that can be folded.
+/// A trace is a sequence of data points organized in a 2D array, constrained.
 pub mod trace;
 
 use ark_ec::bn::Bn;

--- a/optimism/src/main.rs
+++ b/optimism/src/main.rs
@@ -23,7 +23,7 @@ use kimchi_optimism::{
     },
     preimage_oracle::PreImageOracle,
     proof,
-    trace::Tracer,
+    trace::DecomposableTracer,
     BaseSponge, Fp, OpeningProof, ScalarSponge, DOMAIN_SIZE,
 };
 use log::debug;

--- a/optimism/src/mips/folding.rs
+++ b/optimism/src/mips/folding.rs
@@ -4,7 +4,7 @@ use crate::{
         column::{ColumnAlias as MIPSColumn, MIPS_COLUMNS},
         Instruction,
     },
-    trace::{Indexer, Trace},
+    trace::{DecomposableTrace, Indexer},
     Curve, Fp,
 };
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
@@ -70,6 +70,7 @@ impl FoldingConfig for MIPSFoldingConfig {
     type Srs = SRS<Curve>;
     type Instance = MIPSFoldingInstance;
     type Witness = MIPSFoldingWitness;
-    type Structure = Trace<MIPS_COLUMNS, MIPS_REL_COLS, MIPS_SEL_COLS, MIPSFoldingConfig>;
+    type Structure =
+        DecomposableTrace<MIPS_COLUMNS, MIPS_REL_COLS, MIPS_SEL_COLS, MIPSFoldingConfig>;
     type Env = MIPSFoldingEnvironment;
 }

--- a/optimism/src/mips/tests.rs
+++ b/optimism/src/mips/tests.rs
@@ -9,7 +9,7 @@ use crate::{
         },
         trace::MIPSTrace,
     },
-    trace::Tracer,
+    trace::DecomposableTracer,
 };
 use strum::{EnumCount, IntoEnumIterator};
 

--- a/optimism/src/mips/trace.rs
+++ b/optimism/src/mips/trace.rs
@@ -5,7 +5,7 @@ use crate::{
         constraints::Env,
         interpreter::{interpret_instruction, Instruction},
     },
-    trace::{Trace, Tracer},
+    trace::{DecomposableTrace, DecomposableTracer},
 };
 use ark_ff::Zero;
 use kimchi_msm::witness::Witness;
@@ -15,10 +15,11 @@ use strum::IntoEnumIterator;
 use super::folding::MIPSFoldingConfig;
 
 /// The MIPS circuit trace
-pub type MIPSTrace = Trace<MIPS_COLUMNS, MIPS_REL_COLS, MIPS_SEL_COLS, MIPSFoldingConfig>;
+pub type MIPSTrace =
+    DecomposableTrace<MIPS_COLUMNS, MIPS_REL_COLS, MIPS_SEL_COLS, MIPSFoldingConfig>;
 
 impl
-    Tracer<
+    DecomposableTracer<
         MIPS_COLUMNS,
         MIPS_REL_COLS,
         MIPS_SEL_COLS,


### PR DESCRIPTION
This commit groups multiple changes.
First, it renames Trace and Tracer into `DecomposableTrace` and `DecomposableTracer`.
These names represent more the type of "objects"/traces the structure and the trait describe.

On top of that, additional documentation has been added at the top of the file trace.rs. Links to the structures using square brackets are added to detect old/inconsistent documentations mentioning code in the CI.

To finish, lines are broken into 80 characters long-lines to respect (old) coding conventions.