### PR TITLE
IVC/Poseidon: make the round constants public values

### DIFF
--- a/ivc/src/ivc/columns.rs
+++ b/ivc/src/ivc/columns.rs
@@ -25,6 +25,9 @@ pub fn block_height<const N_COL_TOTAL: usize, const N_CHALS: usize>(block_num: u
 pub const IVC_POSEIDON_STATE_SIZE: usize = 3;
 pub const IVC_POSEIDON_NB_FULL_ROUND: usize = 55;
 
+pub const IVC_NB_TOTAL_FIXED_SELECTORS: usize =
+    IVC_POSEIDON_NB_FULL_ROUND * IVC_POSEIDON_STATE_SIZE + N_BLOCKS;
+
 pub type IVCPoseidonColumn = PoseidonColumn<IVC_POSEIDON_STATE_SIZE, IVC_POSEIDON_NB_FULL_ROUND>;
 
 /// The IVC circuit is tiled vertically. We assume we have as many

--- a/ivc/src/ivc/interpreter.rs
+++ b/ivc/src/ivc/interpreter.rs
@@ -33,6 +33,8 @@ use kimchi_msm::{
 use num_bigint::BigUint;
 use std::marker::PhantomData;
 
+use super::columns::IVC_NB_TOTAL_FIXED_SELECTORS;
+
 /// The biggest packing variant for foreign field. Used for hashing. 150-bit limbs.
 pub const LIMB_BITSIZE_XLARGE: usize = 150;
 /// The biggest packing format, 2 limbs.
@@ -887,16 +889,23 @@ where
 }
 
 /// Builds selectors for the IVC circuit.
+/// The round constants for Poseidon are not added in this function, and must be
+/// done separately.
+/// The size of the array is the total number of public values required for the
+/// IVC. Therefore, it includes the potential round constants required by
+/// the hash function.
+// FIXME: rc should be handled here or in the lens
 #[allow(clippy::needless_range_loop)]
 pub fn build_selectors<F, const N_COL_TOTAL: usize, const N_CHALS: usize>(
     domain_size: usize,
-) -> [Vec<F>; N_BLOCKS]
+) -> [Vec<F>; IVC_NB_TOTAL_FIXED_SELECTORS]
 where
     F: PrimeField,
 {
     // 3*N + 6*N+2 + N+1 + 35*N + 5 + N_CHALS + 1 =
     // 45N + 9 + N_CHALS
-    let mut selectors: [Vec<F>; N_BLOCKS] = core::array::from_fn(|_| vec![F::zero(); domain_size]);
+    let mut selectors: [Vec<F>; IVC_NB_TOTAL_FIXED_SELECTORS] =
+        core::array::from_fn(|_| vec![F::zero(); domain_size]);
     let mut curr_row = 0;
     for block_i in 0..N_BLOCKS {
         for _i in 0..block_height::<N_COL_TOTAL, N_CHALS>(block_i) {

--- a/ivc/src/poseidon_55_0_7_3_2/columns.rs
+++ b/ivc/src/poseidon_55_0_7_3_2/columns.rs
@@ -12,11 +12,6 @@
 /// - `3` input columns
 /// - `5 N * 3` round columns, indexed by the round number and the index in the state,
 /// the number of rounds.
-/// The round constants are also added as columns.
-// IMPROVEME: should be split the SBOX and the MDS?
-// IMPROVEME: round constants should be public
-// IMPROVEME: round constants should be part of the expression framework. The
-// expression must be changed to support this.
 use kimchi_msm::columns::{Column, ColumnIndexer};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -45,7 +40,7 @@ impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> ColumnIndexer
     //   - STATE_SIZE state columns for x^7 -> x^6 * x
     //   - STATE_SIZE state columns for x^7 * MDS(., L)
     // - STATE_SIZE * NB_FULL_ROUND constants
-    const N_COL: usize = STATE_SIZE + (5 + 1) * NB_FULL_ROUND * STATE_SIZE;
+    const N_COL: usize = STATE_SIZE + 5 * NB_FULL_ROUND * STATE_SIZE;
 
     fn to_column(self) -> Column {
         match self {
@@ -64,10 +59,8 @@ impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> ColumnIndexer
                 assert!(state_index < STATE_SIZE);
                 // We start round 0
                 assert!(round < NB_FULL_ROUND);
-                //             INPUT              ROUND (5, see above)
-                let offset = STATE_SIZE + 5 * STATE_SIZE * NB_FULL_ROUND;
-                let idx = offset + (round * STATE_SIZE + state_index);
-                Column::Relation(idx)
+                let idx = round * STATE_SIZE + state_index;
+                Column::FixedSelector(idx)
             }
         }
     }

--- a/ivc/src/poseidon_55_0_7_3_2/interpreter.rs
+++ b/ivc/src/poseidon_55_0_7_3_2/interpreter.rs
@@ -52,16 +52,6 @@ where
         env.write_column(PoseidonColumn::Input(i), value);
     });
 
