### PR TITLE
Manually unroll x^7 for poseidon for a ~50% speedup [master]

### DIFF
--- a/poseidon/src/poseidon.rs
+++ b/poseidon/src/poseidon.rs
@@ -24,8 +24,19 @@ pub trait Sponge<Input: Field, Digest> {
     fn reset(&mut self);
 }
 
-pub fn sbox<F: Field, SC: SpongeConstants>(x: F) -> F {
-    x.pow([SC::PERM_SBOX as u64])
+pub fn sbox<F: Field, SC: SpongeConstants>(mut x: F) -> F {
+    if SC::PERM_SBOX == 7 {
+        // This is much faster than using the generic `pow`. Hard-code to get the ~50% speed-up
+        // that it gives to hashing.
+        let mut square = x;
+        square.square_in_place();
+        x *= square;
+        square.square_in_place();
+        x *= square;
+        x
+    } else {
+        x.pow([SC::PERM_SBOX as u64])
+    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Cherry-picked https://github.com/o1-labs/proof-systems/pull/2394.

Output on my machine:

```
poseidon_absorb_permutation kimchi                                                                             
                        time:   [30.086 µs 30.131 µs 30.221 µs]
                        change: [-40.050% -39.774% -39.371%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  10 (10.00%) high severe

poseidon_absorb_permutation legacy                                                                             
                        time:   [49.133 µs 49.157 µs 49.180 µs]
                        change: [-7.0440% -6.9919% -6.9411%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  5 (5.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
```

Therefore getting ~40% improvement compared to current version.