### PR TITLE
utils/field_helpers: introduce from_biguint_err alias

### DIFF
--- a/utils/src/field_helpers.rs
+++ b/utils/src/field_helpers.rs
@@ -89,6 +89,16 @@ pub trait FieldHelpers<F> {
             .map_err(|_| FieldHelpersError::DeserializeBytes)
     }
 
+    /// Deserialize from BigUint, panics on error
+    fn from_biguint_err(big: &BigUint) -> F
+    where
+        F: PrimeField,
+    {
+        big.clone()
+            .try_into()
+            .expect("Failed to deserialize BigUint")
+    }
+
     /// Serialize to bytes
     fn to_bytes(&self) -> Vec<u8>;
 


### PR DESCRIPTION
Simple alias to avoid the `unwrap()`. I use a lot of from_biguint in arrabiata, and it is only to make it shorter. I would prefer going with `exn` for the suffix. I leave the reviewer decides.