### PR TITLE
[#2428] Add native-level folding checks into ivc/simple + folding lib

### DIFF
--- a/folding/src/error_term.rs
+++ b/folding/src/error_term.rs
@@ -458,6 +458,7 @@ impl<CF: FoldingConfig> ExtendedEnv<CF> {
     ) -> (Vec<ScalarField<CF>>, Vec<CF::Curve>) {
         let mut left = self.instances[0].to_absorb();
         let right = self.instances[1].to_absorb();
+
         left.0.extend(right.0);
         left.1.extend(right.1);
         left.1.extend([t0, t1]);

--- a/folding/src/instance_witness.rs
+++ b/folding/src/instance_witness.rs
@@ -167,7 +167,7 @@ impl<G: CommitmentCurve, W: Witness<G>> ExtendedWitness<G, W> {
 /// described by a degree 3 polynomial, an additional column will be added, and
 /// `extended` will contain `1` commitment.
 // FIXME: We should forbid cloning, for memory footprint.
-#[derive(Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct ExtendedInstance<G: CommitmentCurve, I: Instance<G>> {
     /// The original instance.
     pub instance: I,
@@ -234,7 +234,7 @@ impl<G: CommitmentCurve, I: Instance<G>> Instance<G> for ExtendedInstance<G, I> 
 /// slack/error term.
 /// See page 15 of [Nova](https://eprint.iacr.org/2021/370.pdf).
 // FIXME: We should forbid cloning, for memory footprint.
-#[derive(Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct RelaxedInstance<G: CommitmentCurve, I: Instance<G>> {
     /// The original instance, extended with the columns added by
     /// quadriticization

--- a/ivc/src/plonkish_lang.rs
+++ b/ivc/src/plonkish_lang.rs
@@ -102,8 +102,7 @@ impl<const N_COL: usize, const N_FSEL: usize, F: FftField> Index<()>
     }
 }
 
-#[derive(Clone, Debug)]
-
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct PlonkishInstance<
     G: KimchiCurve,
     const N_COL: usize,


### PR DESCRIPTION
This PR:
- Adds code that checks instance-level folding (no witness, verifier side) where missing
- Adds tests to it
- Introduces the corresponding check into `simple.rs` IVC test, where we have to check the last fold validity natively.