### PR TITLE
FEC ADD: Decrease degree to 2

### DIFF
--- a/ivc/src/ivc/mod.rs
+++ b/ivc/src/ivc/mod.rs
@@ -17,7 +17,7 @@ pub const N_LIMBS_XLARGE: usize = 2;
 /// require.
 /// A regression test is available in the tests directory, under the name
 /// `test_regression_additional_columns_reduction_to_degree_2`
-pub const N_ADDITIONAL_WIT_COL_QUAD: usize = 344;
+pub const N_ADDITIONAL_WIT_COL_QUAD: usize = 335;
 
 /// Number of challenges in the IVC circuit.
 /// It is the maximum number of constraints per row.
@@ -171,8 +171,8 @@ mod tests {
 
         // Regression testing for the number of constraints and their degree
         {
-            // 55 + 432 (Poseidon)
-            assert_eq!(constraints.len(), 487);
+            // 67 + 432 (Poseidon)
+            assert_eq!(constraints.len(), 499);
             constraints.iter().for_each(|c| {
                 let degree = c.degree(1, 0);
                 *constraints_degrees.entry(degree).or_insert(0) += 1;
@@ -181,8 +181,8 @@ mod tests {
             assert_eq!(constraints_degrees.get(&1), None);
             assert_eq!(constraints_degrees.get(&2), Some(&6));
             assert_eq!(constraints_degrees.get(&3), Some(&215));
-            assert_eq!(constraints_degrees.get(&4), Some(&245));
-            assert_eq!(constraints_degrees.get(&5), Some(&21));
+            assert_eq!(constraints_degrees.get(&4), Some(&278));
+            assert_eq!(constraints_degrees.get(&5), None);
 
             // Maximum degree is 5
             // - fold_iteration increases by one

--- a/ivc/tests/add.rs
+++ b/ivc/tests/add.rs
@@ -346,7 +346,7 @@ pub fn test_simple_add() {
             .chain(ivc_constraints.iter())
             .map(|c| c.degree(1, 0))
             .max(),
-        Some(5)
+        Some(4)
     );
 
     // Make the constraints folding compatible

--- a/ivc/tests/folding_ivc.rs
+++ b/ivc/tests/folding_ivc.rs
@@ -133,6 +133,8 @@ fn test_regression_additional_columns_reduction_to_degree_2() {
         FoldingScheme::<TestConfig>::new(folding_compat_expresions, &srs, domain, &());
     assert_eq!(
         scheme.get_number_of_additional_columns(),
-        N_ADDITIONAL_WIT_COL_QUAD
+        N_ADDITIONAL_WIT_COL_QUAD,
+        "Expected {N_ADDITIONAL_WIT_COL_QUAD}, got {}",
+        scheme.get_number_of_additional_columns(),
     );
 }

--- a/msm/src/fec/columns.rs
+++ b/msm/src/fec/columns.rs
@@ -4,7 +4,8 @@ use crate::{
 };
 
 /// Number of columns in the FEC circuits.
-pub const FEC_N_COLUMNS: usize = 5 * N_LIMBS_LARGE + 12 * N_LIMBS_SMALL + 9;
+pub const FEC_N_COLUMNS: usize =
+    FECColumnInput::N_COL + FECColumnOutput::N_COL + FECColumnInter::N_COL;
 
 /// FEC ADD inputs: two points = four coordinates, and each in 4
 /// "large format" limbs.
@@ -34,6 +35,9 @@ pub enum FECColumnInter {
     Q1Sign,        // 1
     Q2Sign,        // 1
     Q3Sign,        // 1
+    Q1L(usize),    // 4
+    Q2L(usize),    // 4
+    Q3L(usize),    // 4
     Carry1(usize), // 36
     Carry2(usize), // 36
     Carry3(usize), // 36
@@ -88,7 +92,7 @@ impl ColumnIndexer for FECColumnOutput {
 }
 
 impl ColumnIndexer for FECColumnInter {
-    const N_COL: usize = N_LIMBS_LARGE + 10 * N_LIMBS_SMALL + 9;
+    const N_COL: usize = 4 * N_LIMBS_LARGE + 10 * N_LIMBS_SMALL + 9;
     fn to_column(self) -> Column {
         match self {
             FECColumnInter::F(i) => {
@@ -114,17 +118,29 @@ impl ColumnIndexer for FECColumnInter {
             FECColumnInter::Q1Sign => Column::Relation(N_LIMBS_LARGE + 4 * N_LIMBS_SMALL),
             FECColumnInter::Q2Sign => Column::Relation(N_LIMBS_LARGE + 4 * N_LIMBS_SMALL + 1),
             FECColumnInter::Q3Sign => Column::Relation(N_LIMBS_LARGE + 4 * N_LIMBS_SMALL + 2),
+            FECColumnInter::Q1L(i) => {
+                assert!(i < N_LIMBS_LARGE);
+                Column::Relation(N_LIMBS_LARGE + 4 * N_LIMBS_SMALL + 3 + i)
+            }
+            FECColumnInter::Q2L(i) => {
+                assert!(i < N_LIMBS_LARGE);
+                Column::Relation(2 * N_LIMBS_LARGE + 4 * N_LIMBS_SMALL + 3 + i)
+            }
+            FECColumnInter::Q3L(i) => {
+                assert!(i < N_LIMBS_LARGE);
+                Column::Relation(3 * N_LIMBS_LARGE + 4 * N_LIMBS_SMALL + 3 + i)
+            }
             FECColumnInter::Carry1(i) => {
                 assert!(i < 2 * N_LIMBS_SMALL + 2);
-                Column::Relation(N_LIMBS_LARGE + 4 * N_LIMBS_SMALL + 3 + i)
+                Column::Relation(4 * N_LIMBS_LARGE + 4 * N_LIMBS_SMALL + 3 + i)
             }
             FECColumnInter::Carry2(i) => {
                 assert!(i < 2 * N_LIMBS_SMALL + 2);
-                Column::Relation(N_LIMBS_LARGE + 6 * N_LIMBS_SMALL + 5 + i)
+                Column::Relation(4 * N_LIMBS_LARGE + 6 * N_LIMBS_SMALL + 5 + i)
             }
             FECColumnInter::Carry3(i) => {
                 assert!(i < 2 * N_LIMBS_SMALL + 2);
-                Column::Relation(N_LIMBS_LARGE + 8 * N_LIMBS_SMALL + 7 + i)
+                Column::Relation(4 * N_LIMBS_LARGE + 8 * N_LIMBS_SMALL + 7 + i)
             }
         }
     }

--- a/msm/src/fec/mod.rs
+++ b/msm/src/fec/mod.rs
@@ -91,7 +91,7 @@ mod tests {
 
         let mut constraints_degrees = HashMap::new();
 
-        assert_eq!(constraints.len(), 24);
+        assert_eq!(constraints.len(), 36);
 
         {
             constraints.iter().for_each(|c| {
@@ -100,8 +100,8 @@ mod tests {
             });
 
             assert_eq!(constraints_degrees.get(&1), None);
-            assert_eq!(constraints_degrees.get(&2), Some(&3));
-            assert_eq!(constraints_degrees.get(&3), Some(&21));
+            assert_eq!(constraints_degrees.get(&2), Some(&36));
+            assert_eq!(constraints_degrees.get(&3), None);
 
             assert!(constraints.iter().map(|c| c.degree(1, 0)).max() <= Some(3));
         }
@@ -115,7 +115,7 @@ mod tests {
 
         let mut constraints_degrees = HashMap::new();
 
-        assert_eq!(constraints.len(), 63);
+        assert_eq!(constraints.len(), 75);
 
         {
             constraints.iter().for_each(|c| {
@@ -124,8 +124,8 @@ mod tests {
             });
 
             assert_eq!(constraints_degrees.get(&1), Some(&1));
-            assert_eq!(constraints_degrees.get(&2), Some(&5));
-            assert_eq!(constraints_degrees.get(&3), Some(&21));
+            assert_eq!(constraints_degrees.get(&2), Some(&38));
+            assert_eq!(constraints_degrees.get(&3), None);
             assert_eq!(constraints_degrees.get(&4), None);
             assert_eq!(constraints_degrees.get(&5), Some(&2));
             assert_eq!(constraints_degrees.get(&6), None);


### PR DESCRIPTION
FEC ADD had degree 3 because of `q1_sign`, and about `229` columns. Now it has degree 2 and about `245` columns because I did quadraticisation in place. I added "big" q1/q2/q3 limbs, and I multiply them by sign separately instead of multiplying all together.