### PR TITLE
Git merge

### DIFF
--- a/o1vm/src/keccak/folding.rs
+++ b/o1vm/src/keccak/folding.rs
@@ -1,7 +1,8 @@
 use crate::{
-    folding::{Challenge, DecomposableFoldingEnvironment, FoldingInstance, FoldingWitness},
+    folding::{Challenge, DecomposedFoldingEnvironment, FoldingInstance, FoldingWitness},
     keccak::{
         column::{N_ZKVM_KECCAK_COLS, N_ZKVM_KECCAK_REL_COLS, N_ZKVM_KECCAK_SEL_COLS},
+        trace::DecomposedKeccakTrace,
         KeccakColumn, Steps,
     },
     trace::Indexer,
@@ -17,13 +18,12 @@ use kimchi_msm::columns::Column;
 use poly_commitment::srs::SRS;
 use std::ops::Index;
 
-use super::trace::KeccakTrace;
-
-pub type KeccakFoldingEnvironment = DecomposableFoldingEnvironment<
+pub type KeccakFoldingEnvironment = DecomposedFoldingEnvironment<
     N_ZKVM_KECCAK_COLS,
     N_ZKVM_KECCAK_REL_COLS,
     N_ZKVM_KECCAK_SEL_COLS,
     KeccakConfig,
+    DecomposedKeccakTrace,
 >;
 
 pub type KeccakFoldingWitness = FoldingWitness<N_ZKVM_KECCAK_COLS, Fp>;
@@ -82,7 +82,7 @@ impl FoldingConfig for KeccakConfig {
     type Srs = SRS<Curve>;
     type Instance = KeccakFoldingInstance;
     type Witness = KeccakFoldingWitness;
-    type Structure = KeccakTrace;
+    type Structure = DecomposedKeccakTrace;
     type Env = KeccakFoldingEnvironment;
 }
 

--- a/o1vm/src/keccak/tests.rs
+++ b/o1vm/src/keccak/tests.rs
@@ -8,12 +8,12 @@ use crate::{
         },
         environment::KeccakEnv,
         interpreter::KeccakInterpreter,
-        trace::KeccakTrace,
+        trace::DecomposedKeccakTrace,
         Constraint::*,
         Error, KeccakColumn,
     },
     lookups::{FixedLookupTables, LookupTable, LookupTableIDs::*},
-    trace::{DecomposableTracer, DecomposedTrace},
+    trace::{DecomposableTracer, Tracer},
     BaseSponge, Fp,
 };
 use ark_ff::{One, Zero};
@@ -27,6 +27,7 @@ use kimchi::{
     o1_utils::{self, FieldHelpers, Two},
 };
 use kimchi_msm::test::test_completeness_generic;
+use log::debug;
 use rand::Rng;
 use sha3::{Digest, Keccak256};
 use std::collections::{BTreeMap, HashMap};
