### PR TITLE
test: add the unit test for computing the `domain_size`

### DIFF
--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -970,9 +970,9 @@ pub mod tests {
         let (_, xor_gates_1) = CircuitGate::<Fp>::create_xor_gadget(next_start, 3); /* 1 xor gate */
         let circuit_gates: Vec<CircuitGate<Fp>> = range_check_gates_0
             .into_iter()
-            .chain(range_check_gates_1.into_iter())
-            .chain(xor_gates_0.into_iter())
-            .chain(xor_gates_1.into_iter())
+            .chain(range_check_gates_1)
+            .chain(xor_gates_0)
+            .chain(xor_gates_1)
             .collect(); /* 2 range check gates + 2 xor gates */
 
         // inputs + expected output

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -914,7 +914,8 @@ impl<F: PrimeField + SquareRootField> Builder<F> {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use mina_curves::pasta::Fp;
+    use mina_curves::pasta::{Fp, Fq};
+    use o1_utils::FieldHelpers;
 
     impl<F: PrimeField + SquareRootField> ConstraintSystem<F> {
         pub fn for_testing(gates: Vec<CircuitGate<F>>) -> Self {
@@ -967,13 +968,16 @@ pub mod tests {
         let (next_start, range_check_gates_0) = CircuitGate::<Fp>::create_range_check(0); /* 1 range_check gate */
         let (next_start, range_check_gates_1) = CircuitGate::<Fp>::create_range_check(next_start); /* 1 range_check gate */
         let (next_start, xor_gates_0) = CircuitGate::<Fp>::create_xor_gadget(next_start, 3); /* 1 xor gate */
-        let (_, xor_gates_1) = CircuitGate::<Fp>::create_xor_gadget(next_start, 3); /* 1 xor gate */
+        let (next_start, xor_gates_1) = CircuitGate::<Fp>::create_xor_gadget(next_start, 3); /* 1 xor gate */
+        let (_, ffm_gates) =
+            CircuitGate::<Fp>::create_foreign_field_mul(next_start, &Fq::modulus_biguint()); /* 1 foreign field multiplication gate */
         let circuit_gates: Vec<CircuitGate<Fp>> = range_check_gates_0
             .into_iter()
             .chain(range_check_gates_1)
             .chain(xor_gates_0)
             .chain(xor_gates_1)
-            .collect(); /* 2 range check gates + 2 xor gates */
+            .chain(ffm_gates)
+            .collect(); /* 2 range check gates + 2 xor gates + 1 foreign field multiplication */
 
         // inputs + expected output
         let data = [

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -994,22 +994,23 @@ pub mod tests {
                 8192, /* 8192 > 5 * 100 + 1 * 4096 + 1 * 256 + 1 + zk_row */
             ),
         ];
-        for ((number_of_table_ids, size), expected_domain_size) in data.into_iter() {
-            let builder = ConstraintSystem::create(circuit_gates.clone());
-            let table_ids: Vec<i32> = (3..number_of_table_ids + 3).collect();
-            let lookup_tables: Vec<LookupTable<Fp>> = table_ids
-                .into_iter()
-                .map(|id| {
-                    let indexes: Vec<u32> = (0..size).collect();
-                    let data: Vec<Fp> = indexes.into_iter().map(Fp::from).collect();
-                    LookupTable {
-                        id,
-                        data: vec![data],
-                    }
-                })
-                .collect();
-            let res = builder.lookup(lookup_tables).build().unwrap();
-            assert_eq!(res.domain.d1.size, expected_domain_size);
-        }
+        data.into_iter()
+            .for_each(|((number_of_table_ids, size), expected_domain_size)| {
+                let builder = ConstraintSystem::create(circuit_gates.clone());
+                let table_ids: Vec<i32> = (3..number_of_table_ids + 3).collect();
+                let lookup_tables: Vec<LookupTable<Fp>> = table_ids
+                    .into_iter()
+                    .map(|id| {
+                        let indexes: Vec<u32> = (0..size).collect();
+                        let data: Vec<Fp> = indexes.into_iter().map(Fp::from).collect();
+                        LookupTable {
+                            id,
+                            data: vec![data],
+                        }
+                    })
+                    .collect();
+                let res = builder.lookup(lookup_tables).build().unwrap();
+                assert_eq!(res.domain.d1.size, expected_domain_size);
+            });
     }
 }


### PR DESCRIPTION
## Description
Add the unit test for checking the `domain_size` of circuit, when the gates use the same table

## Related issues
- Resolve #1335 

## Changes
- add the `test_lookup_domain_size_computation` in `kimchi/src/circuits/constraints.rs`