### PR TITLE
Folding: remove rows method in Witness trait

### DIFF
--- a/folding/src/checker.rs
+++ b/folding/src/checker.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     expressions::{FoldingColumnTrait, FoldingCompatibleExpr, FoldingCompatibleExprInner},
-    instance_witness::{Instance, Witness},
+    instance_witness::Instance,
     ExpExtension, FoldingConfig, Radix2EvaluationDomain, RelaxedInstance, RelaxedWitness,
 };
 use ark_ec::AffineCurve;
@@ -55,10 +55,6 @@ impl<C: FoldingConfig> Provider<C> {
     pub fn new(instance: C::Instance, witness: C::Witness) -> Self {
         Self { instance, witness }
     }
-
-    pub fn rows(&self) -> usize {
-        self.witness.rows()
-    }
 }
 
 pub struct ExtendedProvider<C: FoldingConfig> {
@@ -89,6 +85,7 @@ pub trait Provide<C: FoldingConfig> {
     fn resolve(
         &self,
         inner: FoldingCompatibleExprInner<C>,
+        domain: Radix2EvaluationDomain<<C::Curve as AffineCurve>::ScalarField>,
     ) -> Vec<<C::Curve as AffineCurve>::ScalarField>;
 }
 
@@ -113,14 +110,16 @@ where
     fn resolve(
         &self,
         inner: FoldingCompatibleExprInner<C>,
+        domain: Radix2EvaluationDomain<<C::Curve as AffineCurve>::ScalarField>,
     ) -> Vec<<C::Curve as AffineCurve>::ScalarField> {
+        let domain_size = domain.size as usize;
         match inner {
             FoldingCompatibleExprInner::Constant(c) => {
-                vec![c; self.rows()]
+                vec![c; domain_size]
             }
             FoldingCompatibleExprInner::Challenge(chal) => {
                 let v = self.instance[chal];
-                vec![v; self.rows()]
+                vec![v; domain_size]
             }
             FoldingCompatibleExprInner::Cell(var) => {
                 let Variable { col, row } = var;
@@ -162,12 +161,14 @@ where
     fn resolve(
         &self,
         inner: FoldingCompatibleExprInner<C>,
+        domain: Radix2EvaluationDomain<<C::Curve as AffineCurve>::ScalarField>,
     ) -> Vec<<C::Curve as AffineCurve>::ScalarField> {
         match inner {
             FoldingCompatibleExprInner::Extensions(ext) => match ext {
                 ExpExtension::U => {
                     let u = self.instance.u;
-                    vec![u; self.inner_provider.rows()]
+                    let domain_size = domain.size as usize;
+                    vec![u; domain_size]
                 }
                 ExpExtension::Error => self.witness.error_vec.evals.clone(),
                 ExpExtension::ExtendedWitness(i) => {
@@ -181,14 +182,15 @@ where
                         .alphas()
                         .get(i)
                         .unwrap();
-                    vec![alpha; self.inner_provider.rows()]
+                    let domain_size = domain.size as usize;
+                    vec![alpha; domain_size]
                 }
                 ExpExtension::Selector(s) => {
                     let col = &self.inner_provider.witness[s].evals;
                     col.clone()
                 }
             },
-            e => self.inner_provider.resolve(e),
+            e => self.inner_provider.resolve(e, domain),
         }
     }
 }
@@ -197,35 +199,36 @@ pub trait Checker<C: FoldingConfig>: Provide<C> {
     fn check_rec(
         &self,
         exp: FoldingCompatibleExpr<C>,
+        domain: Radix2EvaluationDomain<<C::Curve as AffineCurve>::ScalarField>,
     ) -> Vec<<C::Curve as AffineCurve>::ScalarField> {
         let e2 = exp.clone();
         let res = match exp {
-            FoldingCompatibleExpr::Atom(inner) => self.resolve(inner),
+            FoldingCompatibleExpr::Atom(inner) => self.resolve(inner, domain),
             FoldingCompatibleExpr::Double(e) => {
-                let v = self.check_rec(*e);
+                let v = self.check_rec(*e, domain);
                 v.into_iter().map(|x| x.double()).collect()
             }
             FoldingCompatibleExpr::Square(e) => {
-                let v = self.check_rec(*e);
+                let v = self.check_rec(*e, domain);
                 v.into_iter().map(|x| x.square()).collect()
             }
             FoldingCompatibleExpr::Add(e1, e2) => {
-                let v1 = self.check_rec(*e1);
-                let v2 = self.check_rec(*e2);
+                let v1 = self.check_rec(*e1, domain);
+                let v2 = self.check_rec(*e2, domain);
                 v1.into_iter().zip(v2).map(|(a, b)| a + b).collect()
             }
             FoldingCompatibleExpr::Sub(e1, e2) => {
-                let v1 = self.check_rec(*e1);
-                let v2 = self.check_rec(*e2);
+                let v1 = self.check_rec(*e1, domain);
+                let v2 = self.check_rec(*e2, domain);
                 v1.into_iter().zip(v2).map(|(a, b)| a - b).collect()
             }
             FoldingCompatibleExpr::Mul(e1, e2) => {
-                let v1 = self.check_rec(*e1);
-                let v2 = self.check_rec(*e2);
+                let v1 = self.check_rec(*e1, domain);
+                let v2 = self.check_rec(*e2, domain);
                 v1.into_iter().zip(v2).map(|(a, b)| a * b).collect()
             }
             FoldingCompatibleExpr::Pow(e, exp) => {
-                let v = self.check_rec(*e);
+                let v = self.check_rec(*e, domain);
                 v.into_iter().map(|x| x.pow([exp])).collect()
             }
         };
@@ -238,8 +241,12 @@ pub trait Checker<C: FoldingConfig>: Provide<C> {
         res
     }
 
-    fn check(&self, exp: &FoldingCompatibleExpr<C>) {
-        let res = self.check_rec(exp.clone());
+    fn check(
+        &self,
+        exp: &FoldingCompatibleExpr<C>,
+        domain: Radix2EvaluationDomain<<C::Curve as AffineCurve>::ScalarField>,
+    ) {
+        let res = self.check_rec(exp.clone(), domain);
         for (i, row) in res.iter().enumerate() {
             if !row.is_zero() {
                 panic!("check in row {i} failed, {row} != 0");

--- a/folding/src/examples/example.rs
+++ b/folding/src/examples/example.rs
@@ -75,11 +75,7 @@ impl Foldable<Fp> for TestWitness {
     }
 }
 
-impl Witness<Curve> for TestWitness {
-    fn rows(&self) -> usize {
-        self[0].evals.len()
-    }
-}
+impl Witness<Curve> for TestWitness {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct TestStructure<F: Clone> {
@@ -259,17 +255,18 @@ mod checker {
                 witness,
             }
         }
-
-        pub(crate) fn rows(&self) -> usize {
-            self.witness.rows()
-        }
     }
 
     impl Provide<TestFoldingConfig> for Provider {
-        fn resolve(&self, inner: FoldingCompatibleExprInner<TestFoldingConfig>) -> Vec<Fp> {
+        fn resolve(
+            &self,
+            inner: FoldingCompatibleExprInner<TestFoldingConfig>,
+            domain: Radix2EvaluationDomain<Fp>,
+        ) -> Vec<Fp> {
+            let domain_size = domain.size as usize;
             match inner {
                 FoldingCompatibleExprInner::Constant(c) => {
-                    vec![c; self.rows()]
+                    vec![c; domain_size]
                 }
                 FoldingCompatibleExprInner::Challenge(chall) => {
                     let chals = self.instance.challenges;
@@ -278,7 +275,7 @@ mod checker {
                         TestChallenge::Gamma => chals[1],
                         TestChallenge::JointCombiner => chals[2],
                     };
-                    vec![v; self.rows()]
+                    vec![v; domain_size]
                 }
                 FoldingCompatibleExprInner::Cell(var) => {
                     let Variable { col, row } = var;
@@ -334,12 +331,17 @@ mod checker {
     }
 
     impl Provide<TestFoldingConfig> for ExtendedProvider {
-        fn resolve(&self, inner: FoldingCompatibleExprInner<TestFoldingConfig>) -> Vec<Fp> {
+        fn resolve(
+            &self,
+            inner: FoldingCompatibleExprInner<TestFoldingConfig>,
+            domain: Radix2EvaluationDomain<Fp>,
+        ) -> Vec<Fp> {
+            let domain_size = domain.size as usize;
             match inner {
                 FoldingCompatibleExprInner::Extensions(ext) => match ext {
                     ExpExtension::U => {
                         let u = self.instance.u;
-                        vec![u; self.inner_provider.rows()]
+                        vec![u; domain_size]
                     }
                     ExpExtension::Error => self.witness.error_vec.evals.clone(),
                     ExpExtension::ExtendedWitness(i) => {
@@ -347,11 +349,11 @@ mod checker {
                     }
                     ExpExtension::Alpha(i) => {
                         let alpha = self.instance.inner_instance().inner.alphas.get(i).unwrap();
-                        vec![alpha; self.inner_provider.rows()]
+                        vec![alpha; domain_size]
                     }
                     ExpExtension::Selector(_) => panic!("unused"),
                 },
-                e => self.inner_provider.resolve(e),
+                e => self.inner_provider.resolve(e, domain),
             }
         }
     }
@@ -424,7 +426,7 @@ mod tests {
             );
             constraints
                 .iter()
-                .for_each(|constraint| checker.check(constraint));
+                .for_each(|constraint| checker.check(constraint, domain));
         }
         // check right
         {
@@ -436,7 +438,7 @@ mod tests {
             );
             constraints
                 .iter()
-                .for_each(|constraint| checker.check(constraint));
+                .for_each(|constraint| checker.check(constraint, domain));
         }
 
         // pairs
@@ -459,7 +461,7 @@ mod tests {
             let checker = ExtendedProvider::new(structure, folded_instance, folded_witness);
             debug!("exp: \n {:#?}", final_constraint);
             debug!("check folded");
-            checker.check(&final_constraint);
+            checker.check(&final_constraint, domain);
         }
     }
 }

--- a/folding/src/examples/example_decomposable_folding.rs
+++ b/folding/src/examples/example_decomposable_folding.rs
@@ -91,11 +91,7 @@ impl Foldable<Fp> for TestWitness {
     }
 }
 
-impl Witness<Curve> for TestWitness {
-    fn rows(&self) -> usize {
-        self[0].evals.len()
-    }
-}
+impl Witness<Curve> for TestWitness {}
 
 // our environment, the way in which we provide access to the actual values in the
 // witness and instances, when folding evaluates expressions and reaches leaves (Atom)
@@ -400,7 +396,7 @@ mod tests {
             } = folded;
             let checker = ExtendedProvider::new(folded_instance, folded_witness);
             debug!("exp: \n {:#?}", final_constraint.to_string());
-            checker.check(&final_constraint);
+            checker.check(&final_constraint, domain);
             let ExtendedProvider {
                 instance, witness, ..
             } = checker;
@@ -434,7 +430,7 @@ mod tests {
             let checker = ExtendedProvider::new(folded_instance, folded_witness);
             debug!("exp: \n {:#?}", final_constraint.to_string());
 
-            checker.check(&final_constraint);
+            checker.check(&final_constraint, domain);
             let ExtendedProvider {
                 instance, witness, ..
             } = checker;
@@ -454,7 +450,7 @@ mod tests {
             let checker = ExtendedProvider::new(folded_instance, folded_witness);
             debug!("exp: \n {:#?}", final_constraint.to_string());
 
-            checker.check(&final_constraint);
+            checker.check(&final_constraint, domain);
         };
     }
 }

--- a/folding/src/examples/example_quadriticization.rs
+++ b/folding/src/examples/example_quadriticization.rs
@@ -373,7 +373,7 @@ mod tests {
                 ..
             } = folded;
             let checker = ExtendedProvider::new(folded_instance, folded_witness);
-            checker.check(&final_constraint);
+            checker.check(&final_constraint, domain);
             let ExtendedProvider {
                 instance, witness, ..
             } = checker;
@@ -407,7 +407,7 @@ mod tests {
 
             let checker = ExtendedProvider::new(folded_instance, folded_witness);
 
-            checker.check(&final_constraint);
+            checker.check(&final_constraint, domain);
             let ExtendedProvider {
                 instance, witness, ..
             } = checker;
@@ -427,7 +427,7 @@ mod tests {
 
             let checker = ExtendedProvider::new(folded_instance, folded_witness);
 
-            checker.check(&final_constraint);
+            checker.check(&final_constraint, domain);
         };
     }
 }

--- a/folding/src/instance_witness.rs
+++ b/folding/src/instance_witness.rs
@@ -78,9 +78,6 @@ pub trait Instance<G: CommitmentCurve>: Sized + Foldable<G::ScalarField> {
 }
 
 pub trait Witness<G: CommitmentCurve>: Sized + Foldable<G::ScalarField> {
-    /// Returns the number of rows in the witness
-    fn rows(&self) -> usize;
-
     /// This method takes a witness and a vector of evaluations to the zero polynomial,
     /// returning a relaxed witness which is composed by the extended witness and the error vector
     /// that is set to the zero polynomial.
@@ -233,11 +230,7 @@ impl<G: CommitmentCurve, W: Witness<G>> Foldable<G::ScalarField> for ExtendedWit
     }
 }
 
-impl<G: CommitmentCurve, W: Witness<G>> Witness<G> for ExtendedWitness<G, W> {
-    fn rows(&self) -> usize {
-        self.inner.rows()
-    }
-}
+impl<G: CommitmentCurve, W: Witness<G>> Witness<G> for ExtendedWitness<G, W> {}
 
 impl<G: CommitmentCurve, W: Witness<G>> ExtendedWitness<G, W> {
     pub(crate) fn inner(&self) -> &W {

--- a/folding/src/quadraticization_tests.rs
+++ b/folding/src/quadraticization_tests.rs
@@ -43,12 +43,7 @@ impl Foldable<Fp> for TestWitness {
     }
 }
 
-impl Witness<Curve> for TestWitness {
-    fn rows(&self) -> usize {
-        todo!()
-    }
-}
-
+impl Witness<Curve> for TestWitness {}
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 enum Col {
     A,

--- a/o1vm/src/folding.rs
+++ b/o1vm/src/folding.rs
@@ -108,11 +108,7 @@ impl<const N: usize, F: FftField> Foldable<F> for FoldingWitness<N, F> {
     }
 }
 
-impl<const N: usize, G: CommitmentCurve> Witness<G> for FoldingWitness<N, G::ScalarField> {
-    fn rows(&self) -> usize {
-        self.witness.cols[0].evals.len()
-    }
-}
+impl<const N: usize, G: CommitmentCurve> Witness<G> for FoldingWitness<N, G::ScalarField> {}
 
 /// Environment for the decomposable folding protocol, for a given number of
 /// witness columns and selectors.

--- a/o1vm/src/keccak/tests.rs
+++ b/o1vm/src/keccak/tests.rs
@@ -726,12 +726,12 @@ fn test_keccak_folding() {
                 // Check constraints on Left side
                 let checker = Provider::new(left_instance.clone(), left_witness.clone());
                 constraints[&step].iter().for_each(|c| {
-                    checker.check(c);
+                    checker.check(c, domain);
                 });
                 // Check constraints on Right side
                 let checker = Provider::new(right_instance.clone(), right_witness.clone());
                 constraints[&step].iter().for_each(|c| {
-                    checker.check(c);
+                    checker.check(c, domain);
                 });
             }
 
@@ -754,7 +754,7 @@ fn test_keccak_folding() {
                 assert_eq!(folded_instance.get_number_of_additional_columns(), 0);
 
                 let checker = ExtendedProvider::new(folded_instance, folded_witness);
-                checker.check(&final_constraint);
+                checker.check(&final_constraint, domain);
             }
 
             // CASE 2: Check that `DecomposableFoldingScheme` works when passing the dummy zero constraint
@@ -780,7 +780,7 @@ fn test_keccak_folding() {
                         .pair();
                     let checker =
                         ExtendedProvider::<KeccakConfig>::new(folded_instance, folded_witness);
-                    checker.check(&dummy_final_constraint);
+                    checker.check(&dummy_final_constraint, domain);
                 }
 
                 // Subcase B: Check the folded circuit of decomposable folding applying selectors (Some)
@@ -796,7 +796,7 @@ fn test_keccak_folding() {
                     // Check the constraints on the folded circuit applying selectors
                     let checker =
                         ExtendedProvider::<KeccakConfig>::new(folded_instance, folded_witness);
-                    checker.check(&dummy_final_constraint);
+                    checker.check(&dummy_final_constraint, domain);
                 }
             }
 
@@ -830,7 +830,7 @@ fn test_keccak_folding() {
                         .pair();
                     let checker =
                         ExtendedProvider::<KeccakConfig>::new(folded_instance, folded_witness);
-                    checker.check(&dummy_final_constraint);
+                    checker.check(&dummy_final_constraint, domain);
                 }
 
                 // Subcase B: Check the folded circuit of decomposable folding applying selectors (Some)
@@ -846,7 +846,7 @@ fn test_keccak_folding() {
                     // Check the constraints on the folded circuit applying selectors
                     let checker =
                         ExtendedProvider::<KeccakConfig>::new(folded_instance, folded_witness);
-                    checker.check(&dummy_final_constraint);
+                    checker.check(&dummy_final_constraint, domain);
                 }
             }
 
@@ -867,7 +867,7 @@ fn test_keccak_folding() {
                         .pair();
                     let checker =
                         ExtendedProvider::<KeccakConfig>::new(folded_instance, folded_witness);
-                    checker.check(&dec_final_constraint);
+                    checker.check(&dec_final_constraint, domain);
 
                     // Check constraints on independent sides and in folded circuit applying selectors
                     let (folded_instance, folded_witness) = dec_scheme
@@ -881,7 +881,7 @@ fn test_keccak_folding() {
                     // Check the constraints on the folded circuit applying selectors
                     let checker =
                         ExtendedProvider::<KeccakConfig>::new(folded_instance, folded_witness);
-                    checker.check(&dec_final_constraint);
+                    checker.check(&dec_final_constraint, domain);
                 }
             }
         }
@@ -926,7 +926,7 @@ fn test_keccak_folding() {
                 .fold_instance_witness_pair(left, right, None, &mut fq_sponge)
                 .pair();
             let checker = ExtendedProvider::new(folded_ins, folded_wit);
-            checker.check(&dec_final_constraint);
+            checker.check(&dec_final_constraint, domain);
         }
     });
 }


### PR DESCRIPTION
It seems it was only used for checking.
Using a parameter domain is more scalable, and let the user pick any kind of domain they want. It doesn't require the user to implement a new Witness implementation.

Driving the road to use generically the `GenericWitness` structure.