### PR TITLE
o1vm/pickles: initialize the structure

### DIFF
--- a/o1vm/Cargo.toml
+++ b/o1vm/Cargo.toml
@@ -20,6 +20,10 @@ path = "src/test_preimage_read.rs"
 name = "legacy_o1vm"
 path = "src/legacy/main.rs"
 
+[[bin]]
+name = "pickles_o1vm"
+path = "src/pickles/main.rs"
+
 [dependencies]
 # FIXME: Only activate this when legacy_o1vm is built
 ark-bn254.workspace = true

--- a/o1vm/src/pickles/main.rs
+++ b/o1vm/src/pickles/main.rs
@@ -1,0 +1,71 @@
+use kimchi::circuits::domains::EvaluationDomains;
+use o1vm::{
+    cannon::{self, Meta, Start, State},
+    cannon_cli,
+    interpreters::mips::{
+        constraints as mips_constraints,
+        witness::{self as mips_witness},
+    },
+    preimage_oracle::PreImageOracle,
+};
+use poly_commitment::srs::SRS;
+use std::{fs::File, io::BufReader, process::ExitCode};
+
+use mina_curves::pasta::{Fp, Vesta};
+
+pub const DOMAIN_SIZE: usize = 1 << 15;
+
+pub fn main() -> ExitCode {
+    let cli = cannon_cli::main_cli();
+
+    let configuration = cannon_cli::read_configuration(&cli.get_matches());
+
+    let file =
+        File::open(&configuration.input_state_file).expect("Error opening input state file ");
+
+    let reader = BufReader::new(file);
+    // Read the JSON contents of the file as an instance of `State`.
+    let state: State = serde_json::from_reader(reader).expect("Error reading input state file");
+
+    let meta_file = File::open(&configuration.metadata_file).unwrap_or_else(|_| {
+        panic!(
+            "Could not open metadata file {}",
+            &configuration.metadata_file
+        )
+    });
+
+    let meta: Meta = serde_json::from_reader(BufReader::new(meta_file)).unwrap_or_else(|_| {
+        panic!(
+            "Error deserializing metadata file {}",
+            &configuration.metadata_file
+        )
+    });
+
+    let mut po = PreImageOracle::create(&configuration.host);
+    let _child = po.start();
+
+    // Initialize some data used for statistical computations
+    let start = Start::create(state.step as usize);
+
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let domain_fp = EvaluationDomains::<Fp>::create(DOMAIN_SIZE).unwrap();
+    let _srs: SRS<Vesta> = {
+        let mut srs = SRS::create(DOMAIN_SIZE);
+        srs.add_lagrange_basis(domain_fp.d1);
+        srs
+    };
+
+    // Initialize the environments
+    let mut mips_wit_env =
+        mips_witness::Env::<Fp, PreImageOracle>::create(cannon::PAGE_SIZE as usize, state, po);
+    let mut _mips_con_env = mips_constraints::Env::<Fp>::default();
+
+    while !mips_wit_env.halt {
+        let instr = mips_wit_env.step(&configuration, &meta, &start);
+        println!("Executed instruction: {:?}", instr);
+    }
+
+    // TODO: Logic
+    ExitCode::SUCCESS
+}


### PR DESCRIPTION
I am not able to run it now (unstable Internet connection).
Use
```
cargo run --bin pickles_o1vm \
    --all-features \
    --release \
    -p o1vm -- \        
      --pprof.cpu \
      --info-at "${INFO_AT:-%10000000}" \
      --snapshot-state-at "${SNAPSHOT_STATE_AT:-%10000000}" \
      --proof-at never \
      --stop-at "${STOP_AT:-never}" \
      --input "${ZKVM_STATE_FILENAME:-./state.json}" \
      -- \
      ./ethereum-optimism/op-program/bin/op-program \
      --log.level DEBUG \
      --l1 "${L1_RPC}" \
      --l2 "${L2_RPC}" \
      --network sepolia \
      --datadir "${OP_PROGRAM_DATA_DIR}" \
      --l1.head "${L1_HEAD}" \
      --l2.head "${L2_HEAD}" \
      --l2.outputroot "${STARTING_OUTPUT_ROOT}" \
      --l2.claim "${L2_CLAIM}" \
      --l2.blocknumber "${L2_BLOCK_NUMBER}" \
      --server
```