### PR TITLE
[#2089] Make ix_by_value return Option to support runtime tables

### DIFF
--- a/ivc/src/ivc/lookups.rs
+++ b/ivc/src/ivc/lookups.rs
@@ -38,7 +38,7 @@ impl<Ff: PrimeField> LookupTableID for IVCLookupTable<Ff> {
     }
 
     /// Converts a value to its index in the fixed table.
-    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> Option<usize> {
         match self {
             Self::SerLookupTable(lt) => lt.ix_by_value(value),
         }
@@ -54,7 +54,7 @@ impl<Ff: PrimeField> LookupTableID for IVCLookupTable<Ff> {
 
 impl<Ff: PrimeField> IVCLookupTable<Ff> {
     /// Provides a full list of entries for the given table.
-    pub fn entries<F: PrimeField>(&self, domain_d1_size: u64) -> Vec<F> {
+    pub fn entries<F: PrimeField>(&self, domain_d1_size: u64) -> Option<Vec<F>> {
         match self {
             Self::SerLookupTable(lt) => lt.entries(domain_d1_size),
         }

--- a/msm/src/circuit_design/witness.rs
+++ b/msm/src/circuit_design/witness.rs
@@ -184,7 +184,7 @@ impl<
     > LookupCap<F, CIx, LT> for WitnessBuilderEnv<F, CIx, N_WIT, N_REL, N_DSEL, N_FSEL, LT>
 {
     fn lookup(&mut self, table_id: LT, value: Vec<<Self as ColAccessCap<F, CIx>>::Variable>) {
-        let value_ix = table_id.ix_by_value(&value);
+        let value_ix = table_id.ix_by_value(&value).unwrap();
         self.lookup_multiplicities.get_mut(&table_id).unwrap()[value_ix] += F::one();
         self.lookups
             .last_mut()

--- a/msm/src/fec/lookups.rs
+++ b/msm/src/fec/lookups.rs
@@ -57,10 +57,10 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
     }
 
     /// Converts a value to its index in the fixed table.
-    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> Option<usize> {
         let value = value[0];
         assert!(self.is_member(value));
-        match self {
+        Some(match self {
             Self::RangeCheck15 => TryFrom::try_from(value.to_biguint()).unwrap(),
             Self::RangeCheck14Abs => {
                 if value < F::from(1u64 << 14) {
@@ -77,7 +77,7 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
                 }
             }
             Self::RangeCheckFfHighest(_) => TryFrom::try_from(value.to_biguint()).unwrap(),
-        }
+        })
     }
 
     fn all_variants() -> Vec<Self> {

--- a/msm/src/ffa/lookups.rs
+++ b/msm/src/ffa/lookups.rs
@@ -42,9 +42,9 @@ impl LookupTableID for LookupTable {
     }
 
     /// Converts a value to its index in the fixed table.
-    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> Option<usize> {
         let value = value[0];
-        match self {
+        Some(match self {
             Self::RangeCheck15 => TryFrom::try_from(value.to_biguint()).unwrap(),
             Self::RangeCheck1BitSigned => {
                 if value == F::zero() {
@@ -57,7 +57,7 @@ impl LookupTableID for LookupTable {
                     panic!("Invalid value for rangecheck1abs")
                 }
             }
-        }
+        })
     }
 
     fn all_variants() -> Vec<Self> {

--- a/msm/src/logup.rs
+++ b/msm/src/logup.rs
@@ -207,8 +207,9 @@ pub trait LookupTableID: Send + Sync + Copy + Hash + Eq + PartialEq + Ord + Part
     /// Returns the length of each table.
     fn length(&self) -> usize;
 
-    /// Given a value, returns an index of this value in the table.
-    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> usize;
+    /// Returns None if the table is runtime (and thus mapping value
+    /// -> ix is not known at compile time.
+    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> Option<usize>;
 
     fn all_variants() -> Vec<Self>;
 }

--- a/msm/src/lookups.rs
+++ b/msm/src/lookups.rs
@@ -33,9 +33,9 @@ impl LookupTableID for DummyLookupTable {
         true
     }
 
-    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> Option<usize> {
         if value[0] == F::zero() {
-            0
+            Some(0)
         } else {
             panic!("Invalid value for DummyLookupTable")
         }
@@ -92,7 +92,7 @@ impl LookupTableID for LookupTableIDs {
         true
     }
 
-    fn ix_by_value<F: PrimeField>(&self, _value: &[F]) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, _value: &[F]) -> Option<usize> {
         todo!()
     }
 

--- a/msm/src/serialization/lookups.rs
+++ b/msm/src/serialization/lookups.rs
@@ -62,28 +62,33 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
     }
 
     /// Converts a value to its index in the fixed table.
-    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> Option<usize> {
         let value = value[0];
         assert!(self.is_member(value));
         match self {
-            Self::RangeCheck15 => TryFrom::try_from(value.to_biguint()).unwrap(),
-            Self::RangeCheck4 => TryFrom::try_from(value.to_biguint()).unwrap(),
+            Self::RangeCheck15 => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
+            Self::RangeCheck4 => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
             Self::RangeCheck14Abs => {
                 if value < F::from(1u64 << 14) {
-                    TryFrom::try_from(value.to_biguint()).unwrap()
+                    Some(TryFrom::try_from(value.to_biguint()).unwrap())
                 } else {
-                    TryFrom::try_from((value + F::from(2 * (1u64 << 14))).to_biguint()).unwrap()
+                    Some(
+                        TryFrom::try_from((value + F::from(2 * (1u64 << 14))).to_biguint())
+                            .unwrap(),
+                    )
                 }
             }
             Self::RangeCheck9Abs => {
                 if value < F::from(1u64 << 9) {
-                    TryFrom::try_from(value.to_biguint()).unwrap()
+                    Some(TryFrom::try_from(value.to_biguint()).unwrap())
                 } else {
-                    TryFrom::try_from((value + F::from(2 * (1u64 << 9))).to_biguint()).unwrap()
+                    Some(
+                        TryFrom::try_from((value + F::from(2 * (1u64 << 9))).to_biguint()).unwrap(),
+                    )
                 }
             }
 
-            Self::RangeCheckFfHighest(_) => TryFrom::try_from(value.to_biguint()).unwrap(),
+            Self::RangeCheckFfHighest(_) => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
         }
     }
 
@@ -115,41 +120,47 @@ impl<Ff: PrimeField> LookupTable<Ff> {
     }
 
     /// Provides a full list of entries for the given table.
-    pub fn entries<F: PrimeField>(&self, domain_d1_size: u64) -> Vec<F> {
+    pub fn entries<F: PrimeField>(&self, domain_d1_size: u64) -> Option<Vec<F>> {
         assert!(domain_d1_size >= (1 << 15));
         match self {
-            Self::RangeCheck15 => (0..domain_d1_size).map(|i| F::from(i)).collect(),
-            Self::RangeCheck4 => (0..domain_d1_size)
-                .map(|i| if i < (1 << 4) { F::from(i) } else { F::zero() })
-                .collect(),
-            Self::RangeCheck14Abs => (0..domain_d1_size)
-                .map(|i| {
-                    if i < (1 << 14) {
-                        // [0,1,2 ... (1<<14)-1]
-                        F::from(i)
-                    } else if i < 2 * (1 << 14) {
-                        // [-(i<<14),...-2,-1]
-                        F::from(i) - F::from(2u64 * (1 << 14))
-                    } else {
-                        F::zero()
-                    }
-                })
-                .collect(),
+            Self::RangeCheck15 => Some((0..domain_d1_size).map(|i| F::from(i)).collect()),
+            Self::RangeCheck4 => Some(
+                (0..domain_d1_size)
+                    .map(|i| if i < (1 << 4) { F::from(i) } else { F::zero() })
+                    .collect(),
+            ),
+            Self::RangeCheck14Abs => Some(
+                (0..domain_d1_size)
+                    .map(|i| {
+                        if i < (1 << 14) {
+                            // [0,1,2 ... (1<<14)-1]
+                            F::from(i)
+                        } else if i < 2 * (1 << 14) {
+                            // [-(i<<14),...-2,-1]
+                            F::from(i) - F::from(2u64 * (1 << 14))
+                        } else {
+                            F::zero()
+                        }
+                    })
+                    .collect(),
+            ),
 
-            Self::RangeCheck9Abs => (0..domain_d1_size)
-                .map(|i| {
-                    if i < (1 << 9) {
-                        // [0,1,2 ... (1<<9)-1]
-                        F::from(i)
-                    } else if i < 2 * (1 << 9) {
-                        // [-(i<<9),...-2,-1]
-                        F::from(i) - F::from(2u64 * (1 << 9))
-                    } else {
-                        F::zero()
-                    }
-                })
-                .collect(),
-            Self::RangeCheckFfHighest(_) => Self::entries_ff_highest::<F>(domain_d1_size),
+            Self::RangeCheck9Abs => Some(
+                (0..domain_d1_size)
+                    .map(|i| {
+                        if i < (1 << 9) {
+                            // [0,1,2 ... (1<<9)-1]
+                            F::from(i)
+                        } else if i < 2 * (1 << 9) {
+                            // [-(i<<9),...-2,-1]
+                            F::from(i) - F::from(2u64 * (1 << 9))
+                        } else {
+                            F::zero()
+                        }
+                    })
+                    .collect(),
+            ),
+            Self::RangeCheckFfHighest(_) => Some(Self::entries_ff_highest::<F>(domain_d1_size)),
         }
     }
 

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -89,7 +89,7 @@ mod tests {
         // Fixed tables can be generated inside lookup_tables_data. Runtime should be generated here.
         let mut lookup_tables_data = BTreeMap::new();
         for table_id in LookupTable::<Ff1>::all_variants().into_iter() {
-            lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64));
+            lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64).unwrap());
         }
         let proof_inputs = witness_env.get_proof_inputs(domain_size, lookup_tables_data);
 

--- a/o1vm/src/lookups.rs
+++ b/o1vm/src/lookups.rs
@@ -95,7 +95,7 @@ impl LookupTableID for LookupTableIDs {
         }
     }
 
-    fn ix_by_value<F: PrimeField>(&self, _value: &[F]) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, _value: &[F]) -> Option<usize> {
         todo!()
     }
 


### PR DESCRIPTION
We'll have to support runtime tables, and this is a minor step towards it.