### PR TITLE
Fix `ColumnIndexer` in MIPS (wrong order of selector columns)

### DIFF
--- a/o1vm/src/lib.rs
+++ b/o1vm/src/lib.rs
@@ -49,7 +49,7 @@ pub use ramlookup::{LookupMode as RAMLookupMode, RAMLookup};
 /// trace.
 /// As a reminder, a constraint can be formally defined as a multi-variate
 /// polynomial over a finite field. The variables of the polynomial are defined
-/// as `kimchi_msm::columns::Column``.
+/// as `kimchi_msm::columns::Column`.
 /// The `expression` framework defined in `kimchi::circuits::expr` is used to
 /// describe the multi-variate polynomials.
 /// For instance, a vanilla 3-wires PlonK constraint can be defined using the

--- a/o1vm/src/mips/column.rs
+++ b/o1vm/src/mips/column.rs
@@ -69,18 +69,22 @@ impl From<ColumnAlias> for usize {
 impl From<Instruction> for usize {
     fn from(instr: Instruction) -> usize {
         match instr {
-            RType(rtype) => rtype as usize,
-            JType(jtype) => RTypeInstruction::COUNT + jtype as usize,
-            IType(itype) => RTypeInstruction::COUNT + JTypeInstruction::COUNT + itype as usize,
+            RType(rtype) => N_MIPS_REL_COLS + rtype as usize,
+            JType(jtype) => N_MIPS_REL_COLS + RTypeInstruction::COUNT + jtype as usize,
+            IType(itype) => {
+                N_MIPS_REL_COLS + RTypeInstruction::COUNT + JTypeInstruction::COUNT + itype as usize
+            }
         }
     }
 }
 
-/// Represents one line of the execution trace of the virtual machine It does
-/// contain [N_MIPS_SEL_COLS] columns for the instruction selectors
+/// Represents one line of the execution trace of the virtual machine
+/// It contain
 /// + [SCRATCH_SIZE] columns
-/// + 2 additional columns to keep track of the instruction index and one for
-/// the system error code. The columns are, in order,
+/// + 1 column to keep track of the instruction index
+/// + 1 column for the system error code
+/// + [N_MIPS_SEL_COLS]  columns for the instruction selectors.
+/// The columns are, in order,
 /// - the 32 general purpose registers
 /// - the low and hi registers used by some arithmetic instructions
 /// - the current instruction pointer
@@ -145,9 +149,8 @@ impl<T: Clone> IndexMut<Instruction> for MIPSWitness<T> {
 }
 
 impl ColumnIndexer for Instruction {
-    const N_COL: usize = N_MIPS_COLS;
+    const N_COL: usize = N_MIPS_REL_COLS + N_MIPS_SEL_COLS;
     fn to_column(self) -> Column {
-        // TODO: what happens with error? It does not have a corresponding alias
-        Column::DynamicSelector(usize::from(self))
+        Column::DynamicSelector(usize::from(self) - N_MIPS_REL_COLS)
     }
 }

--- a/o1vm/src/mips/constraints.rs
+++ b/o1vm/src/mips/constraints.rs
@@ -410,7 +410,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         });
 
         // Whether the preimage chunk read has at least n bytes (1, 2, 3, or 4).
-        // It will be zero when the syscall reads the bytelength prefix.
+        // It will be all zero when the syscall reads the bytelength prefix.
         let has_n_bytes: [_; MIPS_CHUNK_BYTES_LEN] = array::from_fn(|i| {
             self.variable(Self::Position::ScratchState(MIPS_HAS_N_BYTES_OFF + i))
         });
@@ -513,7 +513,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
             {
                 // When at least has_1_byte, then any number of bytes can be
                 // read <=> Check that you can only read 1, 2, 3 or 4 bytes
-                self.constraints.push(
+                self.add_constraint(
                     has_n_bytes[0].clone()
                         * (num_read_bytes.clone() - Expr::from(1))
                         * (num_read_bytes.clone() - Expr::from(2))

--- a/o1vm/src/mips/interpreter.rs
+++ b/o1vm/src/mips/interpreter.rs
@@ -653,7 +653,7 @@ pub trait InterpreterEnv {
             let pos = self.alloc_scratch();
             unsafe { self.inverse_or_zero(x, pos) }
         };
-        // If x = 0, then res = 1 and x_inv_or_zero = _
+        // If x = 0, then res = 1 and x_inv_or_zero = 0
         // If x <> 0, then res = 0 and x_inv_or_zero = x^(-1)
         self.add_constraint(x.clone() * x_inv_or_zero.clone() + res.clone() - Self::constant(1));
         self.add_constraint(x.clone() * res.clone());


### PR DESCRIPTION
As part of the debugging process I realized that the witness columns storing the values for the dynamic selectors (instructions) in MIPS were not being mapped to the right indices. In particular, they were appearing _at the beginning_ of the witness, instead of _at the end_, which could be causing potential overwrites of relation witness data (for example, the selector column for `SyscallReadPreimage` was 11 instead of 106, which is 95 (relation columns) + 11, but the scratch state 11 is meant to store other type of data).

I thought that could have been the problem behind the failing constraints containing `self.equal()` (these have a `-1` which can only hold when real data is used, meaning not all zeros). But those are still failing after this fix, so it must be something else. I am printing out the witness for some instructions to check by hand why those constraints are not satisfied. 