### PR TITLE
Lookups: Add support for multiple reads in runtime tables

### DIFF
--- a/msm/src/circuit_design/witness.rs
+++ b/msm/src/circuit_design/witness.rs
@@ -401,11 +401,13 @@ impl<
 
             let mut multiplicities = vec![vec![0u64; domain_size]; num_writes];
 
-            for value in self.lookup_reads.get(&table_id).unwrap()[0].iter() {
-                if let Some((col_i, row_i)) = resolver.get_mut(value) {
-                    multiplicities[*col_i][*row_i] += 1;
-                } else {
-                    panic!("Could not resolve a runtime table read");
+            for lookup_read_column in self.lookup_reads.get(&table_id).unwrap().iter() {
+                for value in lookup_read_column.iter() {
+                    if let Some((col_i, row_i)) = resolver.get_mut(value) {
+                        multiplicities[*col_i][*row_i] += 1;
+                    } else {
+                        panic!("Could not resolve a runtime table read");
+                    }
                 }
             }
 
@@ -553,12 +555,7 @@ impl<
         if !lookup_tables_data.is_empty() {
             for table_id in LT::all_variants().into_iter() {
                 // Find how many lookups are done per table.
-                let number_of_lookup_reads = if table_id.is_fixed() {
-                    self.lookup_reads.get(&table_id).unwrap().len()
-                } else {
-                    // For now we only have 1 runtime lookup read always.
-                    1
-                };
+                let number_of_lookup_reads = self.lookup_reads.get(&table_id).unwrap().len();
                 let number_of_lookup_writes =
                     if table_id.is_fixed() || table_id.runtime_create_column() {
                         1

--- a/msm/src/serialization/interpreter.rs
+++ b/msm/src/serialization/interpreter.rs
@@ -432,7 +432,7 @@ pub fn constrain_multiplication<
         // (prev_i, [VEC])
         let mut vec_input: Vec<_> = coeff_input_limbs_small.clone().to_vec();
         vec_input.insert(0, previous_coeff_row);
-        env.lookup(LookupTable::MultiplicationBus, vec_input);
+        env.lookup(LookupTable::MultiplicationBus, vec_input.clone());
     }
 
     // Quotient sign must be -1 or 1.

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -88,7 +88,7 @@ mod tests {
             .unwrap()
             .clone();
 
-        assert!(multiplication_bus.len() == 2);
+        //assert!(multiplication_bus.len() == 2);
 
         let mut lookup_tables_data: BTreeMap<LookupTable<Ff1>, Vec<Vec<Vec<Fp>>>> = BTreeMap::new();
         for table_id in LookupTable::<Ff1>::all_variants().into_iter() {

--- a/msm/src/test/test_circuit/columns.rs
+++ b/msm/src/test/test_circuit/columns.rs
@@ -3,26 +3,26 @@ use crate::{
     N_LIMBS,
 };
 
-/// Number of columns in the test circuits.
-pub const TEST_N_COLUMNS: usize = 4 * N_LIMBS + 1;
+/// Number of columns in the test circuits, including fixed selectors.
+pub const N_COL_TEST: usize = 4 * N_LIMBS + N_FSEL_TEST;
 
-/// Column indexer for MSM columns.
-///
-/// Columns A to D are used for testing right now, they are used for
-/// either of the two equations:
-///   A + B - C = 0
-///   A * B - D = 0
+/// Number of fixed selectors in the test circuit.
+pub const N_FSEL_TEST: usize = 3;
+
+/// Test column indexer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TestColumn {
     A(usize),
     B(usize),
     C(usize),
     D(usize),
-    FixedE,
+    FixedSel1,
+    FixedSel2,
+    FixedSel3,
 }
 
 impl ColumnIndexer for TestColumn {
-    const N_COL: usize = TEST_N_COLUMNS;
+    const N_COL: usize = N_COL_TEST;
     fn to_column(self) -> Column {
         let to_column_inner = |offset, i| {
             assert!(i < N_LIMBS);
@@ -33,7 +33,9 @@ impl ColumnIndexer for TestColumn {
             TestColumn::B(i) => to_column_inner(1, i),
             TestColumn::C(i) => to_column_inner(2, i),
             TestColumn::D(i) => to_column_inner(3, i),
-            TestColumn::FixedE => Column::FixedSelector(0),
+            TestColumn::FixedSel1 => Column::FixedSelector(0),
+            TestColumn::FixedSel2 => Column::FixedSelector(1),
+            TestColumn::FixedSel3 => Column::FixedSelector(2),
         }
     }
 }

--- a/msm/src/test/test_circuit/interpreter.rs
+++ b/msm/src/test/test_circuit/interpreter.rs
@@ -1,7 +1,7 @@
 use crate::{
     circuit_design::{ColAccessCap, ColWriteCap, DirectWitnessCap},
     serialization::interpreter::limb_decompose_ff,
-    test::test_circuit::columns::TestColumn,
+    test::test_circuit::columns::{TestColumn, N_FSEL_TEST},
     LIMB_BITSIZE, N_LIMBS,
 };
 use ark_ff::{Field, PrimeField, SquareRootField, Zero};
@@ -127,22 +127,22 @@ pub fn test_const<F: PrimeField, Env: ColAccessCap<F, TestColumn> + ColWriteCap<
     constrain_test_const(env, constant);
 }
 
-/// A constraint function for A_0 + B_0 - FIXED_E
+/// A constraint function for A_0 + B_0 - FIXED_SEL_1
 pub fn constrain_test_fixed_sel<F: PrimeField, Env: ColAccessCap<F, TestColumn>>(env: &mut Env) {
     let a0 = Env::read_column(env, TestColumn::A(0));
     let b0 = Env::read_column(env, TestColumn::B(0));
-    let fixed_e = Env::read_column(env, TestColumn::FixedE);
+    let fixed_e = Env::read_column(env, TestColumn::FixedSel1);
     let equation = a0.clone() + b0.clone() - fixed_e;
     env.assert_zero(equation.clone());
 }
 
-/// A constraint function for A_0^7 + B_0 - FIXED_E
+/// A constraint function for A_0^7 + B_0 - FIXED_SEL_1
 pub fn constrain_test_fixed_sel_degree_7<F: PrimeField, Env: ColAccessCap<F, TestColumn>>(
     env: &mut Env,
 ) {
     let a0 = Env::read_column(env, TestColumn::A(0));
     let b0 = Env::read_column(env, TestColumn::B(0));
-    let fixed_e = Env::read_column(env, TestColumn::FixedE);
+    let fixed_e = Env::read_column(env, TestColumn::FixedSel1);
     let a0_2 = a0.clone() * a0.clone();
     let a0_4 = a0_2.clone() * a0_2.clone();
     let a0_6 = a0_4.clone() * a0_2.clone();
@@ -151,7 +151,7 @@ pub fn constrain_test_fixed_sel_degree_7<F: PrimeField, Env: ColAccessCap<F, Tes
     env.assert_zero(equation.clone());
 }
 
-/// A constraint function for 3 * A_0^7 + 42 * B_0 - FIXED_E
+/// A constraint function for 3 * A_0^7 + 42 * B_0 - FIXED_SEL_1
 pub fn constrain_test_fixed_sel_degree_7_with_constants<
     F: PrimeField,
     Env: ColAccessCap<F, TestColumn>,
@@ -162,7 +162,7 @@ pub fn constrain_test_fixed_sel_degree_7_with_constants<
     let fourty_two = Env::constant(F::from(42u32));
     let three = Env::constant(F::from(3u32));
     let b0 = Env::read_column(env, TestColumn::B(0));
-    let fixed_e = Env::read_column(env, TestColumn::FixedE);
+    let fixed_e = Env::read_column(env, TestColumn::FixedSel1);
     let a0_2 = a0.clone() * a0.clone();
     let a0_4 = a0_2.clone() * a0_2.clone();
     let a0_6 = a0_4.clone() * a0_2.clone();
@@ -172,7 +172,7 @@ pub fn constrain_test_fixed_sel_degree_7_with_constants<
 }
 
 // NB: Assumes non-standard selectors
-/// A constraint function for 3 * A_0^7 + B_0 * FIXED_E
+/// A constraint function for 3 * A_0^7 + B_0 * FIXED_SEL_3
 pub fn constrain_test_fixed_sel_degree_7_mul_witness<
     F: PrimeField,
     Env: ColAccessCap<F, TestColumn>,
@@ -182,7 +182,7 @@ pub fn constrain_test_fixed_sel_degree_7_mul_witness<
     let a0 = Env::read_column(env, TestColumn::A(0));
     let three = Env::constant(F::from(3u32));
     let b0 = Env::read_column(env, TestColumn::B(0));
-    let fixed_e = Env::read_column(env, TestColumn::FixedE);
+    let fixed_e = Env::read_column(env, TestColumn::FixedSel3);
     let a0_2 = a0.clone() * a0.clone();
     let a0_4 = a0_2.clone() * a0_2.clone();
     let a0_6 = a0_4.clone() * a0_2.clone();
@@ -191,7 +191,7 @@ pub fn constrain_test_fixed_sel_degree_7_mul_witness<
     env.assert_zero(equation.clone());
 }
 
-/// Circuit generator function for A_0 + B_0 - FIXED_E.
+/// Circuit generator function for A_0 + B_0 - FIXED_SEL_1.
 pub fn test_fixed_sel<
     F: PrimeField,
     Env: ColAccessCap<F, TestColumn> + ColWriteCap<F, TestColumn>,
@@ -200,13 +200,13 @@ pub fn test_fixed_sel<
     a: F,
 ) {
     env.write_column(TestColumn::A(0), &Env::constant(a));
-    let fixed_e = env.read_column(TestColumn::FixedE);
+    let fixed_e = env.read_column(TestColumn::FixedSel1);
     env.write_column(TestColumn::B(0), &(fixed_e - Env::constant(a)));
 
     constrain_test_fixed_sel(env);
 }
 
-/// Circuit generator function for A_0^7 + B_0 - FIXED_E.
+/// Circuit generator function for A_0^7 + B_0 - FIXED_SEL_1.
 pub fn test_fixed_sel_degree_7<
     F: PrimeField,
     Env: ColAccessCap<F, TestColumn> + ColWriteCap<F, TestColumn>,
@@ -219,12 +219,12 @@ pub fn test_fixed_sel_degree_7<
     let a_4 = a_2 * a_2;
     let a_6 = a_4 * a_2;
     let a_7 = a_6 * a;
-    let fixed_e = env.read_column(TestColumn::FixedE);
+    let fixed_e = env.read_column(TestColumn::FixedSel1);
     env.write_column(TestColumn::B(0), &(fixed_e - Env::constant(a_7)));
     constrain_test_fixed_sel_degree_7(env);
 }
 
-/// Circuit generator function for 3 * A_0^7 + 42 * B_0 - FIXED_E.
+/// Circuit generator function for 3 * A_0^7 + 42 * B_0 - FIXED_SEL_1.
 pub fn test_fixed_sel_degree_7_with_constants<
     F: PrimeField,
     Env: ColAccessCap<F, TestColumn> + ColWriteCap<F, TestColumn>,
@@ -237,7 +237,7 @@ pub fn test_fixed_sel_degree_7_with_constants<
     let a_4 = a_2 * a_2;
     let a_6 = a_4 * a_2;
     let a_7 = a_6 * a;
-    let fixed_e = env.read_column(TestColumn::FixedE);
+    let fixed_e = env.read_column(TestColumn::FixedSel1);
     let inv_42 = F::from(42u32).inverse().unwrap();
     let three = F::from(3u32);
     env.write_column(
@@ -248,7 +248,7 @@ pub fn test_fixed_sel_degree_7_with_constants<
 }
 
 // NB: Assumes non-standard selectors
-/// Circuit generator function for 3 * A_0^7 + B_0 * FIXED_E.
+/// Circuit generator function for 3 * A_0^7 + B_0 * FIXED_SEL_3.
 pub fn test_fixed_sel_degree_7_mul_witness<
     F: SquareRootField + PrimeField,
     Env: ColAccessCap<F, TestColumn> + ColWriteCap<F, TestColumn> + DirectWitnessCap<F, TestColumn>,
@@ -261,7 +261,7 @@ pub fn test_fixed_sel_degree_7_mul_witness<
     let a_4 = a_2 * a_2;
     let a_6 = a_4 * a_2;
     let a_7 = a_6 * a;
-    let fixed_e = env.read_column(TestColumn::FixedE);
+    let fixed_e = env.read_column(TestColumn::FixedSel3);
     let three = F::from(3u32);
     let val_fixed_e: F = Env::variable_to_field(fixed_e);
     let inv_fixed_e: F = val_fixed_e.inverse().unwrap();
@@ -272,6 +272,21 @@ pub fn test_fixed_sel_degree_7_mul_witness<
 }
 
 /// Fixed selectors for the test circuit.
