### PR TITLE
[easy] Fix lower bound of zk rows for chunking

### DIFF
--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -208,9 +208,9 @@ where
             .ok_or(ProverError::NoRoomForZkInWitness)?;
 
         let zero_knowledge_limit = zk_rows_strict_lower_bound(num_chunks);
-        if (index.cs.zk_rows as usize) < zero_knowledge_limit {
+        if (index.cs.zk_rows as usize) <= zero_knowledge_limit {
             return Err(ProverError::NotZeroKnowledge(
-                zero_knowledge_limit,
+                zero_knowledge_limit + 1,
                 index.cs.zk_rows as usize,
             ));
         }


### PR DESCRIPTION
When chunking is in place, the number of rows reserved for zero knowledge must be augmented accordingly. In particular, 

```
zk_rows > (2 * permuts * chunks - 2) / 7
```

that means that `zk_rows` must at least be ` (2 * permuts * chunks - 2) / 7 + 1` or what's equivalent,  (2 * permuts * chunks - 5) / 7. Examples of this are [here](https://github.com/MinaProtocol/mina/blob/b6bdcb1a9c8f04534974f3736eb0d20c7c4552b8/src/lib/pickles/step_branch_data.ml#L200).

Nonetheless, on the Kimchi side, the strict lower bound `(2 * permuts * chunks - 2) / 7` is created [here](https://github.com/o1-labs/proof-systems/blob/97950b5ed4735a56ffab6324d88b2247e5a089d8/kimchi/src/circuits/constraints.rs#L622) and is used incorrectly when triggering the error message `ProverError::NotZeroKnowledge`. Meaning, it is raised whenever the number of rows is smaller than that value, when it should be raised anytime it is smaller or equal (because by definition, the number of rows must be **larger** than that value). 

This PR fixes that mismatch and adapts the error message accordingly. 

Example: 

With 2 chunks, the message used to read `there are not enough random rows to achieve zero-knowledge (expected: 4, got: 3)` whereas with 2 chunks you need at least 5 rows for zero knowledge.
