### PR TITLE
MVPoly tests generalization based on example.

### DIFF
--- a/mvpoly/src/lib.rs
+++ b/mvpoly/src/lib.rs
@@ -5,6 +5,7 @@ use kimchi::circuits::expr::{ConstantExpr, Expr};
 use rand::RngCore;
 
 pub mod monomials;
+pub mod pbt;
 pub mod prime;
 pub mod utils;
 
@@ -17,6 +18,7 @@ pub trait MVPoly<F: PrimeField, const N: usize, const D: usize>:
     + ark_ff::One
     + ark_ff::Zero
     + std::fmt::Debug
+    + Clone
     // Comparison operators
     + PartialEq
     + Eq
@@ -106,4 +108,6 @@ pub trait MVPoly<F: PrimeField, const N: usize, const D: usize>:
         u1: F,
         u2: F,
     ) -> HashMap<usize, F>;
+
+    fn modify_monomial_with_scalar(&mut self, scalar: F);
 }

--- a/mvpoly/src/monomials.rs
+++ b/mvpoly/src/monomials.rs
@@ -564,6 +564,10 @@ impl<const N: usize, const D: usize, F: PrimeField> MVPoly<F, N, D> for Sparse<F
         });
         cross_terms_by_powers_of_r
     }
+
+    fn modify_monomial_with_scalar(&mut self, scalar: F) {
+        self.modify_monomial([0; N], scalar);
+    }
 }
 
 impl<const N: usize, const D: usize, F: PrimeField> From<prime::Dense<F, N, D>>

