### PR TITLE
Adding multirow lookup into MSM serialization

### DIFF
--- a/ivc/src/ivc/lookups.rs
+++ b/ivc/src/ivc/lookups.rs
@@ -38,7 +38,7 @@ impl<Ff: PrimeField> LookupTableID for IVCLookupTable<Ff> {
     }
 
     /// Converts a value to its index in the fixed table.
-    fn ix_by_value<F: PrimeField>(&self, value: F) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, value: F) -> Option<usize> {
         match self {
             Self::SerLookupTable(lt) => lt.ix_by_value(value),
         }
@@ -54,7 +54,7 @@ impl<Ff: PrimeField> LookupTableID for IVCLookupTable<Ff> {
 
 impl<Ff: PrimeField> IVCLookupTable<Ff> {
     /// Provides a full list of entries for the given table.
-    pub fn entries<F: PrimeField>(&self, domain_d1_size: u64) -> Vec<F> {
+    pub fn entries<F: PrimeField>(&self, domain_d1_size: u64) -> Option<Vec<F>> {
         match self {
             Self::SerLookupTable(lt) => lt.entries(domain_d1_size),
         }

--- a/msm/src/circuit_design/witness.rs
+++ b/msm/src/circuit_design/witness.rs
@@ -186,8 +186,15 @@ impl<
     fn lookup_vec(&mut self, table_id: LT, values: &[<Self as ColAccessCap<F, CIx>>::Variable]) {
         if values.len() == 1 {
             let value = &values[0];
-            let value_ix = table_id.ix_by_value(*value);
-            self.lookup_multiplicities.get_mut(&table_id).unwrap()[value_ix] += F::one();
+            if table_id.is_fixed() {
+                let value_ix = table_id.ix_by_value(*value).unwrap();
+                self.lookup_multiplicities.get_mut(&table_id).unwrap()[value_ix] += F::one();
+            } else {
+                // Either:
+                // * Find the row in existing lookup table
+                // * Ask user to supply an index, and check against it
+                todo!()
+            }
             self.lookups
                 .last_mut()
                 .unwrap()

--- a/msm/src/fec/lookups.rs
+++ b/msm/src/fec/lookups.rs
@@ -57,9 +57,9 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
     }
 
     /// Converts a value to its index in the fixed table.
-    fn ix_by_value<F: PrimeField>(&self, value: F) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, value: F) -> Option<usize> {
         assert!(self.is_member(value));
-        match self {
+        Some(match self {
             Self::RangeCheck15 => TryFrom::try_from(value.to_biguint()).unwrap(),
             Self::RangeCheck14Abs => {
                 if value < F::from(1u64 << 14) {
@@ -76,7 +76,7 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
                 }
             }
             Self::RangeCheckFfHighest(_) => TryFrom::try_from(value.to_biguint()).unwrap(),
-        }
+        })
     }
 
     fn all_variants() -> Vec<Self> {

--- a/msm/src/ffa/lookups.rs
+++ b/msm/src/ffa/lookups.rs
@@ -42,8 +42,8 @@ impl LookupTableID for LookupTable {
     }
 
     /// Converts a value to its index in the fixed table.
-    fn ix_by_value<F: PrimeField>(&self, value: F) -> usize {
-        match self {
+    fn ix_by_value<F: PrimeField>(&self, value: F) -> Option<usize> {
+        Some(match self {
             Self::RangeCheck15 => TryFrom::try_from(value.to_biguint()).unwrap(),
             Self::RangeCheck1BitSigned => {
                 if value == F::zero() {
@@ -56,7 +56,7 @@ impl LookupTableID for LookupTable {
                     panic!("Invalid value for rangecheck1abs")
                 }
             }
-        }
+        })
     }
 
     fn all_variants() -> Vec<Self> {

--- a/msm/src/logup.rs
+++ b/msm/src/logup.rs
@@ -208,7 +208,9 @@ pub trait LookupTableID: Send + Sync + Copy + Hash + Eq + PartialEq + Ord + Part
     fn length(&self) -> usize;
 
     /// Given a value, returns an index of this value in the table.
-    fn ix_by_value<F: PrimeField>(&self, value: F) -> usize;
+    /// Returns None if the table is runtime (and thus mapping value
+    /// -> ix is not known at compile time.
+    fn ix_by_value<F: PrimeField>(&self, value: F) -> Option<usize>;
 
     fn all_variants() -> Vec<Self>;
 }

--- a/msm/src/lookups.rs
+++ b/msm/src/lookups.rs
@@ -33,9 +33,9 @@ impl LookupTableID for DummyLookupTable {
         true
     }
 
-    fn ix_by_value<F: PrimeField>(&self, value: F) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, value: F) -> Option<usize> {
         if value == F::zero() {
-            0
+            Some(0)
         } else {
             panic!("Invalid value for DummyLookupTable")
         }
@@ -92,7 +92,7 @@ impl LookupTableID for LookupTableIDs {
         true
     }
 
-    fn ix_by_value<F: PrimeField>(&self, _value: F) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, _value: F) -> Option<usize> {
         todo!()
     }
 

--- a/msm/src/serialization/interpreter.rs
+++ b/msm/src/serialization/interpreter.rs
@@ -379,6 +379,8 @@ pub fn constrain_multiplication<
 >(
     env: &mut Env,
 ) {
+    let _current_row = env.read_column(SerializationColumn::CurrentRow);
+
     let chal_converted_limbs_small: [_; N_LIMBS_SMALL] =
         core::array::from_fn(|i| env.read_column(SerializationColumn::ChalConverted(i)));
     let coeff_input_limbs_small: [_; N_LIMBS_SMALL] =
@@ -397,6 +399,8 @@ pub fn constrain_multiplication<
     let constant_u128 = |x: u128| -> <Env as ColAccessCap<F, SerializationColumn>>::Variable {
         Env::constant(From::from(x))
     };
+
+    //env.lookup();
 
     // Result variable must be in the field.
     for (i, x) in coeff_result_limbs_small.iter().enumerate() {

--- a/msm/src/serialization/lookups.rs
+++ b/msm/src/serialization/lookups.rs
@@ -62,27 +62,32 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
     }
 
     /// Converts a value to its index in the fixed table.
-    fn ix_by_value<F: PrimeField>(&self, value: F) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, value: F) -> Option<usize> {
         assert!(self.is_member(value));
         match self {
-            Self::RangeCheck15 => TryFrom::try_from(value.to_biguint()).unwrap(),
-            Self::RangeCheck4 => TryFrom::try_from(value.to_biguint()).unwrap(),
+            Self::RangeCheck15 => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
+            Self::RangeCheck4 => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
             Self::RangeCheck14Abs => {
                 if value < F::from(1u64 << 14) {
-                    TryFrom::try_from(value.to_biguint()).unwrap()
+                    Some(TryFrom::try_from(value.to_biguint()).unwrap())
                 } else {
-                    TryFrom::try_from((value + F::from(2 * (1u64 << 14))).to_biguint()).unwrap()
+                    Some(
+                        TryFrom::try_from((value + F::from(2 * (1u64 << 14))).to_biguint())
+                            .unwrap(),
+                    )
                 }
             }
             Self::RangeCheck9Abs => {
                 if value < F::from(1u64 << 9) {
-                    TryFrom::try_from(value.to_biguint()).unwrap()
+                    Some(TryFrom::try_from(value.to_biguint()).unwrap())
                 } else {
-                    TryFrom::try_from((value + F::from(2 * (1u64 << 9))).to_biguint()).unwrap()
+                    Some(
+                        TryFrom::try_from((value + F::from(2 * (1u64 << 9))).to_biguint()).unwrap(),
+                    )
                 }
             }
 
-            Self::RangeCheckFfHighest(_) => TryFrom::try_from(value.to_biguint()).unwrap(),
+            Self::RangeCheckFfHighest(_) => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
         }
     }
 
@@ -114,41 +119,47 @@ impl<Ff: PrimeField> LookupTable<Ff> {
     }
 
     /// Provides a full list of entries for the given table.
-    pub fn entries<F: PrimeField>(&self, domain_d1_size: u64) -> Vec<F> {
+    pub fn entries<F: PrimeField>(&self, domain_d1_size: u64) -> Option<Vec<F>> {
         assert!(domain_d1_size >= (1 << 15));
         match self {
-            Self::RangeCheck15 => (0..domain_d1_size).map(|i| F::from(i)).collect(),
-            Self::RangeCheck4 => (0..domain_d1_size)
-                .map(|i| if i < (1 << 4) { F::from(i) } else { F::zero() })
-                .collect(),
-            Self::RangeCheck14Abs => (0..domain_d1_size)
-                .map(|i| {
-                    if i < (1 << 14) {
-                        // [0,1,2 ... (1<<14)-1]
-                        F::from(i)
-                    } else if i < 2 * (1 << 14) {
-                        // [-(i<<14),...-2,-1]
-                        F::from(i) - F::from(2u64 * (1 << 14))
-                    } else {
-                        F::zero()
-                    }
-                })
-                .collect(),
+            Self::RangeCheck15 => Some((0..domain_d1_size).map(|i| F::from(i)).collect()),
+            Self::RangeCheck4 => Some(
+                (0..domain_d1_size)
+                    .map(|i| if i < (1 << 4) { F::from(i) } else { F::zero() })
+                    .collect(),
+            ),
+            Self::RangeCheck14Abs => Some(
+                (0..domain_d1_size)
+                    .map(|i| {
+                        if i < (1 << 14) {
+                            // [0,1,2 ... (1<<14)-1]
+                            F::from(i)
+                        } else if i < 2 * (1 << 14) {
+                            // [-(i<<14),...-2,-1]
+                            F::from(i) - F::from(2u64 * (1 << 14))
+                        } else {
+                            F::zero()
+                        }
+                    })
+                    .collect(),
+            ),
 
-            Self::RangeCheck9Abs => (0..domain_d1_size)
-                .map(|i| {
-                    if i < (1 << 9) {
-                        // [0,1,2 ... (1<<9)-1]
-                        F::from(i)
-                    } else if i < 2 * (1 << 9) {
-                        // [-(i<<9),...-2,-1]
-                        F::from(i) - F::from(2u64 * (1 << 9))
-                    } else {
-                        F::zero()
-                    }
-                })
-                .collect(),
-            Self::RangeCheckFfHighest(_) => Self::entries_ff_highest::<F>(domain_d1_size),
+            Self::RangeCheck9Abs => Some(
+                (0..domain_d1_size)
+                    .map(|i| {
+                        if i < (1 << 9) {
+                            // [0,1,2 ... (1<<9)-1]
+                            F::from(i)
+                        } else if i < 2 * (1 << 9) {
+                            // [-(i<<9),...-2,-1]
+                            F::from(i) - F::from(2u64 * (1 << 9))
+                        } else {
+                            F::zero()
+                        }
+                    })
+                    .collect(),
+            ),
+            Self::RangeCheckFfHighest(_) => Some(Self::entries_ff_highest::<F>(domain_d1_size)),
         }
     }
 

--- a/msm/src/serialization/lookups.rs
+++ b/msm/src/serialization/lookups.rs
@@ -19,6 +19,8 @@ pub enum LookupTable<Ff> {
     /// x ∈ [0, ff_highest] where ff_highest is the highest 15-bit
     /// limb of the modulus of the foreign field `Ff`.
     RangeCheckFfHighest(PhantomData<Ff>),
+    /// Communication bus for the multiplication circuit.
+    MultiplicationBus,
 }
 
 impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
@@ -29,6 +31,7 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
             Self::RangeCheck14Abs => 3,
             Self::RangeCheck9Abs => 4,
             Self::RangeCheckFfHighest(_) => 5,
+            Self::MultiplicationBus => 6,
         }
     }
 
@@ -39,13 +42,21 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
             3 => Self::RangeCheck14Abs,
             4 => Self::RangeCheck9Abs,
             5 => Self::RangeCheckFfHighest(PhantomData),
+            6 => Self::MultiplicationBus,
             _ => panic!("Invalid lookup table id"),
         }
     }
 
     /// All tables are fixed tables.
     fn is_fixed(&self) -> bool {
-        true
+        match self {
+            Self::RangeCheck15 => true,
+            Self::RangeCheck4 => true,
+            Self::RangeCheck14Abs => true,
+            Self::RangeCheck9Abs => true,
+            Self::RangeCheckFfHighest(_) => true,
+            Self::MultiplicationBus => false,
+        }
     }
 
     fn length(&self) -> usize {
@@ -58,12 +69,16 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
                 crate::serialization::interpreter::ff_modulus_highest_limb::<Ff>(),
             )
             .unwrap(),
+            Self::MultiplicationBus => 1 << 15,
         }
     }
 
     /// Converts a value to its index in the fixed table.
     fn ix_by_value<F: PrimeField>(&self, value: F) -> Option<usize> {
-        assert!(self.is_member(value));
+        if self.is_fixed() {
+            assert!(self.is_member(value).unwrap());
+        }
+
         match self {
             Self::RangeCheck15 => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
             Self::RangeCheck4 => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
@@ -88,6 +103,7 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
             }
 
             Self::RangeCheckFfHighest(_) => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
+            Self::MultiplicationBus => None,
         }
     }
 
@@ -98,6 +114,7 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
             Self::RangeCheck9Abs,
             Self::RangeCheck4,
             Self::RangeCheckFfHighest(PhantomData),
+            Self::MultiplicationBus,
         ]
     }
 }
