### PR TITLE
Folding Prover 3: Use slices instead of vecs in folding

### DIFF
--- a/folding/src/eval_leaf.rs
+++ b/folding/src/eval_leaf.rs
@@ -2,22 +2,22 @@
 /// Result of a folding expression evaluation.
 pub enum EvalLeaf<'a, F> {
     Const(F),
-    Col(&'a Vec<F>),
+    Col(&'a [F]), // slice will suffice
     Result(Vec<F>),
 }
 
 impl<'a, F: std::fmt::Display> std::fmt::Display for EvalLeaf<'a, F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let vec = match self {
+        let slice = match self {
             EvalLeaf::Const(c) => {
                 write!(f, "Const: {}", c)?;
                 return Ok(());
             }
             EvalLeaf::Col(a) => a,
-            EvalLeaf::Result(a) => a,
+            EvalLeaf::Result(a) => a.as_slice(),
         };
         writeln!(f, "[")?;
-        for e in vec.iter() {
+        for e in slice.iter() {
             writeln!(f, "{e}")?;
         }
         write!(f, "]")?;

--- a/folding/src/expressions.rs
+++ b/folding/src/expressions.rs
@@ -638,6 +638,44 @@ impl<C: FoldingConfig> FoldingCompatibleExpr<C> {
             FoldingCompatibleExpr::Pow(e, p) => Pow(Box::new(e.map_variable(mapper)), p),
         }
     }
+
+    /// Map all quad columns into regular witness columns.
+    pub fn flatten_quad_columns(
+        self,
+        mapper: &(dyn Fn(usize) -> Variable<C::Column>),
+    ) -> FoldingCompatibleExpr<C> {
+        use FoldingCompatibleExpr::*;
+        match self {
+            FoldingCompatibleExpr::Atom(atom) => match atom {
+                FoldingCompatibleExprInner::Extensions(ExpExtension::ExtendedWitness(i)) => {
+                    Atom(FoldingCompatibleExprInner::Cell((mapper)(i)))
+                }
+                atom => Atom(atom),
+            },
+            FoldingCompatibleExpr::Double(exp) => {
+                Double(Box::new(exp.flatten_quad_columns(mapper)))
+            }
+            FoldingCompatibleExpr::Square(exp) => {
+                Square(Box::new(exp.flatten_quad_columns(mapper)))
+            }
+            FoldingCompatibleExpr::Add(e1, e2) => {
+                let e1 = Box::new(e1.flatten_quad_columns(mapper));
+                let e2 = Box::new(e2.flatten_quad_columns(mapper));
+                Add(e1, e2)
+            }
+            FoldingCompatibleExpr::Sub(e1, e2) => {
+                let e1 = Box::new(e1.flatten_quad_columns(mapper));
+                let e2 = Box::new(e2.flatten_quad_columns(mapper));
+                Sub(e1, e2)
+            }
+            FoldingCompatibleExpr::Mul(e1, e2) => {
+                let e1 = Box::new(e1.flatten_quad_columns(mapper));
+                let e2 = Box::new(e2.flatten_quad_columns(mapper));
+                Mul(e1, e2)
+            }
+            FoldingCompatibleExpr::Pow(e, p) => Pow(Box::new(e.flatten_quad_columns(mapper)), p),
+        }
+    }
 }
 
 impl<C: FoldingConfig> FoldingExp<C> {

--- a/folding/src/lib.rs
+++ b/folding/src/lib.rs
@@ -122,11 +122,11 @@ pub trait FoldingEnv<F: Zero + Clone, I, W, Col, Chal, Selector> {
     fn challenge(&self, challenge: Chal, side: Side) -> F;
 
     /// Returns the evaluations of a given column witness at omega or zeta*omega.
-    fn col(&self, col: Col, curr_or_next: CurrOrNext, side: Side) -> &Vec<F>;
+    fn col(&self, col: Col, curr_or_next: CurrOrNext, side: Side) -> &[F];
 
     /// similar to [Self::col], but folding may ask for a dynamic selector directly
     /// instead of just column that happens to be a selector
-    fn selector(&self, s: &Selector, side: Side) -> &Vec<F>;
+    fn selector(&self, s: &Selector, side: Side) -> &[F];
 }
 
 type Evals<F> = Evaluations<F, Radix2EvaluationDomain<F>>;

--- a/folding/src/standard_config.rs
+++ b/folding/src/standard_config.rs
@@ -69,11 +69,11 @@ where
     G: CommitmentCurve,
     I: Instance<G> + Index<Chall, Output = G::ScalarField> + Clone,
     W: Witness<G> + Clone,
-    W: Index<Col, Output = Vec<G::ScalarField>> + Index<Sel, Output = Vec<G::ScalarField>>,
+    W: Index<Col, Output = [G::ScalarField]> + Index<Sel, Output = [G::ScalarField]>,
     Col: Hash + Eq + Debug + Clone + FoldingColumnTrait,
     Sel: Ord + Copy + Hash + Debug,
     Chall: Hash + Eq + Debug + Copy,
-    Str: Clone + Index<Col, Output = Vec<G::ScalarField>>,
+    Str: Clone + Index<Col, Output = [G::ScalarField]>,
 {
     type Column = Col;
 
@@ -99,7 +99,7 @@ where
     G: CommitmentCurve,
     I: Instance<G> + Index<Chall, Output = G::ScalarField> + Clone,
     W: Witness<G> + Clone,
-    W: Index<Col, Output = Vec<G::ScalarField>> + Index<Sel, Output = Vec<G::ScalarField>>,
+    W: Index<Col, Output = [G::ScalarField]> + Index<Sel, Output = [G::ScalarField]>,
     Col: Hash + Eq,
 {
     instances: [I; 2],
@@ -117,10 +117,10 @@ where
     G: CommitmentCurve,
     I: Instance<G> + Index<Chall, Output = G::ScalarField> + Clone,
     W: Witness<G> + Clone,
-    W: Index<Col, Output = Vec<G::ScalarField>> + Index<Sel, Output = Vec<G::ScalarField>>,
+    W: Index<Col, Output = [G::ScalarField]> + Index<Sel, Output = [G::ScalarField]>,
     Col: FoldingColumnTrait + Eq + Hash,
     Sel: Copy,
-    Str: Clone + Index<Col, Output = Vec<G::ScalarField>>,
+    Str: Clone + Index<Col, Output = [G::ScalarField]>,
 {
     type Structure = Str;
 
@@ -148,7 +148,7 @@ where
         instance[challenge]
     }
 
-    fn col(&self, col: Col, curr_or_next: CurrOrNext, side: Side) -> &Vec<G::ScalarField> {
+    fn col(&self, col: Col, curr_or_next: CurrOrNext, side: Side) -> &[G::ScalarField] {
         let witness = match side {
             Side::Left => &self.witnesses[0],
             Side::Right => &self.witnesses[1],
@@ -182,7 +182,7 @@ where
         }
     }
 
-    fn selector(&self, s: &Sel, side: Side) -> &Vec<G::ScalarField> {
+    fn selector(&self, s: &Sel, side: Side) -> &[G::ScalarField] {
         //similar to the witness case of col, as expected
         let witness = match side {
             Side::Left => &self.witnesses[0],
@@ -377,7 +377,7 @@ mod example {
     }
     // for selectors, () in this case as we have none
     impl<G: KimchiCurve> Index<()> for MyWitness<G> {
-        type Output = Vec<G::ScalarField>;
+        type Output = [G::ScalarField];
 
         fn index(&self, _index: ()) -> &Self::Output {
             unreachable!()

--- a/folding/tests/test_decomposable_folding.rs
+++ b/folding/tests/test_decomposable_folding.rs
@@ -157,7 +157,7 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, TestColumn, TestChallenge, Dynami
 
     // provide access to columns, here side refers to one of the two pairs you
     // got in new()
-    fn col(&self, col: TestColumn, curr_or_next: CurrOrNext, side: Side) -> &Vec<Fp> {
+    fn col(&self, col: TestColumn, curr_or_next: CurrOrNext, side: Side) -> &[Fp] {
         let wit = match curr_or_next {
             CurrOrNext::Curr => &self.curr_witnesses[side as usize],
             CurrOrNext::Next => &self.next_witnesses[side as usize],
@@ -182,7 +182,7 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, TestColumn, TestChallenge, Dynami
     // as classic static selectors will be handled as normal structure columns in col().
     // The implementation of this if the same as col(), it is just separated as they
     // have different types to resolve
-    fn selector(&self, s: &DynamicSelector, side: Side) -> &Vec<Fp> {
+    fn selector(&self, s: &DynamicSelector, side: Side) -> &[Fp] {
         let wit = &self.curr_witnesses[side as usize];
         match s {
             DynamicSelector::SelecAdd => &wit.0[3].evals,

--- a/folding/tests/test_folding_with_quadriticization.rs
+++ b/folding/tests/test_folding_with_quadriticization.rs
@@ -159,7 +159,7 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, TestColumn, TestChallenge, Dynami
 
     // provide access to columns, here side refers to one of the two pairs you
     // got in new()
-    fn col(&self, col: TestColumn, curr_or_next: CurrOrNext, side: Side) -> &Vec<Fp> {
+    fn col(&self, col: TestColumn, curr_or_next: CurrOrNext, side: Side) -> &[Fp] {
         let wit = match curr_or_next {
             CurrOrNext::Curr => &self.curr_witnesses[side as usize],
             CurrOrNext::Next => &self.next_witnesses[side as usize],
@@ -184,7 +184,7 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, TestColumn, TestChallenge, Dynami
     // as clasic static selectors will be handle as normal structure columns in col()
     // the implementation of this if the same as col(), it is just separated as they
     // have different types to resolve
-    fn selector(&self, s: &DynamicSelector, side: Side) -> &Vec<Fp> {
+    fn selector(&self, s: &DynamicSelector, side: Side) -> &[Fp] {
         let wit = &self.curr_witnesses[side as usize];
         match s {
             DynamicSelector::SelecAdd => &wit.0[3].evals,

--- a/folding/tests/test_quadraticization.rs
+++ b/folding/tests/test_quadraticization.rs
@@ -99,7 +99,7 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, Col, (), ()> for Env {
         todo!()
     }
 
-    fn col(&self, _col: Col, _curr_or_next: CurrOrNext, _side: Side) -> &Vec<Fp> {
+    fn col(&self, _col: Col, _curr_or_next: CurrOrNext, _side: Side) -> &[Fp] {
         todo!()
     }
 
@@ -107,7 +107,7 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, Col, (), ()> for Env {
         todo!()
     }
 
-    fn selector(&self, _s: &(), _side: Side) -> &Vec<Fp> {
+    fn selector(&self, _s: &(), _side: Side) -> &[Fp] {
         todo!()
     }
 }

--- a/folding/tests/test_vanilla_folding.rs
+++ b/folding/tests/test_vanilla_folding.rs
@@ -135,7 +135,7 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, Column, TestChallenge, ()> for Te
         }
     }
 
-    fn col(&self, col: Column, curr_or_next: CurrOrNext, side: Side) -> &Vec<Fp> {
+    fn col(&self, col: Column, curr_or_next: CurrOrNext, side: Side) -> &[Fp] {
         let wit = match curr_or_next {
             CurrOrNext::Curr => &self.curr_witnesses[side as usize],
             CurrOrNext::Next => &self.next_witnesses[side as usize],
@@ -160,7 +160,7 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, Column, TestChallenge, ()> for Te
         }
     }
 
-    fn selector(&self, _s: &(), _side: Side) -> &Vec<Fp> {
+    fn selector(&self, _s: &(), _side: Side) -> &[Fp] {
         unreachable!()
     }
 }

--- a/ivc/src/plonkish_lang.rs
+++ b/ivc/src/plonkish_lang.rs
@@ -2,7 +2,7 @@
 /// witness, and tools to work with them. The IVC is specialized for
 /// exactly the plonkish language.
 use ark_ec::ProjectiveCurve;
-use ark_ff::{FftField, One};
+use ark_ff::{FftField, Field, One};
 use ark_poly::{Evaluations, Radix2EvaluationDomain as R2D};
 use folding::{instance_witness::Foldable, Alphas, Instance, Witness};
 use itertools::Itertools;
@@ -18,42 +18,74 @@ use rayon::iter::{IntoParallelIterator as _, ParallelIterator as _};
 use std::ops::Index;
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct PlonkishWitness<const N_COL: usize, const N_FSEL: usize, F: FftField> {
-    pub witness: GenericWitness<N_COL, Evaluations<F, R2D<F>>>,
-    // This does not have to be part of the witness... can be a static
-    // precompiled object.
-    pub fixed_selectors: GenericWitness<N_FSEL, Evaluations<F, R2D<F>>>,
+/// Vector field over F. Something like a vector.
+pub trait CombinableEvals<F: Field> {
+    fn e_as_slice(&self) -> &[F];
+    fn e_as_mut_slice(&mut self) -> &mut [F];
 }
 
-impl<const N_COL: usize, const N_FSEL: usize, F: FftField> Foldable<F>
-    for PlonkishWitness<N_COL, N_FSEL, F>
+impl<F: FftField> CombinableEvals<F> for Evaluations<F, R2D<F>> {
+    fn e_as_slice(&self) -> &[F] {
+        self.evals.as_slice()
+    }
+    fn e_as_mut_slice(&mut self) -> &mut [F] {
+        self.evals.as_mut_slice()
+    }
+}
+
+impl<F: FftField> CombinableEvals<F> for Vec<F> {
+    fn e_as_slice(&self) -> &[F] {
+        self.as_slice()
+    }
+    fn e_as_mut_slice(&mut self) -> &mut [F] {
+        self.as_mut_slice()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct PlonkishWitnessGeneric<const N_COL: usize, const N_FSEL: usize, F: Field, Evals> {
+    pub witness: GenericWitness<N_COL, Evals>,
+    // This does not have to be part of the witness... can be a static
+    // precompiled object.
+    pub fixed_selectors: GenericWitness<N_FSEL, Evals>,
+    pub phantom: std::marker::PhantomData<F>,
+}
+
+pub type PlonkishWitness<const N_COL: usize, const N_FSEL: usize, F> =
+    PlonkishWitnessGeneric<N_COL, N_FSEL, F, Evaluations<F, R2D<F>>>;
+
+impl<const N_COL: usize, const N_FSEL: usize, F: Field, Evals: CombinableEvals<F>> Foldable<F>
+    for PlonkishWitnessGeneric<N_COL, N_FSEL, F, Evals>
 {
     fn combine(mut a: Self, b: Self, challenge: F) -> Self {
         for (a, b) in (*a.witness.cols).iter_mut().zip(*(b.witness.cols)) {
-            for (a, b) in a.evals.iter_mut().zip(b.evals) {
-                *a += challenge * b;
+            for (a, b) in (a.e_as_mut_slice()).iter_mut().zip(b.e_as_slice()) {
+                *a += *b * challenge;
             }
         }
         a
     }
 }
 
-impl<const N_COL: usize, const N_FSEL: usize, Curve: CommitmentCurve> Witness<Curve>
-    for PlonkishWitness<N_COL, N_FSEL, Curve::ScalarField>
+impl<
+        const N_COL: usize,
+        const N_FSEL: usize,
+        Curve: CommitmentCurve,
+        Evals: CombinableEvals<Curve::ScalarField>,
+    > Witness<Curve> for PlonkishWitnessGeneric<N_COL, N_FSEL, Curve::ScalarField, Evals>
 {
 }
 
-impl<const N_COL: usize, const N_FSEL: usize, F: FftField> Index<Column>
-    for PlonkishWitness<N_COL, N_FSEL, F>
+impl<const N_COL: usize, const N_FSEL: usize, F: FftField, Evals: CombinableEvals<F>> Index<Column>
+    for PlonkishWitnessGeneric<N_COL, N_FSEL, F, Evals>
 {
-    type Output = Vec<F>;
+    type Output = [F];
 
     /// Map a column alias to the corresponding witness column.
     fn index(&self, index: Column) -> &Self::Output {
         match index {
-            Column::Relation(i) => &self.witness.cols[i].evals,
-            Column::FixedSelector(i) => &self.fixed_selectors[i].evals,
+            Column::Relation(i) => self.witness.cols[i].e_as_slice(),
+            Column::FixedSelector(i) => self.fixed_selectors[i].e_as_slice(),
             other => panic!("Invalid column index: {other:?}"),
         }
     }
@@ -63,7 +95,7 @@ impl<const N_COL: usize, const N_FSEL: usize, F: FftField> Index<Column>
 impl<const N_COL: usize, const N_FSEL: usize, F: FftField> Index<()>
     for PlonkishWitness<N_COL, N_FSEL, F>
 {
-    type Output = Vec<F>;
+    type Output = [F];
 
     fn index(&self, _index: ()) -> &Self::Output {
         unreachable!()

--- a/ivc/tests/add.rs
+++ b/ivc/tests/add.rs
@@ -75,7 +75,7 @@ impl ColumnIndexer for AdditionColumn {
 pub struct GenericVecStructure<G: KimchiCurve>(Vec<Vec<G::ScalarField>>);
 
 impl<G: KimchiCurve> Index<Column> for GenericVecStructure<G> {
-    type Output = Vec<G::ScalarField>;
+    type Output = [G::ScalarField];
 
     fn index(&self, index: Column) -> &Self::Output {
         match index {
@@ -163,7 +163,7 @@ pub fn heavy_test_simple_add() {
     impl<const N_COL: usize, const N_FSEL: usize> Index<AdditionColumn>
         for PlonkishWitness<N_COL, N_FSEL, Fp>
     {
-        type Output = Vec<Fp>;
+        type Output = [Fp];
 
         fn index(&self, index: AdditionColumn) -> &Self::Output {
             match index {
@@ -388,6 +388,7 @@ pub fn heavy_test_simple_add() {
             .map(|w| Evaluations::from_vec_and_domain(w.to_vec(), domain.d1))
             .collect(),
         fixed_selectors: ivc_fixed_selectors_evals_d1.clone().try_into().unwrap(),
+        phantom: std::marker::PhantomData,
     };
 
     let folding_instance_one = PlonkishInstance::from_witness(
@@ -436,6 +437,7 @@ pub fn heavy_test_simple_add() {
     let folding_witness_two = PlonkishWitness {
         witness: folding_witness_two_evals.clone(),
         fixed_selectors: ivc_fixed_selectors_evals_d1.clone().try_into().unwrap(),
+        phantom: std::marker::PhantomData,
     };
 
     let folding_instance_two = PlonkishInstance::from_witness(
@@ -710,6 +712,7 @@ pub fn heavy_test_simple_add() {
     let folding_witness_three = PlonkishWitness {
         witness: folding_witness_three_evals.clone().try_into().unwrap(),
         fixed_selectors: ivc_fixed_selectors_evals_d1.clone().try_into().unwrap(),
+        phantom: std::marker::PhantomData,
     };
 
     let folding_instance_three = PlonkishInstance::from_witness(
@@ -778,6 +781,7 @@ pub fn heavy_test_simple_add() {
                             .into_par_iter()
                             .map(enlarge_to_domain)
                             .collect(),
+                        phantom: std::marker::PhantomData,
                     },
                     extended: BTreeMap::new(), // No extended columns at this point
                 },
@@ -797,7 +801,7 @@ pub fn heavy_test_simple_add() {
 
                 let evaluations_d8 = match eval_leaf {
                     EvalLeaf::Result(evaluations_d8) => evaluations_d8,
-                    EvalLeaf::Col(evaluations_d8) => evaluations_d8.clone(),
+                    EvalLeaf::Col(evaluations_d8) => evaluations_d8.to_vec(),
                     _ => panic!("eval_leaf is not Result"),
                 };
 
@@ -857,6 +861,7 @@ pub fn heavy_test_simple_add() {
                         .into_par_iter()
                         .map(enlarge_to_domain)
                         .collect(),
+                    phantom: std::marker::PhantomData,
                 },
                 extended: folded_witness
                     .extended_witness
@@ -883,7 +888,7 @@ pub fn heavy_test_simple_add() {
 
             let evaluations_big = match eval_leaf {
                 EvalLeaf::Result(evaluations) => evaluations,
-                EvalLeaf::Col(evaluations) => evaluations.clone(),
+                EvalLeaf::Col(evaluations) => evaluations.to_vec(),
                 _ => panic!("eval_leaf is not Result"),
             };
 

--- a/ivc/tests/folding_ivc.rs
+++ b/ivc/tests/folding_ivc.rs
@@ -102,7 +102,7 @@ fn test_regression_additional_columns_reduction_to_degree_2() {
             todo!()
         }
 
-        fn col(&self, _col: Column, _curr_or_next: CurrOrNext, _side: Side) -> &Vec<Fp> {
+        fn col(&self, _col: Column, _curr_or_next: CurrOrNext, _side: Side) -> &[Fp] {
             todo!()
         }
 
@@ -110,7 +110,7 @@ fn test_regression_additional_columns_reduction_to_degree_2() {
             todo!()
         }
 
-        fn selector(&self, _s: &(), _side: Side) -> &Vec<Fp> {
+        fn selector(&self, _s: &(), _side: Side) -> &[Fp] {
             todo!()
         }
     }

--- a/o1vm/src/folding.rs
+++ b/o1vm/src/folding.rs
@@ -187,7 +187,7 @@ where
         }
     }
 
-    fn col(&self, col: C::Column, curr_or_next: CurrOrNext, side: Side) -> &Vec<ScalarField<C>> {
+    fn col(&self, col: C::Column, curr_or_next: CurrOrNext, side: Side) -> &[ScalarField<C>] {
         let wit = match curr_or_next {
             CurrOrNext::Curr => &self.curr_witnesses[side as usize],
             CurrOrNext::Next => &self.next_witnesses[side as usize],
@@ -204,7 +204,7 @@ where
         }
     }
 
-    fn selector(&self, s: &C::Selector, side: Side) -> &Vec<ScalarField<C>> {
+    fn selector(&self, s: &C::Selector, side: Side) -> &[ScalarField<C>] {
         let witness = &self.curr_witnesses[side as usize];
         &witness[*s].evals
     }
@@ -266,7 +266,7 @@ where
         }
     }
 
-    fn col(&self, col: C::Column, curr_or_next: CurrOrNext, side: Side) -> &Vec<ScalarField<C>> {
+    fn col(&self, col: C::Column, curr_or_next: CurrOrNext, side: Side) -> &[ScalarField<C>] {
         let wit = match curr_or_next {
             CurrOrNext::Curr => &self.curr_witnesses[side as usize],
             CurrOrNext::Next => &self.next_witnesses[side as usize],
@@ -283,7 +283,7 @@ where
         }
     }
 
-    fn selector(&self, _s: &(), _side: Side) -> &Vec<ScalarField<C>> {
+    fn selector(&self, _s: &(), _side: Side) -> &[ScalarField<C>] {
         unimplemented!("Selector not implemented for FoldingEnvironment. No selectors are supposed to be used when there is only one instruction.")
     }
 }


### PR DESCRIPTION
This change is needed because:
* In the next PR we will need to generalize our evaluator
* Slices are enough, are strictly more generic then vectors, and allow to avoid cloning where one needs to unify vectors with e.g. tuples.