### PR TITLE
Initial selectorified API

### DIFF
--- a/o1vm/src/mips/mod.rs
+++ b/o1vm/src/mips/mod.rs
@@ -20,7 +20,7 @@ pub mod constraints;
 pub mod folding;
 pub mod interpreter;
 pub mod registers;
-pub mod single;
+pub mod singlestep;
 #[cfg(test)]
 pub mod tests;
 pub mod trace;

--- a/o1vm/src/mips/mod.rs
+++ b/o1vm/src/mips/mod.rs
@@ -20,6 +20,7 @@ pub mod constraints;
 pub mod folding;
 pub mod interpreter;
 pub mod registers;
+pub mod single;
 #[cfg(test)]
 pub mod tests;
 pub mod trace;

--- a/o1vm/src/mips/singlestep.rs
+++ b/o1vm/src/mips/singlestep.rs
@@ -1,0 +1,116 @@
+// Amalgamation of the different MIPS circuits into a "single" circuit.
+
+use super::column;
+
+pub trait SingleStepper {
+    type S<I, P, V>;
+
+    type Position;
+
+    type Instruction;
+
+    type Variable: Clone
+        + std::ops::Add<Self::Variable, Output = Self::Variable>
+        + std::ops::Sub<Self::Variable, Output = Self::Variable>
+        + std::ops::Mul<Self::Variable, Output = Self::Variable>
+        + std::fmt::Debug
+        + ark_ff::Zero
+        + ark_ff::One;
+
+    type State = S<Self::Instruction, Self::Position, Self::Variable>;
+
+    /// Helpers
+
+    fn alloc_scratch(state: Self::State) -> (Self::Position, Self::State);
+
+    fn variable(state: &Self::State, column: Self::Position) -> Self::Variable;
+
+    fn add_constraint(state: Self::State, assert_equals_zero: Self::Variable) -> Self::State;
+
+    // ABORTS
+    fn check_is_zero(assert_equals_zero: &Self::Variable);
+
+    fn assert_is_zero(state: Self::State, assert_equals_zero: Self::Variable) -> Self::State {
+        Self::check_is_zero(&assert_equals_zero);
+        self.add_constraint(assert_equals_zero)
+    }
+
+    // ABORTS
+    fn check_equal(x: &Self::Variable, y: &Self::Variable);
+
+    fn assert_equal(state: Self::State, x: Self::Variable, y: Self::Variable) -> Self::State {
+        Self::check_equal(&x, &y);
+        self.add_constraint(x - y)
+    }
+
+    // ABORTS
+    fn check_boolean(x: &Self::Variable);
+
+    fn assert_boolean(state: Self::State, x: Self::Variable) {
+        Self::check_boolean(&x);
+        self.add_constraint(x.clone() * x.clone() - x); // polynomial with roots {0, 1}
+    }
+
+    fn add_lookup(state: Self::State, lookup: Lookup<Self::Variable>) -> Self::State;
+
+    // compared to original, this is divided by 4.
+    fn instruction_counter(state: &Self::State) -> Self::Variable;
+
+    fn increase_instruction_counter(state: Self::State) -> Self::State;
+
+    /// Actual stepper
+
+    fn step(state: Self::State, instructions: &Vec<Self::Instruction>) -> Self::State;
+}
+
+/// A simple example
+
+#[derive(
+    Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, EnumCount, EnumIter
+)]
+pub enum ExampleRegister {
+    A,
+    B,
+    C,
+    D,
+    Lo,
+    Hi,
+    Ip,
+    NextIp,
+}
+
+pub type ExamplePosition = column::ColumnAlias;
+
+pub type ExampleVariable = ark_bn254::Bn254;
+
+const SCRATCH_SIZE: usize = 64;
+
+pub struct ExampleRegisterBank<T> {
+    a: T,
+    b: T,
+    c: T,
+    d: T,
+    lo: T,
+    hi: T,
+    ip: T,
+    next_ip: T,
+}
+
+#[derive(
+    Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd
+)]
+pub enum ExampleInstruction<F> {
+    Div(ExampleRegister, ExampleRegister),
+    ShiftLeftLogicalVariable(ExampleRegister, ExampleRegister),
+    JumpRegister(ExampleRegister),
+    Load8(ExampleRegister, ExampleRegister, u32),
+    SyscallExitGroup,
+}
+
+pub struct ExampleS<I, P, V> {
+    registers: ExampleRegisterBank<u32>,
+    memory: Vec<(u32, Vec<u8>)>,
+    halt: bool,
+    scratch_state_idx: usize,
+    scratch_state: [V; SCRATCH_SIZE],
+}


### PR DESCRIPTION
I have here a skeleton API for a selectorified API.  This begins to address #2543 and #2545 (Perhaps?  Comments?) by switching from the API used in [`o1vm/src/mips/interpreter.rs`](./o1vm/src/mips/interpreter.rs) to that detailed in [`o1vmsrc/mips/singlestep.rs`](./o1vm/src/mips/singlestep.rs).

The main changes are:

* No use of mutability, instead using the "generator style" of `a -> State -> (b, State)`
* Significantly pared down API, will likely add to it as I realize it was needed, but for now start small!
* Instructions now "know" their arguments, by packing them in the `enum` fields with them.  This allows the generator style to uniformly look like `Instructions -> State -> (Witness, State)` and for witness generation, without having to worry about different arities and register arguments. [Of course, the old instructions with their arguments can be relatively easily converted to this form -- to come].
* A small example of the API in use is below the API with a couple of test curves and an example instruction-set based on a significantly simplified MIPS instruction set, using just one of each of a small class of instructions, for parallel debugging and sanity-checking purposes.
* Simplified register set, again for debugging and sanity-checking
* Simplified `ExampleS` previously an implementor of `InterpreterEnv` (`Env` in `witness.rs` and the like) which will almost surely grow as the number of instructions returns to parity.

The point of these changes is to provide a basic test-bed for the selector changes to come.