--- a/mvpoly/src/pbt.rs
+++ b/mvpoly/src/pbt.rs
@@ -1,0 +1,371 @@
+//! This module contains a list of property tests for the `MVPoly` trait.
+//!
+//! Any type that implements the `MVPoly` trait should pass these tests.
+//!
+//! For instance, one can call the `test_mul_by_one` as follows:
+//!
+//! ```rust
+//! use mvpoly::MVPoly;
+//! use mvpoly::prime::Dense;
+//! use mina_curves::pasta::Fp;
+//!
+//! #[test]
+//! fn test_mul_by_one() {
+//!     mvpoly::pbt::test_mul_by_one::<Fp, 2, 2, Dense<Fp, 2, 2>>();
+//!     mvpoly::pbt::test_mul_by_one::<Fp, 4, 2, Dense<Fp, 4, 2>>();
+//! }
+//! ```
+
+use crate::MVPoly;
+use ark_ff::PrimeField;
+use rand::Rng;
+use std::ops::Neg;
+
+pub fn test_mul_by_one<F: PrimeField, const N: usize, const D: usize, T: MVPoly<F, N, D>>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let p1 = unsafe { T::random(&mut rng, None) };
+    let one = T::one();
+    let p2 = p1.clone() * one.clone();
+    assert_eq!(p1.clone(), p2);
+    let p3 = one * p1.clone();
+    assert_eq!(p1.clone(), p3);
+}
+
+pub fn test_mul_by_zero<F: PrimeField, const N: usize, const D: usize, T: MVPoly<F, N, D>>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let p1 = unsafe { T::random(&mut rng, None) };
+    let zero = T::zero();
+    let p2 = p1.clone() * zero.clone();
+    assert_eq!(zero, p2);
+    let p3 = zero.clone() * p1.clone();
+    assert_eq!(zero.clone(), p3);
+}
+
+pub fn test_add_zero<F: PrimeField, const N: usize, const D: usize, T: MVPoly<F, N, D>>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let p1 = unsafe { T::random(&mut rng, None) };
+    let zero = T::zero();
+    let p2 = p1.clone() + zero.clone();
+    assert_eq!(p1.clone(), p2);
+    let p3 = zero.clone() + p1.clone();
+    assert_eq!(p1.clone(), p3);
+}
+
+pub fn test_double_is_add_twice<
+    F: PrimeField,
+    const N: usize,
+    const D: usize,
+    T: MVPoly<F, N, D>,
+>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let p1 = unsafe { T::random(&mut rng, None) };
+    let p2 = p1.clone() + p1.clone();
+    let p3 = p1.clone().double();
+    assert_eq!(p2, p3);
+}
+
+pub fn test_sub_zero<F: PrimeField, const N: usize, const D: usize, T: MVPoly<F, N, D>>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let p1 = unsafe { T::random(&mut rng, None) };
+    let zero = T::zero();
+    let p2 = p1.clone() - zero.clone();
+    assert_eq!(p1.clone(), p2);
+}
+
+pub fn test_neg<F: PrimeField, const N: usize, const D: usize, T: MVPoly<F, N, D>>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let p1 = unsafe { T::random(&mut rng, None) };
+    let p2 = -p1.clone();
+    // Test that p1 + (-p1) = 0
+    let sum = p1.clone() + p2.clone();
+    assert_eq!(sum, T::zero());
+    // Test that -(-p1) = p1
+    let p3 = -p2;
+    assert_eq!(p1, p3);
+    // Test negation of zero
+    let zero = T::zero();
+    let neg_zero = -zero.clone();
+    assert_eq!(zero, neg_zero);
+}
+
+pub fn test_eval_pbt_add<F: PrimeField, const N: usize, const D: usize, T: MVPoly<F, N, D>>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let random_evaluation: [F; N] = std::array::from_fn(|_| F::rand(&mut rng));
+    let p1 = unsafe { T::random(&mut rng, None) };
+    let p2 = unsafe { T::random(&mut rng, None) };
+    let p3 = p1.clone() + p2.clone();
+    let eval_p1 = p1.eval(&random_evaluation);
+    let eval_p2 = p2.eval(&random_evaluation);
+    let eval_p3 = p3.eval(&random_evaluation);
+    assert_eq!(eval_p3, eval_p1 + eval_p2);
+}
+
+pub fn test_eval_pbt_sub<F: PrimeField, const N: usize, const D: usize, T: MVPoly<F, N, D>>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let random_evaluation: [F; N] = std::array::from_fn(|_| F::rand(&mut rng));
+    let p1 = unsafe { T::random(&mut rng, None) };
+    let p2 = unsafe { T::random(&mut rng, None) };
+    let p3 = p1.clone() - p2.clone();
+    let eval_p1 = p1.eval(&random_evaluation);
+    let eval_p2 = p2.eval(&random_evaluation);
+    let eval_p3 = p3.eval(&random_evaluation);
+    assert_eq!(eval_p3, eval_p1 - eval_p2);
+}
+
+pub fn test_eval_pbt_mul_by_scalar<
+    F: PrimeField,
+    const N: usize,
+    const D: usize,
+    T: MVPoly<F, N, D>,
+>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let random_evaluation: [F; N] = std::array::from_fn(|_| F::rand(&mut rng));
+    let p1 = unsafe { T::random(&mut rng, None) };
+    let c = F::rand(&mut rng);
+    let p2 = p1.clone() * T::from(c);
+    let eval_p1 = p1.eval(&random_evaluation);
+    let eval_p2 = p2.eval(&random_evaluation);
+    assert_eq!(eval_p2, eval_p1 * c);
+}
+
+pub fn test_eval_pbt_neg<F: PrimeField, const N: usize, const D: usize, T: MVPoly<F, N, D>>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let random_evaluation: [F; N] = std::array::from_fn(|_| F::rand(&mut rng));
+    let p1 = unsafe { T::random(&mut rng, None) };
+    let p2 = -p1.clone();
+    let eval_p1 = p1.eval(&random_evaluation);
+    let eval_p2 = p2.eval(&random_evaluation);
+    assert_eq!(eval_p2, -eval_p1);
+}
+
+pub fn test_neg_ref<F: PrimeField, const N: usize, const D: usize, T: MVPoly<F, N, D>>()
+where
+    for<'a> &'a T: Neg<Output = T>,
+{
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let p1 = unsafe { T::random(&mut rng, None) };
+    let p2 = -&p1;
+    // Test that p1 + (-&p1) = 0
+    let sum = p1.clone() + p2.clone();
+    assert_eq!(sum, T::zero());
+    // Test that -(-&p1) = p1
+    let p3 = -&p2;
+    assert_eq!(p1, p3);
+}
+
+pub fn test_mul_by_scalar<F: PrimeField, const N: usize, const D: usize, T: MVPoly<F, N, D>>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let p1 = unsafe { T::random(&mut rng, None) };
+    let mut p2 = T::zero();
+    let c = F::rand(&mut rng);
+    p2.modify_monomial_with_scalar(c);
+    assert_eq!(p2 * p1.clone(), p1.clone().mul_by_scalar(c));
+}
+
+pub fn test_mul_by_scalar_with_zero<
+    F: PrimeField,
+    const N: usize,
+    const D: usize,
+    T: MVPoly<F, N, D>,
+>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let p1 = unsafe { T::random(&mut rng, None) };
+    let c = F::zero();
+    assert_eq!(p1.mul_by_scalar(c), T::zero());
+}
+
+pub fn test_mul_by_scalar_with_one<
+    F: PrimeField,
+    const N: usize,
+    const D: usize,
+    T: MVPoly<F, N, D>,
+>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let p1 = unsafe { T::random(&mut rng, None) };
+    let c = F::one();
+    assert_eq!(p1.mul_by_scalar(c), p1);
+}
+
+pub fn test_evaluation_zero_polynomial<
+    F: PrimeField,
+    const N: usize,
+    const D: usize,
+    T: MVPoly<F, N, D>,
+>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let random_evaluation: [F; N] = std::array::from_fn(|_| F::rand(&mut rng));
+    let zero = T::zero();
+    let evaluation = zero.eval(&random_evaluation);
+    assert_eq!(evaluation, F::zero());
+}
+
+pub fn test_evaluation_constant_polynomial<
+    F: PrimeField,
+    const N: usize,
+    const D: usize,
+    T: MVPoly<F, N, D>,
+>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let random_evaluation: [F; N] = std::array::from_fn(|_| F::rand(&mut rng));
+    let cst = F::rand(&mut rng);
+    let poly = T::from(cst);
+    let evaluation = poly.eval(&random_evaluation);
+    assert_eq!(evaluation, cst);
+}
+
+pub fn test_degree_constant<F: PrimeField, const N: usize, const D: usize, T: MVPoly<F, N, D>>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let c = F::rand(&mut rng);
+    let p = T::from(c);
+    let degree = unsafe { p.degree() };
+    assert_eq!(degree, 0);
+    let p = T::zero();
+    let degree = unsafe { p.degree() };
+    assert_eq!(degree, 0);
+}
+
+pub fn test_degree_random_degree<
+    F: PrimeField,
+    const N: usize,
+    const D: usize,
+    T: MVPoly<F, N, D>,
+>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    // Test with a random degree up to 5
+    let max_degree: usize = rng.gen_range(1..5);
+    let p = unsafe { T::random(&mut rng, Some(max_degree)) };
+    let degree = unsafe { p.degree() };
+    assert!(degree <= max_degree);
+    // Test with a random degree up to 20 (for univariate polynomials)
+    let max_degree: usize = rng.gen_range(1..20);
+    let p = unsafe { T::random(&mut rng, Some(max_degree)) };
+    let degree = unsafe { p.degree() };
+    assert!(degree <= max_degree);
+}
+
+pub fn test_mvpoly_add_degree_pbt<
+    F: PrimeField,
+    const N: usize,
+    const D: usize,
+    T: MVPoly<F, N, D>,
+>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let degree = rng.gen_range(1..5);
+    let p1 = unsafe { T::random(&mut rng, Some(degree)) };
+    let p2 = unsafe { T::random(&mut rng, Some(degree)) };
+    let p3 = p1.clone() + p2.clone();
+    let degree_p1 = unsafe { p1.degree() };
+    let degree_p2 = unsafe { p2.degree() };
+    let degree_p3 = unsafe { p3.degree() };
+    assert!(degree_p3 <= std::cmp::max(degree_p1, degree_p2));
+}
+
+pub fn test_mvpoly_sub_degree_pbt<
+    F: PrimeField,
+    const N: usize,
+    const D: usize,
+    T: MVPoly<F, N, D>,
+>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let degree = rng.gen_range(1..5);
+    let p1 = unsafe { T::random(&mut rng, Some(degree)) };
+    let p2 = unsafe { T::random(&mut rng, Some(degree)) };
+    let p3 = p1.clone() - p2.clone();
+    let degree_p1 = unsafe { p1.degree() };
+    let degree_p2 = unsafe { p2.degree() };
+    let degree_p3 = unsafe { p3.degree() };
+    assert!(degree_p3 <= std::cmp::max(degree_p1, degree_p2));
+}
+
+pub fn test_mvpoly_neg_degree_pbt<
+    F: PrimeField,
+    const N: usize,
+    const D: usize,
+    T: MVPoly<F, N, D>,
+>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let degree = rng.gen_range(1..5);
+    let p1 = unsafe { T::random(&mut rng, Some(degree)) };
+    let p2 = -p1.clone();
+    let degree_p1 = unsafe { p1.degree() };
+    let degree_p2 = unsafe { p2.degree() };
+    assert_eq!(degree_p1, degree_p2);
+}
+
+pub fn test_mvpoly_mul_by_scalar_degree_pbt<
+    F: PrimeField,
+    const N: usize,
+    const D: usize,
+    T: MVPoly<F, N, D>,
+>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let degree = rng.gen_range(1..5);
+    let p1 = unsafe { T::random(&mut rng, Some(degree)) };
+    let c = F::rand(&mut rng);
+    let p2 = p1.clone() * T::from(c);
+    let degree_p1 = unsafe { p1.degree() };
+    let degree_p2 = unsafe { p2.degree() };
+    assert!(degree_p2 <= degree_p1);
+}
+
+pub fn test_mvpoly_mul_degree_pbt<
+    F: PrimeField,
+    const N: usize,
+    const D: usize,
+    T: MVPoly<F, N, D>,
+>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let degree = rng.gen_range(1..3);
+    let p1 = unsafe { T::random(&mut rng, Some(degree)) };
+    let p2 = unsafe { T::random(&mut rng, Some(degree)) };
+    let p3 = p1.clone() * p2.clone();
+    let degree_p1 = unsafe { p1.degree() };
+    let degree_p2 = unsafe { p2.degree() };
+    let degree_p3 = unsafe { p3.degree() };
+    assert!(degree_p3 <= degree_p1 + degree_p2);
+}
+
+pub fn test_mvpoly_mul_eval_pbt<
+    F: PrimeField,
+    const N: usize,
+    const D: usize,
+    T: MVPoly<F, N, D>,
+>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let max_degree = rng.gen_range(1..3);
+    let p1 = unsafe { T::random(&mut rng, Some(max_degree)) };
+    let p2 = unsafe { T::random(&mut rng, Some(max_degree)) };
+    let p3 = p1.clone() * p2.clone();
+    let random_evaluation: [F; N] = std::array::from_fn(|_| F::rand(&mut rng));
+    let eval_p1 = p1.eval(&random_evaluation);
+    let eval_p2 = p2.eval(&random_evaluation);
+    let eval_p3 = p3.eval(&random_evaluation);
+    assert_eq!(eval_p3, eval_p1 * eval_p2);
+}
+
+pub fn test_mvpoly_mul_pbt<F: PrimeField, const N: usize, const D: usize, T: MVPoly<F, N, D>>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let max_degree = rng.gen_range(1..3);
+    let p1 = unsafe { T::random(&mut rng, Some(max_degree)) };
+    let p2 = unsafe { T::random(&mut rng, Some(max_degree)) };
+    assert_eq!(p1.clone() * p2.clone(), p2.clone() * p1.clone());
+}
+
+pub fn test_can_be_printed_with_debug<
+    F: PrimeField,
+    const N: usize,
+    const D: usize,
+    T: MVPoly<F, N, D>,
+>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let p1 = unsafe { T::random(&mut rng, None) };
+    println!("{:?}", p1);
+}
+
+pub fn test_is_zero<F: PrimeField, const N: usize, const D: usize, T: MVPoly<F, N, D>>() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+    let p1 = T::zero();
+    assert!(p1.is_zero());
+    let p2 = unsafe { T::random(&mut rng, None) };
+    assert!(!p2.is_zero());
+}

