### PR TITLE
IVC: verify that the current design supports the MIPS interpreter

### DIFF
--- a/ivc/src/ivc/mod.rs
+++ b/ivc/src/ivc/mod.rs
@@ -92,6 +92,10 @@ mod tests {
             ));
         }
 
+        let comms_left: Box<_> = o1_utils::array::vec_to_boxed_array(comms_left);
+        let comms_right: Box<_> = o1_utils::array::vec_to_boxed_array(comms_right);
+        let comms_output: Box<_> = o1_utils::array::vec_to_boxed_array(comms_output);
+
         println!("Building fixed selectors");
         let mut fixed_selectors: Vec<Vec<Fp>> =
             build_selectors::<Fp, N_COL_TOTAL, N_CHALS>(domain_size).to_vec();
@@ -114,9 +118,9 @@ mod tests {
         ivc_circuit::<_, _, _, _, N_COL_TOTAL, N_CHALS>(
             &mut SubEnvLookup::new(&mut witness_env, lt_lens),
             0,
-            comms_left.try_into().unwrap(),
-            comms_right.try_into().unwrap(),
-            comms_output.try_into().unwrap(),
+            comms_left,
+            comms_right,
+            comms_output,
             [(Ff1::zero(), Ff1::zero()); 3],
             [(Ff1::zero(), Ff1::zero()); 2],
             Fp::zero(),

--- a/ivc/src/ivc/mod.rs
+++ b/ivc/src/ivc/mod.rs
@@ -26,6 +26,7 @@ mod tests {
             constraints::constrain_ivc,
             interpreter::{build_selectors, ivc_circuit},
             lookups::IVCLookupTable,
+            N_ADDITIONAL_WIT_COL_QUAD,
         },
         poseidon_8_56_5_3_2::{
             bn254::{
@@ -216,13 +217,45 @@ mod tests {
     }
 
     #[test]
+    // Verifying the IVC circuit can be built with 50 columns for the
+    // application
     fn test_completeness_ivc_app_50_cols() {
-        // Number of challenges in the IVC circuit.
-        // It is the maximum number of constraints per row.
-        // We do suppose it is Poseidon which has the highest number of constraints
-        // for now.
-        pub const TEST_N_CHALS: usize = IVC_POSEIDON_NB_CONSTRAINTS;
+        // Simulating 3 challenges for PIOP as we do have in general.
+        pub const TEST_N_CHALS: usize =
+            IVC_POSEIDON_NB_CONSTRAINTS + N_BLOCKS + N_ADDITIONAL_WIT_COL_QUAD + 3;
 
         test_completeness_ivc::<{ IVCColumn::N_COL + 50 }, TEST_N_CHALS>()
+    }
+
+    #[test]
+    // Verifying the IVC circuit can be built with 100 columns for the
+    // application
+    fn test_completeness_ivc_app_100_cols() {
+        pub const TEST_N_CHALS: usize =
+            IVC_POSEIDON_NB_CONSTRAINTS + N_BLOCKS + N_ADDITIONAL_WIT_COL_QUAD + 3;
+
+        test_completeness_ivc::<{ IVCColumn::N_COL + 100 }, TEST_N_CHALS>()
+    }
+
+    #[test]
+    // Verifying the IVC circuit can be built with 231 columns for the
+    // application
+    fn test_completeness_ivc_app_233_cols() {
+        pub const TEST_N_CHALS: usize =
+            IVC_POSEIDON_NB_CONSTRAINTS + N_BLOCKS + N_ADDITIONAL_WIT_COL_QUAD + 3;
+
+        test_completeness_ivc::<{ IVCColumn::N_COL + 233 }, TEST_N_CHALS>()
+    }
+
+    #[test]
+    #[should_panic]
+    // Verifying that the maximum number is 234 columns for the application,
+    // without any additional challenge.
+    // It should panic by saying that the domain size is not big enough.
+    fn test_regression_completeness_ivc_app_maximum_234_cols() {
+        pub const TEST_N_CHALS: usize =
+            IVC_POSEIDON_NB_CONSTRAINTS + N_BLOCKS + N_ADDITIONAL_WIT_COL_QUAD + 3;
+
+        test_completeness_ivc::<{ IVCColumn::N_COL + 234 }, TEST_N_CHALS>()
     }
 }

--- a/ivc/src/ivc/mod.rs
+++ b/ivc/src/ivc/mod.rs
@@ -145,7 +145,7 @@ mod tests {
         let mut rng = o1_utils::tests::make_test_rng(None);
         build_ivc_circuit::<_, IVCLookupTable<Ff1>, _>(
             &mut rng,
-            1 << 15,
+            TEST_DOMAIN_SIZE,
             IdMPrism::<IVCLookupTable<Ff1>>::default(),
         );
     }
@@ -178,14 +178,12 @@ mod tests {
     fn test_completeness_ivc() {
         let mut rng = o1_utils::tests::make_test_rng(None);
 
-        let domain_size = 1 << 15;
-
         let witness_env = build_ivc_circuit::<_, IVCLookupTable<Ff1>, _>(
             &mut rng,
-            domain_size,
+            TEST_DOMAIN_SIZE,
             IdMPrism::<IVCLookupTable<Ff1>>::default(),
         );
-        let relation_witness = witness_env.get_relation_witness(domain_size);
+        let relation_witness = witness_env.get_relation_witness(TEST_DOMAIN_SIZE);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, IVCLookupTable<Ff1>>::create();
         constrain_ivc::<Fp, Ff1, _>(&mut constraint_env);
@@ -193,7 +191,7 @@ mod tests {
 
         let mut fixed_selectors: Box<[Vec<Fp>; IVC_NB_TOTAL_FIXED_SELECTORS]> = {
             Box::new(build_selectors::<_, TEST_N_COL_TOTAL, TEST_N_CHALS>(
-                domain_size,
+                TEST_DOMAIN_SIZE,
             ))
         };
 
@@ -202,7 +200,7 @@ mod tests {
             let rc = PoseidonBN254Parameters.constants();
             rc.iter().enumerate().for_each(|(round, rcs)| {
                 rcs.iter().enumerate().for_each(|(state_index, rc)| {
-                    let rc = vec![*rc; domain_size];
+                    let rc = vec![*rc; TEST_DOMAIN_SIZE];
                     fixed_selectors[N_BLOCKS + round * IVC_POSEIDON_STATE_SIZE + state_index] = rc;
                 });
             });
@@ -218,7 +216,7 @@ mod tests {
             constraints,
             fixed_selectors,
             relation_witness,
-            domain_size,
+            TEST_DOMAIN_SIZE,
             &mut rng,
         );
     }


### PR DESCRIPTION
This will help later verifying the IVC circuit can still be built.
It is mostly checking that the changes in the [previous PR](https://github.com/o1-labs/proof-systems/pull/2367) does not change the fact that the current design supports our first real use case, which is the MIPS interpreter (consisting of less than 100 columns).