### PR TITLE
Makefile: use nightly for `format` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ nextest-all-with-coverage:
 
 # Format the code
 format:
-		cargo fmt -- --check
+		cargo +nightly fmt -- --check
 
 # Lint the code
 lint:


### PR DESCRIPTION
We do use some unstable feature, like:

```
Warning: can't set `indent_style = Block`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
```