### PR TITLE
Folding: remove alphas from FoldingEnv as it is obsolete

### DIFF
--- a/folding/src/checker.rs
+++ b/folding/src/checker.rs
@@ -179,7 +179,7 @@ where
                         .instance
                         .inner_instance()
                         .inner
-                        .alphas()
+                        .get_alphas()
                         .get(i)
                         .unwrap();
                     let domain_size = domain.size as usize;

--- a/folding/src/error_term.rs
+++ b/folding/src/error_term.rs
@@ -320,6 +320,14 @@ impl<CF: FoldingConfig> ExtendedEnv<CF> {
         (instances, witnesses)
     }
 
+    pub fn get_relaxed_instance(&self, side: Side) -> &RelaxedInstance<CF::Curve, CF::Instance> {
+        &self.instances[side as usize]
+    }
+
+    pub fn get_relaxed_witness(&self, side: Side) -> &RelaxedWitness<CF::Curve, CF::Witness> {
+        &self.witnesses[side as usize]
+    }
+
     pub fn col(&self, col: &ExtendedFoldingColumn<CF>, side: Side) -> EvalLeaf<ScalarField<CF>> {
         use EvalLeaf::Col;
         use ExtendedFoldingColumn::*;

--- a/folding/src/error_term.rs
+++ b/folding/src/error_term.rs
@@ -190,11 +190,11 @@ pub(crate) fn compute_error<C: FoldingConfig>(
     let alphas_l = env
         .get_relaxed_instance(Side::Left)
         .inner_instance()
-        .alphas();
+        .get_alphas();
     let alphas_r = env
         .get_relaxed_instance(Side::Right)
         .inner_instance()
-        .alphas();
+        .get_alphas();
 
     let t_0 = {
         let t_0 = (zero(), zero());
@@ -333,7 +333,7 @@ impl<CF: FoldingConfig> ExtendedEnv<CF> {
         use ExtendedFoldingColumn::*;
         let instance = self.get_relaxed_instance(side);
         let witness = self.get_relaxed_witness(side);
-        let alphas = instance.inner_instance().alphas();
+        let alphas = instance.inner_instance().get_alphas();
         match col {
             Inner(Variable { col, row }) => Col(self.inner().col(*col, *row, side)),
             WitnessExtended(i) => Col(&witness

--- a/folding/src/examples/example.rs
+++ b/folding/src/examples/example.rs
@@ -144,11 +144,6 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, Column, TestChallenge, ()> for Te
         }
     }
 
-    fn alpha(&self, i: usize, side: Side) -> Fp {
-        let instance = &self.instances[side as usize];
-        instance.alphas.get(i).unwrap()
-    }
-
     fn selector(&self, _s: &(), _side: Side) -> &Vec<Fp> {
         unreachable!()
     }

--- a/folding/src/examples/example.rs
+++ b/folding/src/examples/example.rs
@@ -55,7 +55,7 @@ impl Instance<Curve> for TestInstance {
         (fields, points)
     }
 
-    fn alphas(&self) -> &Alphas<Fp> {
+    fn get_alphas(&self) -> &Alphas<Fp> {
         &self.alphas
     }
 }

--- a/folding/src/examples/example_decomposable_folding.rs
+++ b/folding/src/examples/example_decomposable_folding.rs
@@ -69,7 +69,7 @@ impl Instance<Curve> for TestInstance {
         (vec![], vec![])
     }
 
-    fn alphas(&self) -> &Alphas<Fp> {
+    fn get_alphas(&self) -> &Alphas<Fp> {
         &self.alphas
     }
 }

--- a/folding/src/examples/example_decomposable_folding.rs
+++ b/folding/src/examples/example_decomposable_folding.rs
@@ -158,14 +158,6 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, TestColumn, TestChallenge, Dynami
         }
     }
 
-    // access to the alphas, while folding will decide how many there are and how do
-    // they appear in the expressions, the instances should store them, and the environment
-    // should provide acces to them like this
-    fn alpha(&self, i: usize, side: Side) -> Fp {
-        let instance = &self.instances[side as usize];
-        instance.alphas.get(i).unwrap()
-    }
-
     // This is exclusively for dynamic selectors aiming to make use of optimization
     // as classic static selectors will be handled as normal structure columns in col().
     // The implementation of this if the same as col(), it is just separated as they

--- a/folding/src/examples/example_quadriticization.rs
+++ b/folding/src/examples/example_quadriticization.rs
@@ -71,7 +71,7 @@ impl Instance<Curve> for TestInstance {
         (vec![], vec![])
     }
 
-    fn alphas(&self) -> &Alphas<Fp> {
+    fn get_alphas(&self) -> &Alphas<Fp> {
         &self.alphas
     }
 }

--- a/folding/src/examples/example_quadriticization.rs
+++ b/folding/src/examples/example_quadriticization.rs
@@ -143,14 +143,6 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, TestColumn, TestChallenge, Dynami
         }
     }
 
