### PR TITLE
Folding: handling blinders

### DIFF
--- a/folding/src/error_term.rs
+++ b/folding/src/error_term.rs
@@ -419,6 +419,12 @@ impl<CF: FoldingConfig> ExtendedEnv<CF> {
     /// the given side.
     /// The commitments are added to the instance, in the same order for both
     /// side.
+    /// Note that this function is only going to be called on the left instance
+    /// once. When we fold the second time, the left instance will already be
+    /// relaxed and will have the extended columns.
+    /// Therefore, the blinder is always the one provided by the user, and it is
+    /// saved in the field `blinder` in the case of a relaxed instance that has
+    /// been built from a non-relaxed one.
     fn compute_extended_commitments(mut self, srs: &CF::Srs, side: Side) -> Self {
         let (relaxed_instance, relaxed_witness) = match side {
             Side::Left => (&mut self.instances[0], &self.witnesses[0]),

--- a/folding/src/expressions.rs
+++ b/folding/src/expressions.rs
@@ -256,6 +256,17 @@
 //! T'' = T + r T'
 //! u'' = u + r u'
 //! ```
+//!
+//! ## Supporting polynomial commitment blinders
+//!
+//! The library also supports polynomial commitment blinders. The blinding
+//! factors are represented as new variables in the polynomial describing the NP
+//! relation. The blinding factors are then aggregated in the same way as the
+//! other variables.
+//! We want to support blinders in the polynomial commitment scheme to avoid
+//! committing to the zero zero polynomial. Using a blinder, we can always
+//! suppose that our elliptic curves points are not the point at infinity.
+//! The library handles the blinding factors as variables in each instance.
 
 use crate::{
     columns::ExtendedFoldingColumn,

--- a/folding/src/expressions.rs
+++ b/folding/src/expressions.rs
@@ -267,6 +267,9 @@
 //! committing to the zero zero polynomial. Using a blinder, we can always
 //! suppose that our elliptic curves points are not the point at infinity.
 //! The library handles the blinding factors as variables in each instance.
+//!
+//! When doing the final proof, the blinder factor that will need to be used is
+//! the one from the final relaxed instance.
 
 use crate::{
     columns::ExtendedFoldingColumn,

--- a/folding/tests/test_decomposable_folding.rs
+++ b/folding/tests/test_decomposable_folding.rs
@@ -61,6 +61,8 @@ pub struct TestInstance {
     challenges: [Fp; 3],
     // also challenges, but segregated as folding gives them special treatment
     alphas: Alphas<Fp>,
+    // Used for the blinding factor in the commitment
+    blinder: Fp,
 }
 
 impl Foldable<Fp> for TestInstance {
@@ -71,6 +73,7 @@ impl Foldable<Fp> for TestInstance {
             }),
             challenges: std::array::from_fn(|i| a.challenges[i] + challenge * b.challenges[i]),
             alphas: Alphas::combine(a.alphas, b.alphas, challenge),
+            blinder: a.blinder + challenge * b.blinder,
         }
     }
 }
@@ -83,6 +86,10 @@ impl Instance<Curve> for TestInstance {
 
     fn get_alphas(&self) -> &Alphas<Fp> {
         &self.alphas
+    }
+
+    fn get_blinder(&self) -> Fp {
+        self.blinder
     }
 }
 
@@ -263,10 +270,12 @@ fn instance_from_witness(
     let challenges = [(); 3].map(|_| challenge());
     let alpha = challenge();
     let alphas = Alphas::new(alpha);
+    let blinder = Fp::one();
     TestInstance {
         commitments,
         challenges,
         alphas,
+        blinder,
     }
 }
 

--- a/folding/tests/test_folding_with_quadriticization.rs
+++ b/folding/tests/test_folding_with_quadriticization.rs
@@ -1,7 +1,7 @@
 // this example is a copy of the decomposable folding one, but with a degree 3 gate
 // that triggers quadriticization
 use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_ff::{UniformRand, Zero};
+use ark_ff::{One, UniformRand, Zero};
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 use folding::{
     checker::{Checker, ExtendedProvider},
@@ -61,6 +61,8 @@ pub struct TestInstance {
     challenges: [Fp; 3],
     // also challenges, but segregated as folding gives them special treatment
     alphas: Alphas<Fp>,
+    // To blind the commitments,
+    blinder: Fp,
 }
 
 impl Foldable<Fp> for TestInstance {
@@ -71,6 +73,7 @@ impl Foldable<Fp> for TestInstance {
             }),
             challenges: std::array::from_fn(|i| a.challenges[i] + challenge * b.challenges[i]),
             alphas: Alphas::combine(a.alphas, b.alphas, challenge),
+            blinder: a.blinder + challenge * b.blinder,
         }
     }
 }
