### PR TITLE
Unit test for `LoadWordRight`

### DIFF
--- a/o1vm/src/mips/interpreter.rs
+++ b/o1vm/src/mips/interpreter.rs
@@ -2147,7 +2147,7 @@ pub fn interpret_itype<Env: InterpreterEnv>(env: &mut Env, instr: ITypeInstructi
             let overwrite_2 = env.equal(&byte_subaddr, &Env::constant(1)) + overwrite_1.clone();
             let overwrite_3 = env.equal(&byte_subaddr, &Env::constant(0)) + overwrite_2.clone();
 
-            // The `-3` here feels odd, but simulates the `<< 24` in cannon, and matches the
+            // The `-3` here feels odd, but simulates the `>> 24` in cannon, and matches the
             // behavior defined in the spec.
             // See e.g. 'MIPS IV Instruction Set' Rev 3.2, Table A-31 for reference.
             let m0 = env.read_memory(&(addr.clone() - Env::constant(3)));

--- a/o1vm/src/mips/interpreter.rs
+++ b/o1vm/src/mips/interpreter.rs
@@ -2169,7 +2169,8 @@ pub fn interpret_itype<Env: InterpreterEnv>(env: &mut Env, instr: ITypeInstructi
             let m2 = env.read_memory(&(addr.clone() - Env::constant(1)));
             let m3 = env.read_memory(&addr);
 
-            let [r0, r1, r2, _r3] = {
+            // No need to compute r3 as bitmask(reg,8,0,pos) as it is not used
+            let [r0, r1, r2] = {
                 let initial_register_value = env.read_register(&rt);
                 [
                     {
@@ -2186,11 +2187,6 @@ pub fn interpret_itype<Env: InterpreterEnv>(env: &mut Env, instr: ITypeInstructi
                         // FIXME: Requires a range check
                         let pos = env.alloc_scratch();
                         unsafe { env.bitmask(&initial_register_value, 16, 8, pos) }
-                    },
-                    {
-                        // FIXME: Requires a range check
-                        let pos = env.alloc_scratch();
-                        unsafe { env.bitmask(&initial_register_value, 8, 0, pos) }
                     },
                 ]
             };

--- a/o1vm/src/mips/interpreter.rs
+++ b/o1vm/src/mips/interpreter.rs
@@ -2160,9 +2160,14 @@ pub fn interpret_itype<Env: InterpreterEnv>(env: &mut Env, instr: ITypeInstructi
 
             // The `-3` here feels odd, but simulates the `>> 24` in cannon, and matches the
             // behavior defined in the spec.
+            //
             // See e.g. 'MIPS IV Instruction Set' Rev 3.2, Table A-31 for reference.
             // Because we shift the bytes in memory to the right, we need to access smaller
             // addresses of memory.
+            //
+            // From docs: "EffAddr is the address of the least-significant of
+            //             four consecutive bytes word in memory"
+            //
             // Big-endian notation here
             let m0 = env.read_memory(&(addr.clone() - Env::constant(3)));
             let m1 = env.read_memory(&(addr.clone() - Env::constant(2)));

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -244,7 +244,8 @@ mod unit {
     }
 
     pub(crate) fn bitmask(x: u32, highest_bit: u32, lowest_bit: u32) -> u32 {
-        let res = (x >> lowest_bit) as u64 & (2u64.pow(highest_bit - lowest_bit) - 1);
+        let res =
+            ((x as u64) >> (lowest_bit as u64)) & ((1 << ((highest_bit - lowest_bit) as u64)) - 1);
         res as u32
     }
 
@@ -261,6 +262,7 @@ mod unit {
     fn test_bitmask() {
         assert_eq!(bitmask(0xaf, 8, 0), 0xaf);
         assert_eq!(bitmask(0x3671e4cb, 32, 0), 0x3671e4cb);
+        assert_eq!(bitmask(0x81938da4, 32, 32), 0);
     }
 
     #[test]
@@ -506,7 +508,7 @@ mod unit {
             // The final value that should be in the register after LWR
             // corresponds to the n_left bytes followed by the n_right bytes
 
-            let exp_v = (left << (8 * n_right)) + right;
+            let exp_v = ((left as u64) << (8 * n_right as u64)) + right as u64;
 
             write_instruction(
                 &mut dummy_env,
@@ -521,7 +523,7 @@ mod unit {
             );
             interpret_itype(&mut dummy_env, ITypeInstruction::LoadWordRight);
 
-            assert_eq!(dummy_env.registers[dst], exp_v);
+            assert_eq!(dummy_env.registers[dst] as u64, exp_v);
         }
     }
 }

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -238,9 +238,20 @@ mod unit {
         env.memory[page as usize].1[page_address + 3] = (instr & 0xFF) as u8;
     }
 
+    pub(crate) fn bitmask(x: u32, highest_bit: u32, lowest_bit: u32) -> u32 {
+        let res = (x >> lowest_bit) as u64 & (2u64.pow(highest_bit - lowest_bit) - 1);
+        res as u32
+    }
+
     pub(crate) fn sign_extend(x: u32, bitlength: u32) -> u32 {
         let high_bit = (x >> (bitlength - 1)) & 1;
         high_bit * (((1 << (32 - bitlength)) - 1) << bitlength) + x
+    }
+
+    #[test]
+    fn test_bitmask() {
+        assert_eq!(bitmask(0xaf, 8, 0), 0xaf);
+        assert_eq!(bitmask(0x3671e4cb, 32, 0), 0x3671e4cb);
     }
 
     #[test]

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -238,20 +238,14 @@ mod unit {
         env.memory[page as usize].1[page_address + 3] = (instr & 0xFF) as u8;
     }
 
-    pub(crate) fn bitmask(x: u32, highest_bit: u32, lowest_bit: u32) -> u32 {
-        let res = (x >> lowest_bit) as u64 & (2u64.pow(highest_bit - lowest_bit) - 1);
-        res as u32
-    }
-
     pub(crate) fn sign_extend(x: u32, bitlength: u32) -> u32 {
         let high_bit = (x >> (bitlength - 1)) & 1;
         high_bit * (((1 << (32 - bitlength)) - 1) << bitlength) + x
     }
 
-    #[test]
-    fn test_bitmask() {
-        assert_eq!(bitmask(0xaf, 8, 0), 0xaf);
-        assert_eq!(bitmask(0x3671e4cb, 32, 0), 0x3671e4cb);
+    pub(crate) fn bitmask(x: u32, highest_bit: u32, lowest_bit: u32) -> u32 {
+        let res = (x >> lowest_bit) as u64 & (2u64.pow(highest_bit - lowest_bit) - 1);
+        res as u32
     }
 
     #[test]
@@ -261,6 +255,12 @@ mod unit {
             sign_extend(0b1001_0110_0000_0000, 16),
             0b1111_1111_1111_1111_1001_0110_0000_0000
         );
+    }
+
+    #[test]
+    fn test_bitmask() {
+        assert_eq!(bitmask(0xaf, 8, 0), 0xaf);
+        assert_eq!(bitmask(0x3671e4cb, 32, 0), 0x3671e4cb);
     }
 
     #[test]

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -153,8 +153,8 @@ mod unit {
     {
         let dummy_preimage_oracle = OnDiskPreImageOracle;
         let mut env = WEnv {
-            // Set it to 2 to run 1 instruction that access registers if
-            instruction_counter: 2,
+            // Set it to an arbitrary "large" number
+            instruction_counter: 10,
             // Only 8kb of memory (two PAGE_ADDRESS_SIZE)
             memory: vec![
                 // Read/write memory

--- a/o1vm/src/mips/witness.rs
+++ b/o1vm/src/mips/witness.rs
@@ -617,7 +617,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
         println!(
             "Exited with code {} at step {}",
             *exit_code,
-            self.instruction_counter / MAX_ACC
+            self.instruction_counter_normalized()
         );
     }
 
@@ -1065,6 +1065,18 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
         (opcode, instruction)
     }
 
+    /// Because MAX_NB_REG_ACC = 7 and MAX_NB_MEM_ACC = 12, at most the same
+    /// instruction will increase the instruction counter by MAX_ACC = 19.
+    ///
+    /// NOTE: actually, in practice it will be less than that, as there is no
+    ///       single instruction that performs all of them.
+    ///
+    /// This means that the actual number of instructions executed will result
+    /// from dividing the instruction counter by MAX_ACC (floor).
+    pub fn instruction_counter_normalized(&self) -> u64 {
+        self.instruction_counter / MAX_ACC
+    }
+
     /// Updates the instruction counter, accounting for the maximum number of
     /// register and memory accesses per instruction.
     /// Because MAX_NB_REG_ACC = 7 and MAX_NB_MEM_ACC = 12, at most the same
@@ -1080,7 +1092,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
     /// the real instruction counter and multiply it by MAX_ACC to have a unique
     /// representation of each step (which is helpful for debugging).
     pub fn update_instruction_counter(&mut self) {
-        self.instruction_counter = ((self.instruction_counter / MAX_ACC) + 1) * MAX_ACC;
+        self.instruction_counter = (self.instruction_counter_normalized() + 1) * MAX_ACC;
     }
 
     /// Execute a single step of the MIPS program.
@@ -1102,7 +1114,8 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
             self.halt = true;
             println!(
                 "Halted as requested at step={} instruction={:?}",
-                self.instruction_counter, opcode
+                self.instruction_counter_normalized(),
+                opcode
             );
             return opcode;
         }
@@ -1115,7 +1128,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
         if self.halt {
             println!(
                 "Halted at step={} instruction={:?}",
-                self.instruction_counter / MAX_ACC,
+                self.instruction_counter_normalized(),
                 opcode
             );
         }
@@ -1123,7 +1136,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
     }
 
     fn should_trigger_at(&self, at: &StepFrequency) -> bool {
-        let m: u64 = self.instruction_counter;
+        let m: u64 = self.instruction_counter_normalized();
         match at {
             StepFrequency::Never => false,
             StepFrequency::Always => true,
@@ -1199,7 +1212,8 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
             let _ = serde_json::to_writer(&mut writer, &s);
             info!(
                 "Snapshot state in {}, step {}",
-                filename, self.instruction_counter
+                filename,
+                self.instruction_counter_normalized()
             );
             writer.flush().expect("Flush writer failing")
         }
@@ -1209,7 +1223,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
         if self.should_trigger_at(at) {
             let elapsed = start.time.elapsed();
             // Compute the step number removing the MAX_ACC factor
-            let step = self.instruction_counter / MAX_ACC;
+            let step = self.instruction_counter_normalized();
             let pc = self.registers.current_instruction_pointer;
 
             // Get the 32-bits opcode

--- a/o1vm/src/mips/witness.rs
+++ b/o1vm/src/mips/witness.rs
@@ -616,7 +616,8 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
     fn report_exit(&mut self, exit_code: &Self::Variable) {
         println!(
             "Exited with code {} at step {}",
-            *exit_code, self.instruction_counter
+            *exit_code,
+            self.instruction_counter / MAX_ACC
         );
     }
 


### PR DESCRIPTION
Fixes interpreter to behave like Cannon.