### PR TITLE
Unify cargo requirements with bindings, add asm flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ ark-ec = { version = "0.4.2", features = ["parallel"] }
 ark-ff = { version = "0.4.2", features = ["parallel", "asm"] }
 ark-poly = { version = "0.4.2", features = ["parallel"] }
 ark-serialize = "0.4.2"
-ark-std = "0.4.0"
-ark-test-curves = "0.4.2"
+ark-std = { version = "0.4.0", features = ["parallel"] }
+ark-test-curves = { version = "0.4.2", features = ["parallel", "asm"] }
 base64 = "0.21.5"
 bcs = "0.1.3"
 bitvec = "1.0.0"
@@ -43,7 +43,7 @@ itertools = "0.10.5"
 libc = "0.2.62"
 libflate = "2"
 log = "0.4.20"
-num-bigint = { version = "0.4.3", features = ["rand", "serde"] }
+num-bigint = { version = "0.4.4", features = ["rand", "serde"] }
 num-derive = "0.4"
 num-integer = "0.1.45"
 num-traits = "0.2"
@@ -60,10 +60,10 @@ rand_chacha = { version = "0.3.0" }
 rand_core = { version = "0.6.3" }
 rayon = "1.5.0"
 regex = "1.10.2"
-rmp-serde = "1.1.1"
+rmp-serde = "1.1.2"
 secp256k1 = "0.28.2"
 serde = { version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.79"
+serde_json = "1.0.113"
 serde_with = "3.6.0"
 sha2 = "0.10.2"
 strum = "0.26.1"


### PR DESCRIPTION
* Added `parallel` and `asm` flags to `ark-std` and `ark-test-curves`
* Bumped requirements on `rmp-serde` and `serde_json`: the actual locked packages were already set to this new version, this is just for `Cargo.toml` files to look similar on proof-systems side & bindings side.