### PR TITLE
Folding: output the relaxed extended instances

### DIFF
--- a/folding/src/decomposable_folding.rs
+++ b/folding/src/decomposable_folding.rs
@@ -119,8 +119,9 @@ impl<'a, CF: FoldingConfig> DecomposableFoldingScheme<'a, CF> {
         ) = env.unwrap();
 
         let folded_instance = RelaxedInstance::combine_and_sub_error(
-            relaxed_extended_left_instance,
-            relaxed_extended_right_instance,
+            // FIXME: remove clone
+            relaxed_extended_left_instance.clone(),
+            relaxed_extended_right_instance.clone(),
             challenge,
             &error_commitments,
         );
@@ -136,6 +137,8 @@ impl<'a, CF: FoldingConfig> DecomposableFoldingScheme<'a, CF> {
             folded_witness,
             t_0: error_commitments[0].clone(),
             t_1: error_commitments[1].clone(),
+            relaxed_extended_left_instance,
+            relaxed_extended_right_instance,
             to_absorb,
         }
     }

--- a/folding/src/error_term.rs
+++ b/folding/src/error_term.rs
@@ -394,6 +394,10 @@ impl<CF: FoldingConfig> ExtendedEnv<CF> {
     }
 
     // FIXME: use reference to avoid indirect copying/cloning.
+    /// Computes the commitments of the columns added by quadriaticization, for
+    /// the given side.
+    /// The commitments are added to the instance, in the same order for both
+    /// side.
     fn compute_extended_commitments(mut self, srs: &CF::Srs, side: Side) -> Self {
         let (instance, witness) = match side {
             Side::Left => (&mut self.instances[0], &self.witnesses[0]),

--- a/folding/src/instance_witness.rs
+++ b/folding/src/instance_witness.rs
@@ -119,6 +119,8 @@ impl<G: CommitmentCurve, I: Instance<G>> ExtendedInstance<G, I> {
 /// quadriticization, the scalar `u` and a commitment to the
 /// slack/error term.
 /// See page 15 of [Nova](https://eprint.iacr.org/2021/370.pdf).
+// FIXME: We should forbid cloning, for memory footprint.
+#[derive(Clone)]
 pub struct RelaxedInstance<G: CommitmentCurve, I: Instance<G>> {
     /// The original instance, extended with the columns added by
     /// quadriticization
@@ -253,6 +255,8 @@ impl<G: CommitmentCurve, W: Witness<G>> ExtendedWitness<G, W> {
 }
 
 // -- Extended instance
+// FIXME: We should forbid cloning, for memory footprint.
+#[derive(Clone)]
 pub struct ExtendedInstance<G: CommitmentCurve, I: Instance<G>> {
     pub inner: I,
     /// Commitments to the extra columns added by quadraticization

--- a/folding/tests/test_decomposable_folding.rs
+++ b/folding/tests/test_decomposable_folding.rs
@@ -385,7 +385,11 @@ fn test_decomposable_folding() {
         let FoldingOutput {
             folded_instance,
             folded_witness,
-            ..
+            t_0: _,
+            t_1: _,
+            relaxed_extended_left_instance: _,
+            relaxed_extended_right_instance: _,
+            to_absorb: _,
         } = folded;
         let checker = ExtendedProvider::new(folded_instance, folded_witness);
         debug!("exp: \n {:#?}", final_constraint.to_string());
@@ -417,7 +421,11 @@ fn test_decomposable_folding() {
         let FoldingOutput {
             folded_instance,
             folded_witness,
-            ..
+            t_0: _,
+            t_1: _,
+            relaxed_extended_left_instance: _,
+            relaxed_extended_right_instance: _,
+            to_absorb: _,
         } = folded;
 
         let checker = ExtendedProvider::new(folded_instance, folded_witness);
@@ -439,6 +447,8 @@ fn test_decomposable_folding() {
             folded_witness,
             t_0,
             t_1,
+            relaxed_extended_left_instance: _,
+            relaxed_extended_right_instance: _,
             to_absorb: _,
         } = folded;
 

--- a/folding/tests/test_folding_with_quadriticization.rs
+++ b/folding/tests/test_folding_with_quadriticization.rs
@@ -440,6 +440,8 @@ fn test_quadriticization() {
             folded_witness,
             t_0,
             t_1,
+            relaxed_extended_left_instance: _,
+            relaxed_extended_right_instance: _,
             to_absorb: _,
         } = folded;
 

--- a/folding/tests/test_vanilla_folding.rs
+++ b/folding/tests/test_vanilla_folding.rs
@@ -449,6 +449,8 @@ fn test_folding_instance() {
         folded_witness,
         t_0,
         t_1,
+        relaxed_extended_left_instance: _,
+        relaxed_extended_right_instance: _,
         to_absorb,
     } = folded;
 


### PR DESCRIPTION
It is useful information to pass to the IVC circuit. I would suggest to improve the interface later.

Adding also documentation.

Regarding the usage of `clone`, I am not happy with it. It will imply a possible non-negligeable memory overhead. We should avoid this when the first version is released.