### PR TITLE
[easy] Unit tests for `sext` and `bitmask`

### DIFF
--- a/o1vm/src/mips/interpreter.rs
+++ b/o1vm/src/mips/interpreter.rs
@@ -562,6 +562,8 @@ pub trait InterpreterEnv {
     /// There are no constraints on the returned value; callers must assert the relationship with
     /// the source variable `x` and that the returned value fits in `highest_bit - lowest_bit`
     /// bits.
+    ///
+    /// Do not call this function with highest_bit - lowest_bit >= 32.
     unsafe fn bitmask(
         &mut self,
         x: &Self::Variable,

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -257,7 +257,6 @@ mod unit {
 
     #[test]
     fn test_bitmask() {
-        println!("{:02x}", 1 << 32);
         assert_eq!(bitmask(0xaf, 8, 0), 0xaf);
         assert_eq!(bitmask(0x3671e4cb, 32, 0), 0x3671e4cb);
     }

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -236,6 +236,32 @@ mod unit {
         env.memory[page as usize].1[page_address + 3] = (instr & 0xFF) as u8;
     }
 
+    pub(crate) fn sign_extend(x: u32, bitlength: u32) -> u32 {
+        let high_bit = (x >> (bitlength - 1)) & 1;
+        high_bit * (((1 << (32 - bitlength)) - 1) << bitlength) + x
+    }
+
+    pub(crate) fn bitmask(x: u32, highest_bit: u32, lowest_bit: u32) -> u32 {
+        let res = (x >> lowest_bit) as u64 & (2u64.pow(highest_bit - lowest_bit) - 1);
+        res as u32
+    }
+
+    #[test]
+    fn test_sext() {
+        assert_eq!(sign_extend(0b1001_0110, 16), 0b1001_0110);
+        assert_eq!(
+            sign_extend(0b1001_0110_0000_0000, 16),
+            0b1111_1111_1111_1111_1001_0110_0000_0000
+        );
+    }
+
+    #[test]
+    fn test_bitmask() {
+        println!("{:02x}", 1 << 32);
+        assert_eq!(bitmask(0xaf, 8, 0), 0xaf);
+        assert_eq!(bitmask(0x3671e4cb, 32, 0), 0x3671e4cb);
+    }
+
     #[test]
     fn test_on_disk_preimage_can_read_file() {
         let mut rng = o1_utils::tests::make_test_rng(None);


### PR DESCRIPTION
Added for `LoadWordLeft` (https://github.com/o1-labs/proof-systems/pull/2299), but making them a standalone PR for ease of review.