### PR TITLE
Functionality inside `Trace` to obtain relation columns used in lookups

### DIFF
--- a/msm/src/columns.rs
+++ b/msm/src/columns.rs
@@ -4,7 +4,7 @@ use folding::expressions::FoldingColumnTrait;
 use kimchi::circuits::expr::{CacheId, FormattedOutput};
 
 /// Describe a generic indexed variable X_{i}.
-#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, Ord, PartialOrd)]
 pub enum Column {
     /// Columns related to the relation encoded in the circuit
     Relation(usize),

--- a/o1vm/src/keccak/trace.rs
+++ b/o1vm/src/keccak/trace.rs
@@ -56,7 +56,7 @@ impl Tracer<N_ZKVM_KECCAK_REL_COLS, KeccakConfig, KeccakEnv<ScalarField<KeccakCo
     ) -> Self {
         // Make sure we are using the same round number to refer to round steps
         let step = standardize(selector);
-        Self {
+        let mut trace = Self {
             domain_size,
             witness: Witness {
                 cols: Box::new(std::array::from_fn(|_| Vec::with_capacity(domain_size))),
@@ -64,7 +64,9 @@ impl Tracer<N_ZKVM_KECCAK_REL_COLS, KeccakConfig, KeccakEnv<ScalarField<KeccakCo
             constraints: KeccakEnv::constraints_of(step),
             lookups: KeccakEnv::lookups_of(step),
             delayed_columns: BTreeMap::new(),
-        }
+        };
+        trace.set_delayed_columns();
+        trace
     }
 
     fn push_row(

--- a/o1vm/src/keccak/trace.rs
+++ b/o1vm/src/keccak/trace.rs
@@ -63,6 +63,7 @@ impl Tracer<N_ZKVM_KECCAK_REL_COLS, KeccakConfig, KeccakEnv<ScalarField<KeccakCo
             },
             constraints: KeccakEnv::constraints_of(step),
             lookups: KeccakEnv::lookups_of(step),
+            delayed_columns: BTreeMap::new(),
         }
     }
 

--- a/o1vm/src/mips/tests.rs
+++ b/o1vm/src/mips/tests.rs
@@ -458,6 +458,8 @@ mod unit {
 }
 
 mod folding {
+    use std::collections::BTreeMap;
+
     use super::{
         unit::{dummy_env, write_instruction},
         Fp,
@@ -618,6 +620,7 @@ mod folding {
             witness: witness_one.clone(),
             constraints: constraints.clone(),
             lookups: vec![],
+            delayed_columns: BTreeMap::new(),
         };
 
         impl FoldingConfig for MIPSFoldingConfig {

--- a/o1vm/src/mips/trace.rs
+++ b/o1vm/src/mips/trace.rs
@@ -62,6 +62,7 @@ impl
             },
             constraints: env.constraints.clone(),
             lookups: env.lookups.clone(),
+            delayed_columns: BTreeMap::new(),
         };
         env.scratch_state_idx = 0; // Reset the scratch state index for the next instruction
         env.constraints = vec![]; // Clear the constraints for the next instruction

--- a/o1vm/src/mips/trace.rs
+++ b/o1vm/src/mips/trace.rs
@@ -55,7 +55,7 @@ impl
     ) -> Self {
         interpret_instruction(env, instr);
 
-        let trace = Self {
+        let mut trace = Self {
             domain_size,
             witness: Witness {
                 cols: Box::new(std::array::from_fn(|_| Vec::with_capacity(domain_size))),
@@ -64,6 +64,8 @@ impl
             lookups: env.lookups.clone(),
             delayed_columns: BTreeMap::new(),
         };
+        trace.set_delayed_columns();
+
         env.scratch_state_idx = 0; // Reset the scratch state index for the next instruction
         env.constraints = vec![]; // Clear the constraints for the next instruction
         env.lookups = vec![]; // Clear the lookups for the next instruction

--- a/o1vm/src/ramlookup.rs
+++ b/o1vm/src/ramlookup.rs
@@ -17,7 +17,7 @@ pub struct RAMLookup<T, ID: LookupTableID> {
     pub(crate) mode: LookupMode,
     /// The number of times that this lookup value should be added to / subtracted from the lookup accumulator.
     pub(crate) magnitude: T,
-    /// The columns containing the content of this lookup
+    /// The variables containing the content of this lookup
     pub(crate) value: Vec<T>,
 }
 

--- a/o1vm/src/trace.rs
+++ b/o1vm/src/trace.rs
@@ -49,27 +49,22 @@ impl<const N: usize, C: FoldingConfig> Trace<N, C> {
                 });
             });
         });