-pub fn build_fixed_selectors<F: Field>(domain_size: usize) -> Box<[Vec<F>; 1]> {
-    Box::new([(0..domain_size).map(|i| F::from(i as u64)).collect()])
+pub fn build_fixed_selectors<F: Field>(domain_size: usize) -> Box<[Vec<F>; N_FSEL_TEST]> {
+    // 0 1 2 3 4 ...
+    let sel1 = (0..domain_size).map(|i| F::from(i as u64)).collect();
+    // 0 0 1 2 3 4 ...
+    let sel2 = (0..domain_size)
+        .map(|i| {
+            if i == 0 {
+                F::zero()
+            } else {
+                F::from((i as u64) - 1)
+            }
+        })
+        .collect();
+    // 1 2 3 4 5 ...
+    let sel3 = (0..domain_size).map(|i| F::from((i + 1) as u64)).collect();
+
+    Box::new([sel1, sel2, sel3])
 }

--- a/msm/src/test/test_circuit/lookups.rs
+++ b/msm/src/test/test_circuit/lookups.rs
@@ -1,0 +1,95 @@
+use crate::logup::LookupTableID;
+use ark_ff::PrimeField;
+use num_bigint::BigUint;
+use o1_utils::FieldHelpers;
+use strum_macros::EnumIter;
+
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, EnumIter)]
+pub enum LookupTable {
+    /// x ∈ [0, 2^15]
+    RangeCheck15,
+    /// A runtime table.
+    RuntimeTable1,
+    /// A runtime table.
+    RuntimeTable2,
+}
+
+impl LookupTableID for LookupTable {
+    fn to_u32(&self) -> u32 {
+        match self {
+            Self::RangeCheck15 => 1,
+            Self::RuntimeTable1 => 2,
+            Self::RuntimeTable2 => 3,
+        }
+    }
+
+    fn from_u32(value: u32) -> Self {
+        match value {
+            1 => Self::RangeCheck15,
+            2 => Self::RuntimeTable1,
+            3 => Self::RuntimeTable2,
+            _ => panic!("Invalid lookup table id"),
+        }
+    }
+
+    fn is_fixed(&self) -> bool {
+        match self {
+            Self::RangeCheck15 => true,
+            Self::RuntimeTable1 => false,
+            Self::RuntimeTable2 => false,
+        }
+    }
+
+    fn runtime_create_column(&self) -> bool {
+        match self {
+            Self::RuntimeTable1 => false,
+            _ => panic!("runtime_create_column was called on a non-runtime table"),
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self {
+            Self::RangeCheck15 => 1 << 15,
+            Self::RuntimeTable1 => 1 << 15,
+            Self::RuntimeTable2 => 1 << 15,
+        }
+    }
+
+    /// Converts a value to its index in the fixed table.
+    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> Option<usize> {
+        let value = value[0];
+        if self.is_fixed() {
+            assert!(self.is_member(value).unwrap());
+        }
+
+        match self {
+            Self::RangeCheck15 => Some(TryFrom::try_from(value.to_biguint()).unwrap()),
+            Self::RuntimeTable1 => None,
+            Self::RuntimeTable2 => None,
+        }
+    }
+
+    fn all_variants() -> Vec<Self> {
+        vec![Self::RangeCheck15, Self::RuntimeTable1, Self::RuntimeTable2]
+    }
+}
+
+impl LookupTable {
+    /// Provides a full list of entries for the given table.
+    pub fn entries<F: PrimeField>(&self, domain_d1_size: u64) -> Option<Vec<F>> {
+        assert!(domain_d1_size >= (1 << 15));
+        match self {
+            Self::RangeCheck15 => Some((0..domain_d1_size).map(|i| F::from(i)).collect()),
+            _ => panic!("not possible"),
+        }
+    }
+
+    /// Checks if a value is in a given table.
+    pub fn is_member<F: PrimeField>(&self, value: F) -> Option<bool> {
+        match self {
+            Self::RangeCheck15 => Some(value.to_biguint() < BigUint::from(2u128.pow(15))),
+            Self::RuntimeTable1 => None,
+            Self::RuntimeTable2 => None,
+        }
+    }
+}

--- a/msm/src/test/test_circuit/lookups.rs
+++ b/msm/src/test/test_circuit/lookups.rs
@@ -6,11 +6,11 @@ use strum_macros::EnumIter;
 
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, EnumIter)]
 pub enum LookupTable {
-    /// x ∈ [0, 2^15]
+    /// Fixed table, x ∈ [0, 2^15].
     RangeCheck15,
-    /// A runtime table.
+    /// A runtime table, with no explicit writes.
     RuntimeTable1,
-    /// A runtime table.
+    /// A runtime table, with explicit writes.
     RuntimeTable2,
 }
 