--- a/mvpoly/src/prime.rs
+++ b/mvpoly/src/prime.rs
@@ -448,6 +448,10 @@ impl<F: PrimeField, const N: usize, const D: usize> MVPoly<F, N, D> for Dense<F,
     ) -> HashMap<usize, F> {
         unimplemented!()
     }
+
+    fn modify_monomial_with_scalar(&mut self, scalar: F) {
+        self[0] = scalar;
+    }
 }
 
 impl<F: PrimeField, const N: usize, const D: usize> Dense<F, N, D> {

--- a/mvpoly/tests/monomials.rs
+++ b/mvpoly/tests/monomials.rs
@@ -1,140 +1,35 @@
 use ark_ff::{Field, One, UniformRand, Zero};
 use mina_curves::pasta::Fp;
 use mvpoly::{monomials::Sparse, MVPoly};
-use rand::Rng;
 
 #[test]
 fn test_mul_by_one() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Sparse::<Fp, 7, 2>::random(&mut rng, None) };
-    let one = Sparse::<Fp, 7, 2>::one();
-    let p2 = p1.clone() * one.clone();
-    assert_eq!(p1.clone(), p2);
-    let p3 = one * p1.clone();
-    assert_eq!(p1.clone(), p3);
+    mvpoly::pbt::test_mul_by_one::<Fp, 7, 2, Sparse<Fp, 7, 2>>();
 }
 
 #[test]
 fn test_mul_by_zero() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Sparse::<Fp, 5, 4>::random(&mut rng, None) };
-    let zero = Sparse::<Fp, 5, 4>::zero();
-    let p2 = p1.clone() * zero.clone();
-    assert_eq!(zero, p2);
-    let p3 = zero.clone() * p1.clone();
-    assert_eq!(zero.clone(), p3);
+    mvpoly::pbt::test_mul_by_zero::<Fp, 5, 4, Sparse<Fp, 5, 4>>();
 }
 
 #[test]
 fn test_add_zero() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Sparse::<Fp, 3, 4>::random(&mut rng, None) };
-
-    let zero = Sparse::<Fp, 3, 4>::zero();
-    let p2 = p1.clone() + zero.clone();
-    assert_eq!(p1.clone(), p2);
-    let p3 = zero.clone() + p1.clone();
-    assert_eq!(p1.clone(), p3);
+    mvpoly::pbt::test_add_zero::<Fp, 3, 4, Sparse<Fp, 3, 4>>();
 }
 
 #[test]
 fn test_double_is_add_twice() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Sparse::<Fp, 3, 4>::random(&mut rng, None) };
-    let p2 = p1.clone() + p1.clone();
-    let p3 = p1.clone().double();
-    assert_eq!(p2, p3);
+    mvpoly::pbt::test_double_is_add_twice::<Fp, 3, 4, Sparse<Fp, 3, 4>>();
 }
 
 #[test]
 fn test_sub_zero() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Sparse::<Fp, 3, 4>::random(&mut rng, None) };
