### PR TITLE
Manually unroll MDS calculation

### DIFF
--- a/poseidon/src/permutation.rs
+++ b/poseidon/src/permutation.rs
@@ -33,12 +33,34 @@ pub fn full_round<F: Field, SC: SpongeConstants>(
     state: &mut Vec<F>,
     r: usize,
 ) {
-    for state_i in state.iter_mut() {
-        *state_i = sbox::<F, SC>(*state_i);
-    }
-    *state = apply_mds_matrix::<F, SC>(params, state);
-    for (i, x) in params.round_constants[r].iter().enumerate() {
-        state[i].add_assign(x);
+    if SC::PERM_FULL_MDS && state.len() == 3 {
+        let mut el0 = state[0];
+        let mut el1 = state[1];
+        let mut el2 = state[2];
+        el0 = sbox::<F, SC>(el0);
+        el1 = sbox::<F, SC>(el1);
+        el2 = sbox::<F, SC>(el2);
+        // Manually unrolled loops for multiplying each row by the vector
+        state[0] = params.mds[0][0] * el0
+            + params.mds[0][1] * el1
+            + params.mds[0][2] * el2
+            + params.round_constants[r][0];
+        state[1] = params.mds[1][0] * el0
+            + params.mds[1][1] * el1
+            + params.mds[1][2] * el2
+            + params.round_constants[r][1];
+        state[2] = params.mds[2][0] * el0
+            + params.mds[2][1] * el1
+            + params.mds[2][2] * el2
+            + params.round_constants[r][2];
+    } else {
+        for state_i in state.iter_mut() {
+            *state_i = sbox::<F, SC>(*state_i);
+        }
+        *state = apply_mds_matrix::<F, SC>(params, state);
+        for (i, x) in params.round_constants[r].iter().enumerate() {
+            state[i].add_assign(x);
+        }
     }
 }
 


### PR DESCRIPTION
Modify `full_round` to perform round inline when `params.mds.len() == 3`.

This optimization gave a ~3% speedup (measured by `mina ledger test apply` on top of a PR stack #2394, https://github.com/MinaProtocol/mina/pull/15980 and _TODO open a PR_.

Although 3% isn't much, I expect speed-up to be better when a batch version of hash (https://github.com/MinaProtocol/mina/issues/16053) is delivered.

P.S. change's diff is bloated by `^M` characters present at the end of each line for the previous version of the `poseidon/src/permutation.rs` file.