### PR TITLE
Unit test for `Load16`

### DIFF
--- a/o1vm/src/mips/interpreter.rs
+++ b/o1vm/src/mips/interpreter.rs
@@ -648,6 +648,7 @@ pub trait InterpreterEnv {
         res
     }
 
+    /// Returns 1 if `x` is equal to `y`, or 0 otherwise, storing the result in `position`.
     fn equal(&mut self, x: &Self::Variable, y: &Self::Variable) -> Self::Variable {
         self.is_zero(&(x.clone() - y.clone()))
     }
@@ -888,6 +889,8 @@ pub trait InterpreterEnv {
 
     fn set_halted(&mut self, flag: Self::Variable);
 
+    /// Given a variable `x`, this function extends it to a signed integer of
+    /// `bitlength` bits.
     fn sign_extend(&mut self, x: &Self::Variable, bitlength: u32) -> Self::Variable {
         // FIXME: Constrain `high_bit`
         let high_bit = {
@@ -1323,14 +1326,15 @@ pub fn interpret_rtype<Env: InterpreterEnv>(env: &mut Env, instr: RTypeInstructi
             let fd_id = env.read_register(&Env::constant(4));
             let fd_cmd = env.read_register(&Env::constant(5));
             let is_getfl = env.equal(&fd_cmd, &Env::constant(3));
+            let is_stdin = env.equal(&fd_id, &Env::constant(FD_STDIN));
             let is_stdout = env.equal(&fd_id, &Env::constant(FD_STDOUT));
             let is_stderr = env.equal(&fd_id, &Env::constant(FD_STDERR));
-            let is_preimage_write = env.equal(&fd_id, &Env::constant(FD_PREIMAGE_WRITE));
-            let is_hint_write = env.equal(&fd_id, &Env::constant(FD_HINT_WRITE));
-            let is_stdin = env.equal(&fd_id, &Env::constant(FD_STDIN));
-            let is_preimage_read = env.equal(&fd_id, &Env::constant(FD_PREIMAGE_READ));
             let is_hint_read = env.equal(&fd_id, &Env::constant(FD_HINT_READ));
+            let is_hint_write = env.equal(&fd_id, &Env::constant(FD_HINT_WRITE));
+            let is_preimage_read = env.equal(&fd_id, &Env::constant(FD_PREIMAGE_READ));
+            let is_preimage_write = env.equal(&fd_id, &Env::constant(FD_PREIMAGE_WRITE));
 
+            // These variables are 1 if the condition is true, and 0 otherwise.
             let is_read = is_stdin + is_preimage_read + is_hint_read;
             let is_write = is_stdout + is_stderr + is_preimage_write + is_hint_write;
 

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -320,6 +320,39 @@ mod unit {
         }
 
         #[test]
+        fn test_unit_load16_instruction() {
+            let mut rng = o1_utils::tests::make_test_rng();
+            // lh instruction
+            let mut dummy_env = dummy_env(&mut rng);
+            // Instruction: 0b100001 11101 00100 00000 00000 000000 lh $a0, 0(29) a0 = 4
+            // Random address in SP Address has only one index
+
+            let addr: u32 = rng.gen_range(0u32..100u32);
+            let aligned_addr: u32 = (addr / 4) * 4;
+            dummy_env.registers[29] = aligned_addr;
+            let mem = &dummy_env.memory[0];
+            let mem = &mem.1;
+            let v0 = mem[aligned_addr as usize];
+            let v1 = mem[(aligned_addr + 1) as usize];
+            let v = ((v0 as u32) << 8) + (v1 as u32);
+            let high_bit = (v >> 15) & 1;
+            let exp_v = high_bit * (((1 << 16) - 1) << 16) + v;
+            write_instruction(
+                &mut dummy_env,
+                InstructionParts {
+                    op_code: 0b100001,
+                    rs: 0b11101,
+                    rt: 0b00100,
+                    rd: 0b00000,
+                    shamt: 0b00000,
+                    funct: 0b000000,
+                },
+            );
+            interpret_itype(&mut dummy_env, ITypeInstruction::Load16);
+            assert_eq!(dummy_env.registers.general_purpose[4], exp_v);
+        }
+
+        #[test]
         fn test_unit_load32_instruction() {
             let mut rng = o1_utils::tests::make_test_rng();
             // lw instruction

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -330,7 +330,7 @@ mod unit {
 
         #[test]
         fn test_unit_load16_instruction() {
-            let mut rng = o1_utils::tests::make_test_rng();
+            let mut rng = o1_utils::tests::make_test_rng(None);
             // lh instruction
             let mut dummy_env = dummy_env(&mut rng);
             // Instruction: 0b100001 11101 00100 00000 00000 000000 lh $a0, 0(29) a0 = 4


### PR DESCRIPTION
This PR makes some progress on top of the tracking issue https://github.com/o1-labs/proof-systems/issues/2075. 

In particular, because I didn't find any `Load16` instruction in the MIPS demo for the block I was testing, I added a unit test for `lh` replicating the one for `lw` done by @dannywillems some days ago. This way, we can have some certainty that the witness generated behaves as expected from the constraints.