-    let zero = Sparse::<Fp, 3, 4>::zero();
-    let p2 = p1.clone() - zero.clone();
-    assert_eq!(p1.clone(), p2);
+    mvpoly::pbt::test_sub_zero::<Fp, 3, 4, Sparse<Fp, 3, 4>>();
 }
 
 #[test]
 fn test_neg() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Sparse::<Fp, 3, 4>::random(&mut rng, None) };
-    let p2 = -p1.clone();
-
-    // Test that p1 + (-p1) = 0
-    let sum = p1.clone() + p2.clone();
-    assert_eq!(sum, Sparse::<Fp, 3, 4>::zero());
-
-    // Test that -(-p1) = p1
-    let p3 = -p2;
-    assert_eq!(p1, p3);
-
-    // Test negation of zero
-    let zero = Sparse::<Fp, 3, 4>::zero();
-    let neg_zero = -zero.clone();
-    assert_eq!(zero, neg_zero);
-}
-
-#[test]
-fn test_neg_ref() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Sparse::<Fp, 3, 4>::random(&mut rng, None) };
-    let p2 = -&p1;
-
-    // Test that p1 + (-&p1) = 0
-    let sum = p1.clone() + p2.clone();
-    assert_eq!(sum, Sparse::<Fp, 3, 4>::zero());
-
-    // Test that -(-&p1) = p1
-    let p3 = -&p2;
-    assert_eq!(p1, p3);
-}
-
-#[test]
-fn test_mul_by_scalar() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Sparse::<Fp, 4, 5>::random(&mut rng, None) };
-    let mut p2 = Sparse::<Fp, 4, 5>::zero();
-    let c = Fp::rand(&mut rng);
-    p2.modify_monomial([0; 4], c);
-    assert_eq!(p2 * p1.clone(), p1.clone().mul_by_scalar(c))
-}
-
-#[test]
-fn test_mul_by_scalar_with_zero() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Sparse::<Fp, 4, 5>::random(&mut rng, None) };
-    let c = Fp::zero();
-    assert_eq!(p1.mul_by_scalar(c), Sparse::<Fp, 4, 5>::zero())
-}
-
-#[test]
-fn test_mul_by_scalar_with_one() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Sparse::<Fp, 4, 5>::random(&mut rng, None) };
-    let c = Fp::one();
-    assert_eq!(p1.mul_by_scalar(c), p1)
-}
-
-#[test]
-fn test_evaluation_zero_polynomial() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-
-    let random_evaluation: [Fp; 4] = std::array::from_fn(|_| Fp::rand(&mut rng));
-    let zero = Sparse::<Fp, 4, 5>::zero();
-    let evaluation = zero.eval(&random_evaluation);
-    assert_eq!(evaluation, Fp::zero());
-}
-
-#[test]
-fn test_evaluation_constant_polynomial() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-
-    let random_evaluation: [Fp; 4] = std::array::from_fn(|_| Fp::rand(&mut rng));
-    let cst = Fp::rand(&mut rng);
-    let zero = Sparse::<Fp, 4, 5>::from(cst);
-    let evaluation = zero.eval(&random_evaluation);
-    assert_eq!(evaluation, cst);
+    mvpoly::pbt::test_neg::<Fp, 3, 4, Sparse<Fp, 3, 4>>();
 }
 
 #[test]
@@ -202,55 +97,53 @@ fn test_eval_pbt_sub() {
 
 #[test]
 fn test_eval_pbt_mul_by_scalar() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-
-    let random_evaluation: [Fp; 6] = std::array::from_fn(|_| Fp::rand(&mut rng));
-    let p1 = unsafe { Sparse::<Fp, 6, 4>::random(&mut rng, None) };
-    let c = Fp::rand(&mut rng);
-    let p2 = p1.clone() * Sparse::<Fp, 6, 4>::from(c);
-    let eval_p1 = p1.eval(&random_evaluation);
-    let eval_p2 = p2.eval(&random_evaluation);
-    assert_eq!(eval_p2, eval_p1 * c);
+    mvpoly::pbt::test_eval_pbt_mul_by_scalar::<Fp, 6, 4, Sparse<Fp, 6, 4>>();
 }
 
 #[test]
 fn test_eval_pbt_neg() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
+    mvpoly::pbt::test_eval_pbt_neg::<Fp, 6, 4, Sparse<Fp, 6, 4>>();
+}
 
-    let random_evaluation: [Fp; 6] = std::array::from_fn(|_| Fp::rand(&mut rng));
-    let p1 = unsafe { Sparse::<Fp, 6, 4>::random(&mut rng, None) };
-    let p2 = -p1.clone();
-    let eval_p1 = p1.eval(&random_evaluation);
-    let eval_p2 = p2.eval(&random_evaluation);
-    assert_eq!(eval_p2, -eval_p1);
+#[test]
+fn test_neg_ref() {
+    mvpoly::pbt::test_neg_ref::<Fp, 3, 4, Sparse<Fp, 3, 4>>();
+}
+
+#[test]
+fn test_mul_by_scalar() {
+    mvpoly::pbt::test_mul_by_scalar::<Fp, 4, 5, Sparse<Fp, 4, 5>>();
+}
+
+#[test]
+fn test_mul_by_scalar_with_zero() {
+    mvpoly::pbt::test_mul_by_scalar_with_zero::<Fp, 4, 5, Sparse<Fp, 4, 5>>();
+}
+
+#[test]
+fn test_mul_by_scalar_with_one() {
+    mvpoly::pbt::test_mul_by_scalar_with_one::<Fp, 4, 5, Sparse<Fp, 4, 5>>();
+}
+
+#[test]
+fn test_evaluation_zero_polynomial() {
+    mvpoly::pbt::test_evaluation_zero_polynomial::<Fp, 4, 5, Sparse<Fp, 4, 5>>();
+}
+
+#[test]
+fn test_evaluation_constant_polynomial() {
+    mvpoly::pbt::test_evaluation_constant_polynomial::<Fp, 4, 5, Sparse<Fp, 4, 5>>();
 }
 
 #[test]
 fn test_degree_constant() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let c = Fp::rand(&mut rng);
