### PR TITLE
Use generic completeness/soundness tests

### DIFF
--- a/ivc/src/ivc/mod.rs
+++ b/ivc/src/ivc/mod.rs
@@ -14,7 +14,6 @@ mod tests {
         poseidon::{interpreter::PoseidonParams, params::static_params},
     };
     use ark_ff::{UniformRand, Zero};
-    use kimchi::circuits::domains::EvaluationDomains;
     use kimchi_msm::{
         circuit_design::{
             composition::{IdMPrism, MPrism},
@@ -22,18 +21,12 @@ mod tests {
         },
         columns::ColumnIndexer,
         logup::LookupTableID,
-        precomputed_srs::get_bn254_srs,
-        proof::ProofInputs,
-        prover::prove,
-        verifier::verify,
-        witness::Witness,
-        BaseSponge, Ff1, Fp, OpeningProof, ScalarSponge, BN254,
+        Ff1, Fp,
     };
     use o1_utils::box_array;
-    use poly_commitment::pairing_proof::PairingSRS;
     use rand::{CryptoRng, RngCore};
 
-    // Test number
+    // Total number of columns in IVC and Application circuits.
     pub const TEST_N_COL_TOTAL: usize = IVCColumn::N_COL + 50;
     // Absolutely no idea.
     pub const TEST_N_CHALS: usize = 200;
@@ -133,77 +126,36 @@ mod tests {
     #[test]
     fn test_completeness_ivc() {
         let mut rng = o1_utils::tests::make_test_rng();
-
-        //let mut comms_left: Box<_> = box_array2![(Fp::zero(),Fp::zero()); TEST_N_COL_TOTAL; 3];
-
         let domain_size = 1 << 15;
-        let domain = EvaluationDomains::<Fp>::create(domain_size).unwrap();
-
-        let srs: PairingSRS<BN254> = get_bn254_srs(domain);
 
         let witness_env = build_ivc_circuit::<_, IVCLookupTable<Ff1>, _>(
             &mut rng,
             domain_size,
             IdMPrism::<IVCLookupTable<Ff1>>::default(),
         );
-        // Don't use lookups for now
-        let rel_witness = witness_env.get_relation_witness(domain);
-        let proof_inputs = ProofInputs {
-            evaluations: rel_witness,
-            logups: vec![],
-        };
+        let relation_witness = witness_env.get_relation_witness(domain_size);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, IVCLookupTable<Ff1>>::create();
         constrain_ivc::<Fp, Ff1, _>(&mut constraint_env);
-        // Don't use lookups for now
         let constraints = constraint_env.get_relation_constraints();
 
-        let fixed_selectors: [Vec<Fp>; N_BLOCKS] =
-            build_selectors::<_, TEST_N_COL_TOTAL, TEST_N_CHALS>(domain_size);
+        let fixed_selectors: Box<[Vec<Fp>; N_BLOCKS]> =
+            Box::new(build_selectors::<_, TEST_N_COL_TOTAL, TEST_N_CHALS>(
+                domain_size,
+            ));
 
-        // generate the proof
-        let proof = prove::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            _,
+        kimchi_msm::test::test_completeness_generic_no_lookups::<
             { IVCColumn::N_COL - N_BLOCKS },
             { IVCColumn::N_COL - N_BLOCKS },
             0,
             N_BLOCKS,
-            IVCLookupTable<Ff1>,
+            _,
         >(
-            domain,
-            &srs,
-            &constraints,
-            Box::new(fixed_selectors.clone()),
-            proof_inputs,
+            constraints,
+            fixed_selectors,
+            relation_witness,
+            domain_size,
             &mut rng,
-        )
-        .unwrap();
-
-        // verify the proof
-        let verifies = verify::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            { IVCColumn::N_COL - N_BLOCKS },
-            { IVCColumn::N_COL - N_BLOCKS },
-            0,
-            N_BLOCKS,
-            0,
-            IVCLookupTable<Ff1>,
-        >(
-            domain,
-            &srs,
-            &constraints,
-            Box::new(fixed_selectors),
-            &proof,
-            Witness::zero_vec(domain_size),
         );
-
-        assert!(verifies);
     }
 }

--- a/msm/src/fec/mod.rs
+++ b/msm/src/fec/mod.rs
@@ -14,14 +14,9 @@ mod tests {
             lookups::LookupTable,
         },
         logup::LookupTableID,
-        prover::prove,
-        verifier::verify,
-        witness::Witness,
-        BaseSponge, Ff1, Fp, OpeningProof, ScalarSponge, BN254,
+        Ff1, Fp,
     };
     use ark_ff::UniformRand;
-    use kimchi::circuits::domains::EvaluationDomains;
-    use poly_commitment::pairing_proof::PairingSRS;
     use rand::{CryptoRng, RngCore};
     use std::collections::BTreeMap;
 
