### PR TITLE
CI: bump up setup-ocaml version to v3

### DIFF
--- a/.github/actions/ocaml-shared/action.yml
+++ b/.github/actions/ocaml-shared/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup OCaml ${{ inputs.ocaml_version }}
-      uses: ocaml/setup-ocaml@v2
+      uses: ocaml/setup-ocaml@v3
       with:
         ocaml-compiler: ${{ inputs.ocaml_version }}
         # https://github.com/ocaml/setup-ocaml/issues/211#issuecomment-1058882386


### PR DESCRIPTION
Released earlier this year in July. No big changes. Only bumping up to stay up-to-date.