### PR TITLE
Fix duplicate `write_column` [micro]

### DIFF
--- a/msm/src/circuit_design/witness.rs
+++ b/msm/src/circuit_design/witness.rs
@@ -94,10 +94,7 @@ impl<
     > ColWriteCap<F, CIx> for WitnessBuilderEnv<F, CIx, N_COL, N_REL, N_DSEL, N_FSEL, LT>
 {
     fn write_column(&mut self, ix: CIx, value: &Self::Variable) {
-        let Column::Relation(i) = ix.to_column() else {
-            todo!()
-        };
-        self.witness.last_mut().unwrap().cols[i] = *value;
+        self.write_column_raw(ix.to_column(), *value);
     }
 }
 
@@ -206,8 +203,7 @@ impl<
         LT: LookupTableID,
     > WitnessBuilderEnv<F, CIx, N_COL, N_REL, N_DSEL, N_FSEL, LT>
 {
-    // TODO this function duplicates one from ColWriteCap
-    pub fn write_column(&mut self, position: Column, value: F) {
+    pub fn write_column_raw(&mut self, position: Column, value: F) {
         match position {
             Column::Relation(i) => self.witness.last_mut().unwrap().cols[i] = value,
             Column::FixedSelector(_) => {

--- a/msm/src/serialization/interpreter.rs
+++ b/msm/src/serialization/interpreter.rs
@@ -77,7 +77,7 @@ impl<
         let x_u128 = u128::from_le_bytes(x_bytes_u8.try_into().unwrap());
         let res = (x_u128 >> lowest_bit) & ((1 << (highest_bit - lowest_bit)) - 1);
         let res_fp: F = res.into();
-        self.write_column(position.to_column(), res_fp);
+        self.write_column_raw(position.to_column(), res_fp);
         res_fp
     }
 }


### PR DESCRIPTION
There were two `write_column` that acted in an uncoordinated manner. Now they interact and are called slightly differently.