### PR TITLE
Folding: use () instead of trace structures

### DIFF
--- a/o1vm/src/folding.rs
+++ b/o1vm/src/folding.rs
@@ -324,15 +324,12 @@ mod tests {
     }
 
     #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-    struct TestStructure;
-
-    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
     struct TestConfig;
 
     type TestWitness<T> = kimchi_msm::witness::Witness<3, T>;
     type TestFoldingWitness = FoldingWitness<3, Fp>;
     type TestFoldingInstance = FoldingInstance<3, Curve>;
-    type TestFoldingEnvironment = FoldingEnvironment<3, TestConfig, TestStructure>;
+    type TestFoldingEnvironment = FoldingEnvironment<3, TestConfig, ()>;
 
     impl Index<TestColumn> for TestFoldingWitness {
         type Output = Evaluations<Fp, Radix2EvaluationDomain<Fp>>;
@@ -367,7 +364,7 @@ mod tests {
         type Srs = poly_commitment::srs::SRS<Curve>;
         type Instance = TestFoldingInstance;
         type Witness = TestFoldingWitness;
-        type Structure = TestStructure;
+        type Structure = ();
         type Env = TestFoldingEnvironment;
     }
 

--- a/o1vm/src/keccak/folding.rs
+++ b/o1vm/src/keccak/folding.rs
@@ -2,7 +2,6 @@ use crate::{
     folding::{Challenge, DecomposedFoldingEnvironment, FoldingInstance, FoldingWitness},
     keccak::{
         column::{N_ZKVM_KECCAK_COLS, N_ZKVM_KECCAK_REL_COLS, N_ZKVM_KECCAK_SEL_COLS},
-        trace::DecomposedKeccakTrace,
         KeccakColumn, Steps,
     },
     trace::Indexer,
@@ -23,7 +22,7 @@ pub type KeccakFoldingEnvironment = DecomposedFoldingEnvironment<
     N_ZKVM_KECCAK_REL_COLS,
     N_ZKVM_KECCAK_SEL_COLS,
     KeccakConfig,
-    DecomposedKeccakTrace,
+    (),
 >;
 
 pub type KeccakFoldingWitness = FoldingWitness<N_ZKVM_KECCAK_COLS, Fp>;
@@ -82,7 +81,7 @@ impl FoldingConfig for KeccakConfig {
     type Srs = SRS<Curve>;
     type Instance = KeccakFoldingInstance;
     type Witness = KeccakFoldingWitness;
-    type Structure = DecomposedKeccakTrace;
+    type Structure = ();
     type Env = KeccakFoldingEnvironment;
 }
 

--- a/o1vm/src/keccak/tests.rs
+++ b/o1vm/src/keccak/tests.rs
@@ -710,7 +710,7 @@ fn test_keccak_folding() {
             vec![],
             &srs,
             domain,
-            &default_trace,
+            &(),
         );
 
         // Check folding constraints of individual steps ignoring selectors
@@ -742,7 +742,7 @@ fn test_keccak_folding() {
                     constraints[&step].clone(),
                     &srs,
                     domain,
-                    &default_trace,
+                    &(),
                 );
                 // Fold both sides and check the constraints ignoring the selector columns
                 let (folded_instance, folded_witness) = scheme
@@ -766,7 +766,7 @@ fn test_keccak_folding() {
                         vec![],
                         &srs,
                         domain,
-                        &default_trace,
+                        &(),
                     );
                 // Subcase A: Check the folded circuit of decomposable folding ignoring selectors (None)
                 {
@@ -815,7 +815,7 @@ fn test_keccak_folding() {
                             .collect(),
                         &srs,
                         domain,
-                        &default_trace,
+                        &(),
                     );
 
                 // Subcase A: Check the folded circuit of decomposable folding ignoring selectors (None)

--- a/o1vm/src/main.rs
+++ b/o1vm/src/main.rs
@@ -95,7 +95,7 @@ pub fn main() -> ExitCode {
             vec![],
             &srs.full_srs,
             domain.d1,
-            &mips_trace,
+            &(),
         )
     };
 

--- a/o1vm/src/mips/folding.rs
+++ b/o1vm/src/mips/folding.rs
@@ -12,10 +12,7 @@ use folding::{expressions::FoldingColumnTrait, FoldingConfig};
 use kimchi_msm::columns::Column;
 use std::ops::Index;
 
-use super::{
-    column::{N_MIPS_REL_COLS, N_MIPS_SEL_COLS},
-    trace::DecomposedMIPSTrace,
-};
+use super::column::{N_MIPS_REL_COLS, N_MIPS_SEL_COLS};
 use poly_commitment::srs::SRS;
 
 // Decomposable folding compatibility
@@ -24,7 +21,7 @@ pub type DecomposableMIPSFoldingEnvironment = DecomposedFoldingEnvironment<
     N_MIPS_REL_COLS,
     N_MIPS_SEL_COLS,
     DecomposableMIPSFoldingConfig,
-    DecomposedMIPSTrace,
+    (),
 >;
 
 pub type MIPSFoldingWitness = FoldingWitness<N_MIPS_COLS, Fp>;
@@ -97,6 +94,6 @@ impl FoldingConfig for DecomposableMIPSFoldingConfig {
     type Srs = SRS<Curve>;
     type Instance = MIPSFoldingInstance;
     type Witness = MIPSFoldingWitness;
-    type Structure = DecomposedMIPSTrace;
+    type Structure = ();
     type Env = DecomposableMIPSFoldingEnvironment;
 }


### PR DESCRIPTION
Since https://github.com/o1-labs/proof-systems/pull/2239, no ProvableTrace is required.