### PR TITLE
Separate fixed selectors from the witness

### DIFF
--- a/ivc/src/ivc/interpreter.rs
+++ b/ivc/src/ivc/interpreter.rs
@@ -884,23 +884,16 @@ where
     env.next_row();
 }
 
-pub fn process_misc<F, Env, const N_COL_TOTAL: usize>(_env: &mut Env)
-where
-    F: PrimeField,
-    Env: MultiRowReadCap<F, IVCColumn>,
-{
-}
-
 /// Builds selectors for the IVC circuit.
 pub fn build_selectors<F, const N_COL_TOTAL: usize, const N_CHALS: usize>(
     domain_size: usize,
-) -> Vec<Vec<F>>
+) -> [Vec<F>; N_BLOCKS]
 where
     F: PrimeField,
 {
     // 3*N + 6*N+2 + N+1 + 35*N + 5 + 1 + N_CHALS =
     // 45N + 9 + N_CHALS
-    let mut selectors: Vec<Vec<F>> = vec![vec![F::zero(); domain_size]; N_BLOCKS];
+    let mut selectors: [Vec<F>; N_BLOCKS] = core::array::from_fn(|_| vec![F::zero(); domain_size]);
     let mut cur_row = 0;
     for _i in 0..3 * N_COL_TOTAL {
         selectors[0][cur_row] = F::one();
@@ -960,11 +953,11 @@ where
 
     let s2 = env.read_column(IVCColumn::BlockSel(2));
     env.set_assert_mapper(Box::new(move |x| s2.clone() * x));
-    constrain_ecadds(env);
+    constrain_scalars(env);
 
     let s3 = env.read_column(IVCColumn::BlockSel(3));
     env.set_assert_mapper(Box::new(move |x| s3.clone() * x));
-    constrain_scalars(env);
+    constrain_ecadds(env);
 
     let s4 = env.read_column(IVCColumn::BlockSel(4));
     env.set_assert_mapper(Box::new(move |x| s4.clone() * x));
@@ -1014,5 +1007,4 @@ pub fn ivc_circuit<F, Ff, Env, PParams, const N_COL_TOTAL: usize>(
     process_ecadds::<_, Ff, _, N_COL_TOTAL>(env, scalar_limbs, &comms_large, error_terms, t_terms);
     process_challenges::<_, _, N_COL_TOTAL>(env, hash_r, chal_l, r);
     process_u::<_, _, N_COL_TOTAL>(env, u_l, r);
-    process_misc::<_, _, N_COL_TOTAL>(env);
 }

--- a/ivc/src/ivc/mod.rs
+++ b/ivc/src/ivc/mod.rs
@@ -45,10 +45,10 @@ mod tests {
     type IVCWitnessBuilderEnvRaw<LT> = WitnessBuilderEnv<
         Fp,
         IVCColumn,
-        { <IVCColumn as ColumnIndexer>::N_COL },
-        { <IVCColumn as ColumnIndexer>::N_COL },
+        { <IVCColumn as ColumnIndexer>::N_COL - N_BLOCKS },
+        { <IVCColumn as ColumnIndexer>::N_COL - N_BLOCKS },
         0,
-        0,
+        N_BLOCKS,
         LT,
     >;
 
@@ -98,8 +98,8 @@ mod tests {
 
         println!("Building fixed selectors");
         let fixed_selectors: Vec<Vec<Fp>> =
-            build_selectors::<_, TEST_N_COL_TOTAL, TEST_N_CHALS>(domain_size);
-        witness_env.set_fixed_selectors(fixed_selectors.to_vec());
+            build_selectors::<_, TEST_N_COL_TOTAL, TEST_N_CHALS>(domain_size).to_vec();
+        witness_env.set_fixed_selectors(fixed_selectors);
 
         println!("Calling the IVC circuit");
         // TODO add nonzero E/T values.
@@ -158,6 +158,9 @@ mod tests {
         // Don't use lookups for now
         let constraints = constraint_env.get_relation_constraints();
 
+        let fixed_selectors: [Vec<Fp>; N_BLOCKS] =
+            build_selectors::<_, TEST_N_COL_TOTAL, TEST_N_CHALS>(domain_size);
+
         // generate the proof
         let proof = prove::<
             _,
@@ -165,12 +168,19 @@ mod tests {
             BaseSponge,
             ScalarSponge,
             _,
-            { IVCColumn::N_COL },
+            { IVCColumn::N_COL - N_BLOCKS },
             { IVCColumn::N_COL - N_BLOCKS },
             0,
             N_BLOCKS,
             IVCLookupTable<Ff1>,
-        >(domain, &srs, &constraints, proof_inputs, &mut rng)
+        >(
+            domain,
+            &srs,
+            &constraints,
+            Box::new(fixed_selectors.clone()),
+            proof_inputs,
+            &mut rng,
+        )
         .unwrap();
 
         // verify the proof
@@ -179,7 +189,7 @@ mod tests {
             OpeningProof,
             BaseSponge,
             ScalarSponge,
-            { IVCColumn::N_COL },
+            { IVCColumn::N_COL - N_BLOCKS },
             { IVCColumn::N_COL - N_BLOCKS },
             0,
             N_BLOCKS,
@@ -189,6 +199,7 @@ mod tests {
             domain,
             &srs,
             &constraints,
+            Box::new(fixed_selectors),
             &proof,
             Witness::zero_vec(domain_size),
         );

--- a/ivc/src/poseidon/mod.rs
+++ b/ivc/src/poseidon/mod.rs
@@ -159,7 +159,14 @@ mod tests {
             N_DSEL,
             0,
             DummyLookupTable,
-        >(domain, &srs, &constraints, proof_inputs, &mut rng)
+        >(
+            domain,
+            &srs,
+            &constraints,
+            Box::new([]),
+            proof_inputs,
+            &mut rng,
+        )
         .unwrap();
 
         // verify the proof
@@ -178,6 +185,7 @@ mod tests {
             domain,
             &srs,
             &constraints,
+            Box::new([]),
             &proof,
             Witness::zero_vec(domain_size),
         );

--- a/msm/src/fec/mod.rs
+++ b/msm/src/fec/mod.rs
@@ -103,7 +103,14 @@ mod tests {
             0,
             0,
             _,
-        >(domain, &srs, &constraints, proof_inputs, &mut rng)
+        >(
+            domain,
+            &srs,
+            &constraints,
+            Box::new([]),
+            proof_inputs,
+            &mut rng,
+        )
         .unwrap();
 
         // verify the proof
@@ -122,6 +129,7 @@ mod tests {
             domain,
             &srs,
             &constraints,
+            Box::new([]),
             &proof,
             Witness::zero_vec(domain_size),
         );

--- a/msm/src/ffa/mod.rs
+++ b/msm/src/ffa/mod.rs
@@ -99,7 +99,14 @@ mod tests {
             0,
             0,
             _,
-        >(domain, &srs, &constraints, proof_inputs, &mut rng)
+        >(
+            domain,
+            &srs,
+            &constraints,
+            Box::new([]),
+            proof_inputs,
+            &mut rng,
+        )
         .unwrap();
 
         // verify the proof
@@ -118,6 +125,7 @@ mod tests {
             domain,
             &srs,
             &constraints,
+            Box::new([]),
             &proof,
             Witness::zero_vec(domain_size),
         );

--- a/msm/src/proof.rs
+++ b/msm/src/proof.rs
@@ -70,7 +70,7 @@ pub struct ProofEvaluations<
 > {
     /// Witness evaluations, including public inputs
     pub(crate) witness_evals: Witness<N_WIT, PointEvaluations<F>>,
-    /// Evaluations of fixed selectors. having
+    /// Evaluations of fixed selectors.
     pub(crate) fixed_selectors_evals: Box<[PointEvaluations<F>; N_FSEL]>,
     /// Logup argument evaluations
     pub(crate) logup_evals: Option<LookupProof<PointEvaluations<F>, ID>>,

--- a/msm/src/proof.rs
+++ b/msm/src/proof.rs
@@ -17,21 +17,21 @@ use poly_commitment::{commitment::PolyComm, OpenProof};
 use rand::thread_rng;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProofInputs<const N: usize, F: PrimeField, ID: LookupTableID> {
+pub struct ProofInputs<const N_WIT: usize, F: PrimeField, ID: LookupTableID> {
     /// Actual values w_i of the witness columns. "Evaluations" as in
     /// evaluations of polynomial P_w that interpolates w_i.
-    pub evaluations: Witness<N, Vec<F>>,
+    pub evaluations: Witness<N_WIT, Vec<F>>,
     pub logups: Vec<LogupWitness<F, ID>>,
 }
 
-impl<const N: usize, F: PrimeField> ProofInputs<N, F, LookupTableIDs> {
+impl<const N_WIT: usize, F: PrimeField> ProofInputs<N_WIT, F, LookupTableIDs> {
     // This should be used only for testing purposes.
     // It is not only in the test API because it is used at the moment in the
     // main.rs. It should be moved to the test API when main.rs is replaced with
     // real production code.
     pub fn random(domain: EvaluationDomains<F>) -> Self {
         let mut rng = thread_rng();
-        let cols: Box<[Vec<F>; N]> = Box::new(std::array::from_fn(|_| {
+        let cols: Box<[Vec<F>; N_WIT]> = Box::new(std::array::from_fn(|_| {
             (0..domain.d1.size as usize)
                 .map(|_| F::rand(&mut rng))
                 .collect::<Vec<_>>()
@@ -43,7 +43,7 @@ impl<const N: usize, F: PrimeField> ProofInputs<N, F, LookupTableIDs> {
     }
 }
 
-impl<const N: usize, F: PrimeField, ID: LookupTableID> Default for ProofInputs<N, F, ID> {
+impl<const N_WIT: usize, F: PrimeField, ID: LookupTableID> Default for ProofInputs<N_WIT, F, ID> {
     /// Creates a default proof instance. Note that such an empty "zero" instance will not satisfy any constraint.
     /// E.g. some constraints that have constants inside of them (A - const = 0) cannot be satisfied by it.
     fn default() -> Self {
@@ -59,8 +59,9 @@ impl<const N: usize, F: PrimeField, ID: LookupTableID> Default for ProofInputs<N
 }
 
 #[derive(Debug, Clone)]
+// TODO Should public input and fixed selectors evaluations be here?
 pub struct ProofEvaluations<
-    const N: usize,
+    const N_WIT: usize,
     const N_REL: usize,
     const N_DSEL: usize,
     const N_FSEL: usize,
@@ -68,7 +69,9 @@ pub struct ProofEvaluations<
     ID: LookupTableID,
 > {
     /// Witness evaluations, including public inputs
-    pub(crate) witness_evals: Witness<N, PointEvaluations<F>>,
+    pub(crate) witness_evals: Witness<N_WIT, PointEvaluations<F>>,
+    /// Evaluations of fixed selectors. having
+    pub(crate) fixed_selectors_evals: Box<[PointEvaluations<F>; N_FSEL]>,
     /// Logup argument evaluations
     pub(crate) logup_evals: Option<LookupProof<PointEvaluations<F>, ID>>,
     /// Evaluation of Z_H(ζ) (t_0(X) + ζ^n t_1(X) + ...) at ζω.
@@ -79,19 +82,19 @@ pub struct ProofEvaluations<
 /// It will return the evaluation of the corresponding column at the
 /// evaluation points coined by the verifier during the protocol.
 impl<
-        const N: usize,
+        const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,
         const N_FSEL: usize,
         F: Clone,
         ID: LookupTableID,
-    > ColumnEvaluations<F> for ProofEvaluations<N, N_REL, N_DSEL, N_FSEL, F, ID>
+    > ColumnEvaluations<F> for ProofEvaluations<N_WIT, N_REL, N_DSEL, N_FSEL, F, ID>
 {
     type Column = crate::columns::Column;
 
     fn evaluate(&self, col: Self::Column) -> Result<PointEvaluations<F>, ExprError<Self::Column>> {
         // TODO: substitute when non-literal generic constants are available
-        assert!(N == N_REL + N_DSEL + N_FSEL);
+        assert!(N_WIT == N_REL + N_DSEL);
         let res = match col {
             Self::Column::Relation(i) => {
                 assert!(i < N_REL, "Index out of bounds");
@@ -103,7 +106,7 @@ impl<
             }
             Self::Column::FixedSelector(i) => {
                 assert!(i < N_FSEL, "Index out of bounds");
-                self.witness_evals[N_REL + N_DSEL + i].clone()
+                self.fixed_selectors_evals[i].clone()
             }
             Self::Column::LookupPartialSum((table_id, idx)) => {
                 if let Some(ref lookup) = self.logup_evals {
@@ -139,10 +142,10 @@ impl<
 }
 
 #[derive(Debug, Clone)]
-pub struct ProofCommitments<const N: usize, G: KimchiCurve, ID: LookupTableID> {
+pub struct ProofCommitments<const N_WIT: usize, G: KimchiCurve, ID: LookupTableID> {
     /// Commitments to the N columns of the circuits, also called the 'witnesses'.
     /// If some columns are considered as public inputs, it is counted in the witness.
-    pub(crate) witness_comms: Witness<N, PolyComm<G>>,
+    pub(crate) witness_comms: Witness<N_WIT, PolyComm<G>>,
     /// Commitments to the polynomials used by the lookup argument, coined "logup".
     /// The values contains the chunked polynomials.
     pub(crate) logup_comms: Option<LookupProof<PolyComm<G>, ID>>,
@@ -153,7 +156,7 @@ pub struct ProofCommitments<const N: usize, G: KimchiCurve, ID: LookupTableID> {
 
 #[derive(Debug, Clone)]
 pub struct Proof<
-    const N: usize,
+    const N_WIT: usize,
     const N_REL: usize,
     const N_DSEL: usize,
     const N_FSEL: usize,
@@ -161,7 +164,7 @@ pub struct Proof<
     OpeningProof: OpenProof<G>,
     ID: LookupTableID,
 > {
-    pub(crate) proof_comms: ProofCommitments<N, G, ID>,
-    pub(crate) proof_evals: ProofEvaluations<N, N_REL, N_DSEL, N_FSEL, G::ScalarField, ID>,
+    pub(crate) proof_comms: ProofCommitments<N_WIT, G, ID>,
+    pub(crate) proof_evals: ProofEvaluations<N_WIT, N_REL, N_DSEL, N_FSEL, G::ScalarField, ID>,
     pub(crate) opening_proof: OpeningProof,
 }

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -114,7 +114,14 @@ mod tests {
             0,
             0,
             LookupTable<Ff1>,
-        >(domain, &srs, &constraints, proof_inputs, &mut rng)
+        >(
+            domain,
+            &srs,
+            &constraints,
+            Box::new([]),
+            proof_inputs,
+            &mut rng,
+        )
         .unwrap();
 
         let verifies = verify::<
@@ -132,6 +139,7 @@ mod tests {
             domain,
             &srs,
             &constraints,
+            Box::new([]),
             &proof,
             Witness::zero_vec(DOMAIN_SIZE),
         );

--- a/msm/src/test/logup.rs
+++ b/msm/src/test/logup.rs
@@ -54,7 +54,7 @@ mod tests {
             0,
             0,
             LookupTableIDs,
-        >(domain, &srs, &constraints, inputs, &mut rng)
+        >(domain, &srs, &constraints, Box::new([]), inputs, &mut rng)
         .unwrap();
         let verifies = verify::<
             _,
@@ -71,6 +71,7 @@ mod tests {
             domain,
             &srs,
             &constraints,
+            Box::new([]),
             &proof,
             Witness::zero_vec(domain_size),
         );

--- a/msm/src/test/proof_system.rs
+++ b/msm/src/test/proof_system.rs
@@ -10,13 +10,7 @@ use rand::{CryptoRng, RngCore};
 
 // Generic function to test with different circuits with the generic prover/verifier.
 // It doesn't use the interpreter to build the witness and compute the constraints.
-pub fn test_completeness_generic<
-    const N: usize,
-    const N_REL: usize,
-    const N_DSEL: usize,
-    const N_FSEL: usize,
-    RNG,
->(
+pub fn test_completeness_generic<const N: usize, const N_REL: usize, const N_DSEL: usize, RNG>(
     constraints: Vec<E<Fp>>,
     evaluations: Witness<N, Vec<Fp>>,
     domain_size: usize,
@@ -38,19 +32,16 @@ pub fn test_completeness_generic<
         logups: vec![],
     };
 
-    let proof = prove::<
-        _,
-        OpeningProof,
-        BaseSponge,
-        ScalarSponge,
-        _,
-        N,
-        N_REL,
-        N_DSEL,
-        N_FSEL,
-        LookupTableIDs,
-    >(domain, &srs, &constraints, proof_inputs, rng)
-    .unwrap();
+    let proof =
+        prove::<_, OpeningProof, BaseSponge, ScalarSponge, _, N, N_REL, N_DSEL, 0, LookupTableIDs>(
+            domain,
+            &srs,
+            &constraints,
+            Box::new([]),
+            proof_inputs,
+            rng,
+        )
+        .unwrap();
 
     {
         // Checking the proof size. We should have:
@@ -96,13 +87,14 @@ pub fn test_completeness_generic<
         N,
         N_REL,
         N_DSEL,
-        N_FSEL,
+        0,
         0,
         LookupTableIDs,
     >(
         domain,
         &srs,
         &constraints,
+        Box::new([]),
         &proof,
         Witness::zero_vec(domain_size),
     );
@@ -191,7 +183,7 @@ mod tests {
             cols: Box::new([random_x0s, exp_x1]),
         };
 
-        test_completeness_generic::<N, N, 0, 0, _>(
+        test_completeness_generic::<N, N, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -227,7 +219,7 @@ mod tests {
             cols: Box::new([random_x0s, random_x1s, exp_x2]),
         };
 
-        test_completeness_generic::<N, N, 0, 0, _>(
+        test_completeness_generic::<N, N, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -272,7 +264,7 @@ mod tests {
             cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
-        test_completeness_generic::<N, N, 0, 0, _>(
+        test_completeness_generic::<N, N, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -311,7 +303,7 @@ mod tests {
             cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
-        test_completeness_generic::<N, N, 0, 0, _>(
+        test_completeness_generic::<N, N, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -344,7 +336,7 @@ mod tests {
             cols: Box::new([random_x0s, exp_x1]),
         };
 
-        test_completeness_generic::<N, N, 0, 0, _>(
+        test_completeness_generic::<N, N, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -387,7 +379,7 @@ mod tests {
             cols: Box::new([random_x0s, exp_x1, random_x2s, exp_x3]),
         };
 
-        test_completeness_generic::<N, N, 0, 0, _>(
+        test_completeness_generic::<N, N, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -442,7 +434,7 @@ mod tests {
             cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
-        test_completeness_generic::<N, N, 0, 0, _>(
+        test_completeness_generic::<N, N, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -497,7 +489,7 @@ mod tests {
             cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
-        test_completeness_generic::<N, N, 0, 0, _>(
+        test_completeness_generic::<N, N, 0, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,

--- a/msm/src/test/test_circuit/mod.rs
+++ b/msm/src/test/test_circuit/mod.rs
@@ -27,7 +27,7 @@ mod tests {
     type TestWitnessBuilderEnv<LT> = WitnessBuilderEnv<
         Fp,
         TestColumn,
-        { <TestColumn as ColumnIndexer>::N_COL },
+        { <TestColumn as ColumnIndexer>::N_COL - 1 },
         { <TestColumn as ColumnIndexer>::N_COL - 1 },
         0,
         1,
@@ -40,11 +40,7 @@ mod tests {
     ) -> TestWitnessBuilderEnv<LT> {
         let mut witness_env = WitnessBuilderEnv::create();
 
-        let mut fixed_sel: Vec<Fp> = vec![];
-        for i in 0..domain_size {
-            fixed_sel.push(Fp::from(i as u64));
-        }
-
+        let fixed_sel: Vec<Fp> = (0..domain_size).map(|i| Fp::from(i as u64)).collect();
         witness_env.set_fixed_selector_cix(TestColumn::FixedE, fixed_sel);
 
         for row_i in 0..domain_size {
@@ -91,6 +87,9 @@ mod tests {
         // Don't use lookups for now
         let constraints = constraint_env.get_relation_constraints();
 
+        let fixed_selectors: Box<[Vec<Fp>; 1]> =
+            Box::new([(0..domain_size).map(|i| Fp::from(i as u64)).collect()]);
+
         // generate the proof
         let proof = prove::<
             _,
@@ -98,12 +97,19 @@ mod tests {
             BaseSponge,
             ScalarSponge,
             _,
-            TEST_N_COLUMNS,
+            { TEST_N_COLUMNS - 1 },
             { TEST_N_COLUMNS - 1 },
             0,
             1,
             DummyLookupTable,
-        >(domain, &srs, &constraints, proof_inputs, &mut rng)
+        >(
+            domain,
+            &srs,
+            &constraints,
+            fixed_selectors.clone(),
+            proof_inputs,
+            &mut rng,
+        )
         .unwrap();
 
         // verify the proof
@@ -112,7 +118,7 @@ mod tests {
             OpeningProof,
             BaseSponge,
             ScalarSponge,
-            TEST_N_COLUMNS,
+            { TEST_N_COLUMNS - 1 },
             { TEST_N_COLUMNS - 1 },
             0,
             1,
@@ -122,6 +128,7 @@ mod tests {
             domain,
             &srs,
             &constraints,
+            fixed_selectors,
             &proof,
             Witness::zero_vec(domain_size),
         );
@@ -185,6 +192,9 @@ mod tests {
         // Don't use lookups for now
         let constraints = constraint_env.get_relation_constraints();
 
+        let fixed_selectors: Box<[Vec<Fp>; 1]> =
+            Box::new([(0..domain_size).map(|i| Fp::from(i as u64)).collect()]);
+
         // generate the proof
         let proof = prove::<
             _,
@@ -192,12 +202,19 @@ mod tests {
             BaseSponge,
             ScalarSponge,
             _,
-            TEST_N_COLUMNS,
+            { TEST_N_COLUMNS - 1 },
             { TEST_N_COLUMNS - 1 },
             0,
             1,
             DummyLookupTable,
-        >(domain, &srs, &constraints, proof_inputs, &mut rng)
+        >(
+            domain,
+            &srs,
+            &constraints,
+            fixed_selectors.clone(),
+            proof_inputs,
+            &mut rng,
+        )
         .unwrap();
 
         // verify the proof
@@ -206,7 +223,7 @@ mod tests {
             OpeningProof,
             BaseSponge,
             ScalarSponge,
-            TEST_N_COLUMNS,
+            { TEST_N_COLUMNS - 1 },
             { TEST_N_COLUMNS - 1 },
             0,
             1,
@@ -216,6 +233,7 @@ mod tests {
             domain,
             &srs,
             &constraints,
+            fixed_selectors,
             &proof,
             Witness::zero_vec(domain_size),
         );
@@ -268,6 +286,9 @@ mod tests {
         // Don't use lookups for now
         let constraints = constraint_env.get_relation_constraints();
 
+        let fixed_selectors: Box<[Vec<Fp>; 1]> =
+            Box::new([(0..domain_size).map(|i| Fp::from(i as u64)).collect()]);
+
         let mut lookup_tables_data = BTreeMap::new();
         for table_id in DummyLookupTable::all_variants().into_iter() {
             lookup_tables_data.insert(table_id, table_id.entries(domain.d1.size));
@@ -284,12 +305,19 @@ mod tests {
             BaseSponge,
             ScalarSponge,
             _,
-            TEST_N_COLUMNS,
+            { TEST_N_COLUMNS - 1 },
             { TEST_N_COLUMNS - 1 },
             0,
             1,
             DummyLookupTable,
-        >(domain, &srs, &constraints, proof_inputs, &mut rng)
+        >(
+            domain,
+            &srs,
+            &constraints,
+            fixed_selectors.clone(),
+            proof_inputs,
+            &mut rng,
+        )
         .unwrap();
 
         // verify the proof
@@ -298,7 +326,7 @@ mod tests {
             OpeningProof,
             BaseSponge,
             ScalarSponge,
-            TEST_N_COLUMNS,
+            { TEST_N_COLUMNS - 1 },
             { TEST_N_COLUMNS - 1 },
             0,
             1,
@@ -308,6 +336,7 @@ mod tests {
             domain,
             &srs,
             &constraints,
+            fixed_selectors,
             &proof,
             Witness::zero_vec(domain_size),
         );
@@ -330,6 +359,9 @@ mod tests {
         // Don't use lookups for now
         let constraints = constraint_env.get_relation_constraints();
 
+        let fixed_selectors: Box<[Vec<Fp>; 1]> =
+            Box::new([(0..domain_size).map(|i| Fp::from(i as u64)).collect()]);
+
         let mut lookup_tables_data = BTreeMap::new();
         for table_id in DummyLookupTable::all_variants().into_iter() {
             lookup_tables_data.insert(table_id, table_id.entries(domain.d1.size));
@@ -345,12 +377,19 @@ mod tests {
             BaseSponge,
             ScalarSponge,
             _,
-            TEST_N_COLUMNS,
+            { TEST_N_COLUMNS - 1 },
             { TEST_N_COLUMNS - 1 },
             0,
             1,
             DummyLookupTable,
-        >(domain, &srs, &constraints, proof_inputs, &mut rng)
+        >(
+            domain,
+            &srs,
+            &constraints,
+            fixed_selectors.clone(),
+            proof_inputs,
+            &mut rng,
+        )
         .unwrap();
 
         let witness_env_prime =
@@ -366,12 +405,19 @@ mod tests {
             BaseSponge,
             ScalarSponge,
             _,
-            TEST_N_COLUMNS,
+            { TEST_N_COLUMNS - 1 },
             { TEST_N_COLUMNS - 1 },
             0,
             1,
             DummyLookupTable,
-        >(domain, &srs, &constraints, proof_inputs_prime, &mut rng)
+        >(
+            domain,
+            &srs,
+            &constraints,
+            fixed_selectors.clone(),
+            proof_inputs_prime,
+            &mut rng,
+        )
         .unwrap();
 
         // Swap the opening proof. The verification should fail.
@@ -383,7 +429,7 @@ mod tests {
                 OpeningProof,
                 BaseSponge,
                 ScalarSponge,
-                TEST_N_COLUMNS,
+                { TEST_N_COLUMNS - 1 },
                 { TEST_N_COLUMNS - 1 },
                 0,
                 1,
@@ -393,6 +439,7 @@ mod tests {
                 domain,
                 &srs,
                 &constraints,
+                fixed_selectors.clone(),
                 &proof_clone,
                 Witness::zero_vec(domain_size),
             );
@@ -410,7 +457,7 @@ mod tests {
                 OpeningProof,
                 BaseSponge,
                 ScalarSponge,
-                TEST_N_COLUMNS,
+                { TEST_N_COLUMNS - 1 },
                 { TEST_N_COLUMNS - 1 },
                 0,
                 1,
@@ -420,6 +467,7 @@ mod tests {
                 domain,
                 &srs,
                 &constraints,
+                fixed_selectors.clone(),
                 &proof_clone,
                 Witness::zero_vec(domain_size),
             );
@@ -438,7 +486,7 @@ mod tests {
                 OpeningProof,
                 BaseSponge,
                 ScalarSponge,
-                TEST_N_COLUMNS,
+                { TEST_N_COLUMNS - 1 },
                 { TEST_N_COLUMNS - 1 },
                 0,
                 1,
@@ -448,6 +496,7 @@ mod tests {
                 domain,
                 &srs,
                 &constraints,
+                fixed_selectors,
                 &proof_clone,
                 Witness::zero_vec(domain_size),
             );

--- a/msm/src/witness.rs
+++ b/msm/src/witness.rs
@@ -3,19 +3,19 @@ use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelIterator};
 use std::ops::Index;
 
 /// The witness columns used by a gate of the MSM circuits.
-/// It is generic over the number of columns, N, and the type of the witness, T.
+/// It is generic over the number of columns, `N_WIT`, and the type of the witness, `T`.
 /// It is parametrized by a type `T` which can be either:
 /// - `Vec<G::ScalarField>` for the evaluations
 /// - `PolyComm<G>` for the commitments
 /// It can be used to represent the different subcircuits used by the project.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Witness<const N: usize, T> {
+pub struct Witness<const N_WIT: usize, T> {
     /// A witness row is represented by an array of N witness columns
     /// When T is a vector, then the witness describes the rows of the circuit.
-    pub cols: Box<[T; N]>,
+    pub cols: Box<[T; N_WIT]>,
 }
 
-impl<const N: usize, T: Zero + Clone> Default for Witness<N, T> {
+impl<const N_WIT: usize, T: Zero + Clone> Default for Witness<N_WIT, T> {
     fn default() -> Self {
         Witness {
             cols: Box::new(std::array::from_fn(|_| T::zero())),
@@ -23,7 +23,7 @@ impl<const N: usize, T: Zero + Clone> Default for Witness<N, T> {
     }
 }
 
-impl<const N: usize, T> Index<usize> for Witness<N, T> {
+impl<const N_WIT: usize, T> Index<usize> for Witness<N_WIT, T> {
     type Output = T;
 
     fn index(&self, index: usize) -> &Self::Output {
@@ -31,7 +31,7 @@ impl<const N: usize, T> Index<usize> for Witness<N, T> {
     }
 }
 
-impl<const N: usize, T> Witness<N, T> {
+impl<const N_WIT: usize, T> Witness<N_WIT, T> {
     pub fn len(&self) -> usize {
         self.cols.len()
     }
@@ -41,7 +41,7 @@ impl<const N: usize, T> Witness<N, T> {
     }
 }
 
-impl<const N: usize, T: Zero + Clone> Witness<N, Vec<T>> {
+impl<const N_WIT: usize, T: Zero + Clone> Witness<N_WIT, Vec<T>> {
     pub fn zero_vec(domain_size: usize) -> Self {
         Witness {
             // Ideally the vector should be of domain size, but
@@ -63,30 +63,30 @@ impl<const N: usize, T: Zero + Clone> Witness<N, Vec<T>> {
 
 // IMPLEMENTATION OF ITERATORS FOR THE WITNESS STRUCTURE
 
-impl<'lt, const N: usize, G> IntoIterator for &'lt Witness<N, G> {
+impl<'lt, const N_WIT: usize, G> IntoIterator for &'lt Witness<N_WIT, G> {
     type Item = &'lt G;
     type IntoIter = std::vec::IntoIter<&'lt G>;
 
     fn into_iter(self) -> Self::IntoIter {
-        let mut iter_contents = Vec::with_capacity(N);
+        let mut iter_contents = Vec::with_capacity(N_WIT);
         iter_contents.extend(&*self.cols);
         iter_contents.into_iter()
     }
 }
 
-impl<const N: usize, F: Clone> IntoIterator for Witness<N, F> {
+impl<const N_WIT: usize, F: Clone> IntoIterator for Witness<N_WIT, F> {
     type Item = F;
     type IntoIter = std::vec::IntoIter<F>;
 
     /// Iterate over the columns in the circuit.
     fn into_iter(self) -> Self::IntoIter {
-        let mut iter_contents = Vec::with_capacity(N);
+        let mut iter_contents = Vec::with_capacity(N_WIT);
         iter_contents.extend(*self.cols);
         iter_contents.into_iter()
     }
 }
 
-impl<const N: usize, G> IntoParallelIterator for Witness<N, G>
+impl<const N_WIT: usize, G> IntoParallelIterator for Witness<N_WIT, G>
 where
     Vec<G>: IntoParallelIterator,
 {
@@ -95,20 +95,20 @@ where
 
     /// Iterate over the columns in the circuit, in parallel.
     fn into_par_iter(self) -> Self::Iter {
-        let mut iter_contents = Vec::with_capacity(N);
+        let mut iter_contents = Vec::with_capacity(N_WIT);
         iter_contents.extend(*self.cols);
         iter_contents.into_par_iter()
     }
 }
 
-impl<const N: usize, G: Send + std::fmt::Debug> FromParallelIterator<G> for Witness<N, G> {
+impl<const N_WIT: usize, G: Send + std::fmt::Debug> FromParallelIterator<G> for Witness<N_WIT, G> {
     fn from_par_iter<I>(par_iter: I) -> Self
     where
         I: IntoParallelIterator<Item = G>,
     {
         let mut iter_contents = par_iter.into_par_iter().collect::<Vec<_>>();
         let cols = iter_contents
-            .drain(..N)
+            .drain(..N_WIT)
             .collect::<Vec<G>>()
             .try_into()
             .unwrap();
@@ -116,7 +116,7 @@ impl<const N: usize, G: Send + std::fmt::Debug> FromParallelIterator<G> for Witn
     }
 }
 
-impl<'data, const N: usize, G> IntoParallelIterator for &'data Witness<N, G>
+impl<'data, const N_WIT: usize, G> IntoParallelIterator for &'data Witness<N_WIT, G>
 where
     Vec<&'data G>: IntoParallelIterator,
 {
@@ -124,13 +124,13 @@ where
     type Item = <Vec<&'data G> as IntoParallelIterator>::Item;
 
     fn into_par_iter(self) -> Self::Iter {
-        let mut iter_contents = Vec::with_capacity(N);
+        let mut iter_contents = Vec::with_capacity(N_WIT);
         iter_contents.extend(&*self.cols);
         iter_contents.into_par_iter()
     }
 }
 
-impl<'data, const N: usize, G> IntoParallelIterator for &'data mut Witness<N, G>
+impl<'data, const N_WIT: usize, G> IntoParallelIterator for &'data mut Witness<N_WIT, G>
 where
     Vec<&'data mut G>: IntoParallelIterator,
 {
@@ -138,7 +138,7 @@ where
     type Item = <Vec<&'data mut G> as IntoParallelIterator>::Item;
 
     fn into_par_iter(self) -> Self::Iter {
-        let mut iter_contents = Vec::with_capacity(N);
+        let mut iter_contents = Vec::with_capacity(N_WIT);
         iter_contents.extend(&mut *self.cols);
         iter_contents.into_par_iter()
     }

--- a/o1vm/src/keccak/tests.rs
+++ b/o1vm/src/keccak/tests.rs
@@ -537,7 +537,6 @@ fn test_keccak_prover_constraints() {
                     N_ZKVM_KECCAK_COLS,
                     N_ZKVM_KECCAK_REL_COLS,
                     N_ZKVM_KECCAK_SEL_COLS,
-                    0,
                     _,
                 >(
                     keccak_circuit[step].constraints.clone(),

--- a/o1vm/src/main.rs
+++ b/o1vm/src/main.rs
@@ -227,6 +227,7 @@ pub fn main() -> ExitCode {
                     domain,
                     &srs,
                     &mips_trace[instr].constraints,
+                    Box::new([]),
                     mips_folded_instance[&instr].clone(),
                     &mut rng,
                 );
@@ -247,6 +248,7 @@ pub fn main() -> ExitCode {
                     domain,
                     &srs,
                     &mips_trace[instr].constraints,
+                    Box::new([]),
                     &mips_proof,
                     Witness::zero_vec(DOMAIN_SIZE),
                 );
@@ -281,6 +283,7 @@ pub fn main() -> ExitCode {
                     domain,
                     &srs,
                     &keccak_trace[step].constraints,
+                    Box::new([]),
                     keccak_folded_instance[&step].clone(),
                     &mut rng,
                 );
@@ -301,6 +304,7 @@ pub fn main() -> ExitCode {
                     domain,
                     &srs,
                     &keccak_trace[step].constraints,
+                    Box::new([]),
                     &keccak_proof,
                     Witness::zero_vec(DOMAIN_SIZE),
                 );

--- a/utils/src/array.rs
+++ b/utils/src/array.rs
@@ -1,6 +1,17 @@
 //! This module provides different helpers in creating constant sized
 //! arrays and converting them to different formats.
 
+// Use a generic function so that the pointer cast remains type-safe
+/// Converts a vector of elements to a boxed one. Semantically
+/// equivalent to `vector.into_boxed_slice().try_into().unwrap()`.
+pub fn vec_to_boxed_array<T, const N: usize>(vec: Vec<T>) -> Box<[T; N]> {
+    let boxed_slice = vec.into_boxed_slice();
+
+    let ptr = ::std::boxed::Box::into_raw(boxed_slice) as *mut [T; N];
+
+    unsafe { Box::from_raw(ptr) }
+}
+
 // @volhovm It could potentially be more efficient with unsafe tricks.
 /// Converts a two-dimensional vector to a constant sized two-dimensional array.
 pub fn vec_to_boxed_array2<T, const N: usize, const M: usize>(

--- a/utils/src/array.rs
+++ b/utils/src/array.rs
@@ -10,9 +10,9 @@
 /// Converts a vector of elements to a boxed one. Semantically
 /// equivalent to `vector.into_boxed_slice().try_into().unwrap()`.
 pub fn vec_to_boxed_array<T, const N: usize>(vec: Vec<T>) -> Box<[T; N]> {
-    vec.into_boxed_slice().try_into().unwrap_or_else(|_| {
-        panic!("vec_to_boxed_array: length mismatch, expected {}", N)
-    })
+    vec.into_boxed_slice()
+        .try_into()
+        .unwrap_or_else(|_| panic!("vec_to_boxed_array: length mismatch, expected {}", N))
 }
 
 // @volhovm It could potentially be more efficient with unsafe tricks.


### PR DESCRIPTION
With this PR, fixed selectors are not anymore part of the witness, and are passed separately. The intention is that they must be static for a given circuit.