### PR TITLE
Fix `equal` for witness interpreter

### DIFF
--- a/o1vm/src/mips/constraints.rs
+++ b/o1vm/src/mips/constraints.rs
@@ -205,6 +205,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         self.variable(position)
     }
 
+    fn equal(&mut self, x: &Self::Variable, y: &Self::Variable) -> Self::Variable {
+        self.is_zero(&(x.clone() - y.clone()))
+    }
+
     unsafe fn test_less_than(
         &mut self,
         _x: &Self::Variable,

--- a/o1vm/src/mips/interpreter.rs
+++ b/o1vm/src/mips/interpreter.rs
@@ -648,9 +648,8 @@ pub trait InterpreterEnv {
         res
     }
 
-    fn equal(&mut self, x: &Self::Variable, y: &Self::Variable) -> Self::Variable {
-        self.is_zero(&(x.clone() - y.clone()))
-    }
+    /// Returns 1 if `x` is equal to `y`, or 0 otherwise, storing the result in `position`.
+    fn equal(&mut self, x: &Self::Variable, y: &Self::Variable) -> Self::Variable;
 
     /// Returns 1 if `x < y` as unsigned integers, or 0 otherwise, storing the result in
     /// `position`.

--- a/o1vm/src/mips/interpreter.rs
+++ b/o1vm/src/mips/interpreter.rs
@@ -159,7 +159,7 @@ impl IntoIterator for Instruction {
 
 pub trait InterpreterEnv {
     /// A position can be seen as an indexed variable
-    type Position;
+    type Position: std::fmt::Debug;
 
     /// Allocate a new abstract variable for the current step.
     /// The variable can be used to store temporary values.

--- a/o1vm/src/mips/interpreter.rs
+++ b/o1vm/src/mips/interpreter.rs
@@ -159,7 +159,7 @@ impl IntoIterator for Instruction {
 
 pub trait InterpreterEnv {
     /// A position can be seen as an indexed variable
-    type Position: std::fmt::Debug;
+    type Position;
 
     /// Allocate a new abstract variable for the current step.
     /// The variable can be used to store temporary values.

--- a/o1vm/src/mips/witness.rs
+++ b/o1vm/src/mips/witness.rs
@@ -345,6 +345,15 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
         }
     }
 
+    fn equal(&mut self, x: &Self::Variable, y: &Self::Variable) -> Self::Variable {
+        // To avoid subtraction overflow in the witness interpreter for u32
+        if x > y {
+            self.is_zero(&(x.clone() - y.clone()))
+        } else {
+            self.is_zero(&(y.clone() - x.clone()))
+        }
+    }
+
     unsafe fn test_less_than(
         &mut self,
         x: &Self::Variable,

--- a/o1vm/src/mips/witness.rs
+++ b/o1vm/src/mips/witness.rs
@@ -348,9 +348,9 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
     fn equal(&mut self, x: &Self::Variable, y: &Self::Variable) -> Self::Variable {
         // To avoid subtraction overflow in the witness interpreter for u32
         if x > y {
-            self.is_zero(&(x.clone() - y.clone()))
+            self.is_zero(&(*x - *y))
         } else {
-            self.is_zero(&(y.clone() - x.clone()))
+            self.is_zero(&(*y - *x))
         }
     }
 


### PR DESCRIPTION
This PR proposes a different definition of the `equal` function of the MIPS interpreter so that it does not generate underflows when trying to subtract `x-y` and `y` is larger than `x` (for `u32` types). This is not a problem in fields, but it is when running unit tests built with unsigned types.

This is not the only place where subtraction underflows happen in unit tests. An upcoming PR will address the rest, which corresponds to the `FIXME` to allow multiple register accesses per instruction call.