### PR TITLE
Optimize syscall lookups by sharing the bytes vector

### DIFF
--- a/o1vm/src/mips/column.rs
+++ b/o1vm/src/mips/column.rs
@@ -24,12 +24,10 @@ pub(crate) const MIPS_END_OF_PREIMAGE_OFF: usize = 82;
 pub(crate) const MIPS_NUM_BYTES_READ_OFF: usize = 83;
 /// The at most 4-byte chunk of the preimage that has been read in this step
 pub(crate) const MIPS_PREIMAGE_CHUNK_OFF: usize = 84;
-/// The at most 4-bytes of the preimage that are currently being processed
-pub(crate) const MIPS_PREIMAGE_BYTES_OFF: usize = 85;
-/// The at most 4-bytes of the length that are currently being processed
-pub(crate) const MIPS_LENGTH_BYTES_OFF: usize = 89;
+/// The at most 4-bytes that are currently being processed
+pub(crate) const MIPS_ORACLE_BYTES_OFF: usize = 85;
 /// Flags indicating whether at least N bytes have been processed in this step
-pub(crate) const MIPS_HAS_N_BYTES_OFF: usize = 93;
+pub(crate) const MIPS_HAS_N_BYTES_OFF: usize = 89;
 /// The maximum size of a chunk (4 bytes)
 pub(crate) const MIPS_CHUNK_BYTES_LEN: usize = 4;
 

--- a/o1vm/src/mips/witness.rs
+++ b/o1vm/src/mips/witness.rs
@@ -9,8 +9,7 @@ use crate::{
         column::{
             ColumnAlias as Column, MIPS_BYTE_COUNTER_OFF, MIPS_CHUNK_BYTES_LEN,
             MIPS_END_OF_PREIMAGE_OFF, MIPS_HASH_COUNTER_OFF, MIPS_HAS_N_BYTES_OFF,
-            MIPS_LENGTH_BYTES_OFF, MIPS_NUM_BYTES_READ_OFF, MIPS_PREIMAGE_BYTES_OFF,
-            MIPS_PREIMAGE_CHUNK_OFF,
+            MIPS_NUM_BYTES_READ_OFF, MIPS_ORACLE_BYTES_OFF, MIPS_PREIMAGE_CHUNK_OFF,
         },
         interpreter::{
             self, ITypeInstruction, Instruction, InterpreterEnv, JTypeInstruction, RTypeInstruction,
@@ -34,8 +33,8 @@ pub const NUM_INSTRUCTION_LOOKUP_TERMS: usize = 5;
 pub const NUM_LOOKUP_TERMS: usize =
     NUM_GLOBAL_LOOKUP_TERMS + NUM_DECODING_LOOKUP_TERMS + NUM_INSTRUCTION_LOOKUP_TERMS;
 // TODO: Delete and use a vector instead
-pub const SCRATCH_SIZE: usize = 97; // MIPS + hash_counter + byte_counter + eof + num_bytes_read + chunk + bytes + length + has_n_bytes
-
+// MIPS + hash_counter + byte_counter + eof + num_bytes_read + chunk + bytes + has_n_bytes
+pub const SCRATCH_SIZE: usize = 93;
 #[derive(Clone, Default)]
 pub struct SyscallEnv {
     pub last_hint: Option<Vec<u8>>,
@@ -650,7 +649,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
 
                 // Write the individual byte of the length to the witness
                 self.write_column(
-                    Column::ScratchState(MIPS_LENGTH_BYTES_OFF + len_i),
+                    Column::ScratchState(MIPS_ORACLE_BYTES_OFF + len_i),
                     length_byte as u64,
                 );
 
@@ -670,7 +669,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
 
                 // Write the individual byte of the preimage to the witness
                 self.write_column(
-                    Column::ScratchState(MIPS_PREIMAGE_BYTES_OFF + byte_i),
+                    Column::ScratchState(MIPS_ORACLE_BYTES_OFF + byte_i),
                     preimage_byte as u64,
                 );
 
@@ -704,7 +703,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
             preimage_read_len,
         );
 
-        // Update the flags to count how many bytes are contained at least
+        // Update flags to count how many preimage bytes are contained at least
         for i in 0..MIPS_CHUNK_BYTES_LEN {
             if preimage_read_len > i as u64 {
                 // This amount is only nonzero when it has read some preimage


### PR DESCRIPTION
This PR addresses the concern I raised in https://github.com/o1-labs/proof-systems/pull/2276 about reducing the number of witness columns and lookups required to constrain that the bytes read from the oracle are indeed 8-bits long.

After having tested the behavior of the oracle using our demo, I realized that it always reads the 8 leading bytes corresponding to the preimage length in two instructions reading 4 bytes in each row. This means, it never shares both length bytes with preimage bytes in the same row. 

This simplifies the approach in the previous PR, because now we checked that the vector of bytes can contain length bytes (always 4) or preimage bytes (at most 4). The rest remains unchanged, meaning `has_n_bytes` still refers to preimage bytes. Keeping that meaning results in no changes required for the constraints. And more importantly, this allows us to bring down the number of extra lookups from 8 to 4 per `SyscallReadPreimage` instruction. 