### PR TITLE
Move byte-checks of Keccak to Syscall side and include lookups for length bytes

### DIFF
--- a/o1vm/src/keccak/interpreter.rs
+++ b/o1vm/src/keccak/interpreter.rs
@@ -427,7 +427,7 @@ where
     /// - 538  lookups if Step::Absorb::Middle (400 + 2 + 136)
     /// - 539  lookups if Step::Absorb::Last   (401 + 2 + 136)
     /// - 538  lookups if Step::Absorb::Only   (401 + 1 + 136)
-    /// - 602 lookups if Step::Squeeze         (600 + 1 + 1)
+    /// - 602  lookups if Step::Squeeze        (600 + 1 + 1)
     fn lookups(&mut self, step: Steps) {
         // SPONGE LOOKUPS
         // -> adds  400 lookups if is_sponge

--- a/o1vm/src/keccak/tests.rs
+++ b/o1vm/src/keccak/tests.rs
@@ -289,7 +289,7 @@ fn test_regression_number_of_lookups_and_constraints_and_degree() {
 
         match step {
             Sponge(Absorb(First)) => {
-                assert_eq!(keccak_env.constraints_env.lookups.len(), 737);
+                assert_eq!(keccak_env.constraints_env.lookups.len(), 537);
                 assert_eq!(keccak_env.constraints_env.constraints.len(), 332);
                 // We have 1 different degrees of constraints in Absorbs::First
                 assert_eq!(constraint_degrees.len(), 1);
@@ -297,7 +297,7 @@ fn test_regression_number_of_lookups_and_constraints_and_degree() {
                 assert_eq!(constraint_degrees[&1], 332);
             }
             Sponge(Absorb(Middle)) => {
-                assert_eq!(keccak_env.constraints_env.lookups.len(), 738);
+                assert_eq!(keccak_env.constraints_env.lookups.len(), 538);
                 assert_eq!(keccak_env.constraints_env.constraints.len(), 232);
                 // We have 1 different degrees of constraints in Absorbs::Middle
                 assert_eq!(constraint_degrees.len(), 1);
@@ -305,7 +305,7 @@ fn test_regression_number_of_lookups_and_constraints_and_degree() {
                 assert_eq!(constraint_degrees[&1], 232);
             }
             Sponge(Absorb(Last)) => {
-                assert_eq!(keccak_env.constraints_env.lookups.len(), 739);
+                assert_eq!(keccak_env.constraints_env.lookups.len(), 539);
                 assert_eq!(keccak_env.constraints_env.constraints.len(), 374);
                 // We have 2 different degrees of constraints in Squeeze
                 assert_eq!(constraint_degrees.len(), 2);
@@ -315,7 +315,7 @@ fn test_regression_number_of_lookups_and_constraints_and_degree() {
                 assert_eq!(constraint_degrees[&2], 141);
             }
             Sponge(Absorb(Only)) => {
-                assert_eq!(keccak_env.constraints_env.lookups.len(), 738);
+                assert_eq!(keccak_env.constraints_env.lookups.len(), 538);
                 assert_eq!(keccak_env.constraints_env.constraints.len(), 474);
                 // We have 2 different degrees of constraints in Squeeze
                 assert_eq!(constraint_degrees.len(), 2);

--- a/o1vm/src/mips/column.rs
+++ b/o1vm/src/mips/column.rs
@@ -25,9 +25,12 @@ pub(crate) const MIPS_PREIMAGE_CHUNK_OFF: usize = 84;
 /// The at most 4-bytes of the preimage that are currently being processed
 /// Consists of 4 field elements of at most 1 byte each.
 pub(crate) const MIPS_PREIMAGE_BYTES_OFF: usize = 85;
-/// Flags indicating whether at least N bytes have been processed in this step.
-/// Contains 4 field elements of boolean type each.
-pub(crate) const MIPS_HAS_N_BYTES_OFF: usize = 89;
+/// The at most 4-bytes of the length that are currently being processed
+pub(crate) const MIPS_LENGTH_BYTES_OFF: usize = 89;
+/// Flags indicating whether at least N bytes have been processed in this step
+pub(crate) const MIPS_HAS_N_BYTES_OFF: usize = 93;
+/// The maximum size of a chunk (4 bytes)
+pub(crate) const MIPS_CHUNK_BYTES_LEN: usize = 4;
 
 /// The number of columns used for relation witness in the MIPS circuit
 pub const N_MIPS_REL_COLS: usize = SCRATCH_SIZE + 2;

--- a/o1vm/src/mips/witness.rs
+++ b/o1vm/src/mips/witness.rs
@@ -7,13 +7,13 @@ use crate::{
     lookups::Lookup,
     mips::{
         column::{
-            ColumnAlias as Column, MIPS_BYTE_COUNTER_OFF, MIPS_END_OF_PREIMAGE_OFF,
-            MIPS_HASH_COUNTER_OFF, MIPS_HAS_N_BYTES_OFF, MIPS_NUM_BYTES_READ_OFF,
-            MIPS_PREIMAGE_BYTES_OFF, MIPS_PREIMAGE_CHUNK_OFF,
+            ColumnAlias as Column, MIPS_BYTE_COUNTER_OFF, MIPS_CHUNK_BYTES_LEN,
+            MIPS_END_OF_PREIMAGE_OFF, MIPS_HASH_COUNTER_OFF, MIPS_HAS_N_BYTES_OFF,
+            MIPS_LENGTH_BYTES_OFF, MIPS_NUM_BYTES_READ_OFF, MIPS_PREIMAGE_BYTES_OFF,
+            MIPS_PREIMAGE_CHUNK_OFF,
         },
         interpreter::{
-            self, ITypeInstruction, Instruction, InterpreterEnv, JTypeInstruction,
-            RTypeInstruction, MIPS_CHUNK_BYTES_LEN,
+            self, ITypeInstruction, Instruction, InterpreterEnv, JTypeInstruction, RTypeInstruction,
         },
         registers::Registers,
     },
@@ -44,7 +44,7 @@ pub const NUM_INSTRUCTION_LOOKUP_TERMS: usize = 5;
 pub const NUM_LOOKUP_TERMS: usize =
     NUM_GLOBAL_LOOKUP_TERMS + NUM_DECODING_LOOKUP_TERMS + NUM_INSTRUCTION_LOOKUP_TERMS;
 // TODO: Delete and use a vector instead
-pub const SCRATCH_SIZE: usize = 93; // MIPS + hash_counter + chunk_read + bytes_read + bytes_left + bytes + has_n_bytes
+pub const SCRATCH_SIZE: usize = 97; // MIPS + hash_counter + byte_counter + eof + num_bytes_read + chunk + bytes + length + has_n_bytes
 
 #[derive(Clone, Default)]
 pub struct SyscallEnv {
@@ -674,10 +674,19 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
             // The first 8 bytes of the read preimage are the preimage length,
             // followed by the body of the preimage
             if idx < LENGTH_SIZE {
-                // Do nothing for the count of bytes of the preimage.
-                // TODO: do we want to check anything for these bytes as well?
-                // Like length?
+                // Compute the byte index read from the length
+                let len_i = idx % MIPS_CHUNK_BYTES_LEN;
+
                 let length_byte = u64::to_be_bytes(preimage_len as u64)[idx];
+
+                // Write the individual byte of the length to the witness
+                self.write_column(
+                    Column::ScratchState(MIPS_LENGTH_BYTES_OFF + len_i),
+                    length_byte as u64,
+                );
+
+                // TODO: Proabably, the scratch state of MIPS_LENGTH_BYTES_OFF
+                // is redundant with lines below
                 unsafe {
                     self.push_memory(&(*addr + i), length_byte as u64);
                     self.push_memory_access(&(*addr + i), self.next_instruction_counter());


### PR DESCRIPTION
Cherry-picked from https://github.com/o1-labs/proof-systems/pull/2276/