### PR TITLE
Kimchi/tests: move turshi tests into top-level tests dir

### DIFF
--- a/kimchi/src/tests/mod.rs
+++ b/kimchi/src/tests/mod.rs
@@ -1,3 +1,4 @@
+// IMPROVEME: move all tests in top-level directory tests
 mod and;
 mod chunked;
 mod ec;
@@ -15,6 +16,5 @@ mod range_check;
 mod recursion;
 mod rot;
 mod serde;
-mod turshi;
 mod varbasemul;
 mod xor;

--- a/kimchi/tests/turshi.rs
+++ b/kimchi/tests/turshi.rs
@@ -1,4 +1,4 @@
-use crate::circuits::{
+use kimchi::circuits::{
     gate::CircuitGate,
     polynomials::turshi::{testing::*, witness::*},
 };


### PR DESCRIPTION
We should do that for all tests, as toplevel directory tests is what a good rustacean would do. Not spending time on this for now, though. Not urgent at all.