-    let p = Sparse::<Fp, 4, 5>::from(c);
-    let degree = unsafe { p.degree() };
-    assert_eq!(degree, 0);
-
-    let p = Sparse::<Fp, 4, 5>::zero();
-    let degree = unsafe { p.degree() };
-    assert_eq!(degree, 0);
+    mvpoly::pbt::test_degree_constant::<Fp, 4, 5, Sparse<Fp, 4, 5>>();
 }
 
 #[test]
 fn test_degree_random_degree() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let max_degree: usize = rng.gen_range(1..5);
-    let p: Sparse<Fp, 4, 5> = unsafe { Sparse::random(&mut rng, Some(max_degree)) };
-    let degree = unsafe { p.degree() };
-    assert!(degree <= max_degree);
-
-    let max_degree: usize = rng.gen_range(1..20);
-    // univariate
-    let p = unsafe { Sparse::<Fp, 1, 20>::random(&mut rng, Some(max_degree)) };
-    let degree = unsafe { p.degree() };
-    assert!(degree <= max_degree);
+    mvpoly::pbt::test_degree_random_degree::<Fp, 4, 5, Sparse<Fp, 4, 5>>();
+    mvpoly::pbt::test_degree_random_degree::<Fp, 1, 20, Sparse<Fp, 1, 20>>();
 }
 
 #[test]
@@ -270,105 +163,47 @@ fn test_is_constant() {
 
 #[test]
 fn test_mvpoly_add_degree_pbt() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let degree = rng.gen_range(1..5);
-    let p1 = unsafe { Sparse::<Fp, 4, 5>::random(&mut rng, Some(degree)) };
-    let p2 = unsafe { Sparse::<Fp, 4, 5>::random(&mut rng, Some(degree)) };
-    let p3 = p1.clone() + p2.clone();
-    let degree_p1 = unsafe { p1.degree() };
-    let degree_p2 = unsafe { p2.degree() };
-    let degree_p3 = unsafe { p3.degree() };
-    assert!(degree_p3 <= std::cmp::max(degree_p1, degree_p2));
+    mvpoly::pbt::test_mvpoly_add_degree_pbt::<Fp, 4, 5, Sparse<Fp, 4, 5>>();
 }
 
 #[test]
 fn test_mvpoly_sub_degree_pbt() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let degree = rng.gen_range(1..5);
-    let p1 = unsafe { Sparse::<Fp, 4, 5>::random(&mut rng, Some(degree)) };
-    let p2 = unsafe { Sparse::<Fp, 4, 5>::random(&mut rng, Some(degree)) };
-    let p3 = p1.clone() - p2.clone();
-    let degree_p1 = unsafe { p1.degree() };
-    let degree_p2 = unsafe { p2.degree() };
-    let degree_p3 = unsafe { p3.degree() };
-    assert!(degree_p3 <= std::cmp::max(degree_p1, degree_p2));
+    mvpoly::pbt::test_mvpoly_sub_degree_pbt::<Fp, 4, 5, Sparse<Fp, 4, 5>>();
 }
 
 #[test]
 fn test_mvpoly_neg_degree_pbt() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let degree = rng.gen_range(1..5);
-    let p1 = unsafe { Sparse::<Fp, 4, 5>::random(&mut rng, Some(degree)) };
-    let p2 = -p1.clone();
-    let degree_p1 = unsafe { p1.degree() };
-    let degree_p2 = unsafe { p2.degree() };
-    assert_eq!(degree_p1, degree_p2);
+    mvpoly::pbt::test_mvpoly_neg_degree_pbt::<Fp, 4, 5, Sparse<Fp, 4, 5>>();
 }
 
 #[test]
 fn test_mvpoly_mul_by_scalar_degree_pbt() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let degree = rng.gen_range(1..5);
-    let p1 = unsafe { Sparse::<Fp, 4, 5>::random(&mut rng, Some(degree)) };
-    let c = Fp::rand(&mut rng);
-    let p2 = p1.clone() * Sparse::<Fp, 4, 5>::from(c);
-    let degree_p1 = unsafe { p1.degree() };
-    let degree_p2 = unsafe { p2.degree() };
-    assert!(degree_p2 <= degree_p1);
+    mvpoly::pbt::test_mvpoly_mul_by_scalar_degree_pbt::<Fp, 4, 5, Sparse<Fp, 4, 5>>();
 }
 
 #[test]
 fn test_mvpoly_mul_degree_pbt() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    // half max degree
-    let degree = rng.gen_range(1..3);
-    let p1 = unsafe { Sparse::<Fp, 4, 6>::random(&mut rng, Some(degree)) };
-    let p2 = unsafe { Sparse::<Fp, 4, 6>::random(&mut rng, Some(degree)) };
-    let p3 = p1.clone() * p2.clone();
-    let degree_p1 = unsafe { p1.degree() };
-    let degree_p2 = unsafe { p2.degree() };
-    let degree_p3 = unsafe { p3.degree() };
-    assert!(degree_p3 <= degree_p1 + degree_p2);
+    mvpoly::pbt::test_mvpoly_mul_degree_pbt::<Fp, 4, 6, Sparse<Fp, 4, 6>>();
 }
 
 #[test]
 fn test_mvpoly_mul_eval_pbt() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let max_degree = rng.gen_range(1..3);
-    let p1 = unsafe { Sparse::<Fp, 4, 6>::random(&mut rng, Some(max_degree)) };
-    let p2 = unsafe { Sparse::<Fp, 4, 6>::random(&mut rng, Some(max_degree)) };
-    let p3 = p1.clone() * p2.clone();
-    let random_evaluation: [Fp; 4] = std::array::from_fn(|_| Fp::rand(&mut rng));
-    let eval_p1 = p1.eval(&random_evaluation);
-    let eval_p2 = p2.eval(&random_evaluation);
-    let eval_p3 = p3.eval(&random_evaluation);
-    assert_eq!(eval_p3, eval_p1 * eval_p2);
+    mvpoly::pbt::test_mvpoly_mul_eval_pbt::<Fp, 4, 6, Sparse<Fp, 4, 6>>();
 }
 
 #[test]
 fn test_mvpoly_mul_pbt() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let max_degree = rng.gen_range(1..3);
-    let p1 = unsafe { Sparse::<Fp, 4, 6>::random(&mut rng, Some(max_degree)) };
-    let p2 = unsafe { Sparse::<Fp, 4, 6>::random(&mut rng, Some(max_degree)) };
-    assert_eq!(p1.clone() * p2.clone(), p2.clone() * p1.clone());
+    mvpoly::pbt::test_mvpoly_mul_pbt::<Fp, 4, 6, Sparse<Fp, 4, 6>>();
 }
 
 #[test]
 fn test_can_be_printed_with_debug() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Sparse::<Fp, 2, 2>::random(&mut rng, None) };
