### PR TITLE
Add support for runtime tables

### DIFF
--- a/ivc/src/ivc/lookups.rs
+++ b/ivc/src/ivc/lookups.rs
@@ -38,7 +38,7 @@ impl<Ff: PrimeField> LookupTableID for IVCLookupTable<Ff> {
     }
 
     /// Converts a value to its index in the fixed table.
-    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> Option<usize> {
         match self {
             Self::SerLookupTable(lt) => lt.ix_by_value(value),
         }
@@ -54,7 +54,7 @@ impl<Ff: PrimeField> LookupTableID for IVCLookupTable<Ff> {
 
 impl<Ff: PrimeField> IVCLookupTable<Ff> {
     /// Provides a full list of entries for the given table.
-    pub fn entries<F: PrimeField>(&self, domain_d1_size: u64) -> Vec<F> {
+    pub fn entries<F: PrimeField>(&self, domain_d1_size: u64) -> Option<Vec<F>> {
         match self {
             Self::SerLookupTable(lt) => lt.entries(domain_d1_size),
         }

--- a/msm/src/circuit_design/witness.rs
+++ b/msm/src/circuit_design/witness.rs
@@ -184,7 +184,7 @@ impl<
     > LookupCap<F, CIx, LT> for WitnessBuilderEnv<F, CIx, N_WIT, N_REL, N_DSEL, N_FSEL, LT>
 {
     fn lookup(&mut self, table_id: LT, value: Vec<<Self as ColAccessCap<F, CIx>>::Variable>) {
-        let value_ix = table_id.ix_by_value(&value);
+        let value_ix = table_id.ix_by_value(&value).unwrap();
         self.lookup_multiplicities.get_mut(&table_id).unwrap()[value_ix] += F::one();
         self.lookups
             .last_mut()

--- a/msm/src/circuit_design/witness.rs
+++ b/msm/src/circuit_design/witness.rs
@@ -184,18 +184,28 @@ impl<
     > LookupCap<F, CIx, LT> for WitnessBuilderEnv<F, CIx, N_WIT, N_REL, N_DSEL, N_FSEL, LT>
 {
     fn lookup(&mut self, table_id: LT, value: Vec<<Self as ColAccessCap<F, CIx>>::Variable>) {
-        let value_ix = table_id.ix_by_value(&value).unwrap();
-        self.lookup_multiplicities.get_mut(&table_id).unwrap()[value_ix] += F::one();
-        self.lookups
-            .last_mut()
-            .unwrap()
-            .get_mut(&table_id)
-            .unwrap()
-            .push(Logup {
-                table_id,
-                numerator: F::one(),
-                value,
-            })
+        let value_ix = table_id.ix_by_value(&value);
+        if let Some(value_ix) = value_ix {
+            self.lookup_multiplicities.get_mut(&table_id).unwrap()[value_ix] += F::one();
+            self.lookups
+                .last_mut()
+                .unwrap()
+                .get_mut(&table_id)
+                .unwrap()
+                .push(Logup {
+                    table_id,
+                    numerator: F::one(),
+                    value,
+                })
+        } else {
+            // runtime table lookups are temporarily disabled since we
+            // don't yet have a mechanism to resolve values to indices
+            // for runtime tables.
+            assert!(
+                !table_id.is_fixed(),
+                "Could not resolve lookup for a fixed table"
+            );
+        }
     }
 }
 

--- a/msm/src/fec/lookups.rs
+++ b/msm/src/fec/lookups.rs
@@ -57,10 +57,10 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
     }
 
     /// Converts a value to its index in the fixed table.
-    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> Option<usize> {
         let value = value[0];
         assert!(self.is_member(value));
-        match self {
+        Some(match self {
             Self::RangeCheck15 => TryFrom::try_from(value.to_biguint()).unwrap(),
             Self::RangeCheck14Abs => {
                 if value < F::from(1u64 << 14) {
@@ -77,7 +77,7 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
                 }
             }
             Self::RangeCheckFfHighest(_) => TryFrom::try_from(value.to_biguint()).unwrap(),
-        }
+        })
     }
 
     fn all_variants() -> Vec<Self> {

--- a/msm/src/fec/mod.rs
+++ b/msm/src/fec/mod.rs
@@ -147,7 +147,14 @@ mod tests {
         // Fixed tables can be generated inside lookup_tables_data. Runtime should be generated here.
         let mut lookup_tables_data = BTreeMap::new();
         for table_id in LookupTable::<Ff1>::all_variants().into_iter() {
-            lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64));
+            lookup_tables_data.insert(
+                table_id,
+                table_id
+                    .entries(domain_size as u64)
+                    .into_iter()
+                    .map(|x| vec![x])
+                    .collect(),
+            );
         }
         let proof_inputs = witness_env.get_proof_inputs(domain_size, lookup_tables_data);
 

--- a/msm/src/ffa/lookups.rs
+++ b/msm/src/ffa/lookups.rs
@@ -42,9 +42,9 @@ impl LookupTableID for LookupTable {
     }
 
     /// Converts a value to its index in the fixed table.
-    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> Option<usize> {
         let value = value[0];
-        match self {
+        Some(match self {
             Self::RangeCheck15 => TryFrom::try_from(value.to_biguint()).unwrap(),
             Self::RangeCheck1BitSigned => {
                 if value == F::zero() {
@@ -57,7 +57,7 @@ impl LookupTableID for LookupTable {
                     panic!("Invalid value for rangecheck1abs")
                 }
             }
-        }
+        })
     }
 
     fn all_variants() -> Vec<Self> {

--- a/msm/src/ffa/mod.rs
+++ b/msm/src/ffa/mod.rs
@@ -74,7 +74,14 @@ mod tests {
         // Fixed tables can be generated inside lookup_tables_data. Runtime should be generated here.
         let mut lookup_tables_data = BTreeMap::new();
         for table_id in LookupTable::all_variants().into_iter() {
-            lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64));
+            lookup_tables_data.insert(
+                table_id,
+                table_id
+                    .entries(domain_size as u64)
+                    .into_iter()
+                    .map(|x| vec![x])
+                    .collect(),
+            );
         }
         let proof_inputs = witness_env.get_proof_inputs(domain_size, lookup_tables_data);
 

--- a/msm/src/logup.rs
+++ b/msm/src/logup.rs
@@ -207,8 +207,9 @@ pub trait LookupTableID: Send + Sync + Copy + Hash + Eq + PartialEq + Ord + Part
     /// Returns the length of each table.
     fn length(&self) -> usize;
 
-    /// Given a value, returns an index of this value in the table.
-    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> usize;
+    /// Returns None if the table is runtime (and thus mapping value
+    /// -> ix is not known at compile time.
+    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> Option<usize>;
 
     fn all_variants() -> Vec<Self>;
 }

--- a/msm/src/logup.rs
+++ b/msm/src/logup.rs
@@ -180,7 +180,9 @@ where
 }
 
 /// Trait for lookup table variants
-pub trait LookupTableID: Send + Sync + Copy + Hash + Eq + PartialEq + Ord + PartialOrd {
+pub trait LookupTableID:
+    Send + Sync + Copy + Hash + Eq + PartialEq + Ord + PartialOrd + core::fmt::Debug
+{
     /// Assign a unique ID, as a u32 value
     fn to_u32(&self) -> u32;
 
@@ -298,8 +300,8 @@ impl<'lt, G, ID: LookupTableID> IntoIterator for &'lt LookupProof<G, ID> {
 ///    |------------------------------------------|
 ///    |                           denominators   |
 ///    |                         /--------------\ |
-/// column * (\prod_{i = 1}^{N} (β + f_{i}(X))) =
-/// \sum_{i = 1}^{N} m_{i} * \prod_{j = 1, j \neq i}^{N} (β + f_{j}(X))
+/// column * (\prod_{i = 0}^{N} (β + f_{i}(X))) =
+/// \sum_{i = 0}^{N} m_{i} * \prod_{j = 1, j \neq i}^{N} (β + f_{j}(X))
 ///    |             |--------------------------------------------------|
 ///    |                             Inner part of rhs                  |
 ///    |                                                                |
@@ -311,13 +313,17 @@ impl<'lt, G, ID: LookupTableID> IntoIterator for &'lt LookupProof<G, ID> {
 /// ```
 /// It is because h(X) (column) is defined as:
 /// ```text
-///        n      m_i(X)
-/// h(X)   ∑    ----------
-///       i=1   β + f_i(X)
+///         n      m_i(X)        n         1            m_0(ω^j)
+/// h(X) =  ∑    ----------  =   ∑   ------------  -  -----------
+///        i=0   β + f_i(X)     i=1  β + f_i(ω^j)      β + t(ω^j)
 ///```
-/// For instance, if i = 2, we have
+/// The first form is generic, the second is concrete with f_0 = t; m_0 = m; m_i = 1 for ≠ 1.
+/// We will be thinking in the generic form.
+///
+/// For instance, if N = 2, we have
 /// ```text
 /// h(X) = m_1(X) / (β + f_1(X)) + m_2(X) / (β + f_{2}(X))
+///
 ///        m_1(X) * (β + f_2(X)) + m_2(X) * (β + f_{1}(X))
 ///      = ----------------------------------------------
 ///                  (β + f_2(X)) * (β + f_1(X))
@@ -363,10 +369,13 @@ pub fn combine_lookups<F: PrimeField, ID: LookupTableID>(
             beta.clone() + combined_value + x.table_id.to_constraint()
         })
         .collect::<Vec<_>>();
+
     // Compute `column * (\prod_{i = 1}^{N} (β + f_{i}(X)))`
     let lhs = denominators
         .iter()
         .fold(curr_cell(column), |acc, x| acc * x.clone());
+
+    // Compute `\sum_{i = 0}^{N} m_{i} * \prod_{j = 1, j \neq i}^{N} (β + f_{j}(X))`
     let rhs = lookups
         .into_iter()
         .enumerate()
@@ -387,6 +396,7 @@ pub fn combine_lookups<F: PrimeField, ID: LookupTableID>(
         // Individual sums
         .reduce(|x, y| x + y)
         .unwrap_or(E::zero());
+
     lhs - rhs
 }
 
@@ -522,12 +532,6 @@ pub mod prover {
             > = {
                 (&lookups)
                     .into_par_iter()
-                    .filter(|lookup| {
-                        // FIXME: this is ugly.
-                        // Does not handle RAMLookup
-                        let table_id = lookup.f[0][0].table_id;
-                        table_id.is_fixed()
-                    })
                     .map(|lookup| {
                         let table_id = lookup.f[0][0].table_id;
                         (
@@ -611,21 +615,25 @@ pub mod prover {
                             table_id,
                             value,
                         } = &f_i[j as usize];
-                        // Compute r * x_{1} + r^2 x_{2} + ... r^{N} x_{N}
-                        let combined_value: G::ScalarField =
+                        // Compute x_{1} + r x_{2} + ... r^{N-1} x_{N}
+                        // This is what we actually put into the `fixed_lookup_tables`.
+                        let combined_value_pow0: G::ScalarField =
                             value.iter().rev().fold(G::ScalarField::zero(), |acc, y| {
                                 acc * vector_lookup_combiner + y
-                            }) * vector_lookup_combiner;
+                            });
+                        // Compute r * x_{1} + r^2 x_{2} + ... r^{N} x_{N}
+                        let combined_value: G::ScalarField =
+                            combined_value_pow0 * vector_lookup_combiner;
                         // add table id
                         let combined_value = combined_value + table_id.to_field::<G::ScalarField>();
 
                         // If last element and fixed lookup tables, we keep
                         // the *combined* value of the table.
-                        if i == (n - 1) && table_id.is_fixed() {
+                        if i == (n - 1) {
                             fixed_lookup_tables
                                 .entry(*table_id)
                                 .or_insert_with(Vec::new)
-                                .push(value[0]);
+                                .push(combined_value_pow0);
                         }
 
                         // β + a_{i}

--- a/msm/src/lookups.rs
+++ b/msm/src/lookups.rs
@@ -33,9 +33,9 @@ impl LookupTableID for DummyLookupTable {
         true
     }
 
-    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> Option<usize> {
         if value[0] == F::zero() {
-            0
+            Some(0)
         } else {
             panic!("Invalid value for DummyLookupTable")
         }
@@ -92,7 +92,7 @@ impl LookupTableID for LookupTableIDs {
         true
     }
 
-    fn ix_by_value<F: PrimeField>(&self, _value: &[F]) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, _value: &[F]) -> Option<usize> {
         todo!()
     }
 

--- a/msm/src/serialization/column.rs
+++ b/msm/src/serialization/column.rs
@@ -4,12 +4,19 @@ use crate::{
     N_LIMBS,
 };
 
-/// Total number of columns in the serialization circuit
-pub const SER_N_COLUMNS: usize = 6 * N_LIMBS + N_INTERMEDIATE_LIMBS + 9;
+/// Total number of columns in the serialization circuit, including fixed selectors.
+pub const N_COL_SER: usize = 6 * N_LIMBS + N_INTERMEDIATE_LIMBS + 9 + N_FSEL_SER;
+
+/// Number of fixed selectors for serialization circuit.
+pub const N_FSEL_SER: usize = 2;
 
 /// Columns used by the serialization subcircuit.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SerializationColumn {
+    /// A fixed selector column that gives one the current row, starting with 0.
+    CurrentRow,
+    /// For current row i, this is i - 2^{ceil(log(i)) - 1}
+    PreviousCoeffRow,
     /// 3 88-bit inputs. For the row #i this represents the IPA challenge xi_{log(i)}.
     ChalKimchi(usize),
     /// N_INTERMEDIATE_LIMBS intermediate values, 4 bits long. Represent parts of the IPA challenge.
@@ -25,14 +32,16 @@ pub enum SerializationColumn {
     Quotient(usize),
     /// Carry limbs
     Carry(usize),
-    /// The resulting coefficient C_i = (C_i >> 1) * xi_{log(i)}. In small limbs.
+    /// The resulting coefficient C_i = C_{i - 2^{ceil(log i) - 1}} * xi_{log(i)}. In small limbs.
     CoeffResult(usize),
 }
 
 impl ColumnIndexer for SerializationColumn {
-    const N_COL: usize = SER_N_COLUMNS;
+    const N_COL: usize = N_COL_SER;
     fn to_column(self) -> Column {
         match self {
+            Self::CurrentRow => Column::FixedSelector(0),
+            Self::PreviousCoeffRow => Column::FixedSelector(1),
             Self::ChalKimchi(j) => {
                 assert!(j < 3);
                 Column::Relation(j)

--- a/msm/src/serialization/interpreter.rs
+++ b/msm/src/serialization/interpreter.rs
@@ -383,9 +383,6 @@ pub fn constrain_multiplication<
 >(
     env: &mut Env,
 ) {
-    let current_row = env.read_column(SerializationColumn::CurrentRow);
-    let previous_coeff_row = env.read_column(SerializationColumn::PreviousCoeffRow);
-
     let chal_converted_limbs_small: [_; N_LIMBS_SMALL] =
         core::array::from_fn(|i| env.read_column(SerializationColumn::ChalConverted(i)));
     let coeff_input_limbs_small: [_; N_LIMBS_SMALL] =
@@ -406,6 +403,9 @@ pub fn constrain_multiplication<
     };
 
     {
+        let current_row = env.read_column(SerializationColumn::CurrentRow);
+        let previous_coeff_row = env.read_column(SerializationColumn::PreviousCoeffRow);
+
         // Reading the input:
         // (prev_i, [VEC])
         let mut vec_input: Vec<_> = coeff_input_limbs_small.clone().to_vec();
@@ -415,9 +415,9 @@ pub fn constrain_multiplication<
         // Writing the output
         // FIXME we should actually /write/ here, not read!
         // (cur_i, [VEC])
-        let mut vec_output: Vec<_> = coeff_result_limbs_small.clone().to_vec();
-        vec_output.insert(0, current_row);
-        env.lookup(LookupTable::MultiplicationBus, vec_output);
+        let mut _vec_output: Vec<_> = coeff_result_limbs_small.clone().to_vec();
+        _vec_output.insert(0, current_row);
+        //env.lookup(LookupTable::MultiplicationBus, vec_output);
     }
 
     // Result variable must be in the field.
@@ -686,6 +686,7 @@ pub fn build_selectors<F: PrimeField>(domain_size: usize) -> [Vec<F>; N_FSEL_SER
             }
         })
         .collect();
+
     [sel1, sel2]
 }
 

--- a/msm/src/serialization/lookups.rs
+++ b/msm/src/serialization/lookups.rs
@@ -62,28 +62,33 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
     }
 
     /// Converts a value to its index in the fixed table.
-    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> Option<usize> {
         let value = value[0];
         assert!(self.is_member(value));
         match self {
-            Self::RangeCheck15 => TryFrom::try_from(value.to_biguint()).unwrap(),
-            Self::RangeCheck4 => TryFrom::try_from(value.to_biguint()).unwrap(),
+            Self::RangeCheck15 => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
+            Self::RangeCheck4 => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
             Self::RangeCheck14Abs => {
                 if value < F::from(1u64 << 14) {
-                    TryFrom::try_from(value.to_biguint()).unwrap()
+                    Some(TryFrom::try_from(value.to_biguint()).unwrap())
                 } else {
-                    TryFrom::try_from((value + F::from(2 * (1u64 << 14))).to_biguint()).unwrap()
+                    Some(
+                        TryFrom::try_from((value + F::from(2 * (1u64 << 14))).to_biguint())
+                            .unwrap(),
+                    )
                 }
             }
             Self::RangeCheck9Abs => {
                 if value < F::from(1u64 << 9) {
-                    TryFrom::try_from(value.to_biguint()).unwrap()
+                    Some(TryFrom::try_from(value.to_biguint()).unwrap())
                 } else {
-                    TryFrom::try_from((value + F::from(2 * (1u64 << 9))).to_biguint()).unwrap()
+                    Some(
+                        TryFrom::try_from((value + F::from(2 * (1u64 << 9))).to_biguint()).unwrap(),
+                    )
                 }
             }
 
-            Self::RangeCheckFfHighest(_) => TryFrom::try_from(value.to_biguint()).unwrap(),
+            Self::RangeCheckFfHighest(_) => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
         }
     }
 
@@ -115,41 +120,47 @@ impl<Ff: PrimeField> LookupTable<Ff> {
     }
 
     /// Provides a full list of entries for the given table.
-    pub fn entries<F: PrimeField>(&self, domain_d1_size: u64) -> Vec<F> {
+    pub fn entries<F: PrimeField>(&self, domain_d1_size: u64) -> Option<Vec<F>> {
         assert!(domain_d1_size >= (1 << 15));
         match self {
-            Self::RangeCheck15 => (0..domain_d1_size).map(|i| F::from(i)).collect(),
-            Self::RangeCheck4 => (0..domain_d1_size)
-                .map(|i| if i < (1 << 4) { F::from(i) } else { F::zero() })
-                .collect(),
-            Self::RangeCheck14Abs => (0..domain_d1_size)
-                .map(|i| {
-                    if i < (1 << 14) {
-                        // [0,1,2 ... (1<<14)-1]
-                        F::from(i)
-                    } else if i < 2 * (1 << 14) {
-                        // [-(i<<14),...-2,-1]
-                        F::from(i) - F::from(2u64 * (1 << 14))
-                    } else {
-                        F::zero()
-                    }
-                })
-                .collect(),
+            Self::RangeCheck15 => Some((0..domain_d1_size).map(|i| F::from(i)).collect()),
+            Self::RangeCheck4 => Some(
+                (0..domain_d1_size)
+                    .map(|i| if i < (1 << 4) { F::from(i) } else { F::zero() })
+                    .collect(),
+            ),
+            Self::RangeCheck14Abs => Some(
+                (0..domain_d1_size)
+                    .map(|i| {
+                        if i < (1 << 14) {
+                            // [0,1,2 ... (1<<14)-1]
+                            F::from(i)
+                        } else if i < 2 * (1 << 14) {
+                            // [-(i<<14),...-2,-1]
+                            F::from(i) - F::from(2u64 * (1 << 14))
+                        } else {
+                            F::zero()
+                        }
+                    })
+                    .collect(),
+            ),
 
-            Self::RangeCheck9Abs => (0..domain_d1_size)
-                .map(|i| {
-                    if i < (1 << 9) {
-                        // [0,1,2 ... (1<<9)-1]
-                        F::from(i)
-                    } else if i < 2 * (1 << 9) {
-                        // [-(i<<9),...-2,-1]
-                        F::from(i) - F::from(2u64 * (1 << 9))
-                    } else {
-                        F::zero()
-                    }
-                })
-                .collect(),
-            Self::RangeCheckFfHighest(_) => Self::entries_ff_highest::<F>(domain_d1_size),
+            Self::RangeCheck9Abs => Some(
+                (0..domain_d1_size)
+                    .map(|i| {
+                        if i < (1 << 9) {
+                            // [0,1,2 ... (1<<9)-1]
+                            F::from(i)
+                        } else if i < 2 * (1 << 9) {
+                            // [-(i<<9),...-2,-1]
+                            F::from(i) - F::from(2u64 * (1 << 9))
+                        } else {
+                            F::zero()
+                        }
+                    })
+                    .collect(),
+            ),
+            Self::RangeCheckFfHighest(_) => Some(Self::entries_ff_highest::<F>(domain_d1_size)),
         }
     }
 

--- a/msm/src/serialization/lookups.rs
+++ b/msm/src/serialization/lookups.rs
@@ -19,6 +19,8 @@ pub enum LookupTable<Ff> {
     /// x ∈ [0, ff_highest] where ff_highest is the highest 15-bit
     /// limb of the modulus of the foreign field `Ff`.
     RangeCheckFfHighest(PhantomData<Ff>),
+    /// Communication bus for the multiplication circuit.
+    MultiplicationBus,
 }
 
 impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
@@ -29,6 +31,7 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
             Self::RangeCheck14Abs => 3,
             Self::RangeCheck9Abs => 4,
             Self::RangeCheckFfHighest(_) => 5,
+            Self::MultiplicationBus => 6,
         }
     }
 
@@ -39,13 +42,21 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
             3 => Self::RangeCheck14Abs,
             4 => Self::RangeCheck9Abs,
             5 => Self::RangeCheckFfHighest(PhantomData),
+            6 => Self::MultiplicationBus,
             _ => panic!("Invalid lookup table id"),
         }
     }
 
     /// All tables are fixed tables.
     fn is_fixed(&self) -> bool {
-        true
+        match self {
+            Self::RangeCheck15 => true,
+            Self::RangeCheck4 => true,
+            Self::RangeCheck14Abs => true,
+            Self::RangeCheck9Abs => true,
+            Self::RangeCheckFfHighest(_) => true,
+            Self::MultiplicationBus => false,
+        }
     }
 
     fn length(&self) -> usize {
@@ -58,13 +69,17 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
                 crate::serialization::interpreter::ff_modulus_highest_limb::<Ff>(),
             )
             .unwrap(),
+            Self::MultiplicationBus => 1 << 15,
         }
     }
 
     /// Converts a value to its index in the fixed table.
     fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> Option<usize> {
         let value = value[0];
-        assert!(self.is_member(value));
+        if self.is_fixed() {
+            assert!(self.is_member(value).unwrap());
+        }
+
         match self {
             Self::RangeCheck15 => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
             Self::RangeCheck4 => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
@@ -89,6 +104,7 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
             }
 
             Self::RangeCheckFfHighest(_) => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
+            Self::MultiplicationBus => None,
         }
     }
 
@@ -99,6 +115,7 @@ impl<Ff: PrimeField> LookupTableID for LookupTable<Ff> {
             Self::RangeCheck9Abs,
             Self::RangeCheck4,
             Self::RangeCheckFfHighest(PhantomData),
+            Self::MultiplicationBus,
         ]
     }
 }
@@ -161,26 +178,28 @@ impl<Ff: PrimeField> LookupTable<Ff> {
                     .collect(),
             ),
             Self::RangeCheckFfHighest(_) => Some(Self::entries_ff_highest::<F>(domain_d1_size)),
+            _ => panic!("not possible"),
         }
     }
 
     /// Checks if a value is in a given table.
-    pub fn is_member<F: PrimeField>(&self, value: F) -> bool {
+    pub fn is_member<F: PrimeField>(&self, value: F) -> Option<bool> {
         match self {
-            Self::RangeCheck15 => value.to_biguint() < BigUint::from(2u128.pow(15)),
-            Self::RangeCheck4 => value.to_biguint() < BigUint::from(2u128.pow(4)),
+            Self::RangeCheck15 => Some(value.to_biguint() < BigUint::from(2u128.pow(15))),
+            Self::RangeCheck4 => Some(value.to_biguint() < BigUint::from(2u128.pow(4))),
             Self::RangeCheck14Abs => {
-                value < F::from(1u64 << 14) || value >= F::zero() - F::from(1u64 << 14)
+                Some(value < F::from(1u64 << 14) || value >= F::zero() - F::from(1u64 << 14))
             }
             Self::RangeCheck9Abs => {
-                value < F::from(1u64 << 9) || value >= F::zero() - F::from(1u64 << 9)
+                Some(value < F::from(1u64 << 9) || value >= F::zero() - F::from(1u64 << 9))
             }
             Self::RangeCheckFfHighest(_) => {
                 let f_bui: BigUint = TryFrom::try_from(Ff::Params::MODULUS).unwrap();
                 let top_modulus_f: F =
                     F::from_biguint(&(f_bui >> ((N_LIMBS - 1) * LIMB_BITSIZE))).unwrap();
-                value < top_modulus_f
+                Some(value < top_modulus_f)
             }
+            Self::MultiplicationBus => None,
         }
     }
 }

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -89,7 +89,7 @@ mod tests {
         // Fixed tables can be generated inside lookup_tables_data. Runtime should be generated here.
         let mut lookup_tables_data = BTreeMap::new();
         for table_id in LookupTable::<Ff1>::all_variants().into_iter() {
-            lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64));
+            lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64).unwrap());
         }
         let proof_inputs = witness_env.get_proof_inputs(domain_size, lookup_tables_data);
 

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -87,10 +87,14 @@ mod tests {
         }
 
         // Fixed tables can be generated inside lookup_tables_data. Runtime should be generated here.
