### PR TITLE
Arrabiata: implement PoseidonNextRow - a variant of the gadget Poseidon using "next row"

### DIFF
--- a/arrabiata/src/columns.rs
+++ b/arrabiata/src/columns.rs
@@ -23,6 +23,7 @@ pub enum Gadget {
     EllipticCurveAddition,
     EllipticCurveScaling,
     Poseidon,
+    PoseidonNextRow,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -47,6 +48,7 @@ impl FormattedOutput for Column {
                 Gadget::EllipticCurveAddition => "q_ec_add".to_string(),
                 Gadget::EllipticCurveScaling => "q_ec_mul".to_string(),
                 Gadget::Poseidon => "q_pos".to_string(),
+                Gadget::PoseidonNextRow => "q_pos_next_row".to_string(),
             },
             Column::PublicInput(i) => format!("pi_{{{i}}}").to_string(),
             Column::X(i) => format!("x_{{{i}}}").to_string(),
@@ -64,6 +66,7 @@ impl FormattedOutput for Column {
                 Gadget::EllipticCurveAddition => "q_ec_add".to_string(),
                 Gadget::EllipticCurveScaling => "q_ec_mul".to_string(),
                 Gadget::Poseidon => "q_pos".to_string(),
+                Gadget::PoseidonNextRow => "q_pos_next_row".to_string(),
             },
             Column::PublicInput(i) => format!("pi[{i}]"),
             Column::X(i) => format!("x[{i}]"),

--- a/arrabiata/src/constraints.rs
+++ b/arrabiata/src/constraints.rs
@@ -62,6 +62,13 @@ impl<Fp: PrimeField> InterpreterEnv for Env<Fp> {
         }))
     }
 
