### PR TITLE
WIP: get rid of challenge in folding environment

### DIFF
--- a/folding/src/instance_witness.rs
+++ b/folding/src/instance_witness.rs
@@ -75,6 +75,9 @@ pub trait Instance<G: CommitmentCurve>: Sized + Foldable<G::ScalarField> {
 
     /// Returns the alphas values for the instance
     fn get_alphas(&self) -> &Alphas<G::ScalarField>;
+
+    /// Returns the challenges of the instance
+    fn get_challenges(&self) -> &[G::ScalarField];
 }
 
 pub trait Witness<G: CommitmentCurve>: Sized + Foldable<G::ScalarField> {

--- a/o1vm/src/folding.rs
+++ b/o1vm/src/folding.rs
@@ -80,6 +80,10 @@ impl<const N: usize, G: CommitmentCurve> Instance<G> for FoldingInstance<N, G> {
     fn get_alphas(&self) -> &Alphas<G::ScalarField> {
         &self.alphas
     }
+
+    fn get_challenges(&self) -> &[G::ScalarField] {
+        &self.challenges
+    }
 }
 
 impl<const N: usize, G: CommitmentCurve> Index<Challenge> for FoldingInstance<N, G> {


### PR DESCRIPTION
Breaking things.
It is not a good time to improve this for now.
We should parametrize the expression framework defined in kimchi to use a generic type of challenge, and after that parametrize the folding expressions and this code.

The issue for now comes from the conversions.