-    // Write constants
-    {
-        let rc = param.constants();
-        rc.iter().enumerate().for_each(|(round, rcs)| {
-            rcs.iter().enumerate().for_each(|(j, rc)| {
-                env.write_column(PoseidonColumn::RoundConstant(round, j), &Env::constant(*rc));
-            });
-        });
-    }
-
     // Create, write, and constrain all other columns.
     apply_permutation(env, param)
 }

--- a/ivc/src/poseidon_55_0_7_3_7/columns.rs
+++ b/ivc/src/poseidon_55_0_7_3_7/columns.rs
@@ -1,19 +1,16 @@
-/// The column layout will be as follow, supposing a state size of 3 elements:
-/// | C1 | C2 | C3 | C4  | C5  | C6  | ... | C_(k) | C_(k + 1) | C_(k + 2) |
-/// |--- |----|----|-----|-----|-----|-----|-------|-----------|-----------|
-/// |  x |  y | z  | x'  |  y' |  z' | ... |  x''  |     y''   |    z''    |
-///                | MDS \circ SBOX  |     |        MDS \circ SBOX         |
-///                |-----------------|     |-------------------------------|
-/// where (x', y', z') = MDS(x^7, y^7, z^7), i.e. the result of the linear layer
-/// We will have, for N full rounds:
-/// - `3` input columns
-/// - `N * 3` round columns, indexed by the round number and the index in the state,
-/// the number of rounds.
-/// The round constants are also added as columns.
-// IMPROVEME: should be split the SBOX and the MDS?
-// IMPROVEME: round constants should be public
-// IMPROVEME: round constants should be part of the expression framework. The
-// expression must be changed to support this.
+//! The column layout will be as follow, supposing a state size of 3 elements:
+//! | C1 | C2 | C3 | C4  | C5  | C6  | ... | C_(k) | C_(k + 1) | C_(k + 2) |
+//! |--- |----|----|-----|-----|-----|-----|-------|-----------|-----------|
+//! |  x |  y | z  | x'  |  y' |  z' | ... |  x''  |     y''   |    z''    |
+//!                | MDS \circ SBOX  |     |        MDS \circ SBOX         |
+//!                |-----------------|     |-------------------------------|
+//! where (x', y', z') = MDS(x^7, y^7, z^7), i.e. the result of the linear layer
+//! We will have, for N full rounds:
+//! - `3` input columns
+//! - `N * 3` round columns, indexed by the round number and the index in the state,
+//! the number of rounds.
+//! The round constants are added as fixed selectors.
+
 use kimchi_msm::columns::{Column, ColumnIndexer};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -26,7 +23,7 @@ pub enum PoseidonColumn<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> {
 impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> ColumnIndexer
     for PoseidonColumn<STATE_SIZE, NB_FULL_ROUND>
 {
-    const N_COL: usize = STATE_SIZE + 2 * NB_FULL_ROUND * STATE_SIZE;
+    const N_COL: usize = STATE_SIZE + NB_FULL_ROUND * STATE_SIZE;
 
     fn to_column(self) -> Column {
         match self {
@@ -45,9 +42,8 @@ impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> ColumnIndexer
                 assert!(state_index < STATE_SIZE);
                 // We start round 0
                 assert!(round < NB_FULL_ROUND);
-                let offset = STATE_SIZE + STATE_SIZE * NB_FULL_ROUND;
-                let idx = offset + (round * STATE_SIZE + state_index);
-                Column::Relation(idx)
+                let idx = round * STATE_SIZE + state_index;
+                Column::FixedSelector(idx)
             }
         }
     }

--- a/ivc/src/poseidon_55_0_7_3_7/interpreter.rs
+++ b/ivc/src/poseidon_55_0_7_3_7/interpreter.rs
@@ -52,20 +52,6 @@ where
         env.write_column(PoseidonColumn::Input(i), value);
     });
 
