### PR TITLE
[easy] Remove `Indexer` trait and use `From` instead

### DIFF
--- a/o1vm/src/keccak/folding.rs
+++ b/o1vm/src/keccak/folding.rs
@@ -4,7 +4,6 @@ use crate::{
         column::{N_ZKVM_KECCAK_COLS, N_ZKVM_KECCAK_REL_COLS, N_ZKVM_KECCAK_SEL_COLS},
         KeccakColumn, Steps,
     },
-    trace::Indexer,
     Curve, Fp,
 };
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
@@ -32,7 +31,7 @@ impl Index<KeccakColumn> for KeccakFoldingWitness {
     type Output = Evaluations<Fp, Radix2EvaluationDomain<Fp>>;
 
     fn index(&self, index: KeccakColumn) -> &Self::Output {
-        &self.witness.cols[index.ix()]
+        &self.witness.cols[usize::from(index)]
     }
 }
 
@@ -42,7 +41,7 @@ impl Index<Steps> for KeccakFoldingWitness {
 
     /// Map a selector column to the corresponding witness column.
     fn index(&self, index: Steps) -> &Self::Output {
-        &self.witness.cols[index.ix()]
+        &self.witness.cols[usize::from(index)]
     }
 }
 

--- a/o1vm/src/mips/column.rs
+++ b/o1vm/src/mips/column.rs
@@ -1,9 +1,6 @@
-use crate::{
-    mips::{
-        witness::SCRATCH_SIZE,
-        Instruction::{self, IType, JType, RType},
-    },
-    trace::Indexer,
+use crate::mips::{
+    witness::SCRATCH_SIZE,
+    Instruction::{self, IType, JType, RType},
 };
 use kimchi_msm::{
     columns::{Column, ColumnIndexer},
@@ -46,10 +43,10 @@ pub enum ColumnAlias {
 /// The MIPS circuit is split into three main opcodes: RType, JType, IType.
 /// The columns are shared between different instruction types.
 /// (the total number of columns refers to the maximum of columns used by each mode)
-impl Indexer for ColumnAlias {
-    fn ix(&self) -> usize {
+impl From<ColumnAlias> for usize {
+    fn from(alias: ColumnAlias) -> usize {
         // Note that SCRATCH_SIZE + 1 is for the error
-        match *self {
+        match alias {
             ColumnAlias::ScratchState(i) => {
                 assert!(i < SCRATCH_SIZE);
                 i
@@ -60,9 +57,9 @@ impl Indexer for ColumnAlias {
 }
 
 /// Returns the corresponding index of the corresponding DynamicSelector column.
-impl Indexer for Instruction {
-    fn ix(&self) -> usize {
-        match *self {
+impl From<Instruction> for usize {
+    fn from(instr: Instruction) -> usize {
+        match instr {
             RType(rtype) => rtype as usize,
             JType(jtype) => RTypeInstruction::COUNT + jtype as usize,
             IType(itype) => RTypeInstruction::COUNT + JTypeInstruction::COUNT + itype as usize,
@@ -103,13 +100,13 @@ impl<T: Clone> Index<ColumnAlias> for MIPSWitness<T> {
 
     /// Map the column alias to the actual column index.
     fn index(&self, index: ColumnAlias) -> &Self::Output {
-        &self.cols[index.ix()]
+        &self.cols[usize::from(index)]
     }
 }
 
 impl<T: Clone> IndexMut<ColumnAlias> for MIPSWitness<T> {
     fn index_mut(&mut self, index: ColumnAlias) -> &mut Self::Output {
-        &mut self.cols[index.ix()]
+        &mut self.cols[usize::from(index)]
     }
 }
 
@@ -117,7 +114,7 @@ impl ColumnIndexer for ColumnAlias {
     const N_COL: usize = N_MIPS_COLS;
     fn to_column(self) -> Column {
         // TODO: what happens with error? It does not have a corresponding alias
-        Column::Relation(self.ix())
+        Column::Relation(usize::from(self))
     }
 }
 
@@ -128,13 +125,13 @@ impl<T: Clone> Index<Instruction> for MIPSWitness<T> {
 
     /// Map the column alias to the actual column index.
     fn index(&self, index: Instruction) -> &Self::Output {
-        &self.cols[index.ix()]
+        &self.cols[usize::from(index)]
     }
 }
 
 impl<T: Clone> IndexMut<Instruction> for MIPSWitness<T> {
     fn index_mut(&mut self, index: Instruction) -> &mut Self::Output {
-        &mut self.cols[index.ix()]
+        &mut self.cols[usize::from(index)]
     }
 }
 
@@ -142,6 +139,6 @@ impl ColumnIndexer for Instruction {
     const N_COL: usize = N_MIPS_COLS;
     fn to_column(self) -> Column {
         // TODO: what happens with error? It does not have a corresponding alias
-        Column::DynamicSelector(self.ix())
+        Column::DynamicSelector(usize::from(self))
     }
 }

--- a/o1vm/src/mips/folding.rs
+++ b/o1vm/src/mips/folding.rs
@@ -4,7 +4,6 @@ use crate::{
         column::{ColumnAlias as MIPSColumn, N_MIPS_COLS},
         Instruction,
     },
-    trace::Indexer,
     Curve, Fp,
 };
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
@@ -47,7 +46,7 @@ impl Index<MIPSColumn> for MIPSFoldingWitness {
     type Output = Evaluations<Fp, Radix2EvaluationDomain<Fp>>;
 
     fn index(&self, index: MIPSColumn) -> &Self::Output {
-        &self.witness.cols[index.ix()]
+        &self.witness.cols[usize::from(index)]
     }
 }
 
@@ -57,7 +56,7 @@ impl Index<Instruction> for MIPSFoldingWitness {
 
     /// Map a selector column to the corresponding witness column.
     fn index(&self, index: Instruction) -> &Self::Output {
-        &self.witness.cols[index.ix()]
+        &self.witness.cols[usize::from(index)]
     }
 }
 

--- a/o1vm/src/trace.rs
+++ b/o1vm/src/trace.rs
@@ -21,11 +21,6 @@ use poly_commitment::{commitment::absorb_commitment, PolyComm, SRS as _};
 use rayon::{iter::ParallelIterator, prelude::IntoParallelIterator};
 use std::{collections::BTreeMap, ops::Index};
 
-/// Returns the index of the witness column in the trace.
-pub trait Indexer {
-    fn ix(&self) -> usize;
-}
-
 /// Implement a trace for a single instruction.
 // TODO: we should use the generic traits defined in [kimchi_msm].
 // For now, we want to have this to be able to test the folding library for a
@@ -70,7 +65,7 @@ impl<const N: usize, C: FoldingConfig> Index<C::Selector> for DecomposedTrace<N,
 
 impl<const N: usize, C: FoldingConfig> DecomposedTrace<N, C>
 where
-    C::Selector: Indexer,
+    usize: From<<C as FoldingConfig>::Selector>,
 {
     /// Returns the number of rows that have been instantiated for the given
     /// selector.
@@ -108,7 +103,7 @@ where
         number_of_rows: usize,
     ) {
         (N_REL..N).for_each(|i| {
-            if i == selector.ix() {
+            if i == usize::from(selector) {
                 self.trace.get_mut(&selector).unwrap().witness.cols[i]
                     .extend((0..number_of_rows).map(|_| ScalarField::<C>::one()))
             } else {
@@ -148,7 +143,7 @@ pub trait Foldable<const N: usize, C: FoldingConfig, Sponge> {
 impl<const N: usize, C: FoldingConfig<Column = Column>, Sponge> Foldable<N, C, Sponge>
     for DecomposedTrace<N, C>
 where
-    C::Selector: Indexer,
+    C::Selector: Into<usize>,
     Sponge: FqSponge<BaseField<C>, C::Curve, ScalarField<C>>,
     <C as FoldingConfig>::Challenge: From<ChallengeTerm>,
 {
@@ -288,7 +283,7 @@ impl<const N: usize, const N_REL: usize, C: FoldingConfig, Env> Tracer<N_REL, C,
 where
     DecomposedTrace<N, C>: DecomposableTracer<Env>,
     Trace<N, C>: Tracer<N_REL, C, Env, Selector = ()>,
-    <C as FoldingConfig>::Selector: Indexer,
+    usize: From<<C as FoldingConfig>::Selector>,
 {
     type Selector = C::Selector;
 


### PR DESCRIPTION
This removes the unnecessary trait `Indexer` used to go from column aliases to usize and uses a normal `From` instead. This will be used in the delayed lookup columns, as part of the algorithm to extract columns from expressions.