### PR TITLE
IVC/Poseidon: add documentation and constants

### DIFF
--- a/ivc/src/poseidon_8_56_5_3_2/bn254/mod.rs
+++ b/ivc/src/poseidon_8_56_5_3_2/bn254/mod.rs
@@ -6,10 +6,26 @@ use ark_bn254::Fr;
 use mina_poseidon::{constants::SpongeConstants, poseidon::ArithmeticSpongeParams};
 use once_cell::sync::Lazy;
 
+/// The number of field elements in the state
 pub const STATE_SIZE: usize = 3;
+
+/// Number of full rounds
 pub const NB_FULL_ROUND: usize = 8;
+
+/// Number of partial rounds
 pub const NB_PARTIAL_ROUND: usize = 56;
+
+/// Total number of rounds, including partial and full.
 pub const NB_TOTAL_ROUND: usize = NB_FULL_ROUND + NB_PARTIAL_ROUND;
+
+/// Number of round constants
+pub const NB_ROUND_CONSTANTS: usize = NB_TOTAL_ROUND * STATE_SIZE;
+
+/// The number of constraints required by this gadget
+pub const NB_CONSTRAINTS: usize = 432;
+
+/// The maximum degree of a constraint
+pub const MAX_DEGREE: u64 = 2;
 
 pub type Column = PoseidonColumn<STATE_SIZE, NB_FULL_ROUND, NB_PARTIAL_ROUND>;
 

--- a/ivc/src/poseidon_8_56_5_3_2/mod.rs
+++ b/ivc/src/poseidon_8_56_5_3_2/mod.rs
@@ -9,8 +9,8 @@ pub mod bn254;
 mod tests {
     use crate::poseidon_8_56_5_3_2::{
         bn254::{
-            static_params, Column, PlonkSpongeConstantsIVC, PoseidonBN254Parameters, NB_FULL_ROUND,
-            NB_PARTIAL_ROUND, NB_TOTAL_ROUND, STATE_SIZE,
+            static_params, Column, PlonkSpongeConstantsIVC, PoseidonBN254Parameters, MAX_DEGREE,
+            NB_CONSTRAINTS, NB_FULL_ROUND, NB_PARTIAL_ROUND, NB_TOTAL_ROUND, STATE_SIZE,
         },
         columns::PoseidonColumn,
         interpreter,
@@ -163,8 +163,13 @@ mod tests {
                 constraints.len(),
                 4 * STATE_SIZE * NB_FULL_ROUND + (4 + STATE_SIZE - 1) * NB_PARTIAL_ROUND
             );
+            assert_eq!(constraints.len(), NB_CONSTRAINTS);
+
             // Maximum degree of the constraints is 2
-            assert_eq!(constraints.iter().map(|c| c.degree(1, 0)).max().unwrap(), 2);
+            assert_eq!(
+                constraints.iter().map(|c| c.degree(1, 0)).max().unwrap(),
+                MAX_DEGREE
+            );
 
             constraints
         };


### PR DESCRIPTION
The constants will be useful to the IVC library user to compute the number of challenges it does require.