-    // Write constants
-    {
-        // FIXME:
-        // Round constants should not be considered as columns. We should
-        // handle differently constants. See the comment in the columns file.
-        // This must be improved!
-        let rc = param.constants();
-        rc.iter().enumerate().for_each(|(round, rcs)| {
-            rcs.iter().enumerate().for_each(|(j, rc)| {
-                env.write_column(PoseidonColumn::RoundConstant(round, j), &Env::constant(*rc));
-            });
-        });
-    }
-
     // Create, write, and constrain all other columns.
     apply_permutation(env, param)
 }

--- a/ivc/src/poseidon_55_0_7_3_7/mod.rs
+++ b/ivc/src/poseidon_55_0_7_3_7/mod.rs
@@ -8,7 +8,7 @@ mod tests {
         poseidon_params_55_0_7_3,
         poseidon_params_55_0_7_3::PlonkSpongeConstantsIVC,
     };
-    use ark_ff::UniformRand;
+    use ark_ff::{UniformRand, Zero};
     use kimchi_msm::{
         circuit_design::{ColAccessCap, ConstraintBuilderEnv, WitnessBuilderEnv},
         columns::ColumnIndexer,
@@ -24,6 +24,7 @@ mod tests {
     type TestPoseidonColumn = PoseidonColumn<STATE_SIZE, NB_FULL_ROUND>;
     pub const N_COL: usize = TestPoseidonColumn::N_COL;
     pub const N_DSEL: usize = 0;
+    pub const N_FSEL: usize = 165;
 
     impl PoseidonParams<Fp, STATE_SIZE, NB_FULL_ROUND> for PoseidonBN254Parameters {
         fn constants(&self) -> [[Fp; STATE_SIZE]; NB_FULL_ROUND] {
@@ -42,8 +43,8 @@ mod tests {
         TestPoseidonColumn,
         { <TestPoseidonColumn as ColumnIndexer>::N_COL },
         { <TestPoseidonColumn as ColumnIndexer>::N_COL },
-        0,
-        0,
+        N_DSEL,
+        N_FSEL,
         DummyLookupTable,
     >;
 
@@ -57,6 +58,20 @@ mod tests {
         let domain_size = 1 << 4;
 
         let mut witness_env: PoseidonWitnessBuilderEnv = WitnessBuilderEnv::create();
+
+        // Write constants
+        {
+            let rc = PoseidonBN254Parameters.constants();
+            rc.iter().enumerate().for_each(|(round, rcs)| {
+                rcs.iter().enumerate().for_each(|(state_index, rc)| {
+                    let rc = vec![*rc; domain_size];
+                    witness_env.set_fixed_selector_cix(
+                        PoseidonColumn::RoundConstant(round, state_index),
+                        rc,
+                    )
+                });
+            });
+        }
 
         // Generate random inputs at each row
         for _row in 0..domain_size {
@@ -97,10 +112,26 @@ mod tests {
     /// Checks that poseidon circuit can be proven and verified. Big domain.
     pub fn test_completeness() {
         let mut rng = o1_utils::tests::make_test_rng(None);
-        let domain_size: usize = 1 << 15;
+        let domain_size: usize = 1 << 4;
 
-        let relation_witness = {
+        let (relation_witness, fixed_selectors) = {
             let mut witness_env: PoseidonWitnessBuilderEnv = WitnessBuilderEnv::create();
+
+            let mut fixed_selectors: [Vec<Fp>; N_FSEL] =
+                std::array::from_fn(|_| vec![Fp::zero(); 1]);
+            // Write constants
+            {
+                let rc = PoseidonBN254Parameters.constants();
+                rc.iter().enumerate().for_each(|(round, rcs)| {
+                    rcs.iter().enumerate().for_each(|(state_index, rc)| {
+                        witness_env.set_fixed_selector_cix(
+                            PoseidonColumn::RoundConstant(round, state_index),
+                            vec![*rc; domain_size],
+                        );
+                        fixed_selectors[round * STATE_SIZE + state_index] = vec![*rc; domain_size];
+                    });
+                });
+            }
 
             // Generate random inputs at each row
             for _row in 0..domain_size {
@@ -117,7 +148,10 @@ mod tests {
                 witness_env.next_row();
             }
 
-            witness_env.get_relation_witness(domain_size)
+            (
+                witness_env.get_relation_witness(domain_size),
+                fixed_selectors,
+            )
         };
 
         let constraints = {
@@ -138,9 +172,9 @@ mod tests {
             constraints
         };
 
-        kimchi_msm::test::test_completeness_generic_no_lookups::<N_COL, N_COL, N_DSEL, 0, _>(
+        kimchi_msm::test::test_completeness_generic_no_lookups::<N_COL, N_COL, N_DSEL, N_FSEL, _>(
             constraints,
-            Box::new([]),
+            Box::new(fixed_selectors),
             relation_witness,
             domain_size,
             &mut rng,

--- a/ivc/src/poseidon_8_56_5_3_2/columns.rs
+++ b/ivc/src/poseidon_8_56_5_3_2/columns.rs
@@ -8,7 +8,6 @@
 ///                 blocks of degree 2
 ///                   constraints
 /// where (x', y', z') = MDS(x^5, y^5, z^5), i.e. the result of the linear layer
-// IMPROVEME: round constants should be public
 use kimchi_msm::columns::{Column, ColumnIndexer};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -52,8 +51,7 @@ impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize, const NB_PARTIAL_ROUND
         // input
         STATE_SIZE
             + 4 * NB_FULL_ROUND * STATE_SIZE // full round
-            + (4 + STATE_SIZE - 1) * NB_PARTIAL_ROUND // partial round
-            + STATE_SIZE * (NB_PARTIAL_ROUND + NB_FULL_ROUND); // rc
+            + (4 + STATE_SIZE - 1) * NB_PARTIAL_ROUND; // partial round
 
     fn to_column(self) -> Column {
         // number of reductions for
@@ -81,16 +79,9 @@ impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize, const NB_PARTIAL_ROUND
             }
             PoseidonColumn::RoundConstant(round, state_index) => {
                 assert!(state_index < STATE_SIZE);
-                // We start round 0
                 assert!(round < NB_FULL_ROUND + NB_PARTIAL_ROUND);
-                let offset = STATE_SIZE
-                    + (NB_PARTIAL_ROUND * (nb_red + STATE_SIZE - 1))
-                    + (NB_FULL_ROUND * nb_red * STATE_SIZE);
                 let idx = round * STATE_SIZE + state_index;
-                // FIXME: should be FixedSelector.
-                // It is because I'm getting "can't write into fixed selector
-                // columns" because of the initialization of the round constants
-                Column::Relation(offset + idx)
+                Column::FixedSelector(idx)
             }
         }
     }

--- a/ivc/src/poseidon_8_56_5_3_2/interpreter.rs
+++ b/ivc/src/poseidon_8_56_5_3_2/interpreter.rs
@@ -53,16 +53,6 @@ where
         env.write_column(PoseidonColumn::Input(i), value);
     });
 
-    // Write constants
-    {
-        let rc = param.constants();
-        rc.iter().enumerate().for_each(|(round, rcs)| {
-            rcs.iter().enumerate().for_each(|(j, rc)| {
-                env.write_column(PoseidonColumn::RoundConstant(round, j), &Env::constant(*rc));
-            });
-        });
-    }
-
     // Create, write, and constrain all other columns.
     apply_permutation(env, param)
 }

--- a/ivc/src/poseidon_8_56_5_3_2/mod.rs
+++ b/ivc/src/poseidon_8_56_5_3_2/mod.rs
@@ -10,7 +10,7 @@ mod tests {
         poseidon_params_8_56_5_3,
         poseidon_params_8_56_5_3::PlonkSpongeConstantsIVC,
     };
-    use ark_ff::UniformRand;
+    use ark_ff::{UniformRand, Zero};
     use kimchi_msm::{
         circuit_design::{ColAccessCap, ConstraintBuilderEnv, WitnessBuilderEnv},
         columns::ColumnIndexer,
@@ -29,6 +29,7 @@ mod tests {
     type TestPoseidonColumn = PoseidonColumn<STATE_SIZE, NB_FULL_ROUND, NB_PARTIAL_ROUND>;
     pub const N_COL: usize = TestPoseidonColumn::N_COL;
     pub const N_DSEL: usize = 0;
+    pub const N_FSEL: usize = NB_TOTAL_ROUND * STATE_SIZE;
 
     impl PoseidonParams<Fp, STATE_SIZE, NB_TOTAL_ROUND> for PoseidonBN254Parameters {
         fn constants(&self) -> [[Fp; STATE_SIZE]; NB_TOTAL_ROUND] {
@@ -47,8 +48,8 @@ mod tests {
         TestPoseidonColumn,
         { <TestPoseidonColumn as ColumnIndexer>::N_COL },
         { <TestPoseidonColumn as ColumnIndexer>::N_COL },
-        0,
-        0,
+        N_DSEL,
+        N_FSEL,
         DummyLookupTable,
     >;
 
@@ -63,6 +64,19 @@ mod tests {
         let domain_size = 1 << 4;
 
         let mut witness_env: PoseidonWitnessBuilderEnv = WitnessBuilderEnv::create();
+        // Write constants
+        {
+            let rc = PoseidonBN254Parameters.constants();
+            rc.iter().enumerate().for_each(|(round, rcs)| {
+                rcs.iter().enumerate().for_each(|(state_index, rc)| {
+                    let rc = vec![*rc; domain_size];
+                    witness_env.set_fixed_selector_cix(
+                        PoseidonColumn::RoundConstant(round, state_index),
+                        rc,
+                    )
+                });
+            });
+        }
 
         // Generate random inputs at each row
         for _row in 0..domain_size {
@@ -105,8 +119,24 @@ mod tests {
         let mut rng = o1_utils::tests::make_test_rng(None);
         let domain_size: usize = 1 << 15;
 
-        let relation_witness = {
+        let (relation_witness, fixed_selectors) = {
             let mut witness_env: PoseidonWitnessBuilderEnv = WitnessBuilderEnv::create();
+
+            let mut fixed_selectors: [Vec<Fp>; N_FSEL] =
+                std::array::from_fn(|_| vec![Fp::zero(); 1]);
+            // Write constants
+            {
+                let rc = PoseidonBN254Parameters.constants();
+                rc.iter().enumerate().for_each(|(round, rcs)| {
+                    rcs.iter().enumerate().for_each(|(state_index, rc)| {
+                        witness_env.set_fixed_selector_cix(
+                            PoseidonColumn::RoundConstant(round, state_index),
+                            vec![*rc; domain_size],
+                        );
+                        fixed_selectors[round * STATE_SIZE + state_index] = vec![*rc; domain_size];
+                    });
+                });
+            }
 
             // Generate random inputs at each row
             for _row in 0..domain_size {
@@ -123,7 +153,10 @@ mod tests {
                 witness_env.next_row();
             }
 
-            witness_env.get_relation_witness(domain_size)
+            (
+                witness_env.get_relation_witness(domain_size),
+                fixed_selectors,
+            )
         };
 
         let constraints = {
@@ -151,9 +184,9 @@ mod tests {
             constraints
         };
 
-        kimchi_msm::test::test_completeness_generic_no_lookups::<N_COL, N_COL, N_DSEL, 0, _>(
+        kimchi_msm::test::test_completeness_generic_no_lookups::<N_COL, N_COL, N_DSEL, N_FSEL, _>(
             constraints,
-            Box::new([]),
+            Box::new(fixed_selectors),
             relation_witness,
             domain_size,
             &mut rng,


### PR DESCRIPTION
Built on top of !https://github.com/o1-labs/proof-systems/pull/2306
in 2306, the round constants are considered as witness values. Simply making them public to not fold them later.