-    println!("{:?}", p1);
+    mvpoly::pbt::test_can_be_printed_with_debug::<Fp, 2, 2, Sparse<Fp, 2, 2>>();
 }
 
 #[test]
 fn test_is_zero() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = Sparse::<Fp, 4, 6>::zero();
-    assert!(p1.is_zero());
-
-    let p2 = unsafe { Sparse::<Fp, 4, 6>::random(&mut rng, None) };
-    assert!(!p2.is_zero());
+    mvpoly::pbt::test_is_zero::<Fp, 4, 6, Sparse<Fp, 4, 6>>();
 }
 
 #[test]

--- a/mvpoly/tests/prime.rs
+++ b/mvpoly/tests/prime.rs
@@ -5,7 +5,6 @@ use kimchi::circuits::{
 };
 use mina_curves::pasta::Fp;
 use mvpoly::{prime::Dense, utils::PrimeNumberGenerator, MVPoly};
-use rand::Rng;
 
 #[test]
 fn test_vector_space_dimension() {
@@ -159,115 +158,72 @@ fn test_mul() {
 
 #[test]
 fn test_mul_by_one() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Dense::<Fp, 7, 2>::random(&mut rng, None) };
-    let one = Dense::<Fp, 7, 2>::one();
-    let p2 = p1.clone() * one.clone();
-    assert_eq!(p1.clone(), p2);
-    let p3 = one * p1.clone();
-    assert_eq!(p1.clone(), p3);
+    mvpoly::pbt::test_mul_by_one::<Fp, 7, 2, Dense<Fp, 7, 2>>();
 }
 
 #[test]
 fn test_mul_by_zero() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Dense::<Fp, 5, 4>::random(&mut rng, None) };
-    let zero = Dense::<Fp, 5, 4>::zero();
-    let p2 = p1.clone() * zero.clone();
-    assert_eq!(zero, p2);
-    let p3 = zero.clone() * p1.clone();
-    assert_eq!(zero.clone(), p3);
+    mvpoly::pbt::test_mul_by_zero::<Fp, 5, 4, Dense<Fp, 5, 4>>();
 }
 
 #[test]
 fn test_add_zero() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Dense::<Fp, 3, 4>::random(&mut rng, None) };
-
-    let zero = Dense::<Fp, 3, 4>::zero();
-    let p2 = p1.clone() + zero.clone();
-    assert_eq!(p1.clone(), p2);
-    let p3 = zero.clone() + p1.clone();
-    assert_eq!(p1.clone(), p3);
+    mvpoly::pbt::test_add_zero::<Fp, 3, 4, Dense<Fp, 3, 4>>();
 }
 
 #[test]
 fn test_double_is_add_twice() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Dense::<Fp, 3, 4>::random(&mut rng, None) };
-    let p2 = p1.clone() + p1.clone();
-    let p3 = p1.clone().double();
-    assert_eq!(p2, p3);
+    mvpoly::pbt::test_double_is_add_twice::<Fp, 3, 4, Dense<Fp, 3, 4>>();
 }
 
 #[test]
 fn test_sub_zero() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Dense::<Fp, 3, 4>::random(&mut rng, None) };
-    let zero = Dense::<Fp, 3, 4>::zero();
-    let p2 = p1.clone() - zero.clone();
-    assert_eq!(p1.clone(), p2);
+    mvpoly::pbt::test_sub_zero::<Fp, 3, 4, Dense<Fp, 3, 4>>();
 }
 
 #[test]
 fn test_neg() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Dense::<Fp, 3, 4>::random(&mut rng, None) };
-    let p2 = -p1.clone();
+    mvpoly::pbt::test_neg::<Fp, 3, 4, Dense<Fp, 3, 4>>();
+}
 
-    // Test that p1 + (-p1) = 0
-    let sum = p1.clone() + p2.clone();
-    assert_eq!(sum, Dense::<Fp, 3, 4>::zero());
+#[test]
+fn test_eval_pbt_add() {
+    mvpoly::pbt::test_eval_pbt_add::<Fp, 6, 4, Dense<Fp, 6, 4>>();
+}
 
-    // Test that -(-p1) = p1
-    let p3 = -p2;
-    assert_eq!(p1, p3);
+#[test]
+fn test_eval_pbt_sub() {
+    mvpoly::pbt::test_eval_pbt_sub::<Fp, 6, 4, Dense<Fp, 6, 4>>();
+}
 
-    // Test negation of zero
-    let zero = Dense::<Fp, 3, 4>::zero();
-    let neg_zero = -zero.clone();
-    assert_eq!(zero, neg_zero);
+#[test]
+fn test_eval_pbt_mul_by_scalar() {
+    mvpoly::pbt::test_eval_pbt_mul_by_scalar::<Fp, 6, 4, Dense<Fp, 6, 4>>();
+}
+
+#[test]
+fn test_eval_pbt_neg() {
+    mvpoly::pbt::test_eval_pbt_neg::<Fp, 6, 4, Dense<Fp, 6, 4>>();
 }
 
 #[test]
 fn test_neg_ref() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Dense::<Fp, 3, 4>::random(&mut rng, None) };
-    let p2 = -&p1;
-
-    // Test that p1 + (-&p1) = 0
-    let sum = p1.clone() + p2.clone();
-    assert_eq!(sum, Dense::<Fp, 3, 4>::zero());
-
-    // Test that -(-&p1) = p1
-    let p3 = -&p2;
-    assert_eq!(p1, p3);
+    mvpoly::pbt::test_neg_ref::<Fp, 3, 4, Dense<Fp, 3, 4>>();
 }
 
 #[test]
 fn test_mul_by_scalar() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Dense::<Fp, 4, 5>::random(&mut rng, None) };
-    let mut p2 = Dense::<Fp, 4, 5>::zero();
-    let c = Fp::rand(&mut rng);
-    p2[0] = c;
-    assert_eq!(p2 * p1.clone(), p1.clone().mul_by_scalar(c))
+    mvpoly::pbt::test_mul_by_scalar::<Fp, 4, 5, Dense<Fp, 4, 5>>();
 }
 
 #[test]
 fn test_mul_by_scalar_with_zero() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Dense::<Fp, 4, 5>::random(&mut rng, None) };