@@ -72,11 +67,6 @@ mod tests {
     pub fn test_fec_completeness() {
         let mut rng = o1_utils::tests::make_test_rng();
         let domain_size = 1 << 15; // Otherwise we can't do 15-bit lookups.
-        let domain = EvaluationDomains::<Fp>::create(domain_size).unwrap();
-
-        let srs_trapdoor = Fp::rand(&mut rng);
-        let mut srs: PairingSRS<BN254> = PairingSRS::create(srs_trapdoor, domain.d1.size as usize);
-        srs.full_srs.add_lagrange_basis(domain.d1);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, LookupTable<Ff1>>::create();
         constrain_ec_addition::<Fp, Ff1, _>(&mut constraint_env);
@@ -87,53 +77,23 @@ mod tests {
         // Fixed tables can be generated inside lookup_tables_data. Runtime should be generated here.
         let mut lookup_tables_data = BTreeMap::new();
         for table_id in LookupTable::<Ff1>::all_variants().into_iter() {
-            lookup_tables_data.insert(table_id, table_id.entries(domain.d1.size));
+            lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64));
         }
-        let proof_inputs = witness_env.get_proof_inputs(domain, lookup_tables_data);
+        let proof_inputs = witness_env.get_proof_inputs(domain_size, lookup_tables_data);
 
-        // generate the proof
-        let proof = prove::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            _,
+        crate::test::test_completeness_generic::<
             FEC_N_COLUMNS,
             FEC_N_COLUMNS,
             0,
             0,
+            LookupTable<Ff1>,
             _,
         >(
-            domain,
-            &srs,
-            &constraints,
+            constraints,
             Box::new([]),
             proof_inputs,
+            domain_size,
             &mut rng,
-        )
-        .unwrap();
-
-        // verify the proof
-        let verifies = verify::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            FEC_N_COLUMNS,
-            FEC_N_COLUMNS,
-            0,
-            0,
-            0,
-            _,
-        >(
-            domain,
-            &srs,
-            &constraints,
-            Box::new([]),
-            &proof,
-            Witness::zero_vec(domain_size),
         );
-
-        assert!(verifies);
     }
 }

--- a/msm/src/ffa/mod.rs
+++ b/msm/src/ffa/mod.rs
@@ -87,6 +87,11 @@ mod tests {
         }
         let proof_inputs = witness_env.get_proof_inputs(domain, lookup_tables_data);
 
+        //test_completeness_generic::<            FFA_N_COLUMNS,
+        //    FFA_N_COLUMNS,
+        //    0,
+        //    0>(constraints, proof_inputs,
+
         // generate the proof
         let proof = prove::<
             _,

--- a/msm/src/ffa/mod.rs
+++ b/msm/src/ffa/mod.rs
@@ -9,20 +9,14 @@ mod tests {
         circuit_design::{ConstraintBuilderEnv, WitnessBuilderEnv},
         columns::ColumnIndexer,
         ffa::{
-            columns::{FFAColumn, FFA_N_COLUMNS},
+            columns::FFAColumn,
             interpreter::{self as ffa_interpreter},
             lookups::LookupTable,
         },
         logup::LookupTableID,
-        precomputed_srs::get_bn254_srs,
-        prover::prove,
-        verifier::verify,
-        witness::Witness,
-        BaseSponge, Ff1, Fp, OpeningProof, ScalarSponge, BN254,
+        Ff1, Fp,
     };
     use ark_ff::UniformRand;
-    use kimchi::circuits::domains::EvaluationDomains;
-    use poly_commitment::pairing_proof::PairingSRS;
     use rand::{CryptoRng, RngCore};
     use std::collections::BTreeMap;
 
@@ -70,9 +64,6 @@ mod tests {
     pub fn test_ffa_completeness() {
         let mut rng = o1_utils::tests::make_test_rng();
         let domain_size = 1 << 15; // Otherwise we can't do 15-bit lookups.
-        let domain = EvaluationDomains::<Fp>::create(domain_size).unwrap();
-
-        let srs: PairingSRS<BN254> = get_bn254_srs(domain);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, LookupTable>::create();
         ffa_interpreter::constrain_ff_addition(&mut constraint_env);
@@ -83,58 +74,23 @@ mod tests {
         // Fixed tables can be generated inside lookup_tables_data. Runtime should be generated here.
         let mut lookup_tables_data = BTreeMap::new();
         for table_id in LookupTable::all_variants().into_iter() {
-            lookup_tables_data.insert(table_id, table_id.entries(domain.d1.size));
+            lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64));
         }
-        let proof_inputs = witness_env.get_proof_inputs(domain, lookup_tables_data);
+        let proof_inputs = witness_env.get_proof_inputs(domain_size, lookup_tables_data);
 
-        //test_completeness_generic::<            FFA_N_COLUMNS,
-        //    FFA_N_COLUMNS,
-        //    0,
-        //    0>(constraints, proof_inputs,
-
-        // generate the proof
-        let proof = prove::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            _,
-            FFA_N_COLUMNS,
-            FFA_N_COLUMNS,
+        crate::test::test_completeness_generic::<
+            { <FFAColumn as ColumnIndexer>::N_COL },
+            { <FFAColumn as ColumnIndexer>::N_COL },
             0,
             0,
+            LookupTable,
             _,
         >(
-            domain,
-            &srs,
-            &constraints,
+            constraints,
             Box::new([]),
             proof_inputs,
+            domain_size,
             &mut rng,
-        )
-        .unwrap();
-
-        // verify the proof
-        let verifies = verify::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            FFA_N_COLUMNS,
-            FFA_N_COLUMNS,
-            0,
-            0,
-            0,
-            _,
-        >(
-            domain,
-            &srs,
-            &constraints,
-            Box::new([]),
-            &proof,
-            Witness::zero_vec(domain_size),
         );
-
-        assert!(verifies, "Proof must verify");
     }
 }