+        self.delayed_columns = delayed_columns;
     }
 
     fn columns_in_expr(op: &E<ScalarField<C>>) -> Vec<Column> {
-        // E<F> = Expr<ConstantExpr<F>, Column>;
-        // Expr<C, Column> = Operations<ExprInner<C, Column>>;
-
-        // Expr<ConstantExpr<ScalarField<C>>, Column>;
-        // Operations<ExprInner<ScalarField<C>, Column>>;
-
         match op {
             Atom(x) => match x {
                 Cell(x) => vec![x.col],
                 _ => vec![],
             },
-            Pow(x, _) => Self::columns_in_expr(&x),
+            Pow(x, _) => Self::columns_in_expr(x),
             Add(x, y) | Mul(x, y) | Sub(x, y) => {
-                let mut columns = Self::columns_in_expr(&x);
-                columns.extend(Self::columns_in_expr(&y));
+                let mut columns = Self::columns_in_expr(x);
+                columns.extend(Self::columns_in_expr(y));
                 columns
             }
-            Double(x) | Square(x) => Self::columns_in_expr(&x),
+            Double(x) | Square(x) => Self::columns_in_expr(x),
             Cache(_, _) | IfFeature(_, _, _) => vec![],
         }
     }

--- a/o1vm/src/trace.rs
+++ b/o1vm/src/trace.rs
@@ -280,7 +280,7 @@ pub trait DecomposableTracer<Env> {
 /// Generic implementation of the [Tracer] trait for the [DecomposedTrace] struct.
 /// It requires the [DecomposedTrace] to implement the [DecomposableTracer] trait,
 /// and the [Trace] struct to implement the [Tracer] trait with Selector set to (),
-/// and the `C::Selector` to implement the [Indexer] trait.
+/// and `usize` to implement the [From] trait with `C::Selector`.
 impl<const N: usize, const N_REL: usize, C: FoldingConfig, Env> Tracer<N_REL, C, Env>
     for DecomposedTrace<N, C>
 where

--- a/o1vm/src/trace.rs
+++ b/o1vm/src/trace.rs
@@ -33,6 +33,9 @@ pub struct Trace<const N: usize, C: FoldingConfig> {
     pub witness: Witness<N, Vec<ScalarField<C>>>,
     pub constraints: Vec<E<ScalarField<C>>>,
     pub lookups: Vec<Lookup<E<ScalarField<C>>>>,
+    /// Generic columns involved in the lookups for this step used in delayed argument
+    // NOTE: could be precomputed as they are known per step ahead of time
+    pub delayed_columns: BTreeMap<Column, bool>,
 }
 
 /// Struct representing a circuit execution trace which is decomposable in


### PR DESCRIPTION
This PR supports a new functionality inside the `Trace` struct to extract the columns used in lookups, which shall be used in the delayed lookup argument. 

The rough idea is to recurse over the values of each lookup expression for each instruction/step variant, so that upon initialization of the decomposed traces, the lookup-related columns are identified. This means "collecting" them has no impact on the witness generation code. 

Note that columns are extracted in generic shape. If we wanted to have them in alias shape, then we would need to create all the expressions in alias shape and then before calling the prover, convert them into generic shape.