### PR TITLE
Folding: make the variable name more explicits

### DIFF
--- a/folding/src/decomposable_folding.rs
+++ b/folding/src/decomposable_folding.rs
@@ -76,15 +76,16 @@ impl<'a, CF: FoldingConfig> DecomposableFoldingScheme<'a, CF> {
 
         let u = (a.0.u, b.0.u);
 
-        let (ins1, wit1) = a;
-        let (ins2, wit2) = b;
+        let (left_instance, left_witness) = a;
+        let (right_instance, right_witness) = b;
         let env = ExtendedEnv::new(
             &scheme.structure,
-            [ins1, ins2],
-            [wit1, wit2],
+            [left_instance, right_instance],
+            [left_witness, right_witness],
             scheme.domain,
             selector,
         );
+
         let env = env.compute_extension(&scheme.extended_witness_generator, scheme.srs);
         let error = compute_error(&scheme.expression, &env, u);
         let error_evals = error.map(|e| Evaluations::from_vec_and_domain(e, scheme.domain));
@@ -112,10 +113,24 @@ impl<'a, CF: FoldingConfig> DecomposableFoldingScheme<'a, CF> {
 
         let challenge = fq_sponge.challenge();
 
-        let ([ins1, ins2], [wit1, wit2]) = env.unwrap();
-        let folded_instance =
-            RelaxedInstance::combine_and_sub_error(ins1, ins2, challenge, &error_commitments);
-        let folded_witness = RelaxedWitness::combine_and_sub_error(wit1, wit2, challenge, error);
+        let (
+            [relaxed_extended_left_instance, relaxed_extended_right_instance],
+            [relaxed_extended_left_witness, relaxed_extended_right_witness],
+        ) = env.unwrap();
+
+        let folded_instance = RelaxedInstance::combine_and_sub_error(
+            relaxed_extended_left_instance,
+            relaxed_extended_right_instance,
+            challenge,
+            &error_commitments,
+        );
+
+        let folded_witness = RelaxedWitness::combine_and_sub_error(
+            relaxed_extended_left_witness,
+            relaxed_extended_right_witness,
+            challenge,
+            error,
+        );
         FoldingOutput {
             folded_instance,
             folded_witness,

--- a/folding/src/lib.rs
+++ b/folding/src/lib.rs
@@ -199,12 +199,12 @@ impl<'a, CF: FoldingConfig> FoldingScheme<'a, CF> {
 
         let u = (a.0.u, b.0.u);
 
-        let (ins1, wit1) = a;
-        let (ins2, wit2) = b;
+        let (left_instance, left_witness) = a;
+        let (right_instance, right_witness) = b;
         let env = ExtendedEnv::new(
             &self.structure,
-            [ins1, ins2],
-            [wit1, wit2],
+            [left_instance, right_instance],
+            [left_witness, right_witness],
             self.domain,
             None,
         );
@@ -235,10 +235,24 @@ impl<'a, CF: FoldingConfig> FoldingScheme<'a, CF> {
 
         let challenge = fq_sponge.challenge();
 
-        let ([ins1, ins2], [wit1, wit2]) = env.unwrap();
-        let folded_instance =
-            RelaxedInstance::combine_and_sub_error(ins1, ins2, challenge, &error_commitments);
-        let folded_witness = RelaxedWitness::combine_and_sub_error(wit1, wit2, challenge, error);
+        let (
+            [relaxed_extended_left_instance, relaxed_extended_right_instance],
+            [relaxed_extended_left_witness, relaxed_extended_right_witness],
+        ) = env.unwrap();
+
+        let folded_instance = RelaxedInstance::combine_and_sub_error(
+            relaxed_extended_left_instance,
+            relaxed_extended_right_instance,
+            challenge,
+            &error_commitments,
+        );
+
+        let folded_witness = RelaxedWitness::combine_and_sub_error(
+            relaxed_extended_left_witness,
+            relaxed_extended_right_witness,
+            challenge,
+            error,
+        );
         FoldingOutput {
             folded_instance,
             folded_witness,

--- a/folding/tests/test_vanilla_folding.rs
+++ b/folding/tests/test_vanilla_folding.rs
@@ -6,30 +6,26 @@
 /// ```text
 /// cargo nextest run test_folding_instance --release --all-features
 /// ```
-use crate::{FoldingOutput, FoldingScheme};
-use ark_poly::{EvaluationDomain, Evaluations, Radix2EvaluationDomain as D};
-use checker::{ExtendedProvider, Provider};
-use folding::*;
-use kimchi::curve::KimchiCurve;
-use mina_poseidon::FqSponge;
-use std::println as debug;
-
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{One, UniformRand, Zero};
-use ark_poly::Radix2EvaluationDomain;
+use ark_poly::{EvaluationDomain, Evaluations, Radix2EvaluationDomain};
+use checker::{ExtendedProvider, Provider};
 use folding::{
     checker::{Checker, Column, Provide},
     expressions::FoldingCompatibleExprInner,
     instance_witness::Foldable,
-    Alphas, ExpExtension, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, Instance,
-    RelaxedInstance, RelaxedWitness, Side, Witness,
+    Alphas, ExpExtension, FoldingCompatibleExpr, FoldingConfig, FoldingEnv, FoldingOutput,
+    FoldingScheme, Instance, RelaxedInstance, RelaxedWitness, Side, Witness,
 };
 use itertools::Itertools;
-use kimchi::circuits::{expr::Variable, gate::CurrOrNext};
+use kimchi::{
+    circuits::{expr::Variable, gate::CurrOrNext},
+    curve::KimchiCurve,
+};
+use mina_poseidon::{constants::PlonkSpongeConstantsKimchi, sponge::DefaultFqSponge, FqSponge};
 use poly_commitment::{srs::SRS, SRS as _};
 use rand::thread_rng;
-
-use mina_poseidon::{constants::PlonkSpongeConstantsKimchi, sponge::DefaultFqSponge};
+use std::println as debug;
 
 type Fp = ark_bn254::Fr;
 type Curve = ark_bn254::G1Affine;
@@ -379,7 +375,7 @@ mod checker {
 #[test]
 fn test_folding_instance() {
     let constraints = constraints();
-    let domain = D::<Fp>::new(2).unwrap();
+    let domain = Radix2EvaluationDomain::<Fp>::new(2).unwrap();
     let mut srs = poly_commitment::srs::SRS::<Curve>::create(2);
     srs.add_lagrange_basis(domain);
 


### PR DESCRIPTION
ins_i and wit_i variable names are reused. However, their semantics changed when
called compute_extension on the environment. The values contain the
commitments/evaluations added by quadriticization.

In a future PR, the values will be returned as part of the folded output to pass
them to the IVC circuit.