@@ -160,26 +177,28 @@ impl<Ff: PrimeField> LookupTable<Ff> {
                     .collect(),
             ),
             Self::RangeCheckFfHighest(_) => Some(Self::entries_ff_highest::<F>(domain_d1_size)),
+            _ => panic!("not possible"),
         }
     }
 
     /// Checks if a value is in a given table.
-    pub fn is_member<F: PrimeField>(&self, value: F) -> bool {
+    pub fn is_member<F: PrimeField>(&self, value: F) -> Option<bool> {
         match self {
-            Self::RangeCheck15 => value.to_biguint() < BigUint::from(2u128.pow(15)),
-            Self::RangeCheck4 => value.to_biguint() < BigUint::from(2u128.pow(4)),
+            Self::RangeCheck15 => Some(value.to_biguint() < BigUint::from(2u128.pow(15))),
+            Self::RangeCheck4 => Some(value.to_biguint() < BigUint::from(2u128.pow(4))),
             Self::RangeCheck14Abs => {
-                value < F::from(1u64 << 14) || value >= F::zero() - F::from(1u64 << 14)
+                Some(value < F::from(1u64 << 14) || value >= F::zero() - F::from(1u64 << 14))
             }
             Self::RangeCheck9Abs => {
-                value < F::from(1u64 << 9) || value >= F::zero() - F::from(1u64 << 9)
+                Some(value < F::from(1u64 << 9) || value >= F::zero() - F::from(1u64 << 9))
             }
             Self::RangeCheckFfHighest(_) => {
                 let f_bui: BigUint = TryFrom::try_from(Ff::Params::MODULUS).unwrap();
                 let top_modulus_f: F =
                     F::from_biguint(&(f_bui >> ((N_LIMBS - 1) * LIMB_BITSIZE))).unwrap();
-                value < top_modulus_f
+                Some(value < top_modulus_f)
             }
+            Self::MultiplicationBus => None,
         }
     }
 }

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -89,7 +89,7 @@ mod tests {
         // Fixed tables can be generated inside lookup_tables_data. Runtime should be generated here.
         let mut lookup_tables_data = BTreeMap::new();
         for table_id in LookupTable::<Ff1>::all_variants().into_iter() {
-            lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64));
+            lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64).unwrap());
         }
         let proof_inputs = witness_env.get_proof_inputs(domain_size, lookup_tables_data);
 

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -15,10 +15,10 @@ mod tests {
         columns::ColumnIndexer,
         logup::LookupTableID,
         serialization::{
-            column::{SerializationColumn, SER_N_COLUMNS},
+            column::{SerializationColumn, N_COL_SER, N_FSEL_SER},
             interpreter::{
-                constrain_multiplication, deserialize_field_element, limb_decompose_ff,
-                multiplication_circuit,
+                build_selectors, constrain_multiplication, deserialize_field_element,
+                limb_decompose_ff, multiplication_circuit,
             },
             lookups::LookupTable,
         },
@@ -28,10 +28,10 @@ mod tests {
     type SerializationWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         SerializationColumn,
-        { <SerializationColumn as ColumnIndexer>::N_COL },
-        { <SerializationColumn as ColumnIndexer>::N_COL },
+        { <SerializationColumn as ColumnIndexer>::N_COL - N_FSEL_SER },
+        { <SerializationColumn as ColumnIndexer>::N_COL - N_FSEL_SER },
         0,
-        0,
+        N_FSEL_SER,
         LookupTable<Ff1>,
     >;
 
@@ -86,6 +86,8 @@ mod tests {
             }
         }
 
+        let fixed_selectors = build_selectors(domain_size);
+
         // Fixed tables can be generated inside lookup_tables_data. Runtime should be generated here.
         let multiplication_bus: Vec<Fp> = vec![];
         let mut lookup_tables_data = BTreeMap::new();
@@ -98,15 +100,15 @@ mod tests {
         let proof_inputs = witness_env.get_proof_inputs(domain_size, lookup_tables_data);
 
         crate::test::test_completeness_generic::<
-            SER_N_COLUMNS,
-            SER_N_COLUMNS,
+            { N_COL_SER - N_FSEL_SER },
+            { N_COL_SER - N_FSEL_SER },
             0,
-            0,
+            N_FSEL_SER,
             LookupTable<Ff1>,
             _,
         >(
             constraints,
-            Box::new([]),
+            Box::new(fixed_selectors),
             proof_inputs,
             domain_size,
             &mut rng,

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -87,10 +87,14 @@ mod tests {
         }
 
         // Fixed tables can be generated inside lookup_tables_data. Runtime should be generated here.
+        let multiplication_bus: Vec<Fp> = vec![];
         let mut lookup_tables_data = BTreeMap::new();
         for table_id in LookupTable::<Ff1>::all_variants().into_iter() {
-            lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64).unwrap());
+            if table_id.is_fixed() {
+                lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64).unwrap());
+            }
         }
+        lookup_tables_data.insert(LookupTable::MultiplicationBus, multiplication_bus);
         let proof_inputs = witness_env.get_proof_inputs(domain_size, lookup_tables_data);
 
         crate::test::test_completeness_generic::<

--- a/o1vm/src/lookups.rs
+++ b/o1vm/src/lookups.rs
@@ -95,7 +95,7 @@ impl LookupTableID for LookupTableIDs {
         }
     }
 
-    fn ix_by_value<F: PrimeField>(&self, _value: F) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, _value: F) -> Option<usize> {
         todo!()
     }
 


### PR DESCRIPTION
Adds:
* Capability for vector lookup (no actual support, just interface)
* Some adjustments to support runtime lookup tables
* The "multiplication bus" runtime lookup table and support columns in the MSM serialization circuit
* Code invoking this lookup capability.