### PR TITLE
Speed up poseidon for kimchi by hand-unrolling

### DIFF
--- a/poseidon/src/poseidon.rs
+++ b/poseidon/src/poseidon.rs
@@ -22,8 +22,19 @@ pub trait Sponge<Input: Field, Digest> {
     fn reset(&mut self);
 }
 
-pub fn sbox<F: Field, SC: SpongeConstants>(x: F) -> F {
-    x.pow([SC::PERM_SBOX as u64])
+pub fn sbox<F: Field, SC: SpongeConstants>(mut x: F) -> F {
+    if SC::PERM_SBOX == 7 {
+        // This is much faster than using the generic `pow`. Hard-code to get the ~50% speed-up
+        // that it gives to hashing.
+        let mut square = x;
+        square.square_in_place();
+        x *= square;
+        square.square_in_place();
+        x *= square;
+        x
+    } else {
+        x.pow([SC::PERM_SBOX as u64])
+    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Running an experiment using the Mina code, I see a ~50% speed-up in poseidon by hand-unrolling the `x^7` sbox vs using the built-in `pow` function.