--- a/msm/src/precomputed_srs.rs
+++ b/msm/src/precomputed_srs.rs
@@ -5,14 +5,14 @@ use ark_ff::UniformRand;
 use kimchi::circuits::domains::EvaluationDomains;
 use poly_commitment::pairing_proof::PairingSRS;
 
-use crate::{Fp, BN254, DOMAIN_SIZE};
+use crate::{Fp, BN254};
 
 /// Obtains an SRS for a specific curve from disk, or generates it if absent.
 pub fn get_bn254_srs(domain: EvaluationDomains<Fp>) -> PairingSRS<BN254> {
     // Temporarily just generate it from scratch since SRS serialization is
     // broken.
     let trapdoor = Fp::rand(&mut rand::rngs::OsRng);
-    let mut srs = PairingSRS::create(trapdoor, DOMAIN_SIZE);
+    let mut srs = PairingSRS::create(trapdoor, domain.d1.size as usize);
     srs.full_srs.add_lagrange_basis(domain.d1);
     srs
 }

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -8,16 +8,12 @@ pub const N_INTERMEDIATE_LIMBS: usize = 20;
 #[cfg(test)]
 mod tests {
     use ark_ff::UniformRand;
-    use kimchi::circuits::domains::EvaluationDomains;
-    use poly_commitment::pairing_proof::PairingSRS;
     use std::collections::BTreeMap;
 
     use crate::{
         circuit_design::{constraints::ConstraintBuilderEnv, witness::WitnessBuilderEnv},
         columns::ColumnIndexer,
         logup::LookupTableID,
-        precomputed_srs::get_bn254_srs,
-        prover::prove,
         serialization::{
             column::{SerializationColumn, SER_N_COLUMNS},
             interpreter::{
@@ -26,9 +22,7 @@ mod tests {
             },
             lookups::LookupTable,
         },
-        verifier::verify,
-        witness::Witness,
-        BaseSponge, Ff1, Fp, OpeningProof, ScalarSponge, BN254,
+        Ff1, Fp,
     };
 
     type SerializationWitnessBuilderEnv = WitnessBuilderEnv<
@@ -45,11 +39,7 @@ mod tests {
     fn test_completeness() {
         let mut rng = o1_utils::tests::make_test_rng();
         // Must be at least 1 << 15 to support rangecheck15
-        const DOMAIN_SIZE: usize = 1 << 15;
-
-        let domain = EvaluationDomains::<Fp>::create(DOMAIN_SIZE).unwrap();
-
-        let srs: PairingSRS<BN254> = get_bn254_srs(domain);
+        let domain_size: usize = 1 << 15;
 
         let mut witness_env = SerializationWitnessBuilderEnv::create();
 
@@ -61,7 +51,7 @@ mod tests {
         // constant support/public input yet in the quotient polynomial.
         let input_chal: Ff1 = <Ff1 as UniformRand>::rand(&mut rng);
         let [input1, input2, input3]: [Fp; 3] = limb_decompose_ff::<Fp, Ff1, 88, 3>(&input_chal);
-        for _ in 0..DOMAIN_SIZE {
+        for _ in 0..domain_size {
             field_elements.push([input1, input2, input3])
         }
         let coeff_input: Ff1 = <Ff1 as UniformRand>::rand(&mut rng);
@@ -91,7 +81,7 @@ mod tests {
             multiplication_circuit(&mut witness_env, input_chal, coeff_input, false);
 
             // Don't reset on the last iteration.
-            if i < DOMAIN_SIZE {
+            if i < domain_size {
                 witness_env.next_row()
             }
         }
@@ -99,50 +89,23 @@ mod tests {
         // Fixed tables can be generated inside lookup_tables_data. Runtime should be generated here.
         let mut lookup_tables_data = BTreeMap::new();
         for table_id in LookupTable::<Ff1>::all_variants().into_iter() {
-            lookup_tables_data.insert(table_id, table_id.entries(domain.d1.size));
+            lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64));
         }
-        let proof_inputs = witness_env.get_proof_inputs(domain, lookup_tables_data);
+        let proof_inputs = witness_env.get_proof_inputs(domain_size, lookup_tables_data);
 
-        let proof = prove::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            _,
+        crate::test::test_completeness_generic::<
             SER_N_COLUMNS,
             SER_N_COLUMNS,
             0,
             0,
             LookupTable<Ff1>,
+            _,
         >(
-            domain,
-            &srs,
-            &constraints,
+            constraints,
             Box::new([]),
             proof_inputs,
+            domain_size,
             &mut rng,
-        )
-        .unwrap();
-
-        let verifies = verify::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            SER_N_COLUMNS,
-            SER_N_COLUMNS,
-            0,
-            0,
-            0,
-            LookupTable<Ff1>,
-        >(
-            domain,
-            &srs,
-            &constraints,
-            Box::new([]),
-            &proof,
-            Witness::zero_vec(DOMAIN_SIZE),
         );
-        assert!(verifies)
     }
 }

--- a/msm/src/test/generic.rs
+++ b/msm/src/test/generic.rs
@@ -17,14 +17,10 @@ pub fn test_completeness_generic_only_relation<const N_REL: usize, RNG>(
 ) where
     RNG: RngCore + CryptoRng,
 {
-    let proof_inputs = ProofInputs {
-        evaluations,
-        logups: vec![],
-    };
-    test_completeness_generic::<N_REL, N_REL, 0, 0, LookupTableIDs, _>(
+    test_completeness_generic_no_lookups::<N_REL, N_REL, 0, 0, _>(
         constraints,
         Box::new([]),
-        proof_inputs,
+        evaluations,
         domain_size,
         rng,
     )

--- a/msm/src/test/generic.rs
+++ b/msm/src/test/generic.rs
@@ -1,0 +1,145 @@
+/// Generic test runners for prover/verifier.
+use crate::{
+    expr::E, logup::LookupTableID, lookups::LookupTableIDs, proof::ProofInputs, prover::prove,
+    verifier::verify, witness::Witness, BaseSponge, Fp, OpeningProof, ScalarSponge, BN254,
+};
+use ark_ff::{UniformRand, Zero};
+use kimchi::circuits::domains::EvaluationDomains;
+use poly_commitment::pairing_proof::PairingSRS;
+use rand::{CryptoRng, RngCore};
+
+/// No lookups, no selectors, only witness column. `N_WIT == N_REL`.
+pub fn test_completeness_generic_only_relation<const N_REL: usize, RNG>(
+    constraints: Vec<E<Fp>>,
+    evaluations: Witness<N_REL, Vec<Fp>>,
+    domain_size: usize,
+    rng: &mut RNG,
+) where
+    RNG: RngCore + CryptoRng,
+{
+    let proof_inputs = ProofInputs {
+        evaluations,
+        logups: vec![],
+    };
+    test_completeness_generic::<N_REL, N_REL, 0, 0, LookupTableIDs, _>(
+        constraints,
+        Box::new([]),
+        proof_inputs,
+        domain_size,
+        rng,
+    )
+}
+
+pub fn test_completeness_generic_no_lookups<
+    const N_WIT: usize,
+    const N_REL: usize,
+    const N_DSEL: usize,
+    const N_FSEL: usize,
+    RNG,
+>(
+    constraints: Vec<E<Fp>>,
+    fixed_selectors: Box<[Vec<Fp>; N_FSEL]>,
+    evaluations: Witness<N_WIT, Vec<Fp>>,
+    domain_size: usize,
+    rng: &mut RNG,
+) where
+    RNG: RngCore + CryptoRng,
+{
+    let proof_inputs = ProofInputs {
+        evaluations,
+        logups: vec![],
+    };
+    test_completeness_generic::<N_WIT, N_REL, N_DSEL, N_FSEL, LookupTableIDs, _>(
+        constraints,
+        fixed_selectors,
+        proof_inputs,
+        domain_size,
+        rng,
+    )
+}
+
+// Generic function to test with different circuits with the generic prover/verifier.
+// It doesn't use the interpreter to build the witness and compute the constraints.
+pub fn test_completeness_generic<
+    const N_WIT: usize,
+    const N_REL: usize,
+    const N_DSEL: usize,
+    const N_FSEL: usize,
+    LT: LookupTableID,
+    RNG,
+>(
+    constraints: Vec<E<Fp>>,
+    fixed_selectors: Box<[Vec<Fp>; N_FSEL]>,
+    proof_inputs: ProofInputs<N_WIT, Fp, LT>,
+    domain_size: usize,
+    rng: &mut RNG,
+) where
+    RNG: RngCore + CryptoRng,
+{
+    let domain = EvaluationDomains::<Fp>::create(domain_size).unwrap();
+
+    let mut srs: PairingSRS<BN254> = {
+        // Trusted setup toxic waste
+        let x = Fp::rand(rng);
+        PairingSRS::create(x, domain.d1.size as usize)
+    };
+    srs.full_srs.add_lagrange_basis(domain.d1);
+
+    let proof =
+        prove::<_, OpeningProof, BaseSponge, ScalarSponge, _, N_WIT, N_REL, N_DSEL, N_FSEL, LT>(
+            domain,
+            &srs,
+            &constraints,
+            fixed_selectors.clone(),
+            proof_inputs,
+            rng,
+        )
+        .unwrap();
+
+    {
+        // Checking the proof size. We should have:
+        // - N commitments for the columns
+        // - N evaluations for the columns
+        // - MAX_DEGREE - 1 commitments for the constraints (quotient polynomial)
+        // TODO: add lookups
+
+        // We check there is always only one commitment chunk
+        (&proof.proof_comms.witness_comms)
+            .into_iter()
+            .for_each(|x| assert_eq!(x.len(), 1));
+        // This equality is therefore trivial, but still doing it.
+        assert!(
+            (&proof.proof_comms.witness_comms)
+                .into_iter()
+                .fold(0, |acc, x| acc + x.len())
+                == N_WIT
+        );
+        // Checking that none of the commitments are zero
+        (&proof.proof_comms.witness_comms)
+            .into_iter()
+            .for_each(|v| v.elems.iter().for_each(|x| assert!(!x.is_zero())));
+
+        // Checking the number of chunks of the quotient polynomial
+        let max_degree = constraints
+            .iter()
+            .map(|c| c.degree(1, 0) as usize)
+            .max()
+            .unwrap();
+        if max_degree == 1 {
+            assert_eq!(proof.proof_comms.t_comm.len(), 1);
+        } else {
+            assert_eq!(proof.proof_comms.t_comm.len(), max_degree - 1);
+        }
+    }
+
+    let verifies =
+        verify::<_, OpeningProof, BaseSponge, ScalarSponge, N_WIT, N_REL, N_DSEL, N_FSEL, 0, LT>(
+            domain,
+            &srs,
+            &constraints,
+            fixed_selectors,
+            &proof,
+            Witness::zero_vec(domain_size),
+        );
+    assert!(verifies)
+}

--- a/msm/src/test/generic.rs
+++ b/msm/src/test/generic.rs
@@ -86,7 +86,7 @@ pub fn test_completeness_generic<
             &srs,
             &constraints,
             fixed_selectors.clone(),
-            proof_inputs,
+            proof_inputs.clone(),
             rng,
         )
         .unwrap();
@@ -115,15 +115,22 @@ pub fn test_completeness_generic<
             .for_each(|v| v.elems.iter().for_each(|x| assert!(!x.is_zero())));
 
         // Checking the number of chunks of the quotient polynomial
-        let max_degree = constraints
-            .iter()
-            .map(|c| c.degree(1, 0) as usize)
-            .max()
-            .unwrap();
+        let max_degree = {
+            if proof_inputs.logups.is_empty() {
+                constraints
+                    .iter()
+                    .map(|expr| expr.degree(1, 0))
+                    .max()
+                    .unwrap_or(0)
+            } else {
+                8
+            }
+        };
+
         if max_degree == 1 {
             assert_eq!(proof.proof_comms.t_comm.len(), 1);
         } else {
-            assert_eq!(proof.proof_comms.t_comm.len(), max_degree - 1);
+            assert_eq!(proof.proof_comms.t_comm.len(), max_degree as usize - 1);
         }
     }
 

--- a/msm/src/test/mod.rs
+++ b/msm/src/test/mod.rs
@@ -1,5 +1,7 @@
+pub mod generic;
 pub mod logup;
 pub mod proof_system;
 pub mod test_circuit;
 
-pub use proof_system::test_completeness_generic;
+// Reexport all the generic test functions.
+pub use generic::*;

--- a/msm/src/test/proof_system.rs
+++ b/msm/src/test/proof_system.rs
@@ -1,116 +1,16 @@
-/// Tests for the proof system: proving/verifying.
-use crate::{
-    expr::E, lookups::LookupTableIDs, proof::ProofInputs, prover::prove, verifier::verify,
-    witness::Witness, BaseSponge, Fp, OpeningProof, ScalarSponge, BN254,
-};
-use ark_ff::{UniformRand, Zero};
-use kimchi::circuits::domains::EvaluationDomains;
-use poly_commitment::pairing_proof::PairingSRS;
-use rand::{CryptoRng, RngCore};
-
-// Generic function to test with different circuits with the generic prover/verifier.
-// It doesn't use the interpreter to build the witness and compute the constraints.
-pub fn test_completeness_generic<const N: usize, const N_REL: usize, const N_DSEL: usize, RNG>(
-    constraints: Vec<E<Fp>>,
-    evaluations: Witness<N, Vec<Fp>>,
-    domain_size: usize,
-    rng: &mut RNG,
-) where
-    RNG: RngCore + CryptoRng,
-{
-    let domain = EvaluationDomains::<Fp>::create(domain_size).unwrap();
-
-    let mut srs: PairingSRS<BN254> = {
-        // Trusted setup toxic waste
-        let x = Fp::rand(rng);
-        PairingSRS::create(x, domain.d1.size as usize)
-    };
-    srs.full_srs.add_lagrange_basis(domain.d1);
-
-    let proof_inputs = ProofInputs {
-        evaluations,
-        logups: vec![],
-    };
-
-    let proof =
-        prove::<_, OpeningProof, BaseSponge, ScalarSponge, _, N, N_REL, N_DSEL, 0, LookupTableIDs>(
-            domain,
-            &srs,
-            &constraints,
-            Box::new([]),
-            proof_inputs,
-            rng,
-        )
-        .unwrap();
-
-    {
-        // Checking the proof size. We should have:
-        // - N commitments for the columns
-        // - N evaluations for the columns
-        // - MAX_DEGREE - 1 commitments for the constraints (quotient polynomial)
-        // TODO: add lookups
-
-        // We check there is always only one commitment chunk
-        (&proof.proof_comms.witness_comms)
-            .into_iter()
-            .for_each(|x| assert_eq!(x.len(), 1));
-        // This equality is therefore trivial, but still doing it.
-        assert!(
-            (&proof.proof_comms.witness_comms)
-                .into_iter()
-                .fold(0, |acc, x| acc + x.len())
-                == N
-        );
-        // Checking that none of the commitments are zero
-        (&proof.proof_comms.witness_comms)
-            .into_iter()
-            .for_each(|v| v.elems.iter().for_each(|x| assert!(!x.is_zero())));
-
-        // Checking the number of chunks of the quotient polynomial
-        let max_degree = constraints
-            .iter()
-            .map(|c| c.degree(1, 0) as usize)
-            .max()
-            .unwrap();
-        if max_degree == 1 {
-            assert_eq!(proof.proof_comms.t_comm.len(), 1);
-        } else {
-            assert_eq!(proof.proof_comms.t_comm.len(), max_degree - 1);
-        }
-    }
-
-    let verifies = verify::<
-        _,
-        OpeningProof,
-        BaseSponge,
-        ScalarSponge,
-        N,
-        N_REL,
-        N_DSEL,
-        0,
-        0,
-        LookupTableIDs,
-    >(
-        domain,
-        &srs,
-        &constraints,
-        Box::new([]),
-        &proof,
-        Witness::zero_vec(domain_size),
-    );
-    assert!(verifies)
-}
-
-// TODO: move tests from src/lib.rs into this file
-// TODO: use interpreter/witness/constraint files to define witness/cosntraints
+/// Tests for the proof system itself, targeting prover and verifier.
 
 #[cfg(test)]
 mod tests {
 
-    use super::*;
     use crate::{
         columns::Column,
-        expr::{self, E},
+        expr::{
+            E, {self},
+        },
+        test::test_completeness_generic_only_relation,
+        witness::Witness,
+        Fp,
     };
     use ark_ff::{Field, One, UniformRand};
     use kimchi::circuits::expr::{ConstantExpr, ConstantTerm};
@@ -183,7 +83,7 @@ mod tests {
             cols: Box::new([random_x0s, exp_x1]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic_only_relation::<N, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -219,7 +119,7 @@ mod tests {
             cols: Box::new([random_x0s, random_x1s, exp_x2]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic_only_relation::<N, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -264,7 +164,7 @@ mod tests {
             cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic_only_relation::<N, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -303,7 +203,7 @@ mod tests {
             cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic_only_relation::<N, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -336,7 +236,7 @@ mod tests {
             cols: Box::new([random_x0s, exp_x1]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic_only_relation::<N, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -379,7 +279,7 @@ mod tests {
             cols: Box::new([random_x0s, exp_x1, random_x2s, exp_x3]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic_only_relation::<N, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -434,7 +334,7 @@ mod tests {
             cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic_only_relation::<N, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,
@@ -489,7 +389,7 @@ mod tests {
             cols: Box::new([random_x0s, random_x1s, random_x2s, exp_x3]),
         };
 
-        test_completeness_generic::<N, N, 0, _>(
+        test_completeness_generic_only_relation::<N, _>(
             constraints.clone(),
             witness.clone(),
             domain_size,

--- a/msm/src/test/test_circuit/mod.rs
+++ b/msm/src/test/test_circuit/mod.rs
@@ -8,19 +8,13 @@ mod tests {
         columns::ColumnIndexer,
         logup::LookupTableID,
         lookups::DummyLookupTable,
-        precomputed_srs::get_bn254_srs,
-        prover::prove,
         test::test_circuit::{
             columns::{TestColumn, TEST_N_COLUMNS},
-            interpreter::{self as test_interpreter},
+            interpreter as test_interpreter,
         },
-        verifier::verify,
-        witness::Witness,
-        BaseSponge, Ff1, Fp, OpeningProof, ScalarSponge, BN254,
+        Ff1, Fp,
     };
     use ark_ff::UniformRand;
-    use kimchi::circuits::domains::EvaluationDomains;
-    use poly_commitment::pairing_proof::PairingSRS;
     use rand::{CryptoRng, Rng, RngCore};
     use std::collections::BTreeMap;
 
@@ -68,19 +62,10 @@ mod tests {
         // Include tests for completeness for Logup as the random witness
         // includes all arguments
         let domain_size = 1 << 8;
-        let domain = EvaluationDomains::<Fp>::create(domain_size).unwrap();
 
-        let srs: PairingSRS<BN254> = get_bn254_srs(domain);
-
-        let mut lookup_tables_data = BTreeMap::new();
-        for table_id in DummyLookupTable::all_variants().into_iter() {
-            lookup_tables_data.insert(table_id, table_id.entries(domain.d1.size));
-        }
         let witness_env =
             build_test_fixed_sel_circuit::<_, DummyLookupTable>(&mut rng, domain_size);
-        let mut proof_inputs = witness_env.get_proof_inputs(domain, lookup_tables_data);
-        // Don't use lookups for now
-        proof_inputs.logups = vec![];
+        let relation_witness = witness_env.get_relation_witness(domain_size);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_test_fixed_sel::<Fp, _>(&mut constraint_env);
@@ -90,50 +75,19 @@ mod tests {
         let fixed_selectors: Box<[Vec<Fp>; 1]> =
             Box::new([(0..domain_size).map(|i| Fp::from(i as u64)).collect()]);
 
-        // generate the proof
-        let proof = prove::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            _,
+        crate::test::test_completeness_generic_no_lookups::<
             { TEST_N_COLUMNS - 1 },
             { TEST_N_COLUMNS - 1 },
             0,
             1,
-            DummyLookupTable,
-        >(
-            domain,
-            &srs,
-            &constraints,
-            fixed_selectors.clone(),
-            proof_inputs,
-            &mut rng,
-        )
-        .unwrap();
-
-        // verify the proof
-        let verifies = verify::<
             _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            { TEST_N_COLUMNS - 1 },
-            { TEST_N_COLUMNS - 1 },
-            0,
-            1,
-            0,
-            DummyLookupTable,
         >(
-            domain,
-            &srs,
-            &constraints,
+            constraints,
             fixed_selectors,
-            &proof,
-            Witness::zero_vec(domain_size),
+            relation_witness,
+            domain_size,
+            &mut rng,
         );
-
-        assert!(verifies);
     }
 
     fn build_test_const_circuit<RNG: RngCore + CryptoRng, LT: LookupTableID>(
@@ -173,72 +127,31 @@ mod tests {
         // Include tests for completeness for Logup as the random witness
         // includes all arguments
         let domain_size = 1 << 8;
-        let domain = EvaluationDomains::<Fp>::create(domain_size).unwrap();
 
-        let srs: PairingSRS<BN254> = get_bn254_srs(domain);
-
-        let mut lookup_tables_data = BTreeMap::new();
-        for table_id in DummyLookupTable::all_variants().into_iter() {
-            lookup_tables_data.insert(table_id, table_id.entries(domain.d1.size));
-        }
         let (witness_env, constant) =
             build_test_const_circuit::<_, DummyLookupTable>(&mut rng, domain_size);
-        let mut proof_inputs = witness_env.get_proof_inputs(domain, lookup_tables_data);
-        // Don't use lookups for now
-        proof_inputs.logups = vec![];
+        let relation_witness = witness_env.get_relation_witness(domain_size);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_test_const::<Fp, _>(&mut constraint_env, constant);
-        // Don't use lookups for now
         let constraints = constraint_env.get_relation_constraints();
 
         let fixed_selectors: Box<[Vec<Fp>; 1]> =
             Box::new([(0..domain_size).map(|i| Fp::from(i as u64)).collect()]);
 
-        // generate the proof
-        let proof = prove::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            _,
+        crate::test::test_completeness_generic_no_lookups::<
             { TEST_N_COLUMNS - 1 },
             { TEST_N_COLUMNS - 1 },
             0,
             1,
-            DummyLookupTable,
-        >(
-            domain,
-            &srs,
-            &constraints,
-            fixed_selectors.clone(),
-            proof_inputs,
-            &mut rng,
-        )
-        .unwrap();
-
-        // verify the proof
-        let verifies = verify::<
             _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            { TEST_N_COLUMNS - 1 },
-            { TEST_N_COLUMNS - 1 },
-            0,
-            1,
-            0,
-            DummyLookupTable,
         >(
-            domain,
-            &srs,
-            &constraints,
+            constraints,
             fixed_selectors,
-            &proof,
-            Witness::zero_vec(domain_size),
+            relation_witness,
+            domain_size,
+            &mut rng,
         );
-
-        assert!(verifies);
     }
 
     fn build_test_mul_circuit<RNG: RngCore + CryptoRng, LT: LookupTableID>(
@@ -277,9 +190,6 @@ mod tests {
         // Include tests for completeness for Logup as the random witness
         // includes all arguments
         let domain_size = 1 << 8;
-        let domain = EvaluationDomains::<Fp>::create(domain_size).unwrap();
-
-        let srs: PairingSRS<BN254> = get_bn254_srs(domain);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_multiplication::<Fp, _>(&mut constraint_env);
@@ -289,59 +199,23 @@ mod tests {
         let fixed_selectors: Box<[Vec<Fp>; 1]> =
             Box::new([(0..domain_size).map(|i| Fp::from(i as u64)).collect()]);
 
-        let mut lookup_tables_data = BTreeMap::new();
-        for table_id in DummyLookupTable::all_variants().into_iter() {
-            lookup_tables_data.insert(table_id, table_id.entries(domain.d1.size));
-        }
         let witness_env = build_test_mul_circuit::<_, DummyLookupTable>(&mut rng, domain_size);
-        let mut proof_inputs = witness_env.get_proof_inputs(domain, lookup_tables_data);
-        // Don't use lookups for now
-        proof_inputs.logups = vec![];
 
-        // generate the proof
-        let proof = prove::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            _,
+        let relation_witness = witness_env.get_relation_witness(domain_size);
+
+        crate::test::test_completeness_generic_no_lookups::<
             { TEST_N_COLUMNS - 1 },
             { TEST_N_COLUMNS - 1 },
             0,
             1,
-            DummyLookupTable,
-        >(
-            domain,
-            &srs,
-            &constraints,
-            fixed_selectors.clone(),
-            proof_inputs,
-            &mut rng,
-        )
-        .unwrap();
-
-        // verify the proof
-        let verifies = verify::<
             _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            { TEST_N_COLUMNS - 1 },
-            { TEST_N_COLUMNS - 1 },
-            0,
-            1,
-            0,
-            DummyLookupTable,
         >(
-            domain,
-            &srs,
-            &constraints,
+            constraints,
             fixed_selectors,
-            &proof,
-            Witness::zero_vec(domain_size),
+            relation_witness,
+            domain_size,
+            &mut rng,
         );
-
-        assert!(verifies);
     }
 
     #[test]
@@ -349,158 +223,41 @@ mod tests {
         let mut rng = o1_utils::tests::make_test_rng();
 
         // We generate two different witness and two different proofs.
-        let domain_size = 1 << 8;
-        let domain = EvaluationDomains::<Fp>::create(domain_size).unwrap();
-
-        let srs: PairingSRS<BN254> = get_bn254_srs(domain);
+        let domain_size: usize = 1 << 8;
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_multiplication::<Fp, _>(&mut constraint_env);
-        // Don't use lookups for now
         let constraints = constraint_env.get_relation_constraints();
 
         let fixed_selectors: Box<[Vec<Fp>; 1]> =
             Box::new([(0..domain_size).map(|i| Fp::from(i as u64)).collect()]);
 
-        let mut lookup_tables_data = BTreeMap::new();
-        for table_id in DummyLookupTable::all_variants().into_iter() {
-            lookup_tables_data.insert(table_id, table_id.entries(domain.d1.size));
-        }
+        let lookup_tables_data = BTreeMap::new();
         let witness_env = build_test_mul_circuit::<_, DummyLookupTable>(&mut rng, domain_size);
-        let mut proof_inputs = witness_env.get_proof_inputs(domain, lookup_tables_data.clone());
+        let mut proof_inputs =
+            witness_env.get_proof_inputs(domain_size, lookup_tables_data.clone());
         proof_inputs.logups = vec![];
-
-        // generate the proof
-        let proof = prove::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            _,
-            { TEST_N_COLUMNS - 1 },
-            { TEST_N_COLUMNS - 1 },
-            0,
-            1,
-            DummyLookupTable,
-        >(
-            domain,
-            &srs,
-            &constraints,
-            fixed_selectors.clone(),
-            proof_inputs,
-            &mut rng,
-        )
-        .unwrap();
 
         let witness_env_prime =
             build_test_mul_circuit::<_, DummyLookupTable>(&mut rng, domain_size);
         let mut proof_inputs_prime =
-            witness_env_prime.get_proof_inputs(domain, lookup_tables_data.clone());
+            witness_env_prime.get_proof_inputs(domain_size, lookup_tables_data.clone());
         proof_inputs_prime.logups = vec![];
 
-        // generate another (prime) proof
-        let proof_prime = prove::<
-            _,
-            OpeningProof,
-            BaseSponge,
-            ScalarSponge,
-            _,
+        crate::test::test_soundness_generic::<
             { TEST_N_COLUMNS - 1 },
             { TEST_N_COLUMNS - 1 },
             0,
             1,
             DummyLookupTable,
+            _,
         >(
-            domain,
-            &srs,
-            &constraints,
-            fixed_selectors.clone(),
+            constraints,
+            fixed_selectors,
+            proof_inputs,
             proof_inputs_prime,
+            domain_size,
             &mut rng,
-        )
-        .unwrap();
-
-        // Swap the opening proof. The verification should fail.
-        {
-            let mut proof_clone = proof.clone();
-            proof_clone.opening_proof = proof_prime.opening_proof;
-            let verifies = verify::<
-                _,
-                OpeningProof,
-                BaseSponge,
-                ScalarSponge,
-                { TEST_N_COLUMNS - 1 },
-                { TEST_N_COLUMNS - 1 },
-                0,
-                1,
-                0,
-                DummyLookupTable,
-            >(
-                domain,
-                &srs,
-                &constraints,
-                fixed_selectors.clone(),
-                &proof_clone,
-                Witness::zero_vec(domain_size),
-            );
-            assert!(!verifies, "Proof with a swapped opening must fail");
-        }
-
-        // Changing at least one commitment in the proof should fail the verification.
-        // TODO: improve me by swapping only one commitments. It should be
-        // easier when an index trait is implemented.
-        {
-            let mut proof_clone = proof.clone();
-            proof_clone.proof_comms = proof_prime.proof_comms;
-            let verifies = verify::<
-                _,
-                OpeningProof,
-                BaseSponge,
-                ScalarSponge,
-                { TEST_N_COLUMNS - 1 },
-                { TEST_N_COLUMNS - 1 },
-                0,
-                1,
-                0,
-                DummyLookupTable,
-            >(
-                domain,
-                &srs,
-                &constraints,
-                fixed_selectors.clone(),
-                &proof_clone,
-                Witness::zero_vec(domain_size),
-            );
-            assert!(!verifies, "Proof with a swapped commitment must fail");
-        }
-
-        // Changing at least one evaluation at zeta in the proof should fail
-        // the verification.
-        // TODO: improve me by swapping only one evaluation at \zeta. It should be
-        // easier when an index trait is implemented.
-        {
-            let mut proof_clone = proof.clone();
-            proof_clone.proof_evals.witness_evals = proof_prime.proof_evals.witness_evals;
-            let verifies = verify::<
-                _,
-                OpeningProof,
-                BaseSponge,
-                ScalarSponge,
-                { TEST_N_COLUMNS - 1 },
-                { TEST_N_COLUMNS - 1 },
-                0,
-                1,
-                0,
-                DummyLookupTable,
-            >(
-                domain,
-                &srs,
-                &constraints,
-                fixed_selectors,
-                &proof_clone,
-                Witness::zero_vec(domain_size),
-            );
-            assert!(!verifies, "Proof with a swapped witness eval must fail");
-        }
+        );
     }
 }

--- a/o1vm/src/keccak/tests.rs
+++ b/o1vm/src/keccak/tests.rs
@@ -26,7 +26,7 @@ use kimchi::{
     circuits::polynomials::keccak::{constants::RATE_IN_BYTES, Keccak},
     o1_utils::{self, FieldHelpers, Two},
 };
-use kimchi_msm::test::test_completeness_generic;
+use kimchi_msm::test::test_completeness_generic_no_lookups;
 use rand::Rng;
 use sha3::{Digest, Keccak256};
 use std::collections::{BTreeMap, HashMap};
@@ -533,13 +533,15 @@ fn test_keccak_prover_constraints() {
 
         for step in Steps::iter().flat_map(|x| x.into_iter()) {
             if keccak_circuit.in_circuit(step) {
-                test_completeness_generic::<
+                test_completeness_generic_no_lookups::<
                     N_ZKVM_KECCAK_COLS,
                     N_ZKVM_KECCAK_REL_COLS,
                     N_ZKVM_KECCAK_SEL_COLS,
+                    0,
                     _,
                 >(
                     keccak_circuit[step].constraints.clone(),
+                    Box::new([]),
                     keccak_circuit[step].witness.clone(),
                     domain_size,
                     &mut rng,


### PR DESCRIPTION
Reduces test code duplication by using generic completeness and soundness tests.