-    let c = Fp::zero();
-    assert_eq!(p1.mul_by_scalar(c), Dense::<Fp, 4, 5>::zero())
+    mvpoly::pbt::test_mul_by_scalar_with_zero::<Fp, 4, 5, Dense<Fp, 4, 5>>();
 }
 
 #[test]
 fn test_mul_by_scalar_with_one() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Dense::<Fp, 4, 5>::random(&mut rng, None) };
-    let c = Fp::one();
-    assert_eq!(p1.mul_by_scalar(c), p1)
+    mvpoly::pbt::test_mul_by_scalar_with_one::<Fp, 4, 5, Dense<Fp, 4, 5>>();
 }
 
 #[test]
@@ -362,23 +318,12 @@ fn test_from_variable_column() {
 
 #[test]
 fn test_evaluation_zero_polynomial() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-
-    let random_evaluation: [Fp; 4] = std::array::from_fn(|_| Fp::rand(&mut rng));
-    let zero = Dense::<Fp, 4, 5>::zero();
-    let evaluation = zero.eval(&random_evaluation);
-    assert_eq!(evaluation, Fp::zero());
+    mvpoly::pbt::test_evaluation_zero_polynomial::<Fp, 4, 5, Dense<Fp, 4, 5>>();
 }
 
 #[test]
 fn test_evaluation_constant_polynomial() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-
-    let random_evaluation: [Fp; 4] = std::array::from_fn(|_| Fp::rand(&mut rng));
-    let cst = Fp::rand(&mut rng);
-    let zero = Dense::<Fp, 4, 5>::from(cst);
-    let evaluation = zero.eval(&random_evaluation);
-    assert_eq!(evaluation, cst);
+    mvpoly::pbt::test_evaluation_constant_polynomial::<Fp, 4, 5, Dense<Fp, 4, 5>>();
 }
 
 #[test]
@@ -404,59 +349,6 @@ fn test_evaluation_predefined_polynomial() {
         + Fp::from(7_u32) * random_evaluation[1] * random_evaluation[1];
     let evaluation = p.eval(&random_evaluation);
     assert_eq!(evaluation, exp_eval);
-}
-
-#[test]
-fn test_eval_pbt_add() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-
-    let random_evaluation: [Fp; 6] = std::array::from_fn(|_| Fp::rand(&mut rng));
-    let p1 = unsafe { Dense::<Fp, 6, 4>::random(&mut rng, None) };
-    let p2 = unsafe { Dense::<Fp, 6, 4>::random(&mut rng, None) };
-    let p3 = p1.clone() + p2.clone();
-    let eval_p1 = p1.eval(&random_evaluation);
-    let eval_p2 = p2.eval(&random_evaluation);
-    let eval_p3 = p3.eval(&random_evaluation);
-    assert_eq!(eval_p3, eval_p1 + eval_p2);
-}
-
-#[test]
-fn test_eval_pbt_sub() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-
-    let random_evaluation: [Fp; 6] = std::array::from_fn(|_| Fp::rand(&mut rng));
-    let p1 = unsafe { Dense::<Fp, 6, 4>::random(&mut rng, None) };
-    let p2 = unsafe { Dense::<Fp, 6, 4>::random(&mut rng, None) };
-    let p3 = p1.clone() - p2.clone();
-    let eval_p1 = p1.eval(&random_evaluation);
-    let eval_p2 = p2.eval(&random_evaluation);
-    let eval_p3 = p3.eval(&random_evaluation);
-    assert_eq!(eval_p3, eval_p1 - eval_p2);
-}
-
-#[test]
-fn test_eval_pbt_mul_by_scalar() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-
-    let random_evaluation: [Fp; 6] = std::array::from_fn(|_| Fp::rand(&mut rng));
-    let p1 = unsafe { Dense::<Fp, 6, 4>::random(&mut rng, None) };
-    let c = Fp::rand(&mut rng);
-    let p2 = p1.clone() * Dense::<Fp, 6, 4>::from(c);
-    let eval_p1 = p1.eval(&random_evaluation);
-    let eval_p2 = p2.eval(&random_evaluation);
-    assert_eq!(eval_p2, eval_p1 * c);
-}
-
-#[test]
-fn test_eval_pbt_neg() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-
-    let random_evaluation: [Fp; 6] = std::array::from_fn(|_| Fp::rand(&mut rng));
-    let p1 = unsafe { Dense::<Fp, 6, 4>::random(&mut rng, None) };
-    let p2 = -p1.clone();
-    let eval_p1 = p1.eval(&random_evaluation);
-    let eval_p2 = p2.eval(&random_evaluation);
-    assert_eq!(eval_p2, -eval_p1);
 }
 
 /// As a reminder, here are the equations to compute the addition of two
@@ -670,30 +562,13 @@ fn test_degree_with_coeffs() {
 
 #[test]
 fn test_degree_constant() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let c = Fp::rand(&mut rng);
-    let p = Dense::<Fp, 4, 5>::from(c);
-    let degree = unsafe { p.degree() };
-    assert_eq!(degree, 0);
-
-    let p = Dense::<Fp, 4, 5>::zero();
-    let degree = unsafe { p.degree() };
-    assert_eq!(degree, 0);
+    mvpoly::pbt::test_degree_constant::<Fp, 4, 5, Dense<Fp, 4, 5>>();
 }
 
 #[test]
 fn test_degree_random_degree() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let max_degree: usize = rng.gen_range(1..5);
-    let p: Dense<Fp, 4, 5> = unsafe { Dense::random(&mut rng, Some(max_degree)) };
-    let degree = unsafe { p.degree() };
-    assert!(degree <= max_degree);
-
-    let max_degree: usize = rng.gen_range(1..20);
-    // univariate
-    let p = unsafe { Dense::<Fp, 1, 20>::random(&mut rng, Some(max_degree)) };
-    let degree = unsafe { p.degree() };
-    assert!(degree <= max_degree);
+    mvpoly::pbt::test_degree_random_degree::<Fp, 4, 5, Dense<Fp, 4, 5>>();
+    mvpoly::pbt::test_degree_random_degree::<Fp, 1, 20, Dense<Fp, 1, 20>>();
 }
 
 #[test]
