### PR TITLE
Add initial flake for installing build dependencies for `proof-systems`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,7 @@ The CI will build different targets.
   When CI passes on master, the documentation built from the rust code will be
   available [here](https://o1-labs.github.io/proof-systems/rustdoc) and the book
   will be available [here](https://o1-labs.github.io/proof-systems).
+
+## Nix for Dependencies (WIP)
+
+If you have `nix` installed and in particular, `flakes` enabled, you can install the dependencies for these projects using nix.  Simply `nix develop .` inside this directory to bring into scope `rustup`, `opam`, and `go` (along with a few other tools).  You will have to manage the toolchains yourself using `rustup` and `opam`, in the current iteration.

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "proof-system prerequisites";
+
+  inputs = {
+    naersk.url = "github:nix-community/naersk/master";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils, naersk }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        naersk-lib = pkgs.callPackage naersk { };
+      in
+      {
+        defaultPackage = naersk-lib.buildPackage ./.;
+        devShell = with pkgs; mkShell {
+          buildInputs = [
+            # rust inputs
+            rustup
+            rust-analyzer
+            libiconv # Needed for macOS for rustup
+
+            # ocaml inputs
+            opam
+
+            # go inputs
+            gopls
+            go
+            
+          ];
+          RUST_SRC_PATH = rustPlatform.rustLibSrc;
+        };
+      }
+    );
+}


### PR DESCRIPTION
This is the start of a very simple flake.

In scope for this version of the flake:

1. `nix develop .` will open a dev shell with everything you need to develop on various parts of `proof-systems` in scope (caveat about rust and ocaml toolchain version in next point).
2. You must still use `rustup` to manage your rust toolchains.
3. You must still use `opam` to manage your ocaml toolchains.

Out of scope for this version of the flake:

1. Distributed caching -- only if the others in this list come.
2. Actually building things using `nix` -- likely to come.