### PR TITLE
Fixed selectors cosmetics

### DIFF
--- a/ivc/src/ivc/interpreter.rs
+++ b/ivc/src/ivc/interpreter.rs
@@ -787,7 +787,7 @@ pub fn process_u<F, Env, const N_COL_TOTAL: usize>(
 /// IVC. Therefore, it includes the potential round constants required by
 /// the hash function.
 #[allow(clippy::needless_range_loop)]
-pub fn build_selectors<const N_COL_TOTAL: usize, const N_CHALS: usize>(
+pub fn build_fixed_selectors<const N_COL_TOTAL: usize, const N_CHALS: usize>(
     domain_size: usize,
 ) -> [Vec<kimchi_msm::Fp>; N_FSEL_IVC] {
     // Selectors can be only generated for BN254G1 for now, because

--- a/ivc/src/ivc/mod.rs
+++ b/ivc/src/ivc/mod.rs
@@ -42,7 +42,7 @@ mod tests {
         ivc::{
             columns::{IVCColumn, N_BLOCKS, N_FSEL_IVC},
             constraints::constrain_ivc,
-            interpreter::{build_selectors, ivc_circuit},
+            interpreter::{build_fixed_selectors, ivc_circuit},
             lookups::IVCLookupTable,
         },
         poseidon_8_56_5_3_2::bn254::PoseidonBN254Parameters,
@@ -116,7 +116,7 @@ mod tests {
         println!("Building fixed selectors");
 
         let fixed_selectors: [Vec<Fp>; N_FSEL_IVC] =
-            build_selectors::<TEST_N_COL_TOTAL, TEST_N_CHALS>(domain_size);
+            build_fixed_selectors::<TEST_N_COL_TOTAL, TEST_N_CHALS>(domain_size);
 
         witness_env.set_fixed_selectors(fixed_selectors.to_vec());
 
@@ -208,7 +208,7 @@ mod tests {
         constrain_ivc::<Ff1, _>(&mut constraint_env);
         let constraints = constraint_env.get_relation_constraints();
 
-        let fixed_selectors: Box<[Vec<Fp>; N_FSEL_IVC]> = Box::new(build_selectors::<
+        let fixed_selectors: Box<[Vec<Fp>; N_FSEL_IVC]> = Box::new(build_fixed_selectors::<
             TEST_N_COL_TOTAL,
             TEST_N_CHALS,
         >(domain_size));
@@ -250,7 +250,7 @@ mod tests {
         constrain_ivc::<Ff1, _>(&mut constraint_env);
         let constraints = constraint_env.get_relation_constraints();
 
-        let fixed_selectors: Box<[Vec<Fp>; N_FSEL_IVC]> = Box::new(build_selectors::<
+        let fixed_selectors: Box<[Vec<Fp>; N_FSEL_IVC]> = Box::new(build_fixed_selectors::<
             TEST_N_COL_TOTAL,
             TEST_N_CHALS,
         >(domain_size));

--- a/ivc/tests/simple.rs
+++ b/ivc/tests/simple.rs
@@ -14,7 +14,7 @@ use ivc::{
     ivc::{
         columns::{IVCColumn, N_BLOCKS, N_FSEL_IVC},
         constraints::constrain_ivc,
-        interpreter::{build_selectors, ivc_circuit, ivc_circuit_base_case},
+        interpreter::{build_fixed_selectors, ivc_circuit, ivc_circuit_base_case},
         lookups::IVCLookupTable,
         N_ADDITIONAL_WIT_COL_QUAD as N_COL_QUAD_IVC, N_ALPHAS as N_ALPHAS_IVC,
     },
@@ -195,7 +195,7 @@ pub fn heavy_test_simple_add() {
     // For the IVC, we have all the "block selectors" - which depends on the
     // number of columns of the circuit - and the poseidon round constants.
     let ivc_fixed_selectors: Vec<Vec<Fp>> =
-        build_selectors::<N_COL_TOTAL_QUAD, N_ALPHAS_QUAD>(domain_size).to_vec();
+        build_fixed_selectors::<N_COL_TOTAL_QUAD, N_ALPHAS_QUAD>(domain_size).to_vec();
 
     // Sanity check on the domain size, can be removed later
     assert_eq!(ivc_fixed_selectors.len(), N_FSEL_TOTAL);

--- a/msm/src/test/test_circuit/interpreter.rs
+++ b/msm/src/test/test_circuit/interpreter.rs
@@ -272,6 +272,6 @@ pub fn test_fixed_sel_degree_7_mul_witness<
 }
 
 /// Fixed selectors for the test circuit.
-pub fn build_selectors<F: Field>(domain_size: usize) -> Box<[Vec<F>; 1]> {
+pub fn build_fixed_selectors<F: Field>(domain_size: usize) -> Box<[Vec<F>; 1]> {
     Box::new([(0..domain_size).map(|i| F::from(i as u64)).collect()])
 }

--- a/msm/src/test/test_circuit/interpreter.rs
+++ b/msm/src/test/test_circuit/interpreter.rs
@@ -4,7 +4,7 @@ use crate::{
     test::test_circuit::columns::TestColumn,
     LIMB_BITSIZE, N_LIMBS,
 };
-use ark_ff::{PrimeField, SquareRootField, Zero};
+use ark_ff::{Field, PrimeField, SquareRootField, Zero};
 
 fn fill_limbs_a_b<
     F: PrimeField,
@@ -28,7 +28,7 @@ fn fill_limbs_a_b<
     (a_limbs, b_limbs)
 }
 
-/// A consraint function for A + B - C that reads values from limbs A
+/// A constraint function for A + B - C that reads values from limbs A
 /// and B, and additionally returns resulting value in C.
 pub fn constrain_addition<F: PrimeField, Env: ColAccessCap<F, TestColumn>>(env: &mut Env) {
     let a_limbs: [Env::Variable; N_LIMBS] =
@@ -65,7 +65,7 @@ pub fn test_addition<
     constrain_addition(env);
 }
 
-/// A consraint function for A * B - D that reads values from limbs A
+/// A constraint function for A * B - D that reads values from limbs A
 /// and B, and multiplicationally returns resulting value in D.
 pub fn constrain_multiplication<F: PrimeField, Env: ColAccessCap<F, TestColumn>>(env: &mut Env) {
     let a_limbs: [Env::Variable; N_LIMBS] =
@@ -102,7 +102,7 @@ pub fn test_multiplication<
     constrain_multiplication(env);
 }
 
-/// A consraint function for A * B - D that reads values from limbs A
+/// A constraint function for A * B - D that reads values from limbs A
 /// and B, and multiplication_constally returns resulting value in D.
 pub fn constrain_test_const<F: PrimeField, Env: ColAccessCap<F, TestColumn>>(
     env: &mut Env,
@@ -127,7 +127,7 @@ pub fn test_const<F: PrimeField, Env: ColAccessCap<F, TestColumn> + ColWriteCap<
     constrain_test_const(env, constant);
 }
 
-/// A consraint function for A_0 + B_0 - FIXED_E
+/// A constraint function for A_0 + B_0 - FIXED_E
 pub fn constrain_test_fixed_sel<F: PrimeField, Env: ColAccessCap<F, TestColumn>>(env: &mut Env) {
     let a0 = Env::read_column(env, TestColumn::A(0));
     let b0 = Env::read_column(env, TestColumn::B(0));
@@ -136,7 +136,7 @@ pub fn constrain_test_fixed_sel<F: PrimeField, Env: ColAccessCap<F, TestColumn>>
     env.assert_zero(equation.clone());
 }
 
-/// A consraint function for A_0^7 + B_0 - FIXED_E
+/// A constraint function for A_0^7 + B_0 - FIXED_E
 pub fn constrain_test_fixed_sel_degree_7<F: PrimeField, Env: ColAccessCap<F, TestColumn>>(
     env: &mut Env,
 ) {
@@ -151,7 +151,7 @@ pub fn constrain_test_fixed_sel_degree_7<F: PrimeField, Env: ColAccessCap<F, Tes
     env.assert_zero(equation.clone());
 }
 
-/// A consraint function for 3 * A_0^7 + 42 * B_0 - FIXED_E
+/// A constraint function for 3 * A_0^7 + 42 * B_0 - FIXED_E
 pub fn constrain_test_fixed_sel_degree_7_with_constants<
     F: PrimeField,
     Env: ColAccessCap<F, TestColumn>,
@@ -171,7 +171,8 @@ pub fn constrain_test_fixed_sel_degree_7_with_constants<
     env.assert_zero(equation.clone());
 }
 
-/// A consraint function for 3 * A_0^7 + B_0 * FIXED_E
+// NB: Assumes non-standard selectors
+/// A constraint function for 3 * A_0^7 + B_0 * FIXED_E
 pub fn constrain_test_fixed_sel_degree_7_mul_witness<
     F: PrimeField,
     Env: ColAccessCap<F, TestColumn>,
@@ -246,6 +247,7 @@ pub fn test_fixed_sel_degree_7_with_constants<
     constrain_test_fixed_sel_degree_7_with_constants(env);
 }
 
+// NB: Assumes non-standard selectors
 /// Circuit generator function for 3 * A_0^7 + B_0 * FIXED_E.
 pub fn test_fixed_sel_degree_7_mul_witness<
     F: SquareRootField + PrimeField,
@@ -267,4 +269,9 @@ pub fn test_fixed_sel_degree_7_mul_witness<
     let res_var = Env::constant(res);
     env.write_column(TestColumn::B(0), &res_var);
     constrain_test_fixed_sel_degree_7_mul_witness(env);
+}
+
+/// Fixed selectors for the test circuit.
+pub fn build_selectors<F: Field>(domain_size: usize) -> Box<[Vec<F>; 1]> {
+    Box::new([(0..domain_size).map(|i| F::from(i as u64)).collect()])
 }

--- a/msm/src/test/test_circuit/mod.rs
+++ b/msm/src/test/test_circuit/mod.rs
@@ -34,8 +34,8 @@ mod tests {
     ) -> TestWitnessBuilderEnv<LT> {
         let mut witness_env = WitnessBuilderEnv::create();
 
-        let fixed_sel: Vec<Fp> = (0..domain_size).map(|i| Fp::from(i as u64)).collect();
-        witness_env.set_fixed_selector_cix(TestColumn::FixedE, fixed_sel);
+        let fixed_selectors = test_interpreter::build_selectors(domain_size);
+        witness_env.set_fixed_selectors(fixed_selectors.to_vec());
 
         for row_i in 0..domain_size {
             let a: Fp = <Fp as UniformRand>::rand(rng);
@@ -63,17 +63,16 @@ mod tests {
         // includes all arguments
         let domain_size = 1 << 8;
 
-        let witness_env =
-            build_test_fixed_sel_circuit::<_, DummyLookupTable>(&mut rng, domain_size);
-        let relation_witness = witness_env.get_relation_witness(domain_size);
+        let fixed_selectors = test_interpreter::build_selectors(domain_size);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_test_fixed_sel::<Fp, _>(&mut constraint_env);
         // Don't use lookups for now
         let constraints = constraint_env.get_relation_constraints();
 
-        let fixed_selectors: Box<[Vec<Fp>; 1]> =
-            Box::new([(0..domain_size).map(|i| Fp::from(i as u64)).collect()]);
+        let witness_env =
+            build_test_fixed_sel_circuit::<_, DummyLookupTable>(&mut rng, domain_size);
+        let relation_witness = witness_env.get_relation_witness(domain_size);
 
         crate::test::test_completeness_generic_no_lookups::<
             { TEST_N_COLUMNS - 1 },
@@ -119,17 +118,16 @@ mod tests {
         // includes all arguments
         let domain_size = 1 << 8;
 
-        let witness_env =
-            build_test_fixed_sel_degree_7_circuit::<_, DummyLookupTable>(&mut rng, domain_size);
-        let relation_witness = witness_env.get_relation_witness(domain_size);
+        let fixed_selectors = test_interpreter::build_selectors(domain_size);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_test_fixed_sel_degree_7::<Fp, _>(&mut constraint_env);
         // Don't use lookups for now
         let constraints = constraint_env.get_relation_constraints();
 
-        let fixed_selectors: Box<[Vec<Fp>; 1]> =
-            Box::new([(0..domain_size).map(|i| Fp::from(i as u64)).collect()]);
+        let witness_env =
+            build_test_fixed_sel_degree_7_circuit::<_, DummyLookupTable>(&mut rng, domain_size);
+        let relation_witness = witness_env.get_relation_witness(domain_size);
 
         crate::test::test_completeness_generic_no_lookups::<
             { TEST_N_COLUMNS - 1 },
@@ -178,11 +176,7 @@ mod tests {
         // includes all arguments
         let domain_size = 1 << 8;
 
-        let witness_env = build_test_fixed_sel_degree_7_circuit_with_constants::<_, DummyLookupTable>(
-            &mut rng,
-            domain_size,
-        );
-        let relation_witness = witness_env.get_relation_witness(domain_size);
+        let fixed_selectors = test_interpreter::build_selectors(domain_size);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_test_fixed_sel_degree_7_with_constants::<Fp, _>(
@@ -191,8 +185,11 @@ mod tests {
         // Don't use lookups for now
         let constraints = constraint_env.get_relation_constraints();
 
-        let fixed_selectors: Box<[Vec<Fp>; 1]> =
-            Box::new([(0..domain_size).map(|i| Fp::from(i as u64)).collect()]);
+        let witness_env = build_test_fixed_sel_degree_7_circuit_with_constants::<_, DummyLookupTable>(
+            &mut rng,
+            domain_size,
+        );
+        let relation_witness = witness_env.get_relation_witness(domain_size);
 
         crate::test::test_completeness_generic_no_lookups::<
             { TEST_N_COLUMNS - 1 },
@@ -218,6 +215,7 @@ mod tests {
     ) -> TestWitnessBuilderEnv<LT> {
         let mut witness_env = WitnessBuilderEnv::create();
 
+        // NB: Non-standard fixed selectors.
         let fixed_sel: Vec<Fp> = (0..domain_size).map(|i| Fp::from((i + 1) as u64)).collect();
         witness_env.set_fixed_selector_cix(TestColumn::FixedE, fixed_sel);
 
@@ -241,11 +239,9 @@ mod tests {
         // includes all arguments
         let domain_size = 1 << 8;
 
-        let witness_env = build_test_fixed_sel_degree_7_circuit_mul_witness::<_, DummyLookupTable>(
-            &mut rng,
-            domain_size,
-        );
-        let relation_witness = witness_env.get_relation_witness(domain_size);
+        // NB: Non-standard fixed selectors.
+        let fixed_selectors: Box<[Vec<Fp>; 1]> =
+            Box::new([(0..domain_size).map(|i| Fp::from((i + 1) as u64)).collect()]);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_test_fixed_sel_degree_7_mul_witness::<Fp, _>(
@@ -254,8 +250,11 @@ mod tests {
         // Don't use lookups for now
         let constraints = constraint_env.get_relation_constraints();
 
-        let fixed_selectors: Box<[Vec<Fp>; 1]> =
-            Box::new([(0..domain_size).map(|i| Fp::from((i + 1) as u64)).collect()]);
+        let witness_env = build_test_fixed_sel_degree_7_circuit_mul_witness::<_, DummyLookupTable>(
+            &mut rng,
+            domain_size,
+        );
+        let relation_witness = witness_env.get_relation_witness(domain_size);
 
         crate::test::test_completeness_generic_no_lookups::<
             { TEST_N_COLUMNS - 1 },
@@ -281,8 +280,8 @@ mod tests {
     ) -> TestWitnessBuilderEnv<LT> {
         let mut witness_env = WitnessBuilderEnv::create();
 
-        let fixed_sel: Vec<Fp> = (0..domain_size).map(|_i| Fp::from(42u32)).collect();
-        witness_env.set_fixed_selector_cix(TestColumn::FixedE, fixed_sel);
+        let fixed_selectors = test_interpreter::build_fixed_selectors(domain_size);
+        witness_env.set_fixed_selectors(fixed_selectors.to_vec());
 
         for row_i in 0..domain_size {
             let a: Fp = <Fp as UniformRand>::rand(rng);
@@ -304,19 +303,18 @@ mod tests {
         // includes all arguments
         let domain_size = 1 << 8;
 
-        let witness_env = build_test_fixed_sel_degree_7_circuit_fixed_values::<_, DummyLookupTable>(
-            &mut rng,
-            domain_size,
-        );
-        let relation_witness = witness_env.get_relation_witness(domain_size);
+        let fixed_selectors = test_interpreter::build_selectors(domain_size);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_test_fixed_sel_degree_7::<Fp, _>(&mut constraint_env);
         // Don't use lookups for now
         let constraints = constraint_env.get_relation_constraints();
 
-        let fixed_selectors: Box<[Vec<Fp>; 1]> =
-            Box::new([(0..domain_size).map(|_i| Fp::from(42u32)).collect()]);
+        let witness_env = build_test_fixed_sel_degree_7_circuit_fixed_values::<_, DummyLookupTable>(
+            &mut rng,
+            domain_size,
+        );
+        let relation_witness = witness_env.get_relation_witness(domain_size);
 
         crate::test::test_completeness_generic_no_lookups::<
             { TEST_N_COLUMNS - 1 },
@@ -374,6 +372,8 @@ mod tests {
         // includes all arguments
         let domain_size = 1 << 8;
 
+        let fixed_selectors = test_interpreter::build_selectors(domain_size);
+
         let (witness_env, constant) =
             build_test_const_circuit::<_, DummyLookupTable>(&mut rng, domain_size);
         let relation_witness = witness_env.get_relation_witness(domain_size);
@@ -381,9 +381,6 @@ mod tests {
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_test_const::<Fp, _>(&mut constraint_env, constant);
         let constraints = constraint_env.get_relation_constraints();
-
-        let fixed_selectors: Box<[Vec<Fp>; 1]> =
-            Box::new([(0..domain_size).map(|i| Fp::from(i as u64)).collect()]);
 
         crate::test::test_completeness_generic_no_lookups::<
             { TEST_N_COLUMNS - 1 },
@@ -440,16 +437,14 @@ mod tests {
         // includes all arguments
         let domain_size = 1 << 8;
 
+        let fixed_selectors = test_interpreter::build_selectors(domain_size);
+
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_multiplication::<Fp, _>(&mut constraint_env);
         // Don't use lookups for now
         let constraints = constraint_env.get_relation_constraints();
 
-        let fixed_selectors: Box<[Vec<Fp>; 1]> =
-            Box::new([(0..domain_size).map(|i| Fp::from(i as u64)).collect()]);
-
         let witness_env = build_test_mul_circuit::<_, DummyLookupTable>(&mut rng, domain_size);
-
         let relation_witness = witness_env.get_relation_witness(domain_size);
 
         crate::test::test_completeness_generic_no_lookups::<
@@ -474,12 +469,11 @@ mod tests {
         // We generate two different witness and two different proofs.
         let domain_size: usize = 1 << 8;
 
+        let fixed_selectors = test_interpreter::build_selectors(domain_size);
+
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_multiplication::<Fp, _>(&mut constraint_env);
         let constraints = constraint_env.get_relation_constraints();
-
-        let fixed_selectors: Box<[Vec<Fp>; 1]> =
-            Box::new([(0..domain_size).map(|i| Fp::from(i as u64)).collect()]);
 
         let lookup_tables_data = BTreeMap::new();
         let witness_env = build_test_mul_circuit::<_, DummyLookupTable>(&mut rng, domain_size);

--- a/msm/src/test/test_circuit/mod.rs
+++ b/msm/src/test/test_circuit/mod.rs
@@ -34,7 +34,7 @@ mod tests {
     ) -> TestWitnessBuilderEnv<LT> {
         let mut witness_env = WitnessBuilderEnv::create();
 
-        let fixed_selectors = test_interpreter::build_selectors(domain_size);
+        let fixed_selectors = test_interpreter::build_fixed_selectors(domain_size);
         witness_env.set_fixed_selectors(fixed_selectors.to_vec());
 
         for row_i in 0..domain_size {
@@ -63,7 +63,7 @@ mod tests {
         // includes all arguments
         let domain_size = 1 << 8;
 
-        let fixed_selectors = test_interpreter::build_selectors(domain_size);
+        let fixed_selectors = test_interpreter::build_fixed_selectors(domain_size);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_test_fixed_sel::<Fp, _>(&mut constraint_env);
@@ -118,7 +118,7 @@ mod tests {
         // includes all arguments
         let domain_size = 1 << 8;
 
-        let fixed_selectors = test_interpreter::build_selectors(domain_size);
+        let fixed_selectors = test_interpreter::build_fixed_selectors(domain_size);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_test_fixed_sel_degree_7::<Fp, _>(&mut constraint_env);
@@ -176,7 +176,7 @@ mod tests {
         // includes all arguments
         let domain_size = 1 << 8;
 
-        let fixed_selectors = test_interpreter::build_selectors(domain_size);
+        let fixed_selectors = test_interpreter::build_fixed_selectors(domain_size);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_test_fixed_sel_degree_7_with_constants::<Fp, _>(
@@ -303,7 +303,7 @@ mod tests {
         // includes all arguments
         let domain_size = 1 << 8;
 
-        let fixed_selectors = test_interpreter::build_selectors(domain_size);
+        let fixed_selectors = test_interpreter::build_fixed_selectors(domain_size);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_test_fixed_sel_degree_7::<Fp, _>(&mut constraint_env);
@@ -372,7 +372,7 @@ mod tests {
         // includes all arguments
         let domain_size = 1 << 8;
 
-        let fixed_selectors = test_interpreter::build_selectors(domain_size);
+        let fixed_selectors = test_interpreter::build_fixed_selectors(domain_size);
 
         let (witness_env, constant) =
             build_test_const_circuit::<_, DummyLookupTable>(&mut rng, domain_size);
@@ -437,7 +437,7 @@ mod tests {
         // includes all arguments
         let domain_size = 1 << 8;
 
-        let fixed_selectors = test_interpreter::build_selectors(domain_size);
+        let fixed_selectors = test_interpreter::build_fixed_selectors(domain_size);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_multiplication::<Fp, _>(&mut constraint_env);
@@ -469,7 +469,7 @@ mod tests {
         // We generate two different witness and two different proofs.
         let domain_size: usize = 1 << 8;
 
-        let fixed_selectors = test_interpreter::build_selectors(domain_size);
+        let fixed_selectors = test_interpreter::build_fixed_selectors(domain_size);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_multiplication::<Fp, _>(&mut constraint_env);


### PR DESCRIPTION
This PR:
- Adds a single `build_fixed_selectors` into test circuits, so that we have a single place of reference for them. Fixed selectors have to be (compile-time preferably) fixed.
- Renames `build_selectors` into `build_fixed_selectors` to avoid confusion with dynamic selectors.

Backstory:
- As part of #2088 I was working on a unifying interface that'd allow to define fixed selectors for a particular gadget. 
- But I got progressively more convinced this would be too much of a "circuit language design". I'd like to do it but I think it misaligns with our current goals.
- Therefore, I'll try to focus on features and will close #2088 as soon as we have everything functionally. Feel free to object.