### PR TITLE
o1VM: renaming trace related structures

### DIFF
--- a/o1vm/src/folding.rs
+++ b/o1vm/src/folding.rs
@@ -1,4 +1,4 @@
-use crate::trace::DecomposableTrace;
+use crate::trace::DecomposedTrace;
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{FftField, Zero};
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
@@ -110,9 +110,9 @@ pub struct DecomposableFoldingEnvironment<
     const N_SEL: usize,
     C: FoldingConfig,
 > {
-    /// Structure of the folded circuit (using [DecomposableTrace] for now, as
+    /// Structure of the folded circuit (using [DecomposedTrace] for now, as
     /// it contains the domain size)
-    pub structure: DecomposableTrace<N, N_REL, N_SEL, C>,
+    pub structure: DecomposedTrace<N, N_REL, N_SEL, C>,
     /// Commitments to the witness columns, for both sides
     pub instances: [FoldingInstance<N, C::Curve>; 2],
     /// Corresponds to the omega evaluations, for both sides
@@ -142,7 +142,7 @@ where
         Output = Evaluations<ScalarField<C>, Radix2EvaluationDomain<ScalarField<C>>>,
     >,
 {
-    type Structure = DecomposableTrace<N, N_REL, N_SEL, C>;
+    type Structure = DecomposedTrace<N, N_REL, N_SEL, C>;
 
     fn new(
         structure: &Self::Structure,

--- a/o1vm/src/keccak/tests.rs
+++ b/o1vm/src/keccak/tests.rs
@@ -13,7 +13,7 @@ use crate::{
         Error, KeccakColumn,
     },
     lookups::{FixedLookupTables, LookupTable, LookupTableIDs::*},
-    trace::DecomposableTracer,
+    trace::{DecomposableTracer, DecomposedTrace},
     BaseSponge, Fp,
 };
 use ark_ff::{One, Zero};
@@ -543,11 +543,7 @@ fn test_keccak_prover_constraints() {
 
 #[test]
 fn test_keccak_decomposable_folding() {
-    use crate::{
-        keccak::folding::KeccakConfig,
-        trace::{DecomposableTrace, Foldable},
-        Curve,
-    };
+    use crate::{keccak::folding::KeccakConfig, trace::Foldable, Curve};
     use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as D};
     use folding::{
         checker::{Checker, ExtendedProvider},
@@ -572,7 +568,7 @@ fn test_keccak_decomposable_folding() {
         let mut fq_sponge = BaseSponge::new(Curve::other_curve_sponge_params());
 
         // Create two instances for each selector to be folded
-        let mut keccak_trace: [DecomposableTrace<
+        let mut keccak_trace: [DecomposedTrace<
             N_ZKVM_KECCAK_COLS,
             N_ZKVM_KECCAK_REL_COLS,
             N_ZKVM_KECCAK_SEL_COLS,

--- a/o1vm/src/keccak/trace.rs
+++ b/o1vm/src/keccak/trace.rs
@@ -11,13 +11,13 @@ use crate::{
         environment::KeccakEnv,
         standardize,
     },
-    trace::{DecomposableTrace, DecomposableTracer},
+    trace::{DecomposableTracer, DecomposedTrace},
 };
 
 use super::folding::KeccakConfig;
 
 /// The Keccak circuit trace
-pub type KeccakTrace = DecomposableTrace<
+pub type KeccakTrace = DecomposedTrace<
     N_ZKVM_KECCAK_COLS,
     N_ZKVM_KECCAK_REL_COLS,
     N_ZKVM_KECCAK_SEL_COLS,

--- a/o1vm/src/main.rs
+++ b/o1vm/src/main.rs
@@ -19,7 +19,7 @@ use o1vm::{
         constraints as mips_constraints,
         folding::DecomposableMIPSFoldingConfig,
         interpreter::Instruction,
-        trace::DecomposableMIPSTrace,
+        trace::DecomposedMIPSTrace,
         witness::{self as mips_witness, SCRATCH_SIZE},
     },
     preimage_oracle::PreImageOracle,
@@ -90,7 +90,7 @@ pub fn main() -> ExitCode {
     // The keccak environment is extracted inside the loop
 
     // Initialize the circuits. Includes pre-folding witnesses.
-    let mut mips_trace = DecomposableMIPSTrace::new(DOMAIN_SIZE, &mut mips_con_env);
+    let mut mips_trace = DecomposedMIPSTrace::new(DOMAIN_SIZE, &mut mips_con_env);
     let mut keccak_trace = KeccakTrace::new(DOMAIN_SIZE, &mut KeccakEnv::<Fp>::default());
 
     let _mips_folding = {

--- a/o1vm/src/mips/folding.rs
+++ b/o1vm/src/mips/folding.rs
@@ -14,7 +14,7 @@ use std::ops::Index;
 
 use super::{
     column::{N_MIPS_REL_COLS, N_MIPS_SEL_COLS},
-    trace::DecomposableMIPSTrace,
+    trace::DecomposedMIPSTrace,
 };
 use poly_commitment::srs::SRS;
 
@@ -85,6 +85,6 @@ impl FoldingConfig for DecomposableMIPSFoldingConfig {
     // Using FoldingWitness instead of type alias as the type parameter defines
     // the number of columns
     type Witness = FoldingWitness<N_MIPS_COLS, Fp>;
-    type Structure = DecomposableMIPSTrace;
+    type Structure = DecomposedMIPSTrace;
     type Env = DecomposableMIPSFoldingEnvironment;
 }

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -7,7 +7,7 @@ use crate::{
             JTypeInstruction::{self, *},
             RTypeInstruction::{self, *},
         },
-        trace::DecomposableMIPSTrace,
+        trace::DecomposedMIPSTrace,
     },
     trace::DecomposableTracer,
 };
@@ -28,7 +28,7 @@ fn test_mips_number_constraints() {
     };
 
     // Keep track of the constraints and lookups of the sub-circuits
-    let mips_circuit = DecomposableMIPSTrace::new(domain_size, &mut constraints_env);
+    let mips_circuit = DecomposedMIPSTrace::new(domain_size, &mut constraints_env);
 
     let assert_num_constraints = |instr: &Instruction, num: usize| {
         assert_eq!(mips_circuit.constraints.get(instr).unwrap().len(), num)

--- a/o1vm/src/mips/trace.rs
+++ b/o1vm/src/mips/trace.rs
@@ -5,7 +5,7 @@ use crate::{
         constraints::Env,
         interpreter::{interpret_instruction, Instruction},
     },
-    trace::{DecomposableTrace, DecomposableTracer},
+    trace::{DecomposableTracer, DecomposedTrace},
 };
 use ark_ff::Zero;
 use kimchi_msm::witness::Witness;
@@ -15,8 +15,8 @@ use strum::IntoEnumIterator;
 use super::folding::DecomposableMIPSFoldingConfig;
 
 /// The MIPS circuit trace
-pub type DecomposableMIPSTrace =
-    DecomposableTrace<N_MIPS_COLS, N_MIPS_REL_COLS, N_MIPS_SEL_COLS, DecomposableMIPSFoldingConfig>;
+pub type DecomposedMIPSTrace =
+    DecomposedTrace<N_MIPS_COLS, N_MIPS_REL_COLS, N_MIPS_SEL_COLS, DecomposableMIPSFoldingConfig>;
 
 impl
     DecomposableTracer<
@@ -25,7 +25,7 @@ impl
         N_MIPS_SEL_COLS,
         DecomposableMIPSFoldingConfig,
         Env<ScalarField<DecomposableMIPSFoldingConfig>>,
-    > for DecomposableMIPSTrace
+    > for DecomposedMIPSTrace
 {
     fn new(domain_size: usize, env: &mut Env<ScalarField<DecomposableMIPSFoldingConfig>>) -> Self {
         let mut circuit = Self {

--- a/o1vm/src/trace.rs
+++ b/o1vm/src/trace.rs
@@ -40,7 +40,7 @@ pub trait ProvableTrace {
 // single instruction.
 // It is not recommended to use this in production and it should not be
 // maintained in the long term.
-pub struct SingleInstructionTrace<const N: usize, C: FoldingConfig> {
+pub struct Trace<const N: usize, C: FoldingConfig> {
     pub domain_size: usize,
     pub witness: Witness<N, Vec<ScalarField<C>>>,
     pub constraints: Vec<E<ScalarField<C>>>,
@@ -48,7 +48,7 @@ pub struct SingleInstructionTrace<const N: usize, C: FoldingConfig> {
 }
 
 // Any single instruction trace is provable.
-impl<const N: usize, C: FoldingConfig> ProvableTrace for SingleInstructionTrace<N, C> {
+impl<const N: usize, C: FoldingConfig> ProvableTrace for Trace<N, C> {
     fn domain_size(&self) -> usize {
         self.domain_size
     }
@@ -64,12 +64,8 @@ impl<const N: usize, C: FoldingConfig> ProvableTrace for SingleInstructionTrace<
 /// - `F`: the type of the witness data.
 #[allow(clippy::type_complexity)]
 #[derive(Clone)]
-pub struct DecomposableTrace<
-    const N: usize,
-    const N_REL: usize,
-    const N_SEL: usize,
-    C: FoldingConfig,
-> {
+pub struct DecomposedTrace<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig>
+{
     /// The domain size of the circuit
     pub domain_size: usize,
     /// The witness for a given selector
@@ -84,7 +80,7 @@ pub struct DecomposableTrace<
 
 // Any decomposable trace is provable.
 impl<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig> ProvableTrace
-    for DecomposableTrace<N, N_REL, N_SEL, C>
+    for DecomposedTrace<N, N_REL, N_SEL, C>
 {
     fn domain_size(&self) -> usize {
         self.domain_size
@@ -92,7 +88,7 @@ impl<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig> P
 }
 
 impl<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig>
-    DecomposableTrace<N, N_REL, N_SEL, C>
+    DecomposedTrace<N, N_REL, N_SEL, C>
 where
     C::Selector: Indexer,
 {
@@ -141,7 +137,7 @@ where
 /// The trait [Foldable] describes structures that can be folded.
 /// For that, it requires to be able to implement a way to return a folding
 /// instance and a folding witness.
-/// It is specialized for the [DecomposableTrace] struct for now and is expected
+/// It is specialized for the [DecomposedTrace] struct for now and is expected
 /// to fold individual instructions, selected with a specific [C::Selector].
 pub(crate) trait Foldable<const N: usize, C: FoldingConfig, Sponge> {
     /// Returns the witness for the given selector as a folding witness and
@@ -159,9 +155,9 @@ pub(crate) trait Foldable<const N: usize, C: FoldingConfig, Sponge> {
     );
 }
 
-/// Implement the trait Foldable for the structure [DecomposableTrace]
+/// Implement the trait Foldable for the structure [DecomposedTrace]
 impl<const N: usize, const N_REL: usize, const N_SEL: usize, C: FoldingConfig, Sponge>
-    Foldable<N, C, Sponge> for DecomposableTrace<N, N_REL, N_SEL, C>
+    Foldable<N, C, Sponge> for DecomposedTrace<N, N_REL, N_SEL, C>
 where
     C::Selector: Indexer,
     Sponge: FqSponge<BaseField<C>, C::Curve, ScalarField<C>>,


### PR DESCRIPTION
- SingleInstructionTrace into Trace
- DecomposableTrace into DecomposedTrace
- DecomposableMIPSTrace into DecomposedMIPSTrace
- Keep DecomposableTracer for trait


Addresses https://github.com/o1-labs/proof-systems/pull/2208#pullrequestreview-2048133087