@@ -42,7 +42,8 @@ impl LookupTableID for LookupTable {
 
     fn runtime_create_column(&self) -> bool {
         match self {
-            Self::RuntimeTable1 => false,
+            Self::RuntimeTable1 => true,
+            Self::RuntimeTable2 => false,
             _ => panic!("runtime_create_column was called on a non-runtime table"),
         }
     }

--- a/msm/src/test/test_circuit/mod.rs
+++ b/msm/src/test/test_circuit/mod.rs
@@ -1,5 +1,6 @@
 pub mod columns;
 pub mod interpreter;
+pub mod lookups;
 
 #[cfg(test)]
 mod tests {

--- a/msm/src/test/test_circuit/mod.rs
+++ b/msm/src/test/test_circuit/mod.rs
@@ -5,11 +5,10 @@ pub mod interpreter;
 mod tests {
     use crate::{
         circuit_design::{ConstraintBuilderEnv, WitnessBuilderEnv},
-        columns::ColumnIndexer,
         logup::LookupTableID,
         lookups::DummyLookupTable,
         test::test_circuit::{
-            columns::{TestColumn, TEST_N_COLUMNS},
+            columns::{TestColumn, N_COL_TEST, N_FSEL_TEST},
             interpreter as test_interpreter,
         },
         Ff1, Fp,
@@ -21,10 +20,10 @@ mod tests {
     type TestWitnessBuilderEnv<LT> = WitnessBuilderEnv<
         Fp,
         TestColumn,
-        { <TestColumn as ColumnIndexer>::N_COL - 1 },
-        { <TestColumn as ColumnIndexer>::N_COL - 1 },
+        { N_COL_TEST - N_FSEL_TEST },
+        { N_COL_TEST - N_FSEL_TEST },
         0,
-        1,
+        N_FSEL_TEST,
         LT,
     >;
 
@@ -75,10 +74,10 @@ mod tests {
         let relation_witness = witness_env.get_relation_witness(domain_size);
 
         crate::test::test_completeness_generic_no_lookups::<
-            { TEST_N_COLUMNS - 1 },
-            { TEST_N_COLUMNS - 1 },
+            { N_COL_TEST - N_FSEL_TEST },
+            { N_COL_TEST - N_FSEL_TEST },
             0,
-            1,
+            N_FSEL_TEST,
             _,
         >(
             constraints,
@@ -96,7 +95,7 @@ mod tests {
         let mut witness_env = WitnessBuilderEnv::create();
 
         let fixed_sel: Vec<Fp> = (0..domain_size).map(|i| Fp::from(i as u64)).collect();
-        witness_env.set_fixed_selector_cix(TestColumn::FixedE, fixed_sel);
+        witness_env.set_fixed_selector_cix(TestColumn::FixedSel1, fixed_sel);
 
         for row_i in 0..domain_size {
             let a: Fp = <Fp as UniformRand>::rand(rng);
@@ -130,10 +129,10 @@ mod tests {
         let relation_witness = witness_env.get_relation_witness(domain_size);
 
         crate::test::test_completeness_generic_no_lookups::<
-            { TEST_N_COLUMNS - 1 },
-            { TEST_N_COLUMNS - 1 },
+            { N_COL_TEST - N_FSEL_TEST },
+            { N_COL_TEST - N_FSEL_TEST },
             0,
-            1,
+            N_FSEL_TEST,
             _,
         >(
             constraints,
@@ -154,7 +153,7 @@ mod tests {
         let mut witness_env = WitnessBuilderEnv::create();
 
         let fixed_sel: Vec<Fp> = (0..domain_size).map(|i| Fp::from(i as u64)).collect();
-        witness_env.set_fixed_selector_cix(TestColumn::FixedE, fixed_sel);
+        witness_env.set_fixed_selector_cix(TestColumn::FixedSel1, fixed_sel);
 
         for row_i in 0..domain_size {
             let a: Fp = <Fp as UniformRand>::rand(rng);
@@ -192,10 +191,10 @@ mod tests {
         let relation_witness = witness_env.get_relation_witness(domain_size);
 
         crate::test::test_completeness_generic_no_lookups::<
-            { TEST_N_COLUMNS - 1 },
-            { TEST_N_COLUMNS - 1 },
+            { N_COL_TEST - N_FSEL_TEST },
+            { N_COL_TEST - N_FSEL_TEST },
             0,
-            1,
+            N_FSEL_TEST,
             _,
         >(
             constraints,
@@ -215,9 +214,8 @@ mod tests {
     ) -> TestWitnessBuilderEnv<LT> {
         let mut witness_env = WitnessBuilderEnv::create();
 
-        // NB: Non-standard fixed selectors.
-        let fixed_sel: Vec<Fp> = (0..domain_size).map(|i| Fp::from((i + 1) as u64)).collect();
-        witness_env.set_fixed_selector_cix(TestColumn::FixedE, fixed_sel);
+        let fixed_selectors = test_interpreter::build_fixed_selectors(domain_size);
+        witness_env.set_fixed_selectors(fixed_selectors.to_vec());
 
         for row_i in 0..domain_size {
             let a: Fp = <Fp as UniformRand>::rand(rng);
@@ -239,9 +237,7 @@ mod tests {
         // includes all arguments
         let domain_size = 1 << 8;
 
-        // NB: Non-standard fixed selectors.
-        let fixed_selectors: Box<[Vec<Fp>; 1]> =
-            Box::new([(0..domain_size).map(|i| Fp::from((i + 1) as u64)).collect()]);
+        let fixed_selectors = test_interpreter::build_fixed_selectors(domain_size);
 
         let mut constraint_env = ConstraintBuilderEnv::<Fp, DummyLookupTable>::create();
         test_interpreter::constrain_test_fixed_sel_degree_7_mul_witness::<Fp, _>(
@@ -257,10 +253,10 @@ mod tests {
         let relation_witness = witness_env.get_relation_witness(domain_size);
 
         crate::test::test_completeness_generic_no_lookups::<
-            { TEST_N_COLUMNS - 1 },
-            { TEST_N_COLUMNS - 1 },
+            { N_COL_TEST - N_FSEL_TEST },
+            { N_COL_TEST - N_FSEL_TEST },
             0,
-            1,
+            N_FSEL_TEST,
             _,
         >(
             constraints,
@@ -317,10 +313,10 @@ mod tests {
         let relation_witness = witness_env.get_relation_witness(domain_size);
 
         crate::test::test_completeness_generic_no_lookups::<
-            { TEST_N_COLUMNS - 1 },
-            { TEST_N_COLUMNS - 1 },
+            { N_COL_TEST - N_FSEL_TEST },
+            { N_COL_TEST - N_FSEL_TEST },
             0,
-            1,
+            N_FSEL_TEST,
             _,
         >(
             constraints,
@@ -341,7 +337,7 @@ mod tests {
         //let row_num = rng.gen_range(0..domain_size);
 
         let fixed_sel: Vec<Fp> = (0..domain_size).map(|i| Fp::from(i as u64)).collect();
-        witness_env.set_fixed_selector_cix(TestColumn::FixedE, fixed_sel);
+        witness_env.set_fixed_selector_cix(TestColumn::FixedSel1, fixed_sel);
 
         let constant: Fp = <Fp as UniformRand>::rand(rng);
         for row_i in 0..domain_size {
@@ -383,10 +379,10 @@ mod tests {
         let constraints = constraint_env.get_relation_constraints();
 
         crate::test::test_completeness_generic_no_lookups::<
-            { TEST_N_COLUMNS - 1 },
-            { TEST_N_COLUMNS - 1 },
+            { N_COL_TEST - N_FSEL_TEST },
+            { N_COL_TEST - N_FSEL_TEST },
             0,
-            1,
+            N_FSEL_TEST,
             _,
         >(
             constraints,
@@ -407,7 +403,7 @@ mod tests {
         //let row_num = rng.gen_range(0..domain_size);
 
         let fixed_sel: Vec<Fp> = (0..domain_size).map(|i| Fp::from(i as u64)).collect();
-        witness_env.set_fixed_selector_cix(TestColumn::FixedE, fixed_sel);
+        witness_env.set_fixed_selector_cix(TestColumn::FixedSel1, fixed_sel);
 
         let row_num = 10;
         for row_i in 0..row_num {
@@ -448,10 +444,10 @@ mod tests {
         let relation_witness = witness_env.get_relation_witness(domain_size);
 
         crate::test::test_completeness_generic_no_lookups::<
-            { TEST_N_COLUMNS - 1 },
-            { TEST_N_COLUMNS - 1 },
+            { N_COL_TEST - N_FSEL_TEST },
+            { N_COL_TEST - N_FSEL_TEST },
             0,
-            1,
+            N_FSEL_TEST,
             _,
         >(
             constraints,
@@ -488,10 +484,10 @@ mod tests {
         proof_inputs_prime.logups = Default::default();
 
         crate::test::test_soundness_generic::<
-            { TEST_N_COLUMNS - 1 },
-            { TEST_N_COLUMNS - 1 },
+            { N_COL_TEST - N_FSEL_TEST },
+            { N_COL_TEST - N_FSEL_TEST },
             0,
-            1,
+            N_FSEL_TEST,
             DummyLookupTable,
             _,
         >(


### PR DESCRIPTION
* Now one declare both multiple /reads/ and writes for runtime tables.
* Also tests for lookups are now in `msm/src/test/test_circuit` (and not `serialization`).