@@ -515,10 +516,13 @@ fn test_keccak_prover_constraints() {
         let mut keccak_env = KeccakEnv::<Fp>::new(0, &preimage);
 
         // Keep track of the constraints and lookups of the sub-circuits
-        let mut keccak_circuit = KeccakTrace::new(domain_size, &mut keccak_env);
+        let mut keccak_circuit = <DecomposedKeccakTrace as DecomposableTracer<KeccakEnv<Fp>>>::new(
+            domain_size,
+            &mut keccak_env,
+        );
 
         while keccak_env.step.is_some() {
-            let step = keccak_env.step.unwrap();
+            let step = keccak_env.selector();
 
             // Run the interpreter, which sets the witness columns
             keccak_env.step();
@@ -537,8 +541,8 @@ fn test_keccak_prover_constraints() {
                     0,
                     _,
                 >(
-                    keccak_circuit.constraints[&step].clone(),
-                    keccak_circuit.witness[&step].clone(),
+                    keccak_circuit[step].constraints.clone(),
+                    keccak_circuit[step].witness.clone(),
                     domain_size,
                     &mut rng,
                 );
@@ -572,15 +576,17 @@ fn test_keccak_folding() {
         let mut fq_sponge = BaseSponge::new(Curve::other_curve_sponge_params());
 
         // Create two instances for each selector to be folded
-        let mut keccak_trace: [DecomposedTrace<
-            N_ZKVM_KECCAK_COLS,
-            N_ZKVM_KECCAK_REL_COLS,
-            N_ZKVM_KECCAK_SEL_COLS,
-            KeccakConfig,
-        >; 2] =
-            std::array::from_fn(|_| KeccakTrace::new(domain_size, &mut KeccakEnv::<Fp>::default()));
+        let mut keccak_trace: [DecomposedKeccakTrace; 2] = std::array::from_fn(|_| {
+            <DecomposedKeccakTrace as DecomposableTracer<KeccakEnv<Fp>>>::new(
+                domain_size,
+                &mut KeccakEnv::<Fp>::default(),
+            )
+        });
 
-        let default_trace = KeccakTrace::new(domain_size, &mut KeccakEnv::<Fp>::default());
+        let default_trace = <DecomposedKeccakTrace as DecomposableTracer<KeccakEnv<Fp>>>::new(
+            domain_size,
+            &mut KeccakEnv::<Fp>::default(),
+        );
 
         for trace in &mut keccak_trace {
             // Generate domain_size rows for each of the 6 selectors
@@ -593,7 +599,7 @@ fn test_keccak_folding() {
                     // Initialize the environment and run the interpreter
                     let mut keccak_env = KeccakEnv::<Fp>::new(0, &preimage);
                     while keccak_env.step.is_some() {
-                        let step = keccak_env.step.unwrap();
+                        let step = keccak_env.selector();
                         // Create the relation witness columns
                         keccak_env.step();
                         match step {
@@ -611,9 +617,12 @@ fn test_keccak_folding() {
                 assert!(trace.is_full(Sponge(Squeeze)));
 
                 // Add the columns of the selectors to the circuit
-                trace.set_selector_column(Sponge(Absorb(Only)), domain_size);
-                trace.set_selector_column(Round(0), domain_size);
-                trace.set_selector_column(Sponge(Squeeze), domain_size);
+                trace.set_selector_column::<N_ZKVM_KECCAK_REL_COLS>(
+                    Sponge(Absorb(Only)),
+                    domain_size,
+                );
+                trace.set_selector_column::<N_ZKVM_KECCAK_REL_COLS>(Round(0), domain_size);
+                trace.set_selector_column::<N_ZKVM_KECCAK_REL_COLS>(Sponge(Squeeze), domain_size);
             }
             {
                 // 3 block preimages for Sponge(Absorb(First)), Sponge(Absorb(Middle)), and Sponge(Absorb(Last))
@@ -644,9 +653,18 @@ fn test_keccak_folding() {
                 assert!(trace.is_full(Sponge(Absorb(Last))));
 
                 // Add the columns of the selectors to the circuit
-                trace.set_selector_column(Sponge(Absorb(First)), domain_size);
-                trace.set_selector_column(Sponge(Absorb(Middle)), domain_size);
-                trace.set_selector_column(Sponge(Absorb(Last)), domain_size);
+                trace.set_selector_column::<N_ZKVM_KECCAK_REL_COLS>(
+                    Sponge(Absorb(First)),
+                    domain_size,
+                );
+                trace.set_selector_column::<N_ZKVM_KECCAK_REL_COLS>(
+                    Sponge(Absorb(Middle)),
+                    domain_size,
+                );
+                trace.set_selector_column::<N_ZKVM_KECCAK_SEL_COLS>(
+                    Sponge(Absorb(Last)),
+                    domain_size,
+                );
             }
         }
 
@@ -656,7 +674,8 @@ fn test_keccak_folding() {
             .map(|step| {
                 (
                     step,
-                    default_trace.constraints[&step]
+                    default_trace[step]
+                        .constraints
                         .iter()
                         .map(|c| FoldingCompatibleExpr::<KeccakConfig>::from(c.clone()))
                         .collect(),
@@ -686,9 +705,12 @@ fn test_keccak_folding() {
                 })
                 .collect();
 
-        // Create the decomposable folding scheme reused in some checks
         let (dec_scheme, dec_final_constraint) = DecomposableFoldingScheme::<KeccakConfig>::new(
-            constraints.clone(),
+            <DecomposedKeccakTrace as Foldable<
+                N_ZKVM_KECCAK_COLS,
+                KeccakConfig,
+                BaseSponge,
+            >>::folding_constraints(&default_trace),
             vec![],
             &srs,
             domain,
@@ -698,9 +720,9 @@ fn test_keccak_folding() {
         // Check folding constraints of individual steps ignoring selectors
         for step in Steps::iter().flat_map(|x| x.into_iter()) {
             // Create sides for folding
-            let left = keccak_trace[0].to_folding_pair(step, &srs, &mut fq_sponge);
+            let left = keccak_trace[0].to_folding_pair(step, &mut fq_sponge, domain, &srs);
             let (left_instance, left_witness) = left.clone();
-            let right = keccak_trace[1].to_folding_pair(step, &srs, &mut fq_sponge);
+            let right = keccak_trace[1].to_folding_pair(step, &mut fq_sponge, domain, &srs);
             let (right_instance, right_witness) = right.clone();
 
             // CASE 0: Check instances satisfy the constraints, without folding them
@@ -782,7 +804,8 @@ fn test_keccak_folding() {
                 let (dummy_scheme, dummy_final_constraint) =
                     DecomposableFoldingScheme::<KeccakConfig>::new(
                         zero_constraints.clone(),
-                        default_trace.constraints[&step]
+                        default_trace[step]
+                            .constraints
                             .iter()
                             .map(|c| FoldingCompatibleExpr::<KeccakConfig>::from(c.clone()))
                             .collect(),
@@ -854,8 +877,18 @@ fn test_keccak_folding() {
             // Mix Sponge(Absorb(Only)) and Round(0)
             let left = {
                 let (folded_l_ins, folded_l_wit, _) = dec_scheme.fold_instance_witness_pair(
-                    keccak_trace[0].to_folding_pair(Sponge(Absorb(Only)), &srs, &mut fq_sponge),
-                    keccak_trace[1].to_folding_pair(Sponge(Absorb(Only)), &srs, &mut fq_sponge),
+                    keccak_trace[0].to_folding_pair(
+                        Sponge(Absorb(Only)),
+                        &mut fq_sponge,
+                        domain,
+                        &srs,
+                    ),
+                    keccak_trace[1].to_folding_pair(
+                        Sponge(Absorb(Only)),
+                        &mut fq_sponge,
+                        domain,
+                        &srs,
+                    ),
                     Some(Sponge(Absorb(Only))),
                     &mut fq_sponge,
                 );
@@ -864,8 +897,8 @@ fn test_keccak_folding() {
             };
             let right = {
                 let (folded_r_ins, folded_r_wit, _) = dec_scheme.fold_instance_witness_pair(
-                    keccak_trace[0].to_folding_pair(Round(0), &srs, &mut fq_sponge),
-                    keccak_trace[1].to_folding_pair(Round(0), &srs, &mut fq_sponge),
+                    keccak_trace[0].to_folding_pair(Round(0), &mut fq_sponge, domain, &srs),
+                    keccak_trace[1].to_folding_pair(Round(0), &mut fq_sponge, domain, &srs),
                     Some(Round(0)),
                     &mut fq_sponge,
                 );
@@ -877,5 +910,20 @@ fn test_keccak_folding() {
             let checker = ExtendedProvider::new(folded_ins, folded_wit);
             checker.check(&dec_final_constraint);
         }
-    });
+
+        // Fold Sponge(Absorb(Only))
+        let left =
+            keccak_trace[0].to_folding_pair(Sponge(Absorb(Only)), &mut fq_sponge, domain, &srs);
+        let right =
+            keccak_trace[1].to_folding_pair(Sponge(Absorb(Only)), &mut fq_sponge, domain, &srs);
+        let (folded_instance, folded_witness, [_t0, _t1]) = dec_scheme.fold_instance_witness_pair(
+            left,
+            right,
+            Some(Sponge(Absorb(Only))),
+            &mut fq_sponge,
+        );
+        let checker = ExtendedProvider::new(folded_instance, folded_witness);
+        debug!("exp: \n {:#?}", dec_final_constraint.to_string());
+        checker.check(&dec_final_constraint);
+    })
 }

--- a/o1vm/src/keccak/trace.rs
+++ b/o1vm/src/keccak/trace.rs
@@ -7,118 +7,106 @@ use strum::IntoEnumIterator;
 use crate::{
     folding::ScalarField,
     keccak::{
-        column::{Steps, N_ZKVM_KECCAK_COLS, N_ZKVM_KECCAK_REL_COLS, N_ZKVM_KECCAK_SEL_COLS},
+        column::{Steps, N_ZKVM_KECCAK_COLS, N_ZKVM_KECCAK_REL_COLS},
         environment::KeccakEnv,
         standardize,
     },
-    trace::{DecomposableTracer, DecomposedTrace},
+    trace::{DecomposableTracer, DecomposedTrace, Trace, Tracer},
 };
 
 use super::folding::KeccakConfig;
 
+/// A Keccak instruction trace
+pub type KeccakTrace = Trace<N_ZKVM_KECCAK_COLS, KeccakConfig>;
 /// The Keccak circuit trace
-pub type KeccakTrace = DecomposedTrace<
-    N_ZKVM_KECCAK_COLS,
-    N_ZKVM_KECCAK_REL_COLS,
-    N_ZKVM_KECCAK_SEL_COLS,
-    KeccakConfig,
->;
+pub type DecomposedKeccakTrace = DecomposedTrace<N_ZKVM_KECCAK_COLS, KeccakConfig>;
 
-impl
-    DecomposableTracer<
-        N_ZKVM_KECCAK_COLS,
-        N_ZKVM_KECCAK_REL_COLS,
-        N_ZKVM_KECCAK_SEL_COLS,
-        KeccakConfig,
-        KeccakEnv<ScalarField<KeccakConfig>>,
-    > for KeccakTrace
-{
-    fn new(domain_size: usize, _env: &mut KeccakEnv<ScalarField<KeccakConfig>>) -> Self {
+impl DecomposableTracer<KeccakEnv<ScalarField<KeccakConfig>>> for DecomposedKeccakTrace {
+    fn new(domain_size: usize, env: &mut KeccakEnv<ScalarField<KeccakConfig>>) -> Self {
         let mut circuit = Self {
             domain_size,
-            witness: BTreeMap::new(),
-            constraints: Default::default(),
-            lookups: Default::default(),
+            trace: BTreeMap::new(),
         };
-
-        for opcode in Steps::iter().flat_map(|step| step.into_iter()) {
-            circuit.witness.insert(
-                opcode,
-                Witness {
-                    cols: Box::new(std::array::from_fn(|_| Vec::with_capacity(domain_size))),
-                },
-            );
+        for step in Steps::iter().flat_map(|step| step.into_iter()) {
             circuit
-                .constraints
-                .insert(opcode, KeccakEnv::constraints_of(opcode));
-            circuit
-                .lookups
-                .insert(opcode, KeccakEnv::lookups_of(opcode));
+                .trace
+                .insert(step, KeccakTrace::init(domain_size, step, env));
         }
         circuit
     }
 
+    fn pad_witnesses(&mut self) {
+        for opcode in Steps::iter().flat_map(|opcode| opcode.into_iter()) {
+            if self.in_circuit(opcode) {
+                self.trace.get_mut(&opcode).unwrap().pad_dummy(());
+            }
+        }
+    }
+}
+
+impl Tracer<N_ZKVM_KECCAK_REL_COLS, KeccakConfig, KeccakEnv<ScalarField<KeccakConfig>>>
+    for KeccakTrace
+{
+    type Selector = ();
+
+    fn init(
+        domain_size: usize,
+        selector: Steps,
+        _env: &mut KeccakEnv<ScalarField<KeccakConfig>>,
+    ) -> Self {
+        // Make sure we are using the same round number to refer to round steps
+        let step = standardize(selector);
+        Self {
+            domain_size,
+            witness: Witness {
+                cols: Box::new(std::array::from_fn(|_| Vec::with_capacity(domain_size))),
+            },
+            constraints: KeccakEnv::constraints_of(step),
+            lookups: KeccakEnv::lookups_of(step),
+        }
+    }
+
     fn push_row(
         &mut self,
-        opcode: Steps,
+        _selector: Self::Selector,
         row: &[ScalarField<KeccakConfig>; N_ZKVM_KECCAK_REL_COLS],
     ) {
-        // Make sure we are using the same round number to refer to round steps
-        let opcode = standardize(opcode);
-        self.witness.entry(opcode).and_modify(|wit| {
-            for (i, value) in row.iter().enumerate() {
-                if wit.cols[i].len() < wit.cols[i].capacity() {
-                    wit.cols[i].push(*value);
-                }
+        for (i, value) in row.iter().enumerate() {
+            if self.witness.cols[i].len() < self.witness.cols[i].capacity() {
+                self.witness.cols[i].push(*value);
             }
-        });
+        }
     }
 
     fn pad_with_row(
         &mut self,
-        opcode: Steps,
+        _selector: Self::Selector,
         row: &[ScalarField<KeccakConfig>; N_ZKVM_KECCAK_REL_COLS],
     ) -> usize {
-        let opcode = standardize(opcode);
-        let len = self.witness[&opcode].cols[0].len();
+        let len = self.witness.cols[0].len();
         assert!(len <= self.domain_size);
         let rows_to_add = self.domain_size - len;
         // When we reach the domain size, we don't need to pad anymore.
         for _ in 0..rows_to_add {
-            self.push_row(opcode, row);
+            self.push_row((), row);
         }
         rows_to_add
     }
 
-    fn pad_with_zeros(&mut self, opcode: Steps) -> usize {
-        let opcode = standardize(opcode);
-        let len = self.witness[&opcode].cols[0].len();
+    fn pad_with_zeros(&mut self, _selector: Self::Selector) -> usize {
+        let len = self.witness.cols[0].len();
         assert!(len <= self.domain_size);
         let rows_to_add = self.domain_size - len;
         // When we reach the domain size, we don't need to pad anymore.
-        self.witness.entry(opcode).and_modify(|wit| {
-            for col in wit.cols.iter_mut() {
-                col.extend((0..rows_to_add).map(|_| ScalarField::<KeccakConfig>::zero()));
-            }
-        });
+        for col in self.witness.cols.iter_mut() {
+            col.extend((0..rows_to_add).map(|_| ScalarField::<KeccakConfig>::zero()));
+        }
         rows_to_add
     }
 
-    fn pad_dummy(&mut self, opcode: Steps) -> usize {
-        // We only want to pad non-empty witnesses.
-        if !self.in_circuit(opcode) {
-            0
-        } else {
-            let opcode = standardize(opcode);
-            // We keep track of the first row of the non-empty witness, which is a real step witness.
-            let row = array::from_fn(|i| self.witness[&opcode].cols[i][0]);
-            self.pad_with_row(opcode, &row)
-        }
-    }
-
-    fn pad_witnesses(&mut self) {
-        for opcode in Steps::iter().flat_map(|opcode| opcode.into_iter()) {
-            self.pad_dummy(opcode);
-        }
+    fn pad_dummy(&mut self, _selector: Self::Selector) -> usize {
+        // We keep track of the first row of the non-empty witness, which is a real step witness.
+        let row = array::from_fn(|i| self.witness.cols[i][0]);
+        self.pad_with_row(_selector, &row)
     }
 }

--- a/o1vm/src/main.rs
+++ b/o1vm/src/main.rs
@@ -1,7 +1,5 @@
 use ark_ff::UniformRand;
-use folding::{
-    decomposable_folding::DecomposableFoldingScheme, expressions::FoldingCompatibleExpr,
-};
+use folding::decomposable_folding::DecomposableFoldingScheme;
 use kimchi::o1_utils;
 use kimchi_msm::{proof::ProofInputs, prover::prove, verifier::verify, witness::Witness};
 use log::debug;
@@ -11,7 +9,7 @@ use o1vm::{
     keccak::{
         column::{Steps, N_ZKVM_KECCAK_COLS, N_ZKVM_KECCAK_REL_COLS, N_ZKVM_KECCAK_SEL_COLS},
         environment::KeccakEnv,
-        trace::KeccakTrace,
+        trace::DecomposedKeccakTrace,
     },
     lookups::LookupTableIDs,
     mips::{
@@ -24,16 +22,10 @@ use o1vm::{
     },
     preimage_oracle::PreImageOracle,
     proof,
-    trace::DecomposableTracer,
+    trace::{DecomposableTracer, Foldable, Tracer},
     BaseSponge, Fp, OpeningProof, ScalarSponge, DOMAIN_SIZE,
 };
-use std::{
-    cmp::Ordering,
-    collections::{BTreeMap, HashMap},
-    fs::File,
-    io::BufReader,
-    process::ExitCode,
-};
+use std::{cmp::Ordering, collections::HashMap, fs::File, io::BufReader, process::ExitCode};
 use strum::IntoEnumIterator;
 
 pub fn main() -> ExitCode {
@@ -91,27 +83,15 @@ pub fn main() -> ExitCode {
 
     // Initialize the circuits. Includes pre-folding witnesses.
     let mut mips_trace = DecomposedMIPSTrace::new(DOMAIN_SIZE, &mut mips_con_env);
-    let mut keccak_trace = KeccakTrace::new(DOMAIN_SIZE, &mut KeccakEnv::<Fp>::default());
+    let mut keccak_trace = DecomposedKeccakTrace::new(DOMAIN_SIZE, &mut KeccakEnv::<Fp>::default());
 
     let _mips_folding = {
-        let constraints: BTreeMap<
-            Instruction,
-            Vec<FoldingCompatibleExpr<DecomposableMIPSFoldingConfig>>,
-        > = mips_trace
-            .constraints
-            .iter()
-            .map(|(k, constraints)| {
-                (
-                    *k,
-                    constraints
-                        .iter()
-                        .map(|x| FoldingCompatibleExpr::from(x.clone()))
-                        .collect(),
-                )
-            })
-            .collect();
         DecomposableFoldingScheme::<DecomposableMIPSFoldingConfig>::new(
-            constraints,
+            <DecomposedMIPSTrace as Foldable<
+                N_MIPS_COLS,
+                DecomposableMIPSFoldingConfig,
+                BaseSponge,
+            >>::folding_constraints(&mips_trace),
             vec![],
             &srs.full_srs,
             domain.d1,
@@ -142,7 +122,7 @@ pub fn main() -> ExitCode {
         if let Some(ref mut keccak_env) = mips_wit_env.keccak_env {
             // Run all steps of hash
             while keccak_env.step.is_some() {
-                // Get the current step that will be
+                // Get the current standardize step that is being executed
                 let step = keccak_env.selector();
                 // Run the interpreter, which sets the witness columns
                 keccak_env.step();
@@ -152,12 +132,12 @@ pub fn main() -> ExitCode {
                 // If the witness is full, fold it and reset the pre-folding witness
                 if keccak_trace.number_of_rows(step) == DOMAIN_SIZE {
                     // Set to zero all selectors except for the one corresponding to the current instruction
-                    keccak_trace.set_selector_column(step, DOMAIN_SIZE);
+                    keccak_trace.set_selector_column::<N_ZKVM_KECCAK_REL_COLS>(step, DOMAIN_SIZE);
                     proof::fold::<N_ZKVM_KECCAK_COLS, _, OpeningProof, BaseSponge, ScalarSponge>(
                         domain,
                         &srs,
                         keccak_folded_instance.get_mut(&step).unwrap(),
-                        &keccak_trace.witness[&step],
+                        &keccak_trace[step].witness,
                     );
                     keccak_trace.reset(step);
                 }
@@ -169,13 +149,13 @@ pub fn main() -> ExitCode {
         // TODO: unify witness of MIPS to include scratch state, instruction counter, and error
         for i in 0..N_MIPS_REL_COLS {
             match i.cmp(&SCRATCH_SIZE) {
-                Ordering::Less => mips_trace.witness.get_mut(&instr).unwrap().cols[i]
+                Ordering::Less => mips_trace.trace.get_mut(&instr).unwrap().witness.cols[i]
                     .push(mips_wit_env.scratch_state[i]),
-                Ordering::Equal => mips_trace.witness.get_mut(&instr).unwrap().cols[i]
+                Ordering::Equal => mips_trace.trace.get_mut(&instr).unwrap().witness.cols[i]
                     .push(Fp::from(mips_wit_env.instruction_counter)),
                 Ordering::Greater => {
                     // TODO: error
-                    mips_trace.witness.get_mut(&instr).unwrap().cols[i]
+                    mips_trace.trace.get_mut(&instr).unwrap().witness.cols[i]
                         .push(Fp::rand(&mut rand::rngs::OsRng))
                 }
             }
@@ -183,12 +163,12 @@ pub fn main() -> ExitCode {
 
         if mips_trace.number_of_rows(instr) == DOMAIN_SIZE {
             // Set to zero all selectors except for the one corresponding to the current instruction
-            mips_trace.set_selector_column(instr, DOMAIN_SIZE);
+            mips_trace.set_selector_column::<N_MIPS_REL_COLS>(instr, DOMAIN_SIZE);
             proof::fold::<N_MIPS_COLS, _, OpeningProof, BaseSponge, ScalarSponge>(
                 domain,
                 &srs,
                 mips_folded_instance.get_mut(&instr).unwrap(),
-                &mips_trace.witness[&instr],
+                &mips_trace[instr].witness,
             );
             mips_trace.reset(instr);
         }
@@ -200,27 +180,27 @@ pub fn main() -> ExitCode {
         let needs_folding = mips_trace.pad_dummy(instr) != 0;
         if needs_folding {
             // Then set the selector columns (all of them, none has selectors set)
-            mips_trace.set_selector_column(instr, DOMAIN_SIZE);
+            mips_trace.set_selector_column::<N_MIPS_REL_COLS>(instr, DOMAIN_SIZE);
 
             // Finally fold instance
             proof::fold::<N_MIPS_COLS, _, OpeningProof, BaseSponge, ScalarSponge>(
                 domain,
                 &srs,
                 mips_folded_instance.get_mut(&instr).unwrap(),
-                &mips_trace.witness[&instr],
+                &mips_trace[instr].witness,
             );
         }
     }
     for step in Steps::iter().flat_map(|x| x.into_iter()) {
         let needs_folding = keccak_trace.pad_dummy(step) != 0;
         if needs_folding {
-            keccak_trace.set_selector_column(step, DOMAIN_SIZE);
+            keccak_trace.set_selector_column::<N_ZKVM_KECCAK_REL_COLS>(step, DOMAIN_SIZE);
 
             proof::fold::<N_ZKVM_KECCAK_COLS, _, OpeningProof, BaseSponge, ScalarSponge>(
                 domain,
                 &srs,
                 keccak_folded_instance.get_mut(&step).unwrap(),
-                &keccak_trace.witness[&step],
+                &keccak_trace[step].witness,
             );
         }
     }
@@ -230,7 +210,7 @@ pub fn main() -> ExitCode {
         for instr in Instruction::iter().flat_map(|x| x.into_iter()) {
             // Prove only if the instruction was executed
             // and if the number of constraints is nonzero (otherwise quotient polynomial cannot be created)
-            if mips_trace.in_circuit(instr) && !mips_trace.constraints[&instr].is_empty() {
+            if mips_trace.in_circuit(instr) && !mips_trace[instr].constraints.is_empty() {
                 debug!("Checking MIPS circuit {:?}", instr);
                 let mips_result = prove::<
                     _,
@@ -246,7 +226,7 @@ pub fn main() -> ExitCode {
                 >(
                     domain,
                     &srs,
-                    &mips_trace.constraints[&instr],
+                    &mips_trace[instr].constraints,
                     mips_folded_instance[&instr].clone(),
                     &mut rng,
                 );
@@ -266,7 +246,7 @@ pub fn main() -> ExitCode {
                 >(
                     domain,
                     &srs,
-                    &mips_trace.constraints[&instr],
+                    &mips_trace[instr].constraints,
                     &mips_proof,
                     Witness::zero_vec(DOMAIN_SIZE),
                 );
@@ -300,7 +280,7 @@ pub fn main() -> ExitCode {
                 >(
                     domain,
                     &srs,
-                    &keccak_trace.constraints[&step],
+                    &keccak_trace[step].constraints,
                     keccak_folded_instance[&step].clone(),
                     &mut rng,
                 );
@@ -320,7 +300,7 @@ pub fn main() -> ExitCode {
                 >(
                     domain,
                     &srs,
-                    &keccak_trace.constraints[&step],
+                    &keccak_trace[step].constraints,
                     &keccak_proof,
                     Witness::zero_vec(DOMAIN_SIZE),
                 );

--- a/o1vm/src/mips/folding.rs
+++ b/o1vm/src/mips/folding.rs
@@ -1,5 +1,5 @@
 use crate::{
-    folding::{Challenge, DecomposableFoldingEnvironment, FoldingInstance, FoldingWitness},
+    folding::{Challenge, DecomposedFoldingEnvironment, FoldingInstance, FoldingWitness},
     mips::{
         column::{ColumnAlias as MIPSColumn, N_MIPS_COLS},
         Instruction,
@@ -19,11 +19,12 @@ use super::{
 use poly_commitment::srs::SRS;
 
 // Decomposable folding compatibility
-pub type DecomposableMIPSFoldingEnvironment = DecomposableFoldingEnvironment<
+pub type DecomposableMIPSFoldingEnvironment = DecomposedFoldingEnvironment<
     N_MIPS_COLS,
     N_MIPS_REL_COLS,
     N_MIPS_SEL_COLS,
     DecomposableMIPSFoldingConfig,
+    DecomposedMIPSTrace,
 >;
 
 pub type MIPSFoldingWitness = FoldingWitness<N_MIPS_COLS, Fp>;
@@ -33,6 +34,18 @@ pub type MIPSFoldingInstance = FoldingInstance<N_MIPS_COLS, Curve>;
 // Implement indexers over columns and selectors to implement an abstract
 // folding environment over selectors, see [crate::folding::FoldingEnvironment]
 // for more details
+
+impl Index<Column> for FoldingWitness<N_MIPS_REL_COLS, Fp> {
+    type Output = Evaluations<Fp, Radix2EvaluationDomain<Fp>>;
+
+    fn index(&self, index: Column) -> &Self::Output {
+        match index {
+            Column::Relation(ix) => &self.witness.cols[ix],
+            _ => panic!("Invalid column type"),
+        }
+    }
+}
+
 impl Index<MIPSColumn> for MIPSFoldingWitness {
     type Output = Evaluations<Fp, Radix2EvaluationDomain<Fp>>;
 

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -31,7 +31,10 @@ fn test_mips_number_constraints() {
     let mips_circuit = DecomposedMIPSTrace::new(domain_size, &mut constraints_env);
 
     let assert_num_constraints = |instr: &Instruction, num: usize| {
-        assert_eq!(mips_circuit.constraints.get(instr).unwrap().len(), num)
+        assert_eq!(
+            mips_circuit.trace.get(instr).unwrap().constraints.len(),
+            num
+        )
     };
 
     let mut i = 0;
@@ -112,20 +115,32 @@ fn test_mips_number_constraints() {
 mod folding {
     use crate::{
         cannon::{HostProgram, PAGE_ADDRESS_MASK, PAGE_ADDRESS_SIZE, PAGE_SIZE},
-        folding::ScalarField,
+        folding::{Challenge, FoldingEnvironment, FoldingInstance, FoldingWitness},
         mips::{
-            folding::DecomposableMIPSFoldingConfig,
+            column::N_MIPS_REL_COLS,
+            constraints::Env as CEnv,
             interpreter::{debugging::InstructionParts, interpret_itype, InterpreterEnv},
             registers::Registers,
             witness::{Env as WEnv, SyscallEnv, SCRATCH_SIZE},
             ITypeInstruction,
         },
         preimage_oracle::PreImageOracle,
+        trace::Trace,
+        BaseSponge, Curve,
     };
     use kimchi::o1_utils;
     use rand::{CryptoRng, Rng, RngCore};
 
-    type Fp = ScalarField<DecomposableMIPSFoldingConfig>;
+    use ark_poly::{EvaluationDomain as _, Evaluations, Radix2EvaluationDomain as D};
+    use folding::{expressions::FoldingCompatibleExpr, Alphas, FoldingConfig, FoldingScheme};
+    use itertools::Itertools;
+    use kimchi::curve::KimchiCurve;
+    use kimchi_msm::{columns::Column, witness::Witness};
+    use mina_poseidon::FqSponge;
+    use poly_commitment::{commitment::absorb_commitment, srs::SRS, PolyComm, SRS as _};
+    use rayon::iter::{IntoParallelIterator as _, ParallelIterator as _};
+
+    use super::Fp;
 
     const PAGE_INDEX_EXECUTABLE_MEMORY: u32 = 1;
 
@@ -322,5 +337,201 @@ mod folding {
         );
         interpret_itype(&mut dummy_env, ITypeInstruction::LoadUpperImmediate);
         assert_eq!(dummy_env.registers.general_purpose[1], 0xa0000);
+    }
+
+    fn make_random_witness_for_addiu<RNG>(
+        domain_size: usize,
+        rng: &mut RNG,
+    ) -> Witness<N_MIPS_REL_COLS, Vec<Fp>>
+    where
+        RNG: RngCore + CryptoRng,
+    {
+        let mut dummy_env = dummy_env(rng);
+        let instr = ITypeInstruction::AddImmediateUnsigned;
+        let a = std::array::from_fn(|_| Vec::with_capacity(domain_size));
+        let mut witness = Witness { cols: Box::new(a) };
+        // Building trace for AddImmediateUnsigned
+        (0..domain_size).for_each(|_i| {
+            // Registers should not conflict because RAMlookup does not support
+            // reading from/writing into the same register in the same
+            // instruction
+            let reg_src = rng.gen_range(0..10);
+            let reg_dest = rng.gen_range(10..20);
+            // we simulate always the same instruction, with some random values
+            // and registers
+            write_instruction(
+                &mut dummy_env,
+                InstructionParts {
+                    op_code: 0b001001,
+                    rs: reg_src,  // source register
+                    rt: reg_dest, // destination register
+                    // The rest is the immediate value
+                    rd: rng.gen_range(0..32),
+                    shamt: rng.gen_range(0..32),
+                    funct: rng.gen_range(0..64),
+                },
+            );
+            interpret_itype(&mut dummy_env, instr);
+
+            for j in 0..SCRATCH_SIZE {
+                witness.cols[j].push(dummy_env.scratch_state[j]);
+            }
+            witness.cols[SCRATCH_SIZE].push(Fp::from(dummy_env.instruction_counter));
+            witness.cols[SCRATCH_SIZE + 1].push(Fp::from(0));
+            dummy_env.instruction_counter += 1;
+
+            dummy_env.reset_scratch_state()
+        });
+        // sanity check
+        witness
+            .cols
+            .iter()
+            .for_each(|x| assert_eq!(x.len(), domain_size));
+        witness
+    }
+
+    fn build_folding_instance(
+        witness: &FoldingWitness<N_MIPS_REL_COLS, Fp>,
+        fq_sponge: &mut BaseSponge,
+        domain: D<Fp>,
+        srs: &SRS<Curve>,
+    ) -> FoldingInstance<N_MIPS_REL_COLS, Curve> {
+        let commitments: Witness<N_MIPS_REL_COLS, PolyComm<Curve>> = (&witness.witness)
+            .into_par_iter()
+            .map(|w| srs.commit_evaluations_non_hiding(domain, w))
+            .collect();
+
+        // Absorbing commitments
+        (&commitments)
+            .into_iter()
+            .for_each(|c| absorb_commitment(fq_sponge, c));
+
+        let commitments: [Curve; N_MIPS_REL_COLS] = commitments
+            .into_iter()
+            .map(|c| c.elems[0])
+            .collect_vec()
+            .try_into()
+            .unwrap();
+
+        let beta = fq_sponge.challenge();
+        let gamma = fq_sponge.challenge();
+        let joint_combiner = fq_sponge.challenge();
+        let alpha = fq_sponge.challenge();
+        let challenges = [beta, gamma, joint_combiner];
+        let alphas = Alphas::new(alpha);
+
+        FoldingInstance {
+            commitments,
+            challenges,
+            alphas,
+        }
+    }
+
+    #[test]
+    fn test_folding_mips_addiu_constraint() {
+        let mut fq_sponge: BaseSponge = FqSponge::new(Curve::other_curve_sponge_params());
+        let mut rng = o1_utils::tests::make_test_rng();
+
+        let domain_size = 1 << 3;
+        let domain: D<Fp> = D::<Fp>::new(domain_size).unwrap();
+
+        let mut srs = SRS::<Curve>::create(domain_size);
+        srs.add_lagrange_basis(domain);
+
+        // Generating constraints
+        let constraints = {
+            // Initialize the environment and run the interpreter
+            let mut constraints_env = CEnv::<Fp>::default();
+            interpret_itype(&mut constraints_env, ITypeInstruction::AddImmediateUnsigned);
+            constraints_env.constraints
+        };
+        // We have 3 constraints here. We can select only one.
+        // println!("Nb of constraints: {:?}", constraints.len());
+        // You can select one of the constraints if you want to fold only one
+        // constraints
+        //     .iter()
+        //     .for_each(|constraint| println!("Degree: {:?}", constraint.degree(1, 0)));
+        // Selecting the first constraint for testing
+        // let constraints = vec![constraints.first().unwrap().clone()];
+
+        let witness_one = make_random_witness_for_addiu(domain_size, &mut rng);
+        let witness_two = make_random_witness_for_addiu(domain_size, &mut rng);
+        // FIXME: run PlonK here to check the it is satisfied.
+
+        // Now, we will fold and use the folding scheme to only prove the
+        // aggregation instead of the individual instances
+
+        #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+        struct MIPSFoldingConfig;
+
+        let trace_one: Trace<N_MIPS_REL_COLS, MIPSFoldingConfig> = Trace {
+            domain_size,
+            // FIXME: do not use clone
+            witness: witness_one.clone(),
+            constraints: constraints.clone(),
+            lookups: vec![],
+        };
+
+        impl FoldingConfig for MIPSFoldingConfig {
+            type Column = Column;
+            type Selector = ();
+            type Challenge = Challenge;
+            type Curve = Curve;
+            type Srs = SRS<Curve>;
+            type Instance = FoldingInstance<N_MIPS_REL_COLS, Curve>;
+            type Witness = FoldingWitness<N_MIPS_REL_COLS, Fp>;
+            // The structure must a provable Trace. Here we use a single
+            // instruction trace
+            type Structure = Trace<N_MIPS_REL_COLS, MIPSFoldingConfig>;
+            type Env = FoldingEnvironment<
+                N_MIPS_REL_COLS,
+                MIPSFoldingConfig,
+                Trace<N_MIPS_REL_COLS, MIPSFoldingConfig>,
+            >;
+        }
+
+        let folding_witness_one: FoldingWitness<N_MIPS_REL_COLS, Fp> = {
+            let witness_one = (&witness_one)
+                .into_par_iter()
+                .map(|w| Evaluations::from_vec_and_domain(w.to_vec(), domain))
+                .collect();
+            FoldingWitness {
+                witness: witness_one,
+            }
+        };
+
+        let folding_witness_two: FoldingWitness<N_MIPS_REL_COLS, Fp> = {
+            let witness_two = (&witness_two)
+                .into_par_iter()
+                .map(|w| Evaluations::from_vec_and_domain(w.to_vec(), domain))
+                .collect();
+            FoldingWitness {
+                witness: witness_two,
+            }
+        };
+
+        let folding_instance_one =
+            build_folding_instance(&folding_witness_one, &mut fq_sponge, domain, &srs);
+        let folding_instance_two =
+            build_folding_instance(&folding_witness_two, &mut fq_sponge, domain, &srs);
+
+        let folding_compat_constraints: Vec<FoldingCompatibleExpr<MIPSFoldingConfig>> = constraints
+            .iter()
+            .map(|x| FoldingCompatibleExpr::from(x.clone()))
+            .collect::<Vec<_>>();
+
+        let (folding_scheme, _) = FoldingScheme::<MIPSFoldingConfig>::new(
+            folding_compat_constraints,
+            &srs,
+            domain,
+            &trace_one,
+        );
+
+        let one = (folding_instance_one, folding_witness_one);
+        let two = (folding_instance_two, folding_witness_two);
+        let (_relaxed_instance, _relatex_witness, _error_terms) =
+            folding_scheme.fold_instance_witness_pair(one, two, &mut fq_sponge);
+
+        // FIXME: add IVC
     }
 }

--- a/o1vm/src/mips/trace.rs
+++ b/o1vm/src/mips/trace.rs
@@ -1,111 +1,118 @@
 use crate::{
     folding::ScalarField,
     mips::{
-        column::{N_MIPS_COLS, N_MIPS_REL_COLS, N_MIPS_SEL_COLS},
+        column::{N_MIPS_COLS, N_MIPS_REL_COLS},
         constraints::Env,
+        folding::DecomposableMIPSFoldingConfig,
         interpreter::{interpret_instruction, Instruction},
     },
-    trace::{DecomposableTracer, DecomposedTrace},
+    trace::{DecomposableTracer, DecomposedTrace, Trace, Tracer},
 };
 use ark_ff::Zero;
 use kimchi_msm::witness::Witness;
 use std::{array, collections::BTreeMap};
 use strum::IntoEnumIterator;
 
-use super::folding::DecomposableMIPSFoldingConfig;
-
+/// The MIPS instruction trace
+pub type MIPSTrace = Trace<N_MIPS_COLS, DecomposableMIPSFoldingConfig>;
 /// The MIPS circuit trace
-pub type DecomposedMIPSTrace =
-    DecomposedTrace<N_MIPS_COLS, N_MIPS_REL_COLS, N_MIPS_SEL_COLS, DecomposableMIPSFoldingConfig>;
+pub type DecomposedMIPSTrace = DecomposedTrace<N_MIPS_COLS, DecomposableMIPSFoldingConfig>;
 
-impl
-    DecomposableTracer<
-        N_MIPS_COLS,
-        N_MIPS_REL_COLS,
-        N_MIPS_SEL_COLS,
-        DecomposableMIPSFoldingConfig,
-        Env<ScalarField<DecomposableMIPSFoldingConfig>>,
-    > for DecomposedMIPSTrace
-{
+impl DecomposableTracer<Env<ScalarField<DecomposableMIPSFoldingConfig>>> for DecomposedMIPSTrace {
     fn new(domain_size: usize, env: &mut Env<ScalarField<DecomposableMIPSFoldingConfig>>) -> Self {
         let mut circuit = Self {
             domain_size,
-            witness: BTreeMap::new(),
-            constraints: Default::default(),
-            lookups: Default::default(),
+            trace: BTreeMap::new(),
         };
-
-        for instr in Instruction::iter().flat_map(|x| x.into_iter()) {
-            circuit.witness.insert(
-                instr,
-                Witness {
-                    cols: Box::new(std::array::from_fn(|_| Vec::with_capacity(domain_size))),
-                },
-            );
-            interpret_instruction(env, instr);
-            circuit.constraints.insert(instr, env.constraints.clone());
-            circuit.lookups.insert(instr, env.lookups.clone());
-            env.scratch_state_idx = 0; // Reset the scratch state index for the next instruction
-            env.constraints = vec![]; // Clear the constraints for the next instruction
-            env.lookups = vec![]; // Clear the lookups for the next instruction
+        for instr in Instruction::iter().flat_map(|step| step.into_iter()) {
+            circuit
+                .trace
+                .insert(instr, <MIPSTrace>::init(domain_size, instr, env));
         }
         circuit
     }
 
+    fn pad_witnesses(&mut self) {
+        for opcode in Instruction::iter().flat_map(|opcode| opcode.into_iter()) {
+            self.trace.get_mut(&opcode).unwrap().pad_dummy(());
+        }
+    }
+}
+
+impl
+    Tracer<
+        N_MIPS_REL_COLS,
+        DecomposableMIPSFoldingConfig,
+        Env<ScalarField<DecomposableMIPSFoldingConfig>>,
+    > for MIPSTrace
+{
+    type Selector = ();
+
+    fn init(
+        domain_size: usize,
+        instr: Instruction,
+        env: &mut Env<ScalarField<DecomposableMIPSFoldingConfig>>,
+    ) -> Self {
+        interpret_instruction(env, instr);
+
+        let trace = Self {
+            domain_size,
+            witness: Witness {
+                cols: Box::new(std::array::from_fn(|_| Vec::with_capacity(domain_size))),
+            },
+            constraints: env.constraints.clone(),
+            lookups: env.lookups.clone(),
+        };
+        env.scratch_state_idx = 0; // Reset the scratch state index for the next instruction
+        env.constraints = vec![]; // Clear the constraints for the next instruction
+        env.lookups = vec![]; // Clear the lookups for the next instruction
+
+        trace
+    }
+
     fn push_row(
         &mut self,
-        opcode: Instruction,
+        _selector: Self::Selector,
         row: &[ScalarField<DecomposableMIPSFoldingConfig>; N_MIPS_REL_COLS],
     ) {
-        self.witness.entry(opcode).and_modify(|wit| {
-            for (i, value) in row.iter().enumerate() {
-                if wit.cols[i].len() < wit.cols[i].capacity() {
-                    wit.cols[i].push(*value);
-                }
+        for (i, value) in row.iter().enumerate() {
+            if self.witness.cols[i].len() < self.witness.cols[i].capacity() {
+                self.witness.cols[i].push(*value);
             }
-        });
+        }
     }
 
     fn pad_with_row(
         &mut self,
-        opcode: Instruction,
+        _selector: Self::Selector,
         row: &[ScalarField<DecomposableMIPSFoldingConfig>; N_MIPS_REL_COLS],
     ) -> usize {
-        let len = self.witness[&opcode].cols[0].len();
+        let len = self.witness.cols[0].len();
         assert!(len <= self.domain_size);
         let rows_to_add = self.domain_size - len;
+        // When we reach the domain size, we don't need to pad anymore.
         for _ in 0..rows_to_add {
-            self.push_row(opcode, row);
+            self.push_row(_selector, row);
         }
         rows_to_add
     }
 
-    fn pad_with_zeros(&mut self, opcode: Instruction) -> usize {
-        let len = self.witness[&opcode].cols[0].len();
+    fn pad_with_zeros(&mut self, _selector: Self::Selector) -> usize {
+        let len = self.witness.cols[0].len();
         assert!(len <= self.domain_size);
         let rows_to_add = self.domain_size - len;
-        self.witness.entry(opcode).and_modify(|wit| {
-            for col in wit.cols.iter_mut() {
-                col.extend(
-                    (0..rows_to_add).map(|_| ScalarField::<DecomposableMIPSFoldingConfig>::zero()),
-                );
-            }
-        });
+        // When we reach the domain size, we don't need to pad anymore.
+        for col in self.witness.cols.iter_mut() {
+            col.extend(
+                (0..rows_to_add).map(|_| ScalarField::<DecomposableMIPSFoldingConfig>::zero()),
+            );
+        }
         rows_to_add
     }
 
-    fn pad_dummy(&mut self, opcode: Instruction) -> usize {
-        if !self.in_circuit(opcode) {
-            0
-        } else {
-            let row = array::from_fn(|i| self.witness[&opcode].cols[i][0]);
-            self.pad_with_row(opcode, &row)
-        }
-    }
-
-    fn pad_witnesses(&mut self) {
-        for step in Instruction::iter().flat_map(|step| step.into_iter()) {
-            self.pad_dummy(step);
-        }
+    fn pad_dummy(&mut self, _selector: Self::Selector) -> usize {
+        // We keep track of the first row of the non-empty witness, which is a real step witness.
+        let row = array::from_fn(|i| self.witness.cols[i][0]);
+        self.pad_with_row(_selector, &row)
     }
 }

--- a/o1vm/src/trace.rs
+++ b/o1vm/src/trace.rs
@@ -11,14 +11,15 @@ use crate::{
     E,
 };
 use ark_ff::{One, Zero};
-use ark_poly::{EvaluationDomain, Evaluations, Radix2EvaluationDomain};
-use folding::{Alphas, FoldingConfig};
+use ark_poly::{Evaluations, Radix2EvaluationDomain as D};
+use folding::{expressions::FoldingCompatibleExpr, Alphas, FoldingConfig};
 use itertools::Itertools;
-use kimchi_msm::witness::Witness;
+use kimchi::circuits::expr::ChallengeTerm;
+use kimchi_msm::{columns::Column, witness::Witness};
 use mina_poseidon::sponge::FqSponge;
-use poly_commitment::{PolyComm, SRS as _};
+use poly_commitment::{commitment::absorb_commitment, PolyComm, SRS as _};
 use rayon::{iter::ParallelIterator, prelude::IntoParallelIterator};
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, ops::Index};
 
 /// Returns the index of the witness column in the trace.
 pub trait Indexer {
@@ -40,6 +41,7 @@ pub trait ProvableTrace {
 // single instruction.
 // It is not recommended to use this in production and it should not be
 // maintained in the long term.
+#[derive(Clone)]
 pub struct Trace<const N: usize, C: FoldingConfig> {
     pub domain_size: usize,
     pub witness: Witness<N, Vec<ScalarField<C>>>,
@@ -62,37 +64,34 @@ impl<const N: usize, C: FoldingConfig> ProvableTrace for Trace<N, C> {
 /// - `N_DSEL`: the number of dynamic selector columns (constant),
 /// - `Selector`: an enum representing the different gate behaviours,
 /// - `F`: the type of the witness data.
-#[allow(clippy::type_complexity)]
 #[derive(Clone)]
-pub struct DecomposedTrace<
-    const N: usize,
-    const N_REL: usize,
-    const N_DSEL: usize,
-    C: FoldingConfig,
-> {
-    /// The domain size of the circuit
+pub struct DecomposedTrace<const N: usize, C: FoldingConfig> {
+    /// The domain size of the circuit (should coincide with that of the traces)
     pub domain_size: usize,
-    /// The witness for a given selector
-    /// - the last N_DSEL columns represent the selector columns
+    /// The traces are indexed by the selector
+    /// Inside the witness of the trace for a given selector,
+    /// - the last N_SEL columns represent the selector columns
     ///   and only the one for `Selector` should be all ones (the rest of selector columns should be all zeros)
-    pub witness: BTreeMap<C::Selector, Witness<N, Vec<ScalarField<C>>>>,
-    /// The vector of constraints for a given selector
-    pub constraints: BTreeMap<C::Selector, Vec<E<ScalarField<C>>>>,
-    /// The vector of lookups for a given selector
-    pub lookups: BTreeMap<C::Selector, Vec<Lookup<E<ScalarField<C>>>>>,
+    pub trace: BTreeMap<C::Selector, Trace<N, C>>,
+}
+
+// Implementation of [Index] using `C::Selector`` as the index for [DecomposedTrace] to access the trace directly.
+impl<const N: usize, C: FoldingConfig> Index<C::Selector> for DecomposedTrace<N, C> {
+    type Output = Trace<N, C>;
+
+    fn index(&self, index: C::Selector) -> &Self::Output {
+        &self.trace[&index]
+    }
 }
 
 // Any decomposable trace is provable.
-impl<const N: usize, const N_REL: usize, const N_DSEL: usize, C: FoldingConfig> ProvableTrace
-    for DecomposedTrace<N, N_REL, N_DSEL, C>
-{
+impl<const N: usize, C: FoldingConfig> ProvableTrace for DecomposedTrace<N, C> {
     fn domain_size(&self) -> usize {
         self.domain_size
     }
 }
 
-impl<const N: usize, const N_REL: usize, const N_DSEL: usize, C: FoldingConfig>
-    DecomposedTrace<N, N_REL, N_DSEL, C>
+impl<const N: usize, C: FoldingConfig> DecomposedTrace<N, C>
 where
     C::Selector: Indexer,
 {
@@ -103,7 +102,7 @@ where
     /// could be zero most times.
     /// That is the reason that relation columns are located first.
     pub fn number_of_rows(&self, opcode: C::Selector) -> usize {
-        self.witness[&opcode].cols[0].len()
+        self[opcode].witness.cols[0].len()
     }
 
     /// Returns a boolean indicating whether the witness for the given selector
@@ -120,19 +119,23 @@ where
 
     /// Resets the witness after folding
     pub fn reset(&mut self, opcode: C::Selector) {
-        (self.witness.get_mut(&opcode).unwrap().cols.as_mut())
+        (self.trace.get_mut(&opcode).unwrap().witness.cols.as_mut())
             .iter_mut()
             .for_each(Vec::clear);
     }
 
     /// Sets the selector column to all ones, and the rest to all zeros
-    pub fn set_selector_column(&mut self, selector: C::Selector, number_of_rows: usize) {
+    pub fn set_selector_column<const N_REL: usize>(
+        &mut self,
+        selector: C::Selector,
+        number_of_rows: usize,
+    ) {
         (N_REL..N).for_each(|i| {
             if i == selector.ix() {
-                self.witness.get_mut(&selector).unwrap().cols[i]
+                self.trace.get_mut(&selector).unwrap().witness.cols[i]
                     .extend((0..number_of_rows).map(|_| ScalarField::<C>::one()))
             } else {
-                self.witness.get_mut(&selector).unwrap().cols[i]
+                self.trace.get_mut(&selector).unwrap().witness.cols[i]
                     .extend((0..number_of_rows).map(|_| ScalarField::<C>::zero()))
             }
         });
@@ -143,8 +146,8 @@ where
 /// For that, it requires to be able to implement a way to return a folding
 /// instance and a folding witness.
 /// It is specialized for the [DecomposedTrace] struct for now and is expected
-/// to fold individual instructions, selected with a specific [C::Selector].
-pub(crate) trait Foldable<const N: usize, C: FoldingConfig, Sponge> {
+/// to fold individual instructions, selected with a specific `C::Selector`.
+pub trait Foldable<const N: usize, C: FoldingConfig, Sponge> {
     /// Returns the witness for the given selector as a folding witness and
     /// folding instance pair.
     /// Note that this function will also absorb all commitments to the columns
@@ -152,33 +155,38 @@ pub(crate) trait Foldable<const N: usize, C: FoldingConfig, Sponge> {
     fn to_folding_pair(
         &self,
         selector: C::Selector,
+        fq_sponge: &mut Sponge,
+        domain: D<ScalarField<C>>,
         srs: &poly_commitment::srs::SRS<C::Curve>,
-        sponge: &mut Sponge,
     ) -> (
         FoldingInstance<N, C::Curve>,
         FoldingWitness<N, ScalarField<C>>,
     );
+
+    /// Returns a map of constraints that are compatible with folding for each selector
+    fn folding_constraints(&self) -> BTreeMap<C::Selector, Vec<FoldingCompatibleExpr<C>>>;
 }
 
 /// Implement the trait Foldable for the structure [DecomposedTrace]
-impl<const N: usize, const N_REL: usize, const N_DSEL: usize, C: FoldingConfig, Sponge>
-    Foldable<N, C, Sponge> for DecomposedTrace<N, N_REL, N_DSEL, C>
+impl<const N: usize, C: FoldingConfig<Column = Column>, Sponge> Foldable<N, C, Sponge>
+    for DecomposedTrace<N, C>
 where
     C::Selector: Indexer,
     Sponge: FqSponge<BaseField<C>, C::Curve, ScalarField<C>>,
+    <C as FoldingConfig>::Challenge: From<ChallengeTerm>,
 {
     fn to_folding_pair(
         &self,
         selector: C::Selector,
-        srs: &poly_commitment::srs::SRS<C::Curve>,
         fq_sponge: &mut Sponge,
+        domain: D<ScalarField<C>>,
+        srs: &poly_commitment::srs::SRS<C::Curve>,
     ) -> (
         FoldingInstance<N, C::Curve>,
         FoldingWitness<N, ScalarField<C>>,
     ) {
-        let domain = Radix2EvaluationDomain::<ScalarField<C>>::new(self.domain_size).unwrap();
         let folding_witness = FoldingWitness {
-            witness: (&self.witness[&selector])
+            witness: (&self[selector].witness)
                 .into_par_iter()
                 .map(|w| Evaluations::from_vec_and_domain(w.to_vec(), domain))
                 .collect(),
@@ -188,6 +196,12 @@ where
             .into_par_iter()
             .map(|w| srs.commit_evaluations_non_hiding(domain, w))
             .collect();
+
+        // Absorbing commitments
+        (&commitments)
+            .into_iter()
+            .for_each(|c| absorb_commitment(fq_sponge, c));
+
         let commitments: [C::Curve; N] = commitments
             .into_iter()
             .map(|c| c.elems[0])
@@ -211,57 +225,128 @@ where
 
         (instance, folding_witness)
     }
+
+    fn folding_constraints(&self) -> BTreeMap<C::Selector, Vec<FoldingCompatibleExpr<C>>> {
+        self.trace
+            .iter()
+            .map(|(k, instr)| {
+                (
+                    *k,
+                    instr
+                        .constraints
+                        .iter()
+                        .map(|x| FoldingCompatibleExpr::from(x.clone()))
+                        .collect(),
+                )
+            })
+            .collect()
+    }
 }
 
 /// Tracer builds traces for some program executions.
-/// The constant type `N` is defined as the maximum number of columns the trace
-/// can use per row.
 /// The constant type `N_REL` is defined as the maximum number of relation
 /// columns the trace can use per row.
-/// The constant type `N_DSEL` is defined as the number of selector columns the
-/// trace can use per row.
-/// The type `Selector` encodes the information of the kind of information the
-/// trace encodes. Examples:
+/// The type `C` encodes the folding configuration, from which the selector,
+/// which encodes the information of the kind of information the trace encodes,
+/// and scalar field are derived. Examples of selectors are:
 /// - For Keccak, `Step` encodes the row being performed at a time: round,
 /// squeeze, padding, etc...
 /// - For MIPS, `Instruction` encodes the CPU instruction being executed: add,
 /// sub, load, store, etc...
-/// The type parameter `F` is the type the data points in the trace are encoded
-/// into. It can be a field or a native type (u64).
-pub trait DecomposableTracer<
-    const N: usize,
-    const N_REL: usize,
-    const N_DSEL: usize,
-    C: FoldingConfig,
-    Env,
->
-{
-    /// Create a new circuit
-    fn new(domain_size: usize, env: &mut Env) -> Self;
+pub trait Tracer<const N_REL: usize, C: FoldingConfig, Env> {
+    type Selector;
+
+    /// Initialize a new trace with the given domain size, selector, and environment.
+    fn init(domain_size: usize, selector: C::Selector, env: &mut Env) -> Self;
 
     /// Add a witness row to the circuit (only for relation columns)
-    fn push_row(&mut self, opcode: C::Selector, row: &[ScalarField<C>; N_REL]);
+    fn push_row(&mut self, selector: Self::Selector, row: &[ScalarField<C>; N_REL]);
 
     /// Pad the rows of one opcode with the given row until
     /// reaching the domain size if needed.
     /// Returns the number of rows that were added.
     /// It does not add selector columns.
-    fn pad_with_row(&mut self, opcode: C::Selector, row: &[ScalarField<C>; N_REL]) -> usize;
+    fn pad_with_row(&mut self, selector: Self::Selector, row: &[ScalarField<C>; N_REL]) -> usize;
 
     /// Pads the rows of one opcode with zero rows until
     /// reaching the domain size if needed.
     /// Returns the number of rows that were added.
     /// It does not add selector columns.
-    fn pad_with_zeros(&mut self, opcode: C::Selector) -> usize;
+    fn pad_with_zeros(&mut self, selector: Self::Selector) -> usize;
 
     /// Pad the rows of one opcode with the first row until
     /// reaching the domain size if needed.
     /// It only tries to pad witnesses which are non empty.
     /// Returns the number of rows that were added.
     /// It does not add selector columns.
-    fn pad_dummy(&mut self, opcode: C::Selector) -> usize;
+    /// - Use `None` for single traces
+    /// - Use `Some(selector)` for multi traces
+    fn pad_dummy(&mut self, selector: Self::Selector) -> usize;
+}
+
+/// DecomposableTracer builds traces for some program executions.
+/// The constant type `N_REL` is defined as the maximum number of relation
+/// columns the trace can use per row.
+/// The type `C` encodes the folding configuration, from which the selector,
+/// and scalar field are derived. Examples of selectors are:
+/// - For Keccak, `Step` encodes the row being performed at a time: round,
+/// squeeze, padding, etc...
+/// - For MIPS, `Instruction` encodes the CPU instruction being executed: add,
+/// sub, load, store, etc...
+pub trait DecomposableTracer<Env> {
+    /// Create a new decomposable trace with the given domain size, and environment.
+    fn new(domain_size: usize, env: &mut Env) -> Self;
 
     /// Pads the rows of the witnesses until reaching the domain size using the first
     /// row repeatedly. It does not add selector columns.
     fn pad_witnesses(&mut self);
+}
+
+/// Generic implementation of the [Tracer] trait for the [DecomposedTrace] struct.
+/// It requires the [DecomposedTrace] to implement the [DecomposableTracer] trait,
+/// and the [Trace] struct to implement the [Tracer] trait with Selector set to (),
+/// and the `C::Selector` to implement the [Indexer] trait.
+impl<const N: usize, const N_REL: usize, C: FoldingConfig, Env> Tracer<N_REL, C, Env>
+    for DecomposedTrace<N, C>
+where
+    DecomposedTrace<N, C>: DecomposableTracer<Env>,
+    Trace<N, C>: Tracer<N_REL, C, Env, Selector = ()>,
+    <C as FoldingConfig>::Selector: Indexer,
+{
+    type Selector = C::Selector;
+
+    fn init(domain_size: usize, _selector: C::Selector, env: &mut Env) -> Self {
+        <Self as DecomposableTracer<Env>>::new(domain_size, env)
+    }
+
+    fn push_row(&mut self, selector: Self::Selector, row: &[ScalarField<C>; N_REL]) {
+        self.trace.get_mut(&selector).unwrap().push_row((), row);
+    }
+
+    fn pad_with_row(&mut self, selector: Self::Selector, row: &[ScalarField<C>; N_REL]) -> usize {
+        // We only want to pad non-empty witnesses.
+        if !self.in_circuit(selector) {
+            0
+        } else {
+            self.trace.get_mut(&selector).unwrap().pad_with_row((), row)
+        }
+    }
+
+    fn pad_with_zeros(&mut self, selector: Self::Selector) -> usize {
+        // We only want to pad non-empty witnesses.
+        if !self.in_circuit(selector) {
+            0
+        } else {
+            self.trace.get_mut(&selector).unwrap().pad_with_zeros(())
+        }
+    }
+
+    fn pad_dummy(&mut self, selector: Self::Selector) -> usize {
+        // We only want to pad non-empty witnesses.
+        if !self.in_circuit(selector) {
+            0
+        } else {
+            self.trace.get_mut(&selector).unwrap().pad_dummy(())
+        }
+    }
 }


### PR DESCRIPTION
Only opening for the CI.
It is using `git merge` on the branch https://github.com/o1-labs/proof-systems/tree/zkvm/keccak/check-fold-steps

I might have broken something. Locally, it gives me this:
```
207', ' panicked at '
207
' panicked at '207thread '' panicked at ':9:207', 
thread '9<unnamed><unnamed>assertion failed: `(left == right)`
  left: `64`,
 right: `128`::<unnamed>:' panicked at 'thread ':/home/soc/codes/o1-labs/proof-systems/poly-commitment/src/commitment.rsassertion failed: `(left == right)`
  left: `64`,
 right: `128`:thread 'assertion failed: `(left == right)`
  left: `64`,
 right: `128`:<unnamed>thread 'assertion failed: `(left == right)`
  left: `64`,
 right: `128`9
207:/home/soc/codes/o1-labs/proof-systems/poly-commitment/src/commitment.rs<unnamed>
' panicked at '' panicked at 'thread '', 9207' panicked at '207assertion failed: `(left == right)`
  left: `64`,
 right: `128`<unnamed>9' panicked at ':', 9<unnamed>', 9' panicked at '<unnamed>', 
/home/soc/codes/o1-labs/proof-systems/poly-commitment/src/commitment.rs207:9:' panicked at 'assertion failed: `(left == right)`
  left: `64`,
 right: `128`assertion failed: `(left == right)`
  left: `64`,
 right: `128`<unnamed>/home/soc/codes/o1-labs/proof-systems/poly-commitment/src/commitment.rs
:assertion failed: `(left == right)`
  left: `64`,
 right: `128`:', 
assertion failed: `(left == right)`
  left: `64`,
 right: `128`207/home/soc/codes/o1-labs/proof-systems/poly-commitment/src/commitment.rs
' panicked at '/home/soc/codes/o1-labs/proof-systems/poly-commitment/src/commitment.rs
assertion failed: `(left == right)`
  left: `64`,
 right: `128`' panicked at ':2079:
207:assertion failed: `(left == right)`
  left: `64`,
 right: `128`', ', ' panicked at ':9', 9/home/soc/codes/o1-labs/proof-systems/poly-commitment/src/commitment.rs', ::assertion failed: `(left == right)`
  left: `64`,
 right: `128`:', assertion failed: `(left == right)`
  left: `64`,
 right: `128`207
9::207', /home/soc/codes/o1-labs/proof-systems/poly-commitment/src/commitment.rs/home/soc/codes/o1-labs/proof-systems/poly-commitment/src/commitment.rsassertion failed: `(left == right)`
  left: `64`,
 right: `128`207
/home/soc/codes/o1-labs/proof-systems/poly-commitment/src/commitment.rs
:/home/soc/codes/o1-labs/proof-systems/poly-commitment/src/commitment.rs9207', 207/home/soc/codes/o1-labs/proof-systems/poly-commitment/src/commitment.rs', :
99:/home/soc/codes/o1-labs/proof-systems/poly-commitment/src/commitment.rs::', ::207:
:/home/soc/codes/o1-labs/proof-systems/poly-commitment/src/commitment.rs::/home/soc/codes/o1-labs/proof-systems/poly-commitment/src/commitment.rs9

```

running `cargo nextest run "test_keccak_folding" --release --nocapture`