### PR TITLE
IVC: reuse definitions of Poseidon parameters for bn254

### DIFF
--- a/ivc/src/ivc/columns.rs
+++ b/ivc/src/ivc/columns.rs
@@ -1,4 +1,14 @@
-use crate::{ivc::interpreter::N_LIMBS_XLARGE, poseidon_8_56_5_3_2::columns::PoseidonColumn};
+use crate::{
+    ivc::interpreter::N_LIMBS_XLARGE,
+    poseidon_8_56_5_3_2::{
+        bn254::{
+            Column as IVCPoseidonColumn, NB_FULL_ROUND as IVC_POSEIDON_NB_FULL_ROUND,
+            NB_PARTIAL_ROUND as IVC_POSEIDON_NB_PARTIAL_ROUND,
+            STATE_SIZE as IVC_POSEIDON_STATE_SIZE,
+        },
+        columns::PoseidonColumn,
+    },
+};
 use kimchi_msm::{
     circuit_design::composition::MPrism,
     columns::{Column, ColumnIndexer},
@@ -22,20 +32,9 @@ pub fn block_height<const N_COL_TOTAL: usize, const N_CHALS: usize>(block_num: u
     }
 }
 
-pub const IVC_POSEIDON_STATE_SIZE: usize = 3;
-pub const IVC_POSEIDON_NB_FULL_ROUND: usize = 8;
-pub const IVC_POSEIDON_NB_PARTIAL_ROUND: usize = 56;
-pub const IVC_POSEIDON_NB_TOTAL_ROUND: usize = 64;
-
 pub const IVC_NB_TOTAL_FIXED_SELECTORS: usize =
     (IVC_POSEIDON_NB_FULL_ROUND + IVC_POSEIDON_NB_PARTIAL_ROUND) * IVC_POSEIDON_STATE_SIZE
         + N_BLOCKS;
-
-pub type IVCPoseidonColumn = PoseidonColumn<
-    IVC_POSEIDON_STATE_SIZE,
-    IVC_POSEIDON_NB_FULL_ROUND,
-    IVC_POSEIDON_NB_PARTIAL_ROUND,
->;
 
 /// The IVC circuit is tiled vertically. We assume we have as many
 /// rows as we need: if we don't, we wrap around and continue.

--- a/ivc/src/ivc/interpreter.rs
+++ b/ivc/src/ivc/interpreter.rs
@@ -2,12 +2,15 @@
 
 use crate::{
     ivc::{
-        columns::{
-            block_height, IVCColumn, IVCFECLens, IVCHashLens, IVC_POSEIDON_STATE_SIZE, N_BLOCKS,
-        },
+        columns::{block_height, IVCColumn, IVCFECLens, IVCHashLens, N_BLOCKS},
         lookups::{IVCFECLookupLens, IVCLookupTable},
     },
-    poseidon_8_56_5_3_2::interpreter::{poseidon_circuit, PoseidonParams},
+    poseidon_8_56_5_3_2::{
+        bn254::{
+            NB_TOTAL_ROUND as IVC_POSEIDON_NB_TOTAL_ROUND, STATE_SIZE as IVC_POSEIDON_STATE_SIZE,
+        },
+        interpreter::{poseidon_circuit, PoseidonParams},
+    },
 };
 use ark_ff::PrimeField;
 use kimchi_msm::{
@@ -32,7 +35,7 @@ use kimchi_msm::{
 use num_bigint::BigUint;
 use std::marker::PhantomData;
 
-use super::columns::{IVC_NB_TOTAL_FIXED_SELECTORS, IVC_POSEIDON_NB_TOTAL_ROUND};
+use super::columns::IVC_NB_TOTAL_FIXED_SELECTORS;
 
 /// The biggest packing variant for foreign field. Used for hashing. 150-bit limbs.
 pub const LIMB_BITSIZE_XLARGE: usize = 150;


### PR DESCRIPTION
In https://github.com/o1-labs/proof-systems/pull/2269/files, it redefines the same structure. Removing here to avoid duplication.