### PR TITLE
Fix evaluation order error in folding

### DIFF
--- a/folding/src/eval_leaf.rs
+++ b/folding/src/eval_leaf.rs
@@ -113,7 +113,7 @@ impl<'a, F: Clone> EvalLeaf<'a, F> {
             }
             (Col(a), Result(mut b)) => {
                 for (a, b) in a.iter().zip(b.iter_mut()) {
-                    *b = f(b.clone(), a.clone())
+                    *b = f(a.clone(), b.clone())
                 }
                 Result(b)
             }


### PR DESCRIPTION
Because of this order in `bin_op`, the subtraction `a - b` was evaluated as `eval(b) - eval(a)` which is wrong.