### PR TITLE
IVC: Add selector columns

### DIFF
--- a/ivc/src/ivc/columns.rs
+++ b/ivc/src/ivc/columns.rs
@@ -293,7 +293,8 @@ impl ColumnIndexer for IVCColumn {
     // This should be
     //   const N_COL: usize = std::cmp::max(IVCPoseidonColumn::N_COL, FECColumn::N_COL);
     // which is runtime-only expression..?
-    const N_COL: usize = IVCPoseidonColumn::N_COL;
+    // 333 is not enough
+    const N_COL: usize = 400;
 
     fn to_column(self) -> Column {
         match self {
@@ -315,7 +316,9 @@ impl ColumnIndexer for IVCColumn {
                 Column::Relation(N_BLOCKS + 2 * N_LIMBS_SMALL + 2 * N_LIMBS_LARGE + i)
             }
 
-            IVCColumn::Block2Hash(poseidon_col) => poseidon_col.to_column(),
+            IVCColumn::Block2Hash(poseidon_col) => {
+                poseidon_col.to_column().add_rel_offset(N_BLOCKS)
+            }
 
             IVCColumn::Block3ConstPhi => Column::Relation(N_BLOCKS),
             IVCColumn::Block3ConstR => Column::Relation(N_BLOCKS + 1),

--- a/ivc/src/ivc/columns.rs
+++ b/ivc/src/ivc/columns.rs
@@ -299,84 +299,79 @@ impl ColumnIndexer for IVCColumn {
     fn to_column(self) -> Column {
         match self {
             IVCColumn::BlockSel(i) => {
-                assert!(i < 2 * N_BLOCKS);
+                assert!(i < N_BLOCKS);
                 Column::FixedSelector(i)
             }
 
             IVCColumn::Block1Input(i) => {
                 assert!(i < 2 * N_LIMBS_SMALL);
-                Column::Relation(N_BLOCKS + i)
+                Column::Relation(i)
             }
             IVCColumn::Block1InputRepacked75(i) => {
                 assert!(i < 2 * N_LIMBS_LARGE);
-                Column::Relation(N_BLOCKS + 2 * N_LIMBS_SMALL + i)
+                Column::Relation(2 * N_LIMBS_SMALL + i)
             }
             IVCColumn::Block1InputRepacked150(i) => {
                 assert!(i < 2 * N_LIMBS_XLARGE);
-                Column::Relation(N_BLOCKS + 2 * N_LIMBS_SMALL + 2 * N_LIMBS_LARGE + i)
+                Column::Relation(2 * N_LIMBS_SMALL + 2 * N_LIMBS_LARGE + i)
             }
 
-            IVCColumn::Block2Hash(poseidon_col) => {
-                poseidon_col.to_column().add_rel_offset(N_BLOCKS)
-            }
+            IVCColumn::Block2Hash(poseidon_col) => poseidon_col.to_column(),
 
-            IVCColumn::Block3ConstPhi => Column::Relation(N_BLOCKS),
-            IVCColumn::Block3ConstR => Column::Relation(N_BLOCKS + 1),
-            IVCColumn::Block3PhiPow => Column::Relation(N_BLOCKS + 2),
-            IVCColumn::Block3PhiPowR => Column::Relation(N_BLOCKS + 3),
-            IVCColumn::Block3PhiPowR2 => Column::Relation(N_BLOCKS + 4),
-            IVCColumn::Block3PhiPowR3 => Column::Relation(N_BLOCKS + 5),
+            IVCColumn::Block3ConstPhi => Column::Relation(0),
+            IVCColumn::Block3ConstR => Column::Relation(1),
+            IVCColumn::Block3PhiPow => Column::Relation(2),
+            IVCColumn::Block3PhiPowR => Column::Relation(3),
+            IVCColumn::Block3PhiPowR2 => Column::Relation(4),
+            IVCColumn::Block3PhiPowR3 => Column::Relation(5),
             IVCColumn::Block3PhiPowLimbs(i) => {
                 assert!(i < N_LIMBS_SMALL);
-                Column::Relation(N_BLOCKS + 6 + i)
+                Column::Relation(6 + i)
             }
             IVCColumn::Block3PhiPowRLimbs(i) => {
                 assert!(i < N_LIMBS_SMALL);
-                Column::Relation(N_BLOCKS + 6 + N_LIMBS_SMALL + i)
+                Column::Relation(6 + N_LIMBS_SMALL + i)
             }
             IVCColumn::Block3PhiPowR2Limbs(i) => {
                 assert!(i < N_LIMBS_SMALL);
-                Column::Relation(N_BLOCKS + 6 + 2 * N_LIMBS_SMALL + i)
+                Column::Relation(6 + 2 * N_LIMBS_SMALL + i)
             }
             IVCColumn::Block3PhiPowR3Limbs(i) => {
                 assert!(i < N_LIMBS_SMALL);
-                Column::Relation(N_BLOCKS + 6 + 3 * N_LIMBS_SMALL + i)
+                Column::Relation(6 + 3 * N_LIMBS_SMALL + i)
             }
 
             IVCColumn::Block4Input1(i) => {
                 assert!(i < 2 * N_LIMBS_LARGE);
-                Column::Relation(N_BLOCKS + i)
+                Column::Relation(i)
             }
-            IVCColumn::Block4Coeff => Column::Relation(N_BLOCKS + 8),
-            IVCColumn::Block4Input2AccessTime => Column::Relation(N_BLOCKS + 9),
+            IVCColumn::Block4Coeff => Column::Relation(8),
+            IVCColumn::Block4Input2AccessTime => Column::Relation(9),
             IVCColumn::Block4Input2(i) => {
                 assert!(i < 2 * N_LIMBS_LARGE);
-                Column::Relation(N_BLOCKS + 10 + i)
+                Column::Relation(10 + i)
             }
-            IVCColumn::Block4ECAddInter(fec_inter) => {
-                fec_inter.to_column().add_rel_offset(N_BLOCKS + 18)
-            }
+            IVCColumn::Block4ECAddInter(fec_inter) => fec_inter.to_column().add_rel_offset(18),
             IVCColumn::Block4OutputRaw(fec_output) => fec_output
                 .to_column()
-                .add_rel_offset(N_BLOCKS + 18 + FECColumnInter::N_COL),
+                .add_rel_offset(18 + FECColumnInter::N_COL),
             IVCColumn::Block4OutputAccessTime => {
-                Column::Relation(N_BLOCKS + 18 + FECColumnInter::N_COL + FECColumnOutput::N_COL)
+                Column::Relation(18 + FECColumnInter::N_COL + FECColumnOutput::N_COL)
             }
             IVCColumn::Block4OutputRepacked(i) => {
                 assert!(i < 2 * N_LIMBS_LARGE);
-                Column::Relation(
-                    N_BLOCKS + 18 + FECColumnInter::N_COL + FECColumnOutput::N_COL + 1 + i,
-                )
+                Column::Relation(18 + FECColumnInter::N_COL + FECColumnOutput::N_COL + 1 + i)
             }
-            IVCColumn::Block5ConstHr => Column::Relation(N_BLOCKS),
-            IVCColumn::Block5ConstR => Column::Relation(N_BLOCKS + 1),
-            IVCColumn::Block5ChalLeft => Column::Relation(N_BLOCKS + 2),
-            IVCColumn::Block5ChalRight => Column::Relation(N_BLOCKS + 3),
-            IVCColumn::Block5ChalOutput => Column::Relation(N_BLOCKS + 4),
 
-            IVCColumn::Block6ConstR => Column::Relation(N_BLOCKS),
-            IVCColumn::Block6ULeft => Column::Relation(N_BLOCKS + 1),
-            IVCColumn::Block6UOutput => Column::Relation(N_BLOCKS + 2),
+            IVCColumn::Block5ConstHr => Column::Relation(0),
+            IVCColumn::Block5ConstR => Column::Relation(1),
+            IVCColumn::Block5ChalLeft => Column::Relation(2),
+            IVCColumn::Block5ChalRight => Column::Relation(3),
+            IVCColumn::Block5ChalOutput => Column::Relation(4),
+
+            IVCColumn::Block6ConstR => Column::Relation(0),
+            IVCColumn::Block6ULeft => Column::Relation(1),
+            IVCColumn::Block6UOutput => Column::Relation(2),
         }
     }
 }

--- a/ivc/src/ivc/columns.rs
+++ b/ivc/src/ivc/columns.rs
@@ -6,6 +6,9 @@ use kimchi_msm::{
     serialization::interpreter::{N_LIMBS_LARGE, N_LIMBS_SMALL},
 };
 
+/// Number of blocks in the circuit.
+pub const N_BLOCKS: usize = 6;
+
 pub const IVC_POSEIDON_STATE_SIZE: usize = 3;
 pub const IVC_POSEIDON_NB_FULL_ROUND: usize = 55;
 
@@ -285,9 +288,6 @@ pub enum IVCColumn {
     /// u_O = u_L + r
     Block6UOutput,
 }
-
-/// Number of blocks in the circuit.
-const N_BLOCKS: usize = 6;
 
 impl ColumnIndexer for IVCColumn {
     // This should be

--- a/ivc/src/ivc/interpreter.rs
+++ b/ivc/src/ivc/interpreter.rs
@@ -915,7 +915,7 @@ where
 }
 
 /// Builds selectors for the IVC circuit.
-pub fn build_selectors<F, const N_COL_TOTAL: usize, const CHAL_LEN: usize>(
+pub fn build_selectors<F, const N_COL_TOTAL: usize, const N_CHALS: usize>(
     domain_size: usize,
 ) -> [Vec<F>; N_BLOCKS]
 where
@@ -939,7 +939,7 @@ where
         selectors[3][cur_row] = F::one();
         cur_row += 1;
     }
-    for _i in 0..CHAL_LEN {
+    for _i in 0..N_CHALS {
         selectors[4][cur_row] = F::one();
         cur_row += 1;
     }

--- a/ivc/src/ivc/interpreter.rs
+++ b/ivc/src/ivc/interpreter.rs
@@ -914,6 +914,43 @@ where
 {
 }
 
+/// Builds selectors for the IVC circuit.
+pub fn build_selectors<F, const N_COL_TOTAL: usize, const CHAL_LEN: usize>(
+    domain_size: usize,
+) -> [Vec<F>; N_BLOCKS]
+where
+    F: PrimeField,
+{
+    let mut selectors: [Vec<F>; N_BLOCKS] = std::array::from_fn(|_| vec![F::zero(); domain_size]);
+    let mut cur_row = 0;
+    for _i in 0..3 * N_COL_TOTAL {
+        selectors[0][cur_row] = F::one();
+        cur_row += 1;
+    }
+    for _i in 0..6 * N_COL_TOTAL + 2 {
+        selectors[1][cur_row] = F::one();
+        cur_row += 1;
+    }
+    for _i in 0..N_COL_TOTAL + 1 {
+        selectors[2][cur_row] = F::one();
+        cur_row += 1;
+    }
+    for _i in 0..(35 * N_COL_TOTAL + 5) {
+        selectors[3][cur_row] = F::one();
+        cur_row += 1;
+    }
+    for _i in 0..CHAL_LEN {
+        selectors[4][cur_row] = F::one();
+        cur_row += 1;
+    }
+    for _i in 0..1 {
+        selectors[5][cur_row] = F::one();
+        cur_row += 1;
+    }
+
+    selectors
+}
+
 /// This function generates constraitns for the whole IVC circuit.
 pub fn constrain_selectors<F, Env>(env: &mut Env)
 where
@@ -938,7 +975,7 @@ where
 
     env.set_assert_mapper(env.read_column(IVCColumn::BlockSel(0)));
     constrain_inputs(env);
-    // TODO hashes
+    // TODO FIXME add constraints for hashes
     env.set_assert_mapper(env.read_column(IVCColumn::BlockSel(2)));
     constrain_ecadds(env);
     env.set_assert_mapper(env.read_column(IVCColumn::BlockSel(3)));

--- a/ivc/src/ivc/interpreter.rs
+++ b/ivc/src/ivc/interpreter.rs
@@ -928,8 +928,7 @@ where
     let mut selectors: Vec<Vec<F>> = vec![vec![F::zero(); domain_size]; N_BLOCKS];
     let mut cur_row = 0;
     for _i in 0..3 * N_COL_TOTAL {
-        //selectors[0][cur_row] = F::one();
-        selectors[0][cur_row] = F::from(2u32);
+        selectors[0][cur_row] = F::one();
         cur_row += 1;
     }
     for _i in 0..6 * N_COL_TOTAL + 2 {
@@ -978,19 +977,29 @@ where
 {
     constrain_selectors(env);
 
-    env.set_assert_mapper(env.read_column(IVCColumn::BlockSel(0)));
+    let s0 = env.read_column(IVCColumn::BlockSel(0));
+    env.set_assert_mapper(Box::new(move |x| s0.clone() * x));
     constrain_inputs(env);
+
     // TODO FIXME add constraints for hashes
-    env.set_assert_mapper(env.read_column(IVCColumn::BlockSel(2)));
+
+    let s2 = env.read_column(IVCColumn::BlockSel(2));
+    env.set_assert_mapper(Box::new(move |x| s2.clone() * x));
     constrain_ecadds(env);
-    env.set_assert_mapper(env.read_column(IVCColumn::BlockSel(3)));
+
+    let s3 = env.read_column(IVCColumn::BlockSel(3));
+    env.set_assert_mapper(Box::new(move |x| s3.clone() * x));
     constrain_scalars(env);
-    env.set_assert_mapper(env.read_column(IVCColumn::BlockSel(4)));
+
+    let s4 = env.read_column(IVCColumn::BlockSel(4));
+    env.set_assert_mapper(Box::new(move |x| s4.clone() * x));
     constrain_challenges(env);
-    env.set_assert_mapper(env.read_column(IVCColumn::BlockSel(5)));
+
+    let s5 = env.read_column(IVCColumn::BlockSel(5));
+    env.set_assert_mapper(Box::new(move |x| s5.clone() * x));
     constrain_u(env);
 
-    env.set_assert_mapper(Env::constant(F::one()));
+    env.set_assert_mapper(Box::new(move |x| x));
 }
 
 /// Instantiates the IVC circuit for folding. L is relaxed (folded)

--- a/ivc/src/ivc/interpreter.rs
+++ b/ivc/src/ivc/interpreter.rs
@@ -968,7 +968,7 @@ where
     for i in 0..N_BLOCKS {
         // Each selector must have value either 0 or 1.
         let sel = env.read_column(IVCColumn::BlockSel(i));
-        env.assert_zero(sel.clone() * (sel.clone() - Env::constant(F::from(1u64))));
+        env.assert_zero(sel.clone() * (sel.clone() - Env::constant(F::one())));
     }
 }
 

--- a/ivc/src/ivc/lookups.rs
+++ b/ivc/src/ivc/lookups.rs
@@ -52,6 +52,15 @@ impl<Ff: PrimeField> LookupTableID for IVCLookupTable<Ff> {
     }
 }
 
+impl<Ff: PrimeField> IVCLookupTable<Ff> {
+    /// Provides a full list of entries for the given table.
+    pub fn entries<F: PrimeField>(&self, domain_d1_size: u64) -> Vec<F> {
+        match self {
+            Self::SerLookupTable(lt) => lt.entries(domain_d1_size),
+        }
+    }
+}
+
 pub struct IVCFECLookupLens<Ff>(pub PhantomData<Ff>);
 
 impl<Ff> MPrism for IVCFECLookupLens<Ff> {

--- a/ivc/src/ivc/mod.rs
+++ b/ivc/src/ivc/mod.rs
@@ -127,7 +127,7 @@ mod tests {
         let mut rng = o1_utils::tests::make_test_rng();
         build_ivc_circuit::<_, IVCLookupTable<Ff1>, _>(
             &mut rng,
-            1 << 8,
+            1 << 15,
             IdMPrism::<IVCLookupTable<Ff1>>::default(),
         );
     }

--- a/msm/src/circuit_design/capabilities.rs
+++ b/msm/src/circuit_design/capabilities.rs
@@ -11,21 +11,24 @@ use ark_ff::PrimeField;
 /// Environment capability for accessing and reading columns. This is necessary for
 /// building constraints.
 pub trait ColAccessCap<F: PrimeField, CIx: ColumnIndexer> {
+    // NB: 'static here means that `Variable` does not contain any
+    // references witha a lifetime less than 'static. Which is true in
+    // our case. Necessary for `set_assert_mapper`
     type Variable: Clone
         + std::ops::Add<Self::Variable, Output = Self::Variable>
         + std::ops::Sub<Self::Variable, Output = Self::Variable>
         + std::ops::Mul<Self::Variable, Output = Self::Variable>
         + std::ops::Neg<Output = Self::Variable>
         + From<u64>
-        + std::fmt::Debug;
+        + std::fmt::Debug
+        + 'static;
 
     /// Asserts that the value is zero.
     fn assert_zero(&mut self, cst: Self::Variable);
 
-    // TODO we need mapper: Box<impl Fn(Self::Variable) -> Self::Variable>
     /// Sets an assert predicate `f(X)` such that when assert_zero is
     /// called on x, it will actually perform `assert_zero(f(x))`.
-    fn set_assert_mapper(&mut self, mapper: Self::Variable);
+    fn set_assert_mapper(&mut self, mapper: Box<dyn Fn(Self::Variable) -> Self::Variable>);
 
     /// Reads value from a column position.
     fn read_column(&self, col: CIx) -> Self::Variable;

--- a/msm/src/circuit_design/capabilities.rs
+++ b/msm/src/circuit_design/capabilities.rs
@@ -12,7 +12,7 @@ use ark_ff::PrimeField;
 /// building constraints.
 pub trait ColAccessCap<F: PrimeField, CIx: ColumnIndexer> {
     // NB: 'static here means that `Variable` does not contain any
-    // references witha a lifetime less than 'static. Which is true in
+    // references with a lifetime less than 'static. Which is true in
     // our case. Necessary for `set_assert_mapper`
     type Variable: Clone
         + std::ops::Add<Self::Variable, Output = Self::Variable>

--- a/msm/src/circuit_design/capabilities.rs
+++ b/msm/src/circuit_design/capabilities.rs
@@ -22,6 +22,11 @@ pub trait ColAccessCap<F: PrimeField, CIx: ColumnIndexer> {
     /// Asserts that the value is zero.
     fn assert_zero(&mut self, cst: Self::Variable);
 
+    // TODO we need mapper: Box<impl Fn(Self::Variable) -> Self::Variable>
+    /// Sets an assert predicate `f(X)` such that when assert_zero is
+    /// called on x, it will actually perform `assert_zero(f(x))`.
+    fn set_assert_mapper(&mut self, mapper: Self::Variable);
+
     /// Reads value from a column position.
     fn read_column(&self, col: CIx) -> Self::Variable;
 

--- a/msm/src/circuit_design/composition.rs
+++ b/msm/src/circuit_design/composition.rs
@@ -209,7 +209,7 @@ impl<
         self.env.assert_zero(cst);
     }
 
-    fn set_assert_mapper(&mut self, mapper: Self::Variable) {
+    fn set_assert_mapper(&mut self, mapper: Box<dyn Fn(Self::Variable) -> Self::Variable>) {
         self.env.set_assert_mapper(mapper);
     }
 
@@ -265,7 +265,7 @@ impl<
         self.0.assert_zero(cst);
     }
 
-    fn set_assert_mapper(&mut self, mapper: Self::Variable) {
+    fn set_assert_mapper(&mut self, mapper: Box<dyn Fn(Self::Variable) -> Self::Variable>) {
         self.0.set_assert_mapper(mapper);
     }
 
@@ -315,7 +315,7 @@ impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L> Col
         self.0.env.assert_zero(cst);
     }
 
-    fn set_assert_mapper(&mut self, mapper: Self::Variable) {
+    fn set_assert_mapper(&mut self, mapper: Box<dyn Fn(Self::Variable) -> Self::Variable>) {
         self.0.env.set_assert_mapper(mapper);
     }
 

--- a/msm/src/circuit_design/composition.rs
+++ b/msm/src/circuit_design/composition.rs
@@ -47,11 +47,14 @@
 ///
 /// Similar "mapping" intuition applies to lookup tables.
 use crate::{
-    circuit_design::capabilities::{ColAccessCap, ColWriteCap, HybridCopyCap, LookupCap},
+    circuit_design::capabilities::{
+        ColAccessCap, ColWriteCap, DirectWitnessCap, HybridCopyCap, LookupCap, MultiRowReadCap,
+    },
     columns::ColumnIndexer,
     logup::LookupTableID,
 };
 use ark_ff::PrimeField;
+use std::marker::PhantomData;
 
 /// `MPrism` allows one to Something like a Prism, but for Maybe and not just any Applicative.
 ///
@@ -68,6 +71,29 @@ pub trait MPrism {
     fn traverse(&self, source: Self::Source) -> Option<Self::Target>;
 
     fn re_get(&self, target: Self::Target) -> Self::Source;
+}
+
+/// Identity `MPrism` from any type `T` to itself.
+#[derive(Clone, Copy, Debug)]
+pub struct IdMPrism<T>(pub PhantomData<T>);
+
+impl<T> Default for IdMPrism<T> {
+    fn default() -> Self {
+        IdMPrism(PhantomData)
+    }
+}
+
+impl<T> MPrism for IdMPrism<T> {
+    type Source = T;
+    type Target = T;
+
+    fn traverse(&self, source: Self::Source) -> Option<Self::Target> {
+        Some(source)
+    }
+
+    fn re_get(&self, target: Self::Target) -> Self::Source {
+        target
+    }
 }
 
 pub struct ComposedMPrism<LHS, RHS> {
@@ -123,7 +149,7 @@ where
 struct SubEnv<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L> {
     env: &'a mut Env1,
     lens: L,
-    phantom: core::marker::PhantomData<(F, CIx1)>,
+    phantom: PhantomData<(F, CIx1)>,
 }
 
 /// Sub environment with a lens that is mapping columns.
@@ -347,3 +373,32 @@ impl<
         self.0.env.lookup(lookup_id, value)
     }
 }
+
+impl<'a, F: PrimeField, CIx: ColumnIndexer, Env1: MultiRowReadCap<F, CIx>, L>
+    MultiRowReadCap<F, CIx> for SubEnvLookup<'a, F, CIx, Env1, L>
+{
+    /// Read value from a (row,column) position.
+    fn read_row_column(&mut self, row: usize, col: CIx) -> Self::Variable {
+        self.0.env.read_row_column(row, col)
+    }
+
+    /// Progresses to the next row.
+    fn next_row(&mut self) {
+        self.0.env.next_row();
+    }
+
+    /// Returns the current row.
+    fn curr_row(&self) -> usize {
+        self.0.env.curr_row()
+    }
+}
+
+impl<'a, F: PrimeField, CIx: ColumnIndexer, Env1: DirectWitnessCap<F, CIx>, L>
+    DirectWitnessCap<F, CIx> for SubEnvLookup<'a, F, CIx, Env1, L>
+{
+    fn variable_to_field(value: Self::Variable) -> F {
+        Env1::variable_to_field(value)
+    }
+}
+
+// TODO add traits for SubEnvColumn

--- a/msm/src/circuit_design/composition.rs
+++ b/msm/src/circuit_design/composition.rs
@@ -183,6 +183,10 @@ impl<
         self.env.assert_zero(cst);
     }
 
+    fn set_assert_mapper(&mut self, mapper: Self::Variable) {
+        self.env.set_assert_mapper(mapper);
+    }
+
     fn constant(value: F) -> Self::Variable {
         Env1::constant(value)
     }
@@ -235,6 +239,10 @@ impl<
         self.0.assert_zero(cst);
     }
 
+    fn set_assert_mapper(&mut self, mapper: Self::Variable) {
+        self.0.set_assert_mapper(mapper);
+    }
+
     fn constant(value: F) -> Self::Variable {
         Env1::constant(value)
     }
@@ -279,6 +287,10 @@ impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L> Col
 
     fn assert_zero(&mut self, cst: Self::Variable) {
         self.0.env.assert_zero(cst);
+    }
+
+    fn set_assert_mapper(&mut self, mapper: Self::Variable) {
+        self.0.env.set_assert_mapper(mapper);
     }
 
     fn constant(value: F) -> Self::Variable {

--- a/msm/src/circuit_design/witness.rs
+++ b/msm/src/circuit_design/witness.rs
@@ -43,6 +43,9 @@ pub struct WitnessBuilderEnv<
     /// value for row #j of the selector #i.
     pub fixed_selectors: Vec<Vec<F>>,
 
+    /// Function used to map assertions.
+    pub assert_mapper: F,
+
     // A Phantom Data for CIx -- right now WitnessBUilderEnv does not
     // depend on CIx, but in the future (with associated generics
     // enabled?) it might be convenient to put all the `NT_COL` (and
@@ -67,7 +70,11 @@ impl<
     type Variable = F;
 
     fn assert_zero(&mut self, cst: Self::Variable) {
-        assert_eq!(cst, F::zero());
+        assert_eq!(self.assert_mapper * cst, F::zero());
+    }
+
+    fn set_assert_mapper(&mut self, mapper: Self::Variable) {
+        self.assert_mapper = mapper;
     }
 
     fn constant(value: F) -> Self::Variable {
@@ -301,6 +308,7 @@ impl<
             lookups: vec![lookups_row],
             fixed_selectors,
             phantom_cix: PhantomData,
+            assert_mapper: F::one(),
         }
     }
 

--- a/msm/src/circuit_design/witness.rs
+++ b/msm/src/circuit_design/witness.rs
@@ -44,7 +44,7 @@ pub struct WitnessBuilderEnv<
     pub fixed_selectors: Vec<Vec<F>>,
 
     /// Function used to map assertions.
-    pub assert_mapper: F,
+    pub assert_mapper: Box<dyn Fn(F) -> F>,
 
     // A Phantom Data for CIx -- right now WitnessBUilderEnv does not
     // depend on CIx, but in the future (with associated generics
@@ -70,10 +70,10 @@ impl<
     type Variable = F;
 
     fn assert_zero(&mut self, cst: Self::Variable) {
-        assert_eq!(self.assert_mapper * cst, F::zero());
+        assert_eq!((self.assert_mapper)(cst), F::zero());
     }
 
-    fn set_assert_mapper(&mut self, mapper: Self::Variable) {
+    fn set_assert_mapper(&mut self, mapper: Box<dyn Fn(Self::Variable) -> Self::Variable>) {
         self.assert_mapper = mapper;
     }
 
@@ -308,7 +308,7 @@ impl<
             lookups: vec![lookups_row],
             fixed_selectors,
             phantom_cix: PhantomData,
-            assert_mapper: F::one(),
+            assert_mapper: Box::new(|x| x),
         }
     }
 

--- a/msm/src/circuit_design/witness.rs
+++ b/msm/src/circuit_design/witness.rs
@@ -314,12 +314,18 @@ impl<
 
     /// Sets a fixed selector, the vector of length equal to the
     /// domain size (circuit height).
-    pub fn set_fixed_selector(&mut self, sel: CIx, sel_values: Vec<F>) {
+    pub fn set_fixed_selector_cix(&mut self, sel: CIx, sel_values: Vec<F>) {
         if let Column::FixedSelector(i) = sel.to_column() {
             self.fixed_selectors[i] = sel_values;
         } else {
             panic!("Tried to assign values to non-fixed-selector typed column {sel:?}");
         }
+    }
+
+    /// Sets all fixed selectors directly. Each item in `selectors` is
+    /// a vector of `domain_size` length.
+    pub fn set_fixed_selectors(&mut self, selectors: Vec<Vec<F>>) {
+        self.fixed_selectors = selectors
     }
 
     /// Generates proof inputs, repacking/collecting internal witness builder state.

--- a/msm/src/test/test_circuit/mod.rs
+++ b/msm/src/test/test_circuit/mod.rs
@@ -45,7 +45,7 @@ mod tests {
             fixed_sel.push(Fp::from(i as u64));
         }
 
-        witness_env.set_fixed_selector(TestColumn::FixedE, fixed_sel);
+        witness_env.set_fixed_selector_cix(TestColumn::FixedE, fixed_sel);
 
         for row_i in 0..domain_size {
             let a: Fp = <Fp as UniformRand>::rand(rng);


### PR DESCRIPTION
Before: `ivc_circuit` was building all /witness/ wires, but /constraints/, e.g. `c_{b0,i}`, were available for every block separately. This means `c_{b0,i}` for block 0 would not work on rows of block 1.

Now:
* There are selectors for each block.
* Every constraint is now working for the /whole circuit/, since it's now multiplied by selector: `sel0 * c_{b0,i}`.
* Completeness test is added with lookups disabled.


Offtop:
* I added the `ID` lens because I wanted to generalise circuit generator to work for two tables simultaneously. This proved to /not/ be useful. But the `ID` lens is useful I think so I keep it.

Next step:
* Reduce stack usage. It overflows if stack is default 128KB, but fine with 2MB. Done in next PR https://github.com/o1-labs/proof-systems/pull/2247.