-    // access to the alphas, while folding will decide how many there are and how do
-    // they appear in the expressions, the instances should store them, and the environment
-    // should provide acces to them like this
-    fn alpha(&self, i: usize, side: Side) -> Fp {
-        let instance = &self.instances[side as usize];
-        instance.alphas.get(i).unwrap()
-    }
-
     // this is exclusively for dynamic selectors aiming to make use of optimization
     // as clasic static selectors will be handle as normal structure columns in col()
     // the implementation of this if the same as col(), it is just separated as they

--- a/folding/src/instance_witness.rs
+++ b/folding/src/instance_witness.rs
@@ -74,8 +74,7 @@ pub trait Instance<G: CommitmentCurve>: Sized + Foldable<G::ScalarField> {
     }
 
     /// Returns the alphas values for the instance
-    // FIXME: rename in get_alphas
-    fn alphas(&self) -> &Alphas<G::ScalarField>;
+    fn get_alphas(&self) -> &Alphas<G::ScalarField>;
 }
 
 pub trait Witness<G: CommitmentCurve>: Sized + Foldable<G::ScalarField> {
@@ -296,8 +295,8 @@ impl<G: CommitmentCurve, I: Instance<G>> Instance<G> for ExtendedInstance<G, I> 
         elements
     }
 
-    fn alphas(&self) -> &Alphas<G::ScalarField> {
-        self.inner.alphas()
+    fn get_alphas(&self) -> &Alphas<G::ScalarField> {
+        self.inner.get_alphas()
     }
 }
 

--- a/folding/src/instance_witness.rs
+++ b/folding/src/instance_witness.rs
@@ -74,6 +74,7 @@ pub trait Instance<G: CommitmentCurve>: Sized + Foldable<G::ScalarField> {
     }
 
     /// Returns the alphas values for the instance
+    // FIXME: rename in get_alphas
     fn alphas(&self) -> &Alphas<G::ScalarField>;
 }
 
