### PR TITLE
Unit test for `LoadWordLeft`

### DIFF
--- a/o1vm/src/mips/interpreter.rs
+++ b/o1vm/src/mips/interpreter.rs
@@ -2086,6 +2086,8 @@ pub fn interpret_itype<Env: InterpreterEnv>(env: &mut Env, instr: ITypeInstructi
                 unsafe { env.bitmask(&addr, 2, 0, pos) }
             };
 
+            // From docs: "EffAddr is the address of the most-significant of
+            //             four consecutive bytes word in memory"
             // Big-endian: smallest address is the most significant byte
             let m0 = env.read_memory(&addr);
             let m1 = env.read_memory(&(addr.clone() + Env::constant(1)));

--- a/o1vm/src/mips/interpreter.rs
+++ b/o1vm/src/mips/interpreter.rs
@@ -2092,14 +2092,10 @@ pub fn interpret_itype<Env: InterpreterEnv>(env: &mut Env, instr: ITypeInstructi
             let m2 = env.read_memory(&(addr.clone() + Env::constant(2)));
             let m3 = env.read_memory(&(addr.clone() + Env::constant(3)));
 
-            let [_r0, r1, r2, r3] = {
+            // No need to define r0 as bitmask(reg, 32,24,pos) since it is not used
+            let [r1, r2, r3] = {
                 let initial_register_value = env.read_register(&rt);
                 [
-                    {
-                        // FIXME: Requires a range check
-                        let pos = env.alloc_scratch();
-                        unsafe { env.bitmask(&initial_register_value, 32, 24, pos) }
-                    },
                     {
                         // FIXME: Requires a range check
                         let pos = env.alloc_scratch();

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -238,6 +238,11 @@ mod unit {
         env.memory[page as usize].1[page_address + 3] = (instr & 0xFF) as u8;
     }
 
+    pub(crate) fn bitmask(x: u32, highest_bit: u32, lowest_bit: u32) -> u32 {
+        let res = (x >> lowest_bit) as u64 & (2u64.pow(highest_bit - lowest_bit) - 1);
+        res as u32
+    }
+
     pub(crate) fn sign_extend(x: u32, bitlength: u32) -> u32 {
         let high_bit = (x >> (bitlength - 1)) & 1;
         high_bit * (((1 << (32 - bitlength)) - 1) << bitlength) + x
@@ -250,6 +255,12 @@ mod unit {
             sign_extend(0b1001_0110_0000_0000, 16),
             0b1111_1111_1111_1111_1001_0110_0000_0000
         );
+    }
+
+    #[test]
+    fn test_bitmask() {
+        assert_eq!(bitmask(0xaf, 8, 0), 0xaf);
+        assert_eq!(bitmask(0x3671e4cb, 32, 0), 0x3671e4cb);
     }
 
     #[test]

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -238,14 +238,14 @@ mod unit {
         env.memory[page as usize].1[page_address + 3] = (instr & 0xFF) as u8;
     }
 
-    pub(crate) fn bitmask(x: u32, highest_bit: u32, lowest_bit: u32) -> u32 {
-        let res = (x >> lowest_bit) as u64 & (2u64.pow(highest_bit - lowest_bit) - 1);
-        res as u32
-    }
-
     pub(crate) fn sign_extend(x: u32, bitlength: u32) -> u32 {
         let high_bit = (x >> (bitlength - 1)) & 1;
         high_bit * (((1 << (32 - bitlength)) - 1) << bitlength) + x
+    }
+
+    pub(crate) fn bitmask(x: u32, highest_bit: u32, lowest_bit: u32) -> u32 {
+        let res = (x >> lowest_bit) as u64 & (2u64.pow(highest_bit - lowest_bit) - 1);
+        res as u32
     }
 
     #[test]

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -470,7 +470,7 @@ mod unit {
             assert!(!ovf);
 
             let shift_left = (addr & 3) * 8;
-            let mask = 0xFFffFFffu32 << shift_left;
+            let mask = 0xFFFFFFFFu32 << shift_left;
 
             let mem = &dummy_env.memory[0];
             let mem = &mem.1;

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -386,6 +386,69 @@ mod unit {
             interpret_itype(&mut dummy_env, ITypeInstruction::Load32);
             assert_eq!(dummy_env.registers.general_purpose[4], exp_v);
         }
+
+        #[test]
+        fn test_unit_lwl_instruction() {
+            let mut rng = o1_utils::tests::make_test_rng(None);
+            // lwl instruction
+            let mut dummy_env = dummy_env(&mut rng);
+            // Instruction: 0b100010 10101 00001 0000000001000000
+            // lwl rt offset(21)
+            // Random address in SP Address has only one index
+
+            // Values used in the instruction
+            let rs = 21;
+            let dst = 1;
+            let offset = sign_extend(64, 16);
+
+            // Set the base address to a small number so dummy_env does not ovf
+            dummy_env.registers[rs] = rng.gen_range(0u32..4000u32);
+            let base = dummy_env.registers[rs];
+            // The effective address
+            let (addr, ovf) = base.overflowing_add(offset);
+            assert!(!ovf);
+
+            // Number of bytes that will remain unchanged on the right
+            let n_right = addr % 4;
+
+            let mem = &dummy_env.memory[0];
+            let mem = &mem.1;
+
+            // Here start the (at most 4) bytes we want to load from memory
+            let v0 = mem[addr as usize];
+            let v1 = mem[(addr + 1) as usize];
+            let v2 = mem[(addr + 2) as usize];
+            let v3 = mem[(addr + 3) as usize];
+            // Big endian: small addresses of memory represent more significant
+            let memory =
+                ((v0 as u32) << 24) + ((v1 as u32) << 16) + ((v2 as u32) << 8) + (v3 as u32);
+
+            // Load n_left=4-n_right bytes from the memory
+            let left = bitmask(memory, 32, 8 * n_right);
+
+            // Right part of the word (must not change content of register)
+            let right = bitmask(dummy_env.registers[dst], 8 * n_right, 0);
+
+            // The final value that should be in the register after LWL
+            // corresponds to the n_left bytes followed from the n_right bytes
+            let exp_v = (left << (8 * n_right)) + right;
+
+            write_instruction(
+                &mut dummy_env,
+                InstructionParts {
+                    op_code: 0b100010,
+                    rs: rs as u32,  // where base address is obtained from
+                    rt: dst as u32, // destination
+                    rd: 0b00000,
+                    shamt: 0b00001, // offset = 64
+                    funct: 0b000000,
+                },
+            );
+
+            interpret_itype(&mut dummy_env, ITypeInstruction::LoadWordLeft);
+
+            assert_eq!(dummy_env.registers[dst], exp_v);
+        }
     }
 }
 

--- a/o1vm/src/mips/witness.rs
+++ b/o1vm/src/mips/witness.rs
@@ -617,7 +617,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
         println!(
             "Exited with code {} at step {}",
             *exit_code,
-            self.instruction_counter / MAX_ACC
+            self.instruction_counter_normalized()
         );
     }
 
@@ -1065,6 +1065,18 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
         (opcode, instruction)
     }
 
+    /// Because MAX_NB_REG_ACC = 7 and MAX_NB_MEM_ACC = 12, at most the same
+    /// instruction will increase the instruction counter by MAX_ACC = 19.
+    ///
+    /// NOTE: actually, in practice it will be less than that, as there is no
+    ///       single instruction that performs all of them.
+    ///
+    /// This means that the actual number of instructions executed will result
+    /// from dividing the instruction counter by MAX_ACC (floor).
+    pub fn instruction_counter_normalized(&self) -> u64 {
+        self.instruction_counter / MAX_ACC
+    }
+
     /// Updates the instruction counter, accounting for the maximum number of
     /// register and memory accesses per instruction.
     /// Because MAX_NB_REG_ACC = 7 and MAX_NB_MEM_ACC = 12, at most the same
@@ -1080,7 +1092,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
     /// the real instruction counter and multiply it by MAX_ACC to have a unique
     /// representation of each step (which is helpful for debugging).
     pub fn update_instruction_counter(&mut self) {
-        self.instruction_counter = ((self.instruction_counter / MAX_ACC) + 1) * MAX_ACC;
+        self.instruction_counter = (self.instruction_counter_normalized() + 1) * MAX_ACC;
     }
 
     /// Execute a single step of the MIPS program.
@@ -1102,7 +1114,8 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
             self.halt = true;
             println!(
                 "Halted as requested at step={} instruction={:?}",
-                self.instruction_counter, opcode
+                self.instruction_counter_normalized(),
+                opcode
             );
             return opcode;
         }
@@ -1115,7 +1128,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
         if self.halt {
             println!(
                 "Halted at step={} instruction={:?}",
-                self.instruction_counter / MAX_ACC,
+                self.instruction_counter_normalized(),
                 opcode
             );
         }
@@ -1123,7 +1136,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
     }
 
     fn should_trigger_at(&self, at: &StepFrequency) -> bool {
-        let m: u64 = self.instruction_counter;
+        let m: u64 = self.instruction_counter_normalized();
         match at {
             StepFrequency::Never => false,
             StepFrequency::Always => true,
@@ -1199,7 +1212,8 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
             let _ = serde_json::to_writer(&mut writer, &s);
             info!(
                 "Snapshot state in {}, step {}",
-                filename, self.instruction_counter
+                filename,
+                self.instruction_counter_normalized()
             );
             writer.flush().expect("Flush writer failing")
         }
@@ -1209,7 +1223,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
         if self.should_trigger_at(at) {
             let elapsed = start.time.elapsed();
             // Compute the step number removing the MAX_ACC factor
-            let step = self.instruction_counter / MAX_ACC;
+            let step = self.instruction_counter_normalized();
             let pc = self.registers.current_instruction_pointer;
 
             // Get the 32-bits opcode

--- a/o1vm/src/mips/witness.rs
+++ b/o1vm/src/mips/witness.rs
@@ -616,7 +616,8 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
     fn report_exit(&mut self, exit_code: &Self::Variable) {
         println!(
             "Exited with code {} at step {}",
-            *exit_code, self.instruction_counter
+            *exit_code,
+            self.instruction_counter / MAX_ACC
         );
     }
 


### PR DESCRIPTION
<details>

<summary>
This PR provides a unit test for the `LoadWordLeft` instruction. It matches closely the Cannon definition of the instruction given by 

```
		case 0x22: // lwl
			val := mem << ((rs & 3) * 8)
			mask := uint32(0xFFFFFFFF) << ((rs & 3) * 8)
			return (rt & ^mask) | val
```

I used this test to realize that our current implementation of the interpreter for that function was not working properly. In particular, bytes were being mapped to different positions. I changed the interpreter code to avoid the confusing (and error prone) use of `overwrite_n` in favor of a more direct set of variables called `mod_n`. I included comments to help understand what the above function does and what it expects in each byte position of the destination register.

</summary> 

Old description

This unit test matches what the interpreter of `LoadWordLeft` is doing. Nonetheless, the constraints still do not pass when trying to make a proof for them. In particular:

```bash
"Unsatisfied expression: ((((Curr(x[19]) - 0x0100000000000000000000000000000000000000000000000000000000000000) * Curr(x[23])) + Curr(x[22])) - 0x0100000000000000000000000000000000000000000000000000000000000000)"
```

Still figuring out why. The obvious answer would be dummy rows initialized to zeros so the `-1` will not hold. But we already solved that issue when creating the trace, by padding with a dummy row that is known to be a "real" row.~

</details>