### PR TITLE
[EASY] CI: bump up actions-gh-pages to version 4

### DIFF
--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -58,7 +58,7 @@ jobs:
           mv ./target/doc ./book/book/html/rustdoc
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         if: github.ref == 'refs/heads/master'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See https://github.com/peaceiris/actions-gh-pages/blob/v4.0.0/CHANGELOG.md

Also, see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Currently there are warnings in the CI when publishing the documentation