### PR TITLE
Fix instruction counter to allow multiple register/memory accesses per instruction call

### DIFF
--- a/o1vm/src/mips/constraints.rs
+++ b/o1vm/src/mips/constraints.rs
@@ -90,6 +90,10 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         self.variable(MIPSColumn::InstructionCounter)
     }
 
+    fn increase_instruction_counter(&mut self) {
+        // No-op, witness only
+    }
+
     unsafe fn fetch_register(
         &mut self,
         _idx: &Self::Variable,

--- a/o1vm/src/mips/interpreter.rs
+++ b/o1vm/src/mips/interpreter.rs
@@ -217,6 +217,8 @@ pub trait InterpreterEnv {
 
     fn instruction_counter(&self) -> Self::Variable;
 
+    fn increase_instruction_counter(&mut self);
+
     /// Fetch the value of the general purpose register with index `idx` and store it in local
     /// position `output`.
     ///
@@ -315,10 +317,9 @@ pub trait InterpreterEnv {
             // Here, we write as if the register had been written *at the start of the next
             // instruction*. This ensures that we can't 'time travel' within this
             // instruction, and claim to read the value that we're about to write!
-
-            // FIXME: A register should allow multiple accesses within the same instruction.
-
             instruction_counter + Self::constant(1)
+            // A register should allow multiple accesses to the same register within the same instruction.
+            // In order to allow this, we always increase the instruction counter by 1.
         };
         unsafe { self.push_register_access_if(idx, new_accessed.clone(), if_is_true) };
         self.add_lookup(Lookup::write_if(
@@ -332,6 +333,9 @@ pub trait InterpreterEnv {
             vec![idx.clone(), new_accessed, new_value.clone()],
         ));
         self.range_check64(&elapsed_time);
+
+        // Update instruction counter after accessing a register.
+        self.increase_instruction_counter();
     }
 
     fn read_register(&mut self, idx: &Self::Variable) -> Self::Variable {

--- a/o1vm/src/mips/interpreter.rs
+++ b/o1vm/src/mips/interpreter.rs
@@ -469,6 +469,9 @@ pub trait InterpreterEnv {
             vec![addr.clone(), new_accessed, new_value.clone()],
         ));
         self.range_check64(&elapsed_time);
+
+        // Update instruction counter after accessing a memory address.
+        self.increase_instruction_counter();
     }
 
     fn read_memory(&mut self, addr: &Self::Variable) -> Self::Variable {

--- a/o1vm/src/mips/witness.rs
+++ b/o1vm/src/mips/witness.rs
@@ -169,6 +169,10 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
         self.instruction_counter
     }
 
+    fn increase_instruction_counter(&mut self) {
+        self.instruction_counter += 1;
+    }
+
     unsafe fn fetch_register(
         &mut self,
         idx: &Self::Variable,

--- a/o1vm/src/mips/witness.rs
+++ b/o1vm/src/mips/witness.rs
@@ -1207,7 +1207,8 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
     fn pp_info(&mut self, at: &StepFrequency, meta: &Meta, start: &Start) {
         if self.should_trigger_at(at) {
             let elapsed = start.time.elapsed();
-            let step = self.instruction_counter;
+            // Compute the step number removing the MAX_ACC factor
+            let step = self.instruction_counter / MAX_ACC;
             let pc = self.registers.current_instruction_pointer;
 
             // Get the 32-bits opcode

--- a/o1vm/src/mips/witness.rs
+++ b/o1vm/src/mips/witness.rs
@@ -27,6 +27,16 @@ use std::{
     io::{BufWriter, Write},
 };
 
+// TODO: do we want to be more restrictive and refer to the number of accesses
+//       to the SAME register/memory addrss?
+
+/// Maximum number of register accesses per instruction (based on demo)
+pub const MAX_NB_REG_ACC: u64 = 7;
+/// Maximum number of memory accesses per instruction (based on demo)
+pub const MAX_NB_MEM_ACC: u64 = 12;
+/// Maximum number of memory or register accesses per instruction
+pub const MAX_ACC: u64 = MAX_NB_REG_ACC + MAX_NB_MEM_ACC;
+
 pub const NUM_GLOBAL_LOOKUP_TERMS: usize = 1;
 pub const NUM_DECODING_LOOKUP_TERMS: usize = 2;
 pub const NUM_INSTRUCTION_LOOKUP_TERMS: usize = 5;
@@ -1055,6 +1065,24 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
         (opcode, instruction)
     }
 
+    /// Updates the instruction counter, accounting for the maximum number of
+    /// register and memory accesses per instruction.
+    /// Because MAX_NB_REG_ACC = 7 and MAX_NB_MEM_ACC = 12, at most the same
+    /// instruction will increase the instruction counter by MAX_ACC = 19.
+    ///
+    /// NOTE: actually, in practice it will be less than that, as there is no
+    ///       single instruction that performs all of them.
+    ///
+    /// This means that the actual number of instructions executed will result
+    /// from dividing the instruction counter by MAX_ACC (floor).
+    ///
+    /// Then, in order to update the instruction counter, we need to add 1 to
+    /// the real instruction counter and multiply it by MAX_ACC to have a unique
+    /// representation of each step (which is helpful for debugging).
+    pub fn update_instruction_counter(&mut self) {
+        self.instruction_counter = ((self.instruction_counter / MAX_ACC) + 1) * MAX_ACC;
+    }
+
     /// Execute a single step of the MIPS program.
     /// Returns the instruction that was executed.
     pub fn step(
@@ -1081,12 +1109,14 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
 
         interpreter::interpret_instruction(self, opcode);
 
-        self.instruction_counter += 1;
+        self.update_instruction_counter();
 
+        // Integer division by MAX_ACC to obtain the actual instruction count
         if self.halt {
             println!(
                 "Halted at step={} instruction={:?}",
-                self.instruction_counter, opcode
+                self.instruction_counter / MAX_ACC,
+                opcode
             );
         }
         opcode


### PR DESCRIPTION
This PR is meant to fix the subtraction underflows that appeared in unit tests when the same instruction was accessing the same register multiple times. This PR solves that issue by artificially increasing the instruction counter every time that register access takes place (so that the elapsed time is always a positive value). 

It compliments https://github.com/o1-labs/proof-systems/pull/2310. 

I tested it in a local branch with `LoadWordLeft` which used to fail for this reason (https://github.com/o1-labs/proof-systems/actions/runs/9447808562/job/26020430671?pr=2299), and now with the same seed the test `RUSTFLAGS="-Coverflow-checks=y -Cdebug-assertions=y" cargo test --package o1vm --lib --all-features --release -- mips::tests::unit::itype::test_unit_lwl_instruction --exact --show-output` works.

I will be updating the unit tests accordingly now, meaning
https://github.com/o1-labs/proof-systems/pull/2299
https://github.com/o1-labs/proof-systems/pull/2293
https://github.com/o1-labs/proof-systems/pull/2305

to check that this solves the issue.

Nonetheless, we need to run the whole demo to make sure that this fix does not break other parts of the system.