@@ -83,6 +86,10 @@ impl Instance<Curve> for TestInstance {
 
     fn get_alphas(&self) -> &Alphas<Fp> {
         &self.alphas
+    }
+
+    fn get_blinder(&self) -> Fp {
+        self.blinder
     }
 }
 
@@ -263,10 +270,12 @@ fn instance_from_witness(
     let challenges = [(); 3].map(|_| challenge());
     let alpha = challenge();
     let alphas = Alphas::new(alpha);
+    let blinder = Fp::one();
     TestInstance {
         commitments,
         challenges,
         alphas,
+        blinder,
     }
 }
 

--- a/folding/tests/test_quadraticization.rs
+++ b/folding/tests/test_quadraticization.rs
@@ -37,6 +37,10 @@ impl Instance<Curve> for TestInstance {
     fn to_absorb(&self) -> (Vec<Fp>, Vec<Curve>) {
         todo!()
     }
+
+    fn get_blinder(&self) -> Fp {
+        todo!()
+    }
 }
 
 #[derive(Clone)]

--- a/folding/tests/test_vanilla_folding.rs
+++ b/folding/tests/test_vanilla_folding.rs
@@ -40,6 +40,7 @@ struct TestInstance {
     commitments: [Curve; 3],
     challenges: [Fp; 3],
     alphas: Alphas<Fp>,
+    blinder: Fp,
 }
 
 impl Foldable<Fp> for TestInstance {
@@ -50,6 +51,7 @@ impl Foldable<Fp> for TestInstance {
             }),
             challenges: std::array::from_fn(|i| a.challenges[i] + challenge * b.challenges[i]),
             alphas: Alphas::combine(a.alphas, b.alphas, challenge),
+            blinder: a.blinder + challenge * b.blinder,
         }
     }
 }
@@ -66,6 +68,10 @@ impl Instance<Curve> for TestInstance {
 
     fn get_alphas(&self) -> &Alphas<Fp> {
         &self.alphas
+    }
+
+    fn get_blinder(&self) -> Fp {
+        self.blinder
     }
 }
 
@@ -222,17 +228,20 @@ fn instance_from_witness(
         .collect_vec();
     let commitments: [_; 3] = commitments.try_into().unwrap();
 
-    // here we should absorve the commitments and similar things to later compute challenges
-    // but for this example I just use random values
+    // here we should absorve the commitments and similar things to later
+    // compute challenges but for this example I just use random values
     let mut rng = thread_rng();
     let mut challenge = || Fp::rand(&mut rng);
     let challenges = [(); 3].map(|_| challenge());
     let alpha = challenge();
     let alphas = Alphas::new(alpha);
+    // We suppose we always have a blinder to one.
+    let blinder = Fp::one();
     TestInstance {
         commitments,
         challenges,
         alphas,
+        blinder,
     }
 }
 

--- a/ivc/tests/add.rs
+++ b/ivc/tests/add.rs
@@ -19,7 +19,7 @@ use std::{array, collections::BTreeMap, ops::Index};
 use strum::EnumCount;
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 
-use ark_ff::UniformRand;
+use ark_ff::{One, UniformRand};
 use ark_poly::Radix2EvaluationDomain;
 use kimchi::circuits::domains::EvaluationDomains;
 use kimchi_msm::{
@@ -166,6 +166,7 @@ pub fn test_simple_add() {
         commitments: [Curve; AdditionColumn::COUNT],
         challenges: [Fp; Challenge::COUNT],
         alphas: Alphas<Fp>,
+        blinder: Fp,
     }
 
     impl Foldable<Fp> for PlonkishInstance {
@@ -176,6 +177,7 @@ pub fn test_simple_add() {
                 }),
                 challenges: array::from_fn(|i| a.challenges[i] + challenge * b.challenges[i]),
                 alphas: Alphas::combine(a.alphas, b.alphas, challenge),
+                blinder: a.blinder + challenge * b.blinder,
             }
         }
     }