+        let multiplication_bus: Vec<Fp> = vec![];
         let mut lookup_tables_data = BTreeMap::new();
         for table_id in LookupTable::<Ff1>::all_variants().into_iter() {
-            lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64).unwrap());
+            if table_id.is_fixed() {
+                lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64).unwrap());
+            }
         }
+        lookup_tables_data.insert(LookupTable::MultiplicationBus, multiplication_bus);
         let proof_inputs = witness_env.get_proof_inputs(domain_size, lookup_tables_data);
 
         crate::test::test_completeness_generic::<

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -15,10 +15,10 @@ mod tests {
         columns::ColumnIndexer,
         logup::LookupTableID,
         serialization::{
-            column::{SerializationColumn, SER_N_COLUMNS},
+            column::{SerializationColumn, N_COL_SER, N_FSEL_SER},
             interpreter::{
-                constrain_multiplication, deserialize_field_element, limb_decompose_ff,
-                multiplication_circuit,
+                build_selectors, constrain_multiplication, deserialize_field_element,
+                limb_decompose_ff, multiplication_circuit,
             },
             lookups::LookupTable,
         },
@@ -28,10 +28,10 @@ mod tests {
     type SerializationWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         SerializationColumn,
-        { <SerializationColumn as ColumnIndexer>::N_COL },
-        { <SerializationColumn as ColumnIndexer>::N_COL },
+        { <SerializationColumn as ColumnIndexer>::N_COL - N_FSEL_SER },
+        { <SerializationColumn as ColumnIndexer>::N_COL - N_FSEL_SER },
         0,
-        0,
+        N_FSEL_SER,
         LookupTable<Ff1>,
     >;
 
@@ -42,6 +42,9 @@ mod tests {
         let domain_size: usize = 1 << 15;
 
         let mut witness_env = SerializationWitnessBuilderEnv::create();
+
+        let fixed_selectors = build_selectors(domain_size);
+        witness_env.set_fixed_selectors(fixed_selectors.to_vec());
 
         // Boxing to avoid stack overflow
         let mut field_elements = vec![];
@@ -98,15 +101,15 @@ mod tests {
         let proof_inputs = witness_env.get_proof_inputs(domain_size, lookup_tables_data);
 
         crate::test::test_completeness_generic::<
-            SER_N_COLUMNS,
-            SER_N_COLUMNS,
+            { N_COL_SER - N_FSEL_SER },
+            { N_COL_SER - N_FSEL_SER },
             0,
-            0,
+            N_FSEL_SER,
             LookupTable<Ff1>,
             _,
         >(
             constraints,
-            Box::new([]),
+            Box::new(fixed_selectors),
             proof_inputs,
             domain_size,
             &mut rng,

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -89,12 +89,27 @@ mod tests {
             }
         }
 
+        let runtime_tables: BTreeMap<_, _> = witness_env.get_runtime_tables(domain_size);
+
+        // TODO remove this clone
         // Fixed tables can be generated inside lookup_tables_data. Runtime should be generated here.
-        let multiplication_bus: Vec<Fp> = vec![];
-        let mut lookup_tables_data = BTreeMap::new();
+        let multiplication_bus: Vec<Vec<Fp>> = runtime_tables
+            .get(&LookupTable::MultiplicationBus)
+            .unwrap()
+            .clone();
+
+        let mut lookup_tables_data: BTreeMap<LookupTable<Ff1>, Vec<Vec<Fp>>> = BTreeMap::new();
         for table_id in LookupTable::<Ff1>::all_variants().into_iter() {
             if table_id.is_fixed() {
-                lookup_tables_data.insert(table_id, table_id.entries(domain_size as u64).unwrap());
+                lookup_tables_data.insert(
+                    table_id,
+                    table_id
+                        .entries(domain_size as u64)
+                        .unwrap()
+                        .into_iter()
+                        .map(|x| vec![x])
+                        .collect(),
+                );
             }
         }
         lookup_tables_data.insert(LookupTable::MultiplicationBus, multiplication_bus);

--- a/msm/src/verifier.rs
+++ b/msm/src/verifier.rs
@@ -151,6 +151,12 @@ where
                 .values()
                 .for_each(|comm| absorb_commitment(&mut fq_sponge, comm));
 
+            // FIXME @volhovm it seems that the verifier does not
+            // actually check that the fixed tables used in the proof
+            // are the fixed tables defined in the code. In other
+            // words, all the currently used "fixed" tables are
+            // runtime and can be chosen freely by the prover.
+
             // To generate the challenges
             let joint_combiner = fq_sponge.challenge();
             let beta = fq_sponge.challenge();

--- a/o1vm/src/lookups.rs
+++ b/o1vm/src/lookups.rs
@@ -95,7 +95,7 @@ impl LookupTableID for LookupTableIDs {
         }
     }
 
-    fn ix_by_value<F: PrimeField>(&self, _value: &[F]) -> usize {
+    fn ix_by_value<F: PrimeField>(&self, _value: &[F]) -> Option<usize> {
         todo!()
     }
 


### PR DESCRIPTION
Work in progress branch. 

I'm extending the existing `logup` module to support non-compile-time-fixed tables.

Addresses #2089