@@ -128,6 +129,8 @@ pub struct RelaxedInstance<G: CommitmentCurve, I: Instance<G>> {
 }
 
 impl<G: CommitmentCurve, I: Instance<G>> RelaxedInstance<G, I> {
+    /// Return the original instance that has been relaxed, with the extra
+    /// columns added by quadraticization
     pub(crate) fn inner_instance(&self) -> &ExtendedInstance<G, I> {
         &self.instance
     }

--- a/folding/src/lib.rs
+++ b/folding/src/lib.rs
@@ -121,7 +121,8 @@ pub trait FoldingEnv<F: Zero + Clone, I, W, Col, Chal, Selector> {
     /// Structure which could be storing useful information like selectors, etc.
     type Structure;
 
-    /// Creates a new environment storing the structure, instances and witnesses.
+    /// Creates a new environment storing the structure, instances and
+    /// witnesses.
     fn new(structure: &Self::Structure, instances: [&I; 2], witnesses: [&W; 2]) -> Self;
 
     // TODO: move into `FoldingConfig`
@@ -133,16 +134,12 @@ pub trait FoldingEnv<F: Zero + Clone, I, W, Col, Chal, Selector> {
         vec![F::zero(); n]
     }
 
-    /// Returns the evaluations of a given column witness at omega or zeta*omega.
-    fn col(&self, col: Col, curr_or_next: CurrOrNext, side: Side) -> &Vec<F>;
-
     /// Obtains a given challenge from the expanded instance for one side.
     /// The challenges are stored inside the instances structs.
     fn challenge(&self, challenge: Chal, side: Side) -> F;
 
-    /// Computes the i-th power of alpha for a given side.
-    /// Folding itself will provide us with the alpha value.
-    fn alpha(&self, i: usize, side: Side) -> F;
+    /// Returns the evaluations of a given column witness at omega or zeta*omega.
+    fn col(&self, col: Col, curr_or_next: CurrOrNext, side: Side) -> &Vec<F>;
 
     /// similar to [Self::col], but folding may ask for a dynamic selector directly
     /// instead of just column that happens to be a selector

--- a/folding/src/quadraticization_tests.rs
+++ b/folding/src/quadraticization_tests.rs
@@ -25,7 +25,7 @@ impl Foldable<Fp> for TestInstance {
 }
 
 impl Instance<Curve> for TestInstance {
-    fn alphas(&self) -> &crate::Alphas<Fp> {
+    fn get_alphas(&self) -> &crate::Alphas<Fp> {
         todo!()
     }
 

--- a/folding/src/quadraticization_tests.rs
+++ b/folding/src/quadraticization_tests.rs
@@ -97,10 +97,6 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, Col, (), ()> for Env {
         todo!()
     }
 
-    fn alpha(&self, _i: usize, _side: crate::Side) -> Fp {
-        todo!()
-    }
-
     fn selector(&self, _s: &(), _side: crate::Side) -> &Vec<Fp> {
         todo!()
     }

--- a/o1vm/src/folding.rs
+++ b/o1vm/src/folding.rs
@@ -196,11 +196,6 @@ where
         }
     }
 
-    fn alpha(&self, i: usize, side: Side) -> ScalarField<C> {
-        let instance = &self.instances[side as usize];
-        instance.alphas.get(i).unwrap()
-    }
-
     fn selector(&self, s: &C::Selector, side: Side) -> &Vec<ScalarField<C>> {
         let witness = &self.curr_witnesses[side as usize];
         &witness[*s].evals
@@ -278,11 +273,6 @@ where
             Challenge::Gamma => self.instances[side as usize].challenges[1],
             Challenge::JointCombiner => self.instances[side as usize].challenges[2],
         }
-    }
-
-    fn alpha(&self, i: usize, side: Side) -> ScalarField<C> {
-        let instance = &self.instances[side as usize];
-        instance.alphas.get(i).unwrap()
     }
 
     fn selector(&self, _s: &(), _side: Side) -> &Vec<ScalarField<C>> {

--- a/o1vm/src/folding.rs
+++ b/o1vm/src/folding.rs
@@ -77,7 +77,7 @@ impl<const N: usize, G: CommitmentCurve> Instance<G> for FoldingInstance<N, G> {
         (scalars, points)
     }
 
-    fn alphas(&self) -> &Alphas<G::ScalarField> {
+    fn get_alphas(&self) -> &Alphas<G::ScalarField> {
         &self.alphas
     }
 }

--- a/o1vm/src/folding.rs
+++ b/o1vm/src/folding.rs
@@ -207,9 +207,9 @@ pub struct FoldingEnvironment<const N: usize, C: FoldingConfig, Structure> {
     pub structure: Structure,
     /// Commitments to the witness columns, for both sides
     pub instances: [FoldingInstance<N, C::Curve>; 2],
-    /// Corresponds to the omega evaluations, for both sides
+    /// Corresponds to the evaluations at ω, for both sides
     pub curr_witnesses: [FoldingWitness<N, ScalarField<C>>; 2],
-    /// Corresponds to the zeta*omega evaluations, for both sides
+    /// Corresponds to the evaluations at ζω, for both sides
     /// This is curr_witness but left shifted by 1
     pub next_witnesses: [FoldingWitness<N, ScalarField<C>>; 2],
 }


### PR DESCRIPTION
The alphas can be inferred while evaluating. It removes a method to implement within the folding environment. For the challenges, it will be done in a follow-up PR.