@@ -719,105 +594,47 @@ fn test_is_constant() {
 
 #[test]
 fn test_mvpoly_add_degree_pbt() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let degree = rng.gen_range(1..5);
-    let p1 = unsafe { Dense::<Fp, 4, 5>::random(&mut rng, Some(degree)) };
-    let p2 = unsafe { Dense::<Fp, 4, 5>::random(&mut rng, Some(degree)) };
-    let p3 = p1.clone() + p2.clone();
-    let degree_p1 = unsafe { p1.degree() };
-    let degree_p2 = unsafe { p2.degree() };
-    let degree_p3 = unsafe { p3.degree() };
-    assert!(degree_p3 <= std::cmp::max(degree_p1, degree_p2));
+    mvpoly::pbt::test_mvpoly_add_degree_pbt::<Fp, 4, 5, Dense<Fp, 4, 5>>();
 }
 
 #[test]
 fn test_mvpoly_sub_degree_pbt() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let degree = rng.gen_range(1..5);
-    let p1 = unsafe { Dense::<Fp, 4, 5>::random(&mut rng, Some(degree)) };
-    let p2 = unsafe { Dense::<Fp, 4, 5>::random(&mut rng, Some(degree)) };
-    let p3 = p1.clone() - p2.clone();
-    let degree_p1 = unsafe { p1.degree() };
-    let degree_p2 = unsafe { p2.degree() };
-    let degree_p3 = unsafe { p3.degree() };
-    assert!(degree_p3 <= std::cmp::max(degree_p1, degree_p2));
+    mvpoly::pbt::test_mvpoly_sub_degree_pbt::<Fp, 4, 5, Dense<Fp, 4, 5>>();
 }
 
 #[test]
 fn test_mvpoly_neg_degree_pbt() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let degree = rng.gen_range(1..5);
-    let p1 = unsafe { Dense::<Fp, 4, 5>::random(&mut rng, Some(degree)) };
-    let p2 = -p1.clone();
-    let degree_p1 = unsafe { p1.degree() };
-    let degree_p2 = unsafe { p2.degree() };
-    assert_eq!(degree_p1, degree_p2);
+    mvpoly::pbt::test_mvpoly_neg_degree_pbt::<Fp, 4, 5, Dense<Fp, 4, 5>>();
 }
 
 #[test]
 fn test_mvpoly_mul_by_scalar_degree_pbt() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let degree = rng.gen_range(1..5);
-    let p1 = unsafe { Dense::<Fp, 4, 5>::random(&mut rng, Some(degree)) };
-    let c = Fp::rand(&mut rng);
-    let p2 = p1.clone() * Dense::<Fp, 4, 5>::from(c);
-    let degree_p1 = unsafe { p1.degree() };
-    let degree_p2 = unsafe { p2.degree() };
-    assert!(degree_p2 <= degree_p1);
+    mvpoly::pbt::test_mvpoly_mul_by_scalar_degree_pbt::<Fp, 4, 5, Dense<Fp, 4, 5>>();
 }
 
 #[test]
 fn test_mvpoly_mul_degree_pbt() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    // half max degree
-    let degree = rng.gen_range(1..3);
-    let p1 = unsafe { Dense::<Fp, 4, 6>::random(&mut rng, Some(degree)) };
-    let p2 = unsafe { Dense::<Fp, 4, 6>::random(&mut rng, Some(degree)) };
-    let p3 = p1.clone() * p2.clone();
-    let degree_p1 = unsafe { p1.degree() };
-    let degree_p2 = unsafe { p2.degree() };
-    let degree_p3 = unsafe { p3.degree() };
-    assert!(degree_p3 <= degree_p1 + degree_p2);
+    mvpoly::pbt::test_mvpoly_mul_degree_pbt::<Fp, 4, 6, Dense<Fp, 4, 6>>();
 }
 
 #[test]
 fn test_mvpoly_mul_eval_pbt() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let max_degree = rng.gen_range(1..3);
-    let p1 = unsafe { Dense::<Fp, 4, 6>::random(&mut rng, Some(max_degree)) };
-    let p2 = unsafe { Dense::<Fp, 4, 6>::random(&mut rng, Some(max_degree)) };
-    let p3 = p1.clone() * p2.clone();
-    let random_evaluation: [Fp; 4] = std::array::from_fn(|_| Fp::rand(&mut rng));
-    let eval_p1 = p1.eval(&random_evaluation);
-    let eval_p2 = p2.eval(&random_evaluation);
-    let eval_p3 = p3.eval(&random_evaluation);
-    assert_eq!(eval_p3, eval_p1 * eval_p2);
+    mvpoly::pbt::test_mvpoly_mul_eval_pbt::<Fp, 4, 6, Dense<Fp, 4, 6>>();
 }
 
 #[test]
 fn test_mvpoly_mul_pbt() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let max_degree = rng.gen_range(1..3);
-    let p1 = unsafe { Dense::<Fp, 4, 6>::random(&mut rng, Some(max_degree)) };
-    let p2 = unsafe { Dense::<Fp, 4, 6>::random(&mut rng, Some(max_degree)) };
-    assert_eq!(p1.clone() * p2.clone(), p2.clone() * p1.clone());
+    mvpoly::pbt::test_mvpoly_mul_pbt::<Fp, 4, 6, Dense<Fp, 4, 6>>();
 }
 
 #[test]
 fn test_can_be_printed_with_debug() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = unsafe { Dense::<Fp, 2, 2>::random(&mut rng, None) };
-    println!("{:?}", p1);
+    mvpoly::pbt::test_can_be_printed_with_debug::<Fp, 2, 2, Dense<Fp, 2, 2>>();
 }
 
 #[test]
 fn test_is_zero() {
-    let mut rng = o1_utils::tests::make_test_rng(None);
-    let p1 = Dense::<Fp, 4, 6>::zero();
-    assert!(p1.is_zero());
-
-    let p2 = unsafe { Dense::<Fp, 4, 6>::random(&mut rng, None) };
-    assert!(!p2.is_zero());
+    mvpoly::pbt::test_is_zero::<Fp, 4, 6, Dense<Fp, 4, 6>>();
 }
 
 #[test]


### PR DESCRIPTION
#### Examples provided:

- https://github.com/o1-labs/proof-systems/pull/2540

#### Notes

- It was required for generic tests to extend the `MVPoly` trait with the:

  ```rust
  fn modify_monomial_with_scalar(&mut self, scalar: F);
  ```

  And implement it for `Sparse` and `Dense` structs.
  Not sure though if it makes sense to do for `MVPoly` or maybe we should do it with some helper trait instead.

#### Tasks left:
- [ ] Generalize the `test_homogeneous_eval` tests.
- [ ] Generalize the `test_add_monomial` tests.

