### PR TITLE
Folding: the number of additional columns should only be on the schem…

### DIFF
--- a/folding/src/decomposable_folding.rs
+++ b/folding/src/decomposable_folding.rs
@@ -1,7 +1,8 @@
 //! This variant of folding is designed to efficiently handle cases where
 //! certain assumptions about the witness can be made.
 //! Specifically, an alternative is provided such that the scheme is created
-//! from a set of list of constraints, each set associated with a particular selector, as opposed to a single list of constraints.
+//! from a set of list of constraints, each set associated with a particular
+//! selector, as opposed to a single list of constraints.
 
 use crate::{
     columns::ExtendedFoldingColumn,
@@ -23,13 +24,17 @@ impl<'a, CF: FoldingConfig> DecomposableFoldingScheme<'a, CF> {
     /// Creates a new folding scheme for decomposable circuits.
     /// It takes as input:
     /// - a set of constraints, each associated with a particular selector;
-    /// - a list of common constraints, that are applied to every instance regardless of the selector (can be empty);
+    /// - a list of common constraints, that are applied to every instance
+    /// regardless of the selector (can be empty);
     /// - a structured reference string;
     /// - a domain;
     /// - a structure of the associated folding configuration.
-    /// The function uses the normal `FoldingScheme::new()` function to create the decomposable scheme, using for that
-    /// the concatenation of the constraints associated with each selector multiplied by the selector, and the common constraints.
-    /// This product is performed with `FoldingCompatibleExprInner::Extensions(ExpExtension::Selector(s))`.
+    /// The function uses the normal `FoldingScheme::new()` function to create
+    /// the decomposable scheme, using for that the concatenation of the
+    /// constraints associated with each selector multiplied by the selector,
+    /// and the common constraints.
+    /// This product is performed with
+    /// `FoldingCompatibleExprInner::Extensions(ExpExtension::Selector(s))`.
     pub fn new(
         // constraints with a dynamic selector
         constraints: BTreeMap<CF::Selector, Vec<FoldingCompatibleExpr<CF>>>,
@@ -54,10 +59,16 @@ impl<'a, CF: FoldingConfig> DecomposableFoldingScheme<'a, CF> {
         (DecomposableFoldingScheme { inner }, exp)
     }
 
+    /// Return the number of additional columns added by quadraticization
+    pub fn get_number_of_additional_columns(&self) -> usize {
+        self.inner.get_number_of_additional_columns()
+    }
+
     #[allow(clippy::type_complexity)]
-    /// folding with a selector will assume that only the selector in question is enabled (1)
-    /// in all rows, and any other selector is 0 over all rows.
-    /// If that is not the case, providing None will fold without assumptions
+    /// folding with a selector will assume that only the selector in question
+    /// is enabled (i.e. set to 1) in all rows, and any other selector is 0 over
+    /// all rows.
+    /// If that is not the case, providing `None` will fold without assumptions
     pub fn fold_instance_witness_pair<A, B, Sponge>(
         &self,
         a: A,

--- a/folding/src/instance_witness.rs
+++ b/folding/src/instance_witness.rs
@@ -144,11 +144,6 @@ impl<G: CommitmentCurve, I: Instance<G>> RelaxedInstance<G, I> {
     pub fn get_extended_column_commitment(&self, i: usize) -> Option<&PolyComm<G>> {
         self.extended_instance.extended.get(i)
     }
-
-    /// Return the number of additional columns added by quadraticization
-    pub fn get_number_of_additional_columns(&self) -> usize {
-        self.extended_instance.extended.len()
-    }
 }
 
 // -- Relaxed witnesses

--- a/folding/src/lib.rs
+++ b/folding/src/lib.rs
@@ -177,8 +177,9 @@ impl<'a, CF: FoldingConfig> FoldingScheme<'a, CF> {
         };
         (scheme, final_expression)
     }
-    //the number of columns added by quadraticization to lower the degree
-    pub fn quadraticization_columns(&self) -> usize {
+
+    /// Return the number of additional columns added by quadraticization
+    pub fn get_number_of_additional_columns(&self) -> usize {
         self.quadraticization_columns
     }
 

--- a/folding/tests/test_quadraticization.rs
+++ b/folding/tests/test_quadraticization.rs
@@ -45,6 +45,7 @@ impl Foldable<Fp> for TestWitness {
 }
 
 impl Witness<Curve> for TestWitness {}
+
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 enum Col {
     A,
@@ -102,6 +103,7 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, Col, (), ()> for Env {
         todo!()
     }
 }
+
 fn degree_1_constraint(col: Col) -> FoldingCompatibleExpr<TestConfig> {
     let col = Variable {
         col,
@@ -109,13 +111,13 @@ fn degree_1_constraint(col: Col) -> FoldingCompatibleExpr<TestConfig> {
     };
     FoldingCompatibleExpr::Atom(FoldingCompatibleExprInner::Cell(col))
 }
+
 fn degree_n_constraint(n: usize, col: Col) -> FoldingCompatibleExpr<TestConfig> {
     match n {
-        //as I don't use it
         0 => {
-            panic!()
+            panic!("Degree 0 is not supposed to be used by the test suite.")
         }
-        //base case
+        // base case
         1 => degree_1_constraint(col),
         _ => {
             let one = degree_1_constraint(col);
@@ -124,14 +126,14 @@ fn degree_n_constraint(n: usize, col: Col) -> FoldingCompatibleExpr<TestConfig> 
         }
     }
 }
-//create 2 constraints of degree a and b
+// create 2 constraints of degree a and b
 fn constraints(a: usize, b: usize) -> Vec<FoldingCompatibleExpr<TestConfig>> {
     vec![
         degree_n_constraint(a, Col::A),
         degree_n_constraint(b, Col::B),
     ]
 }
-//creates and scheme with the constraints and returns the number of columns added
+// creates a scheme with the constraints and returns the number of columns added
 fn test_with_constraints(constraints: Vec<FoldingCompatibleExpr<TestConfig>>) -> usize {
     use ark_poly::EvaluationDomain;
 
@@ -141,10 +143,10 @@ fn test_with_constraints(constraints: Vec<FoldingCompatibleExpr<TestConfig>>) ->
 
     let (scheme, _) = FoldingScheme::<TestConfig>::new(constraints, &srs, domain, &());
     // println!("exp:\n {}", exp.to_string());
-    scheme.quadraticization_columns()
+    scheme.get_number_of_additional_columns()
 }
 
-//1 constraint of degree 1
+// 1 constraint of degree 1
 #[test]
 fn quadraticization_test_1() {
     let mut constraints = constraints(1, 1);
@@ -152,21 +154,23 @@ fn quadraticization_test_1() {
     assert_eq!(test_with_constraints(constraints), 0);
 }
 
-//1 constraint of degree 2
+// 1 constraint of degree 2
 #[test]
 fn quadraticization_test_2() {
     let mut constraints = constraints(2, 1);
     constraints.truncate(1);
     assert_eq!(test_with_constraints(constraints), 0);
 }
-//1 constraint of degree 3
+
+// 1 constraint of degree 3
 #[test]
 fn quadraticization_test_3() {
     let mut constraints = constraints(3, 1);
     constraints.truncate(1);
     assert_eq!(test_with_constraints(constraints), 1);
 }
-//1 constraint of degree 4 to 8 (as we usually support up to 8).
+
+// 1 constraint of degree 4 to 8 (as we usually support up to 8).
 #[test]
 fn quadraticization_test_4() {
     let cols = [2, 3, 4, 5, 6];
@@ -176,35 +180,39 @@ fn quadraticization_test_4() {
         assert_eq!(test_with_constraints(constraints), cols[i - 4]);
     }
 }
-//2 constraints of degree 1
+
+// 2 constraints of degree 1
 #[test]
 fn quadraticization_test_5() {
     let constraints = constraints(1, 1);
     assert_eq!(test_with_constraints(constraints), 0);
 }
-//2 constraints, one of degree 1 and one of degree 2
+
+// 2 constraints, one of degree 1 and one of degree 2
 #[test]
 fn quadraticization_test_6() {
     let constraints = constraints(1, 2);
     assert_eq!(test_with_constraints(constraints), 0);
 }
-//2 constraints: one of degree 1 and one of degree 3
+
+// 2 constraints: one of degree 1 and one of degree 3
 #[test]
 fn quadraticization_test_7() {
     let constraints = constraints(1, 3);
     assert_eq!(test_with_constraints(constraints), 1);
 }
-//2 constraints, each with degree higher than 2.
+
+// 2 constraints, each with degree higher than 2.
 #[test]
 fn quadraticization_test_8() {
     let constraints = constraints(4, 3);
     assert_eq!(test_with_constraints(constraints), 3);
 }
 
-//shared subexpression
+// shared subexpression
 #[test]
 fn quadraticization_test_9() {
-    //here I duplicate the first constraint
+    // here I duplicate the first constraint
     let mut constraints = constraints(3, 1);
     constraints.truncate(1);
     constraints.push(constraints[0].clone());

--- a/o1vm/src/keccak/tests.rs
+++ b/o1vm/src/keccak/tests.rs
@@ -710,7 +710,7 @@ fn test_keccak_folding() {
 
                 // We should always have 0 as the degree of the constraints,
                 // without selectors, they are never higher than 2 in Keccak.
-                assert_eq!(fout.folded_instance.get_number_of_additional_columns(), 0);
+                assert_eq!(scheme.get_number_of_additional_columns(), 0);
 
                 let checker = ExtendedProvider::new(fout.folded_instance, fout.folded_witness);
                 checker.check(&final_constraint, domain);
@@ -727,7 +727,7 @@ fn test_keccak_folding() {
                 let fout =
                     scheme.fold_instance_witness_pair(left.clone(), right.clone(), step, fq_sponge);
 
-                let extra_cols = fout.folded_instance.get_number_of_additional_columns();
+                let extra_cols = scheme.get_number_of_additional_columns();
                 if let Some(quadri_cols) = quadri_cols {
                     assert!(extra_cols == quadri_cols);
                 }


### PR DESCRIPTION
…e level

Previously, we could get the number of additional columns on a relaxed instance object.

However, this is not the appropriate solution, and it duplicates a method already existing on the scheme level.

This commit cleans the interface to unify.

Also, enforce 80 characters per line.