### PR TITLE
MVPoly: implement homogeneous_eval

### DIFF
--- a/mvpoly/src/lib.rs
+++ b/mvpoly/src/lib.rs
@@ -72,4 +72,8 @@ pub trait MVPoly<F: PrimeField, const N: usize, const D: usize>:
     /// As a reminder, a polynomial is homogeneous if all its monomials have the
     /// same degree.
     fn is_homogeneous(&self) -> bool;
+
+    /// Evaluate the polynomial at the vector point `x` and the extra variable
+    /// `u` using its homogeneous form of degree D.
+    fn homogeneous_eval(&self, x: &[F; N], u: F) -> F;
 }

--- a/mvpoly/src/monomials.rs
+++ b/mvpoly/src/monomials.rs
@@ -453,6 +453,21 @@ impl<const N: usize, const D: usize, F: PrimeField> MVPoly<F, N, D> for Sparse<F
             .iter()
             .all(|(exponents, _)| exponents.iter().sum::<usize>() == D)
     }
+
+    // IMPROVEME: powers can be cached
+    fn homogeneous_eval(&self, x: &[F; N], u: F) -> F {
+        self.monomials
+            .iter()
+            .map(|(exponents, coeff)| {
+                let mut term = F::one();
+                for (exp, point) in exponents.iter().zip(x.iter()) {
+                    term *= point.pow([*exp as u64]);
+                }
+                term *= u.pow([D as u64 - exponents.iter().sum::<usize>() as u64]);
+                term * coeff
+            })
+            .sum()
+    }
 }
 
 impl<const N: usize, const D: usize, F: PrimeField> From<prime::Dense<F, N, D>>

--- a/mvpoly/tests/monomials.rs
+++ b/mvpoly/tests/monomials.rs
@@ -370,3 +370,63 @@ fn test_is_zero() {
     let p2 = unsafe { Sparse::<Fp, 4, 6>::random(&mut rng, None) };
     assert!(!p2.is_zero());
 }
+
+#[test]
+fn test_homogeneous_eval() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let random_eval = std::array::from_fn(|_| Fp::rand(&mut rng));
+    let u = Fp::rand(&mut rng);
+    // Homogeneous form is u^2
+    let p1 = Sparse::<Fp, 4, 2>::one();
+    let homogenous_eval = p1.homogeneous_eval(&random_eval, u);
+    assert_eq!(homogenous_eval, u * u);
+
+    let mut p2 = Sparse::<Fp, 4, 2>::zero();
+    // X1
+    p2.add_monomial([1, 0, 0, 0], Fp::one());
+    let homogenous_eval = p2.homogeneous_eval(&random_eval, u);
+    assert_eq!(homogenous_eval, random_eval[0] * u);
+
+    let mut p3 = Sparse::<Fp, 4, 2>::zero();
+    // X2
+    p3.add_monomial([0, 1, 0, 0], Fp::one());
+    let homogenous_eval = p3.homogeneous_eval(&random_eval, u);
+    assert_eq!(homogenous_eval, random_eval[1] * u);
+
+    let mut p4 = Sparse::<Fp, 4, 2>::zero();
+    // X1 * X2
+    p4.add_monomial([1, 1, 0, 0], Fp::one());
+    let homogenous_eval = p4.homogeneous_eval(&random_eval, u);
+    assert_eq!(homogenous_eval, random_eval[0] * random_eval[1]);
+
+    let mut p5 = Sparse::<Fp, 4, 2>::zero();
+    // X1^2
+    p5.add_monomial([2, 0, 0, 0], Fp::one());
+    let homogenous_eval = p5.homogeneous_eval(&random_eval, u);
+    assert_eq!(homogenous_eval, random_eval[0] * random_eval[0]);
+
+    let mut p6 = Sparse::<Fp, 4, 2>::zero();
+    // X2^2 + X1^2
+    p6.add_monomial([0, 2, 0, 0], Fp::one());
+    p6.add_monomial([2, 0, 0, 0], Fp::one());
+    let homogenous_eval = p6.homogeneous_eval(&random_eval, u);
+    assert_eq!(
+        homogenous_eval,
+        random_eval[1] * random_eval[1] + random_eval[0] * random_eval[0]
+    );
+
+    let mut p7 = Sparse::<Fp, 4, 2>::zero();
+    // X2^2 + X1^2 + X1 + 42
+    p7.add_monomial([0, 2, 0, 0], Fp::one());
+    p7.add_monomial([2, 0, 0, 0], Fp::one());
+    p7.add_monomial([1, 0, 0, 0], Fp::one());
+    p7.add_monomial([0, 0, 0, 0], Fp::from(42));
+    let homogenous_eval = p7.homogeneous_eval(&random_eval, u);
+    assert_eq!(
+        homogenous_eval,
+        random_eval[1] * random_eval[1]
+            + random_eval[0] * random_eval[0]
+            + u * random_eval[0]
+            + u * u * Fp::from(42)
+    );
+}

--- a/mvpoly/tests/prime.rs
+++ b/mvpoly/tests/prime.rs
@@ -819,3 +819,14 @@ fn test_is_zero() {
     let p2 = unsafe { Dense::<Fp, 4, 6>::random(&mut rng, None) };
     assert!(!p2.is_zero());
 }
+
+#[test]
+fn test_homogeneous_eval() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let random_eval = std::array::from_fn(|_| Fp::rand(&mut rng));
+    let u = Fp::rand(&mut rng);
+    // Homogeneous form is u^2
+    let p1 = Dense::<Fp, 4, 2>::one();
+    let homogenous_eval = p1.homogeneous_eval(&random_eval, u);
+    assert_eq!(homogenous_eval, u * u);
+}


### PR DESCRIPTION
Will be used in https://github.com/o1-labs/proof-systems/pull/2502 and https://github.com/o1-labs/proof-systems/pull/2520

The tests using add_monomial implemented for `monomials` will be implemented for prime after https://github.com/o1-labs/proof-systems/pull/2531 is merged as it requires `add_monomial` to make it generic.