### PR TITLE
Folding/tests: checking that commitments to error terms are non-zero

### DIFF
--- a/folding/tests/test_decomposable_folding.rs
+++ b/folding/tests/test_decomposable_folding.rs
@@ -1,5 +1,5 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_ff::{One, UniformRand};
+use ark_ff::{One, UniformRand, Zero};
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 use folding::{
     checker::{Checker, ExtendedProvider},
@@ -437,8 +437,18 @@ fn test_decomposable_folding() {
         let FoldingOutput {
             folded_instance,
             folded_witness,
-            ..
+            t_0,
+            t_1,
+            to_absorb: _,
         } = folded;
+
+        // Verifying that error terms are not points at infinity
+        // It doesn't test that the computation happens correctly, but at least
+        // show that there is some non trivial computation.
+        assert_eq!(t_0.len(), 1);
+        assert_eq!(t_1.len(), 1);
+        assert!(!t_0.elems[0].is_zero());
+        assert!(!t_1.elems[0].is_zero());
 
         let checker = ExtendedProvider::new(folded_instance, folded_witness);
         debug!("exp: \n {:#?}", final_constraint.to_string());

--- a/folding/tests/test_folding_with_quadriticization.rs
+++ b/folding/tests/test_folding_with_quadriticization.rs
@@ -1,7 +1,7 @@
 // this example is a copy of the decomposable folding one, but with a degree 3 gate
 // that triggers quadriticization
 use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_ff::UniformRand;
+use ark_ff::{UniformRand, Zero};
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 use folding::{
     checker::{Checker, ExtendedProvider},
@@ -438,8 +438,18 @@ fn test_quadriticization() {
         let FoldingOutput {
             folded_instance,
             folded_witness,
-            ..
+            t_0,
+            t_1,
+            to_absorb: _,
         } = folded;
+
+        // Verifying that error terms are not points at infinity
+        // It doesn't test that the computation happens correctly, but at least
+        // show that there is some non trivial computation.
+        assert_eq!(t_0.len(), 1);
+        assert_eq!(t_1.len(), 1);
+        assert!(!t_0.elems[0].is_zero());
+        assert!(!t_1.elems[0].is_zero());
 
         let checker = ExtendedProvider::new(folded_instance, folded_witness);
 

--- a/folding/tests/test_vanilla_folding.rs
+++ b/folding/tests/test_vanilla_folding.rs
@@ -451,9 +451,19 @@ fn test_folding_instance() {
     let FoldingOutput {
         folded_instance,
         folded_witness,
+        t_0,
+        t_1,
         to_absorb,
-        ..
     } = folded;
+
+    // Verifying that error terms are not points at infinity
+    // It doesn't test that the computation happens correctly, but at least
+    // show that there is some non trivial computation.
+    assert_eq!(t_0.len(), 1);
+    assert_eq!(t_1.len(), 1);
+    assert!(!t_0.elems[0].is_zero());
+    assert!(!t_1.elems[0].is_zero());
+
     // checking that we have the expected number of elements to absorb
     // 3+2 from each instance + 1 from u, times 2 instances
     assert_eq!(to_absorb.0.len(), (3 + 2 + 1) * 2);


### PR DESCRIPTION
It doesn't test that the computation happens correctly, but at least show that there is some non trivial computation.