+    fn access_current_row(&self, pos: Self::Position) -> Self::Variable {
+        Expr::Atom(ExprInner::Cell(Variable {
+            col: pos,
+            row: CurrOrNext::Curr,
+        }))
+    }
+
     fn allocate_public_input(&mut self) -> Self::Position {
         assert!(self.idx_var_pi < NUMBER_OF_PUBLIC_INPUTS, "Maximum number of public inputs reached ({NUMBER_OF_PUBLIC_INPUTS}), increase the number of public inputs");
         let pos = Column::PublicInput(self.idx_var_pi);

--- a/arrabiata/src/interpreter.rs
+++ b/arrabiata/src/interpreter.rs
@@ -401,6 +401,10 @@ pub trait InterpreterEnv {
     /// Return the corresponding variable at the given position, for the next row.
     fn access_next_row(&self, pos: Self::Position) -> Self::Variable;
 
+    /// Return the corresponding variable at the given position, for the current
+    /// row.
+    fn access_current_row(&self, pos: Self::Position) -> Self::Variable;
+
     fn allocate_public_input(&mut self) -> Self::Position;
 
     /// Set the value of the variable at the given position for the current row

--- a/arrabiata/src/interpreter.rs
+++ b/arrabiata/src/interpreter.rs
@@ -117,14 +117,56 @@
 //!
 //! We start with the assumption that 17 columns are available for the whole
 //! circuit, and we can support constraints up to degree 5.
-//! Therefore, we can compute 4 full rounds per row.
+//! Therefore, we can compute 4 full rounds per row if we rely on the
+//! permutation argument, or 5 full rounds per row if we use the "next row".
 //!
-//! FIXME: we can do one more by using "the next row". Also, we can optimize
-//! this by using a partial/full round instance of Poseidon. We leave this when
-//! we move to Poseidon2.
+//! We provide two implementations of the Poseidon hash function. The first one
+//! does not use the "next row" and is limited to 4 full rounds per row. The
+//! second one uses the "next row" and can compute 5 full rounds per row.
+//! The second implementation is more efficient as it allows to compute one
+//! additional round per row.
+//! For the second implementation, the permutation argument will only be
+//! activated on the first and last group of 5 rounds.
 //!
-//! TBD/FIXME: define gadget layout + maybe change the current implementation
-//! for the permutation argument.
+//! The layout for the one not using the "next row" is as follow (4 full rounds):
+//! ```text
+//! | C1 | C2 | C3 | C4 | C5 | C6 | C7 | C8 | C9 | C10 | C11 | C12 | C13 | C14 | C15 |
+//! | -- | -- | -- | -- | -- | -- | -- | -- | -- | --- | --- | --- | --- | --- | --- |
+//! | x  | y  | z  | a1 | a2 | a3 | b1 | b2 | b3 | c1  | c2  | c3  | o1  | o2  | o3  |
+//! ```
+//! where (x, y, z) is the input of the current step, (o1, o2, o3) is the
+//! output, and the other values are intermediary values. And we have the following equalities:
+//! ```text
+//! (a1, a2, a3) = PoseidonPerm(x, y, z)
+//! (b1, b2, b3) = PoseidonPerm(a1, a2, a3)
+//! (c1, c2, c3) = PoseidonPerm(b1, b2, b3)
+//! (o1, o2, o3) = PoseidonPerm(c1, c2, c3)
+//! ```
+//!
+//! The layout for the one using the "next row" is as follow (5 full rounds):
+//! ```text
+//! | C1 | C2 | C3 | C4 | C5 | C6 | C7 | C8 | C9 | C10 | C11 | C12 | C13 | C14 | C15 |
+//! | -- | -- | -- | -- | -- | -- | -- | -- | -- | --- | --- | --- | --- | --- | --- |
+//! | x  | y  | z  | a1 | a2 | a3 | b1 | b2 | b3 | c1  | c2  | c3  | d1  | d2  | d3  |
+//! | o1 | o2 | o2
+//! ```
+//! where (x, y, z) is the input of the current step, (o1, o2, o3) is the
+//! output, and the other values are intermediary values. And we have the
+//! following equalities:
+//! ```text
+//! (a1, a2, a3) = PoseidonPerm(x, y, z)
+//! (b1, b2, b3) = PoseidonPerm(a1, a2, a3)
+//! (c1, c2, c3) = PoseidonPerm(b1, b2, b3)
+//! (d1, d2, d3) = PoseidonPerm(c1, c2, c3)
+//! (o1, o2, o3) = PoseidonPerm(d1, d2, d3)
+//! ```
+//!
+//! For both implementations, round constants are passed as public inputs. As a
+//! reminder, public inputs are simply additional columns known by the prover
+//! and verifier.
+//! Also, the elements to absorb are added to the initial state at the beginning
+//! of the call of the Poseidon full hash. The elements to absorb are supposed
+//! to be passed as public inputs.
 //!
 //! ### Elliptic curve scalar multiplication
 //!
@@ -360,6 +402,13 @@ pub enum Instruction {
     /// and is unsafe at the moment as no permutation argument is implemented.
     // FIXME: use the permutation argument or deprecate it.
     Poseidon(usize),
+    /// This gadget implement the Poseidon hash instance described in the
+    /// top-level documentation. Compared to the previous one (that might be
+    /// deprecated in the future), this implementation does use the "next row"
+    /// to allow the computation of one additional round per row. In the current
+    /// setup, with [NUMBER_OF_COLUMNS] columns, we can compute 5 full rounds
+    /// per row.
+    PoseidonNextRow(usize),
     EllipticCurveScaling(usize, u64),
     EllipticCurveAddition(usize),
     // The NoOp will simply do nothing
@@ -973,6 +1022,108 @@ pub fn run_ivc<E: InterpreterEnv>(env: &mut E, instr: Instruction) {
                 state.iter().enumerate().for_each(|(i, x)| {
                     unsafe { env.save_poseidon_state(x.clone(), i) };
                 })
+            } else {
+                panic!("Invalid index: it is supposed to be less than {POSEIDON_ROUNDS_FULL}");
+            }
+        }
+        Instruction::PoseidonNextRow(curr_round) => {
+            env.activate_gadget(Gadget::PoseidonNextRow);
+            debug!("Executing instruction PoseidonNextRow({curr_round})");
+            if curr_round < POSEIDON_ROUNDS_FULL {
+                // Values to be absorbed are 0 when when the round is not zero,
+                // i.e. when we are processing the rounds.
+                let values_to_absorb: Vec<E::Variable> = (0..POSEIDON_STATE_SIZE - 1)
+                    .map(|_i| {
+                        let pos = env.allocate_public_input();
+                        // fetch_value_to_absorb is supposed to return 0 if curr_round != 0.
+                        unsafe { env.fetch_value_to_absorb(pos, curr_round) }
+                    })
+                    .collect();
+                let first_col_positions: Vec<E::Position> =
+                    (0..POSEIDON_STATE_SIZE).map(|_i| env.allocate()).collect();
+                // If we are at the first round, we load the state from the environment.
+                // The permutation argument is used to load the state the
+                // current call to Poseidon might be a succession of Poseidon
+                // calls, like when we need to hash the public inputs, and the
+                // state might be from a previous place in the execution trace.
+                let state: Vec<E::Variable> = if curr_round == 0 {
+                    env.activate_gadget(Gadget::PermutationArgument);
+                    first_col_positions
+                        .iter()
+                        .enumerate()
+                        .map(|(i, pos)| {
+                            let res = env.load_poseidon_state(*pos, i);
+                            // Absorb value. The capacity is POSEIDON_STATE_SIZE - 1
+                            if i < POSEIDON_STATE_SIZE - 1 {
+                                res + values_to_absorb[i].clone()
+                            } else {
+                                res
+                            }
+                        })
+                        .collect()
+                } else {
+                    // Otherwise, as we do use the "next row" trick, the current
+                    // state has been loaded in the "next_row" state during the
+                    // previous call, and we can simply load it. No permutation
+                    // argument needed.
+                    first_col_positions
+                        .iter()
+                        .map(|pos| env.access_current_row(*pos))
+                        .collect()
+                };
+
+                // 5 is the number of rounds we treat per row
+                (0..5).fold(state, |state, idx_round| {
+                    let state: Vec<E::Variable> =
+                        state.iter().map(|x| env.compute_x5(x.clone())).collect();
+
+                    let round = curr_round + idx_round;
+
+                    let rcs: Vec<E::Variable> = (0..POSEIDON_STATE_SIZE)
+                        .map(|i| {
+                            let pos = env.allocate_public_input();
+                            env.get_poseidon_round_constant(pos, round, i)
+                        })
+                        .collect();
+
+                    let state: Vec<E::Variable> = rcs
+                        .iter()
+                        .enumerate()
+                        .map(|(i, rc)| {
+                            let acc: E::Variable =
+                                state.iter().enumerate().fold(env.zero(), |acc, (j, x)| {
+                                    acc + env.get_poseidon_mds_matrix(i, j) * x.clone()
+                                });
+                            // The last iteration is written on the next row.
+                            if idx_round == 4 {
+                                env.write_column_next_row(first_col_positions[i], acc + rc.clone())
+                            } else {
+                                // Otherwise, we simply allocate a new position
+                                // in the circuit.
+                                let pos = env.allocate();
+                                env.write_column(pos, acc + rc.clone())
+                            }
+                        })
+                        .collect();
+                    // If we are at the last round, we save the state in the
+                    // environment.
+                    // It does require the permutation argument to be activated.
+                    // FIXME: activating the permutation argument has no effect
+                    // for now.
+                    // FIXME/IMPROVEME: we might want to execute more Poseidon
+                    // full hash in sequentially, and then save one row. For
+                    // now, we will save the state at the end of the last round
+                    // and reload it at the beginning of the next Poseidon full
+                    // hash.
+                    if round == POSEIDON_ROUNDS_FULL - 1 {
+                        env.activate_gadget(Gadget::PermutationArgument);
+                        state.iter().enumerate().for_each(|(i, x)| {
+                            unsafe { env.save_poseidon_state(x.clone(), i) };
+                        });
+                        env.reset();
+                    };
+                    state
+                });
             } else {
                 panic!("Invalid index: it is supposed to be less than {POSEIDON_ROUNDS_FULL}");
             }

--- a/arrabiata/src/lib.rs
+++ b/arrabiata/src/lib.rs
@@ -29,8 +29,9 @@ pub const NUMBER_OF_COLUMNS: usize = 17;
 
 /// The maximum number of public inputs the circuit can use per row
 /// We do have 15 for now as we want to compute 5 rounds of poseidon per row
-/// using the gadget [Gadget::PoseidonNextRow]. In addition to the 12 public
-/// inputs required for the rounds, we add 2 more for the values to absorb.
+/// using the gadget [crate::columns::Gadget::PoseidonNextRow]. In addition to
+/// the 12 public inputs required for the rounds, we add 2 more for the values
+/// to absorb.
 pub const NUMBER_OF_PUBLIC_INPUTS: usize = 15 + 2;
 
 /// The low-exponentiation value used by the Poseidon hash function for the

--- a/arrabiata/src/lib.rs
+++ b/arrabiata/src/lib.rs
@@ -28,11 +28,10 @@ pub const IVC_CIRCUIT_SIZE: usize = 1 << 13;
 pub const NUMBER_OF_COLUMNS: usize = 17;
 
 /// The maximum number of public inputs the circuit can use per row
-/// We do have 12 for now as we want to compute 4 rounds of poseidon per row.
-/// In addition to the 12 public inputs required for the rounds, we add 2 more
-/// for the values to absorb.
-// FIXME: we can do 5 rounds per row by using "the next row"
-pub const NUMBER_OF_PUBLIC_INPUTS: usize = 12 + 2;
+/// We do have 15 for now as we want to compute 5 rounds of poseidon per row
+/// using the gadget [Gadget::PoseidonNextRow]. In addition to the 12 public
+/// inputs required for the rounds, we add 2 more for the values to absorb.
+pub const NUMBER_OF_PUBLIC_INPUTS: usize = 15 + 2;
 
 /// The low-exponentiation value used by the Poseidon hash function for the
 /// substitution box.

--- a/arrabiata/src/witness.rs
+++ b/arrabiata/src/witness.rs
@@ -1084,7 +1084,8 @@ impl<
             Instruction::Poseidon(i) => {
                 if i < POSEIDON_ROUNDS_FULL - 4 {
                     // We perform 4 rounds per row
-                    // FIXME: we can do 5 by using the "next row"
+                    // FIXME: we can do 5 by using the "next row", see
+                    // PoseidonNextRow
                     Instruction::Poseidon(i + 4)
                 } else {
                     // If we absorbed all the elements, we go to the next instruction
@@ -1097,6 +1098,23 @@ impl<
                     } else {
                         // Otherwise, we continue absorbing
                         Instruction::Poseidon(0)
+                    }
+                }
+            }
+            Instruction::PoseidonNextRow(i) => {
+                if i < POSEIDON_ROUNDS_FULL - 5 {
+                    Instruction::PoseidonNextRow(i + 5)
+                } else {
+                    // If we absorbed all the elements, we go to the next instruction
+                    // In this case, it is the decomposition of the folding combiner
+                    // FIXME: it is not the correct next instruction.
+                    // We must check the computed value is the one given as a
+                    // public input.
+                    if self.idx_values_to_absorb >= NUMBER_OF_VALUES_TO_ABSORB_PUBLIC_IO {
+                        Instruction::BitDecomposition(0)
+                    } else {
+                        // Otherwise, we continue absorbing
+                        Instruction::PoseidonNextRow(0)
                     }
                 }
             }

--- a/arrabiata/src/witness.rs
+++ b/arrabiata/src/witness.rs
@@ -212,7 +212,7 @@ where
         let Column::X(idx) = pos else {
             unimplemented!("Only works for private inputs")
         };
-        self.witness[idx][self.current_row + 1].clone()
+        self.next_state[idx].clone()
     }
 
     fn allocate_public_input(&mut self) -> Self::Position {

--- a/arrabiata/src/witness.rs
+++ b/arrabiata/src/witness.rs
@@ -215,6 +215,13 @@ where
         self.next_state[idx].clone()
     }
 
+    fn access_current_row(&self, pos: Self::Position) -> Self::Variable {
+        let Column::X(idx) = pos else {
+            unimplemented!("Only works for private inputs")
+        };
+        self.state[idx].clone()
+    }
+
     fn allocate_public_input(&mut self) -> Self::Position {
         assert!(self.idx_var_pi < NUMBER_OF_PUBLIC_INPUTS, "Maximum number of public inputs reached ({NUMBER_OF_PUBLIC_INPUTS}), increase the number of public inputs");
         let pos = Column::PublicInput(self.idx_var_pi);

--- a/arrabiata/tests/witness.rs
+++ b/arrabiata/tests/witness.rs
@@ -85,6 +85,9 @@ fn test_unit_witness_poseidon_next_row_gadget_one_full_hash() {
     assert_eq!(env.sponge_e1.to_vec(), exp_output);
     // Check the other sponge hasn't been modified
     assert_eq!(env.sponge_e2, sponge.clone());
+
+    // Number of rows used by one full hash
+    assert_eq!(env.current_row, 13);
 }
 
 #[test]

--- a/arrabiata/tests/witness.rs
+++ b/arrabiata/tests/witness.rs
@@ -47,6 +47,47 @@ where
 }
 
 #[test]
+fn test_unit_witness_poseidon_next_row_gadget_one_full_hash() {
+    let srs_log2_size = 6;
+    let sponge: [BigInt; POSEIDON_STATE_SIZE] = std::array::from_fn(|_i| BigInt::from(42u64));
+    let mut env = Env::<Fp, Fq, Vesta, Pallas>::new(
+        srs_log2_size,
+        BigInt::from(1u64),
+        sponge.clone(),
+        sponge.clone(),
+    );
+
+    env.current_instruction = Instruction::PoseidonNextRow(0);
+
+    (0..(POSEIDON_ROUNDS_FULL / 5)).for_each(|i| {
+        interpreter::run_ivc(&mut env, Instruction::PoseidonNextRow(5 * i));
+        env.reset();
+    });
+    let exp_output = {
+        let mut state = sponge
+            .clone()
+            .to_vec()
+            .iter()
+            .map(|x| Fp::from_biguint(&x.to_biguint().unwrap()).unwrap())
+            .collect::<Vec<_>>();
+        state[0] += env.srs_e2.h.x;
+        state[1] += env.srs_e2.h.y;
+        poseidon_block_cipher::<Fp, PlonkSpongeConstants>(
+            poseidon_3_60_0_5_5_fp::static_params(),
+            &mut state,
+        );
+        state
+            .iter()
+            .map(|x| x.to_biguint().into())
+            .collect::<Vec<_>>()
+    };
+    // Check correctness for current iteration
+    assert_eq!(env.sponge_e1.to_vec(), exp_output);
+    // Check the other sponge hasn't been modified
+    assert_eq!(env.sponge_e2, sponge.clone());
+}
+
+#[test]
 fn test_unit_witness_poseidon_gadget_one_full_hash() {
     let srs_log2_size = 6;
     let sponge: [BigInt; POSEIDON_STATE_SIZE] = std::array::from_fn(|_i| BigInt::from(42u64));


### PR DESCRIPTION
Note: we will certainly deprecate other versions later. Only leaving it for now.
Constraints checks come right after.

Fix https://github.com/o1-labs/proof-systems/issues/2565