@@ -193,6 +195,10 @@ pub fn test_simple_add() {
 
         fn get_alphas(&self) -> &Alphas<Fp> {
             &self.alphas
+        }
+
+        fn get_blinder(&self) -> Fp {
+            self.blinder
         }
     }
 
@@ -228,10 +234,13 @@ pub fn test_simple_add() {
             let alpha = fq_sponge.challenge();
             let alphas = Alphas::new(alpha);
 
+            let blinder = Fp::one();
+
             Self {
                 commitments,
                 challenges,
                 alphas,
+                blinder,
             }
         }
     }

--- a/o1vm/src/folding.rs
+++ b/o1vm/src/folding.rs
@@ -52,6 +52,9 @@ pub struct FoldingInstance<const N: usize, G: CommitmentCurve> {
     pub challenges: [<G as AffineCurve>::ScalarField; Challenge::COUNT],
     /// Reuses the Alphas defined in the example of folding
     pub alphas: Alphas<<G as AffineCurve>::ScalarField>,
+
+    /// Blinder used in the polynomial commitment scheme
+    pub blinder: <G as AffineCurve>::ScalarField,
 }
 
 impl<const N: usize, G: CommitmentCurve> Foldable<G::ScalarField> for FoldingInstance<N, G> {
@@ -62,6 +65,7 @@ impl<const N: usize, G: CommitmentCurve> Foldable<G::ScalarField> for FoldingIns
             }),
             challenges: array::from_fn(|i| a.challenges[i] + challenge * b.challenges[i]),
             alphas: Alphas::combine(a.alphas, b.alphas, challenge),
+            blinder: a.blinder + challenge * b.blinder,
         }
     }
 }
@@ -79,6 +83,10 @@ impl<const N: usize, G: CommitmentCurve> Instance<G> for FoldingInstance<N, G> {
 
     fn get_alphas(&self) -> &Alphas<G::ScalarField> {
         &self.alphas
+    }
+
+    fn get_blinder(&self) -> <G>::ScalarField {
+        self.blinder
     }
 }
 

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -128,6 +128,7 @@ mod folding {
         trace::Trace,
         BaseSponge, Curve,
     };
+    use ark_ff::One;
     use kimchi::o1_utils;
     use rand::{CryptoRng, Rng, RngCore};
     use std::{fs, path::PathBuf};
@@ -447,11 +448,13 @@ mod folding {
         let alpha = fq_sponge.challenge();
         let challenges = [beta, gamma, joint_combiner];
         let alphas = Alphas::new(alpha);
+        let blinder = Fp::one();
 
         FoldingInstance {
             commitments,
             challenges,
             alphas,
+            blinder,
         }
     }
 

--- a/o1vm/src/trace.rs
+++ b/o1vm/src/trace.rs
@@ -192,10 +192,12 @@ where
         let alpha = fq_sponge.challenge();
         let challenges = [beta, gamma, joint_combiner];
         let alphas = Alphas::new(alpha);
+        let blinder = ScalarField::<C>::one();
         let instance = FoldingInstance {
             commitments,
             challenges,
             alphas,
+            blinder,
         };
 
         (instance, folding_witness)


### PR DESCRIPTION
We want to add blinders to our polynomials to handle commitments to zero.
We suppose the blinders are single scalars, and instead of committing to `P(X)`, we commit to `P(X) + r`, which results in `Comm(P) + r G` where `G` is the first element of our SRS.
We must coin a new random blinder for each folding execution, and use it for instance and witness.

~~The blinders must be coined *before* computing and absorbing the commitments to the error terms~~

We use the blinder `1`.