### PR TITLE
Rustfmt-unify imports in develop

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,3 @@
+indent_style = "Block"
+imports_granularity = "Crate"
+reorder_imports = true

--- a/curves/src/pasta/curves/tests.rs
+++ b/curves/src/pasta/curves/tests.rs
@@ -1,5 +1,4 @@
-use crate::pasta::ProjectivePallas;
-use crate::pasta::ProjectiveVesta;
+use crate::pasta::{ProjectivePallas, ProjectiveVesta};
 use ark_algebra_test_templates::*;
 
 test_group!(g1; ProjectivePallas; sw);

--- a/curves/src/pasta/fields/fp.rs
+++ b/curves/src/pasta/fields/fp.rs
@@ -1,6 +1,9 @@
 use super::fft::{FftParameters, Fp256Parameters};
-use ark_ff::fields::{MontBackend, MontConfig};
-use ark_ff::{biginteger::BigInteger256 as BigInteger, Fp256};
+use ark_ff::{
+    biginteger::BigInteger256 as BigInteger,
+    fields::{MontBackend, MontConfig},
+    Fp256,
+};
 
 #[derive(MontConfig)]
 #[modulus = "28948022309329048855892746252171976963363056481941560715954676764349967630337"]

--- a/hasher/src/tests/hasher.rs
+++ b/hasher/src/tests/hasher.rs
@@ -1,8 +1,7 @@
 use crate::{create_kimchi, create_legacy, Fp, Hashable, Hasher, ROInput};
 use o1_utils::FieldHelpers;
 use serde::Deserialize;
-use std::fs::File;
-use std::path::PathBuf;
+use std::{fs::File, path::PathBuf};
 
 //
 // Helpers for test vectors

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -28,9 +28,7 @@ use once_cell::sync::OnceCell;
 use poly_commitment::OpenProof;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
-use std::array;
-use std::default::Default;
-use std::sync::Arc;
+use std::{array, default::Default, sync::Arc};
 
 //
 // ConstraintSystem

--- a/kimchi/src/circuits/domain_constant_evaluation.rs
+++ b/kimchi/src/circuits/domain_constant_evaluation.rs
@@ -2,9 +2,10 @@
 
 use crate::circuits::domains::EvaluationDomains;
 use ark_ff::FftField;
-use ark_poly::DenseUVPolynomial;
-use ark_poly::EvaluationDomain;
-use ark_poly::{univariate::DensePolynomial as DP, Evaluations as E, Radix2EvaluationDomain as D};
+use ark_poly::{
+    univariate::DensePolynomial as DP, DenseUVPolynomial, EvaluationDomain, Evaluations as E,
+    Radix2EvaluationDomain as D,
+};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -20,11 +20,12 @@ use itertools::Itertools;
 use o1_utils::{foreign_field::ForeignFieldHelpers, FieldHelpers};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::ops::{Add, AddAssign, Mul, Neg, Sub};
-use std::{cmp::Ordering, fmt, iter::FromIterator};
 use std::{
+    cmp::Ordering,
     collections::{HashMap, HashSet},
-    ops::MulAssign,
+    fmt,
+    iter::FromIterator,
+    ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub},
 };
 use thiserror::Error;
 use CurrOrNext::{Curr, Next};
@@ -2965,8 +2966,7 @@ pub mod test {
         srs::{endos, SRS},
     };
     use rand::{prelude::StdRng, SeedableRng};
-    use std::array;
-    use std::sync::Arc;
+    use std::{array, sync::Arc};
 
     #[test]
     #[should_panic]

--- a/kimchi/src/circuits/lookup/index.rs
+++ b/kimchi/src/circuits/lookup/index.rs
@@ -500,8 +500,11 @@ mod tests {
 
     use super::{LookupError, LookupTable, RuntimeTableCfg};
     use crate::{
-        circuits::constraints::ConstraintSystem, circuits::gate::CircuitGate,
-        circuits::lookup::tables::xor, circuits::polynomials::range_check, error::SetupError,
+        circuits::{
+            constraints::ConstraintSystem, gate::CircuitGate, lookup::tables::xor,
+            polynomials::range_check,
+        },
+        error::SetupError,
     };
     use mina_curves::pasta::Fp;
 

--- a/kimchi/src/circuits/lookup/lookups.rs
+++ b/kimchi/src/circuits/lookup/lookups.rs
@@ -1,18 +1,22 @@
 use crate::circuits::{
     domains::EvaluationDomains,
     gate::{CircuitGate, CurrOrNext, GateType},
-    lookup::index::LookupSelectors,
-    lookup::tables::{
-        combine_table_entry, get_table, GateLookupTable, LookupTable, RANGE_CHECK_TABLE_ID,
-        XOR_TABLE_ID,
+    lookup::{
+        index::LookupSelectors,
+        tables::{
+            combine_table_entry, get_table, GateLookupTable, LookupTable, RANGE_CHECK_TABLE_ID,
+            XOR_TABLE_ID,
+        },
     },
 };
 use ark_ff::{Field, One, PrimeField, Zero};
 use ark_poly::{EvaluationDomain, Evaluations as E, Radix2EvaluationDomain as D};
 use o1_utils::field_helpers::i32_to_field;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
-use std::ops::{Mul, Neg};
+use std::{
+    collections::HashSet,
+    ops::{Mul, Neg},
+};
 use strum_macros::EnumIter;
 
 type Evaluations<Field> = E<Field, D<Field>>;

--- a/kimchi/src/circuits/polynomials/endomul_scalar.rs
+++ b/kimchi/src/circuits/polynomials/endomul_scalar.rs
@@ -12,8 +12,7 @@ use crate::{
     curve::KimchiCurve,
 };
 use ark_ff::{BitIteratorLE, Field, PrimeField};
-use std::array;
-use std::marker::PhantomData;
+use std::{array, marker::PhantomData};
 
 impl<F: PrimeField> CircuitGate<F> {
     /// Verify the `EndoMulscalar` gate.

--- a/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
@@ -1,11 +1,10 @@
 //! This module computes the witness of a foreign field addition circuit.
 
-use crate::circuits::expr::constraints::compact_limb;
-use crate::circuits::witness::Variables;
 use crate::{
     circuits::{
+        expr::constraints::compact_limb,
         polynomial::COLUMNS,
-        witness::{self, ConstantCell, VariableCell, WitnessCell},
+        witness::{self, ConstantCell, VariableCell, Variables, WitnessCell},
     },
     variable_map,
 };

--- a/kimchi/src/circuits/polynomials/generic.rs
+++ b/kimchi/src/circuits/polynomials/generic.rs
@@ -33,19 +33,21 @@
 //~ and c1 (resp. c2) the constant selector for the first (resp. second) gate.
 //~
 
-use crate::circuits::{
-    argument::{Argument, ArgumentEnv, ArgumentType},
-    expr::{constraints::ExprOps, Cache},
-    gate::{CircuitGate, GateType},
-    polynomial::COLUMNS,
-    wires::GateWires,
+use crate::{
+    circuits::{
+        argument::{Argument, ArgumentEnv, ArgumentType},
+        expr::{constraints::ExprOps, Cache},
+        gate::{CircuitGate, GateType},
+        polynomial::COLUMNS,
+        wires::GateWires,
+    },
+    curve::KimchiCurve,
+    prover_index::ProverIndex,
 };
-use crate::{curve::KimchiCurve, prover_index::ProverIndex};
 use ark_ff::{FftField, PrimeField, Zero};
 use ark_poly::univariate::DensePolynomial;
 use poly_commitment::OpenProof;
-use std::array;
-use std::marker::PhantomData;
+use std::{array, marker::PhantomData};
 
 /// Number of constraints produced by the gate.
 pub const CONSTRAINTS: u32 = 2;

--- a/kimchi/src/circuits/polynomials/permutation.rs
+++ b/kimchi/src/circuits/polynomials/permutation.rs
@@ -52,9 +52,8 @@ use crate::{
 use ark_ff::{FftField, PrimeField, Zero};
 use ark_poly::{
     univariate::{DenseOrSparsePolynomial, DensePolynomial},
-    EvaluationDomain, Evaluations, Radix2EvaluationDomain as D,
+    DenseUVPolynomial, EvaluationDomain, Evaluations, Polynomial, Radix2EvaluationDomain as D,
 };
-use ark_poly::{DenseUVPolynomial, Polynomial};
 use blake2::{Blake2b512, Digest};
 use o1_utils::{ExtendedDensePolynomial, ExtendedEvaluations};
 use poly_commitment::OpenProof;

--- a/kimchi/src/circuits/polynomials/range_check/witness.rs
+++ b/kimchi/src/circuits/polynomials/range_check/witness.rs
@@ -3,18 +3,15 @@
 use ark_ff::PrimeField;
 use num_bigint::BigUint;
 use num_integer::Integer;
-use o1_utils::field_helpers::BigUintFieldHelpers;
-use o1_utils::{FieldHelpers, ForeignElement};
+use o1_utils::{field_helpers::BigUintFieldHelpers, FieldHelpers, ForeignElement};
 use std::array;
 
-use crate::circuits::witness::Variables;
-use crate::variable_map;
 use crate::{
     circuits::{
         polynomial::COLUMNS,
-        witness::{init_row, CopyBitsCell, CopyCell, VariableCell, WitnessCell},
+        witness::{init_row, CopyBitsCell, CopyCell, VariableCell, Variables, WitnessCell},
     },
-    variables,
+    variable_map, variables,
 };
 use o1_utils::foreign_field::BigUintForeignFieldHelpers;
 

--- a/kimchi/src/circuits/polynomials/turshi.rs
+++ b/kimchi/src/circuits/polynomials/turshi.rs
@@ -92,8 +92,7 @@ use crate::{
 };
 use ark_ff::{FftField, Field, PrimeField};
 use rand::{prelude::StdRng, SeedableRng};
-use std::array;
-use std::marker::PhantomData;
+use std::{array, marker::PhantomData};
 use turshi::{
     runner::{CairoInstruction, CairoProgram, Pointers},
     word::{FlagBits, Offsets},

--- a/kimchi/src/circuits/serialization_helper.rs
+++ b/kimchi/src/circuits/serialization_helper.rs
@@ -5,8 +5,7 @@ use serde::{
     Deserialize, Deserializer, Serializer,
 };
 use serde_with::{de::DeserializeAsWrap, ser::SerializeAsWrap, DeserializeAs, SerializeAs};
-use std::fmt::Formatter;
-use std::marker::PhantomData;
+use std::{fmt::Formatter, marker::PhantomData};
 
 impl<F, G> SerializeAs<JointLookupValue<F>> for JointLookupValue<G>
 where

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -1,25 +1,28 @@
 //! This module implements the linearization.
 
-use crate::alphas::Alphas;
-use crate::circuits::argument::{Argument, ArgumentType};
-use crate::circuits::expr;
-use crate::circuits::lookup;
-use crate::circuits::lookup::{
-    constraints::LookupConfiguration,
-    lookups::{LookupFeatures, LookupInfo, LookupPattern, LookupPatterns},
-};
-use crate::circuits::polynomials::{
-    complete_add::CompleteAdd,
-    endomul_scalar::EndomulScalar,
-    endosclmul::EndosclMul,
-    foreign_field_add::circuitgates::ForeignFieldAdd,
-    foreign_field_mul::circuitgates::ForeignFieldMul,
-    generic, permutation,
-    poseidon::Poseidon,
-    range_check::circuitgates::{RangeCheck0, RangeCheck1},
-    rot,
-    varbasemul::VarbaseMul,
-    xor,
+use crate::{
+    alphas::Alphas,
+    circuits::{
+        argument::{Argument, ArgumentType},
+        expr, lookup,
+        lookup::{
+            constraints::LookupConfiguration,
+            lookups::{LookupFeatures, LookupInfo, LookupPattern, LookupPatterns},
+        },
+        polynomials::{
+            complete_add::CompleteAdd,
+            endomul_scalar::EndomulScalar,
+            endosclmul::EndosclMul,
+            foreign_field_add::circuitgates::ForeignFieldAdd,
+            foreign_field_mul::circuitgates::ForeignFieldMul,
+            generic, permutation,
+            poseidon::Poseidon,
+            range_check::circuitgates::{RangeCheck0, RangeCheck1},
+            rot,
+            varbasemul::VarbaseMul,
+            xor,
+        },
+    },
 };
 
 use crate::circuits::{

--- a/kimchi/src/plonk_sponge.rs
+++ b/kimchi/src/plonk_sponge.rs
@@ -1,8 +1,8 @@
 use ark_ff::{Field, PrimeField};
-use mina_poseidon::sponge::{DefaultFrSponge, ScalarChallenge};
 use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi as SC,
     poseidon::{ArithmeticSponge, ArithmeticSpongeParams, Sponge},
+    sponge::{DefaultFrSponge, ScalarChallenge},
 };
 
 use crate::proof::{PointEvaluations, ProofEvaluations};

--- a/kimchi/src/precomputed_srs.rs
+++ b/kimchi/src/precomputed_srs.rs
@@ -5,8 +5,7 @@
 //! We generate the SRS within the test in this module.
 //! If you modify the SRS, you will need to regenerate the SRS by passing the `SRS_OVERWRITE` env var.
 
-use std::path::PathBuf;
-use std::{fs::File, io::BufReader};
+use std::{fs::File, io::BufReader, path::PathBuf};
 
 use poly_commitment::srs::SRS;
 

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -49,8 +49,7 @@ use poly_commitment::{
     OpenProof, SRS as _,
 };
 use rayon::prelude::*;
-use std::array;
-use std::collections::HashMap;
+use std::{array, collections::HashMap};
 
 /// The result of a proof creation or verification.
 type Result<T> = std::result::Result<T, ProverError>;

--- a/kimchi/src/snarky/asm.rs
+++ b/kimchi/src/snarky/asm.rs
@@ -1,12 +1,16 @@
 //! An ASM-like language to print a human-friendly version of a circuit.
 
-use std::collections::{HashMap, HashSet};
-use std::fmt::Write;
-use std::hash::Hash;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Write,
+    hash::Hash,
+};
 
-use crate::circuits::gate::{Circuit, CircuitGate, GateType};
-use crate::circuits::polynomials::generic::{GENERIC_COEFFS, GENERIC_REGISTERS};
-use crate::circuits::wires::Wire;
+use crate::circuits::{
+    gate::{Circuit, CircuitGate, GateType},
+    polynomials::generic::{GENERIC_COEFFS, GENERIC_REGISTERS},
+    wires::Wire,
+};
 use ark_ff::PrimeField;
 
 /// Print a field in a negative form if it's past the half point.

--- a/kimchi/src/snarky/constraint_system.rs
+++ b/kimchi/src/snarky/constraint_system.rs
@@ -1,8 +1,10 @@
 #![allow(clippy::all)]
 
-use crate::circuits::gate::{CircuitGate, GateType};
-use crate::circuits::polynomials::poseidon::{ROUNDS_PER_HASH, SPONGE_WIDTH};
-use crate::circuits::wires::{Wire, COLUMNS, PERMUTS};
+use crate::circuits::{
+    gate::{CircuitGate, GateType},
+    polynomials::poseidon::{ROUNDS_PER_HASH, SPONGE_WIDTH},
+    wires::{Wire, COLUMNS, PERMUTS},
+};
 use ark_ff::PrimeField;
 use itertools::Itertools;
 use std::collections::{HashMap, HashSet};

--- a/kimchi/src/tests/chunked.rs
+++ b/kimchi/src/tests/chunked.rs
@@ -1,7 +1,7 @@
 use super::framework::TestFramework;
-use crate::circuits::polynomials::generic::GenericGateSpec;
 use crate::circuits::{
     gate::CircuitGate,
+    polynomials::generic::GenericGateSpec,
     wires::{Wire, COLUMNS},
 };
 use ark_ff::{UniformRand, Zero};

--- a/kimchi/src/tests/ec.rs
+++ b/kimchi/src/tests/ec.rs
@@ -10,8 +10,7 @@ use mina_poseidon::{
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use rand::{rngs::StdRng, SeedableRng};
-use std::array;
-use std::ops::Mul;
+use std::{array, ops::Mul};
 
 use super::framework::TestFramework;
 

--- a/kimchi/src/tests/endomul.rs
+++ b/kimchi/src/tests/endomul.rs
@@ -1,9 +1,11 @@
-use crate::circuits::{
-    gate::{CircuitGate, GateType},
-    polynomials::endosclmul,
-    wires::*,
+use crate::{
+    circuits::{
+        gate::{CircuitGate, GateType},
+        polynomials::endosclmul,
+        wires::*,
+    },
+    tests::framework::TestFramework,
 };
-use crate::tests::framework::TestFramework;
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{BigInteger, BitIteratorLE, Field, One, PrimeField, UniformRand, Zero};
 use mina_curves::pasta::{Fp as F, Pallas as Other, Vesta, VestaParameters};
@@ -13,8 +15,7 @@ use mina_poseidon::{
 };
 use poly_commitment::srs::endos;
 use rand::{rngs::StdRng, SeedableRng};
-use std::array;
-use std::ops::Mul;
+use std::{array, ops::Mul};
 
 type SpongeParams = PlonkSpongeConstantsKimchi;
 type BaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;

--- a/kimchi/src/tests/foreign_field_add.rs
+++ b/kimchi/src/tests/foreign_field_add.rs
@@ -1,18 +1,19 @@
 use super::framework::TestFramework;
-use crate::circuits::gate::CircuitGateResult;
-use crate::circuits::polynomials::generic::GenericGateSpec;
-use crate::circuits::{
-    constraints::ConstraintSystem,
-    gate::{CircuitGate, CircuitGateError, Connect, GateType},
-    polynomial::COLUMNS,
-    polynomials::{
-        foreign_field_add::witness::{self, FFOps},
-        range_check::{self, witness::extend_multi},
+use crate::{
+    circuits::{
+        constraints::ConstraintSystem,
+        gate::{CircuitGate, CircuitGateError, CircuitGateResult, Connect, GateType},
+        polynomial::COLUMNS,
+        polynomials::{
+            foreign_field_add::witness::{self, FFOps},
+            generic::GenericGateSpec,
+            range_check::{self, witness::extend_multi},
+        },
+        wires::Wire,
     },
-    wires::Wire,
+    curve::KimchiCurve,
+    prover_index::ProverIndex,
 };
-use crate::curve::KimchiCurve;
-use crate::prover_index::ProverIndex;
 use ark_ec::AffineRepr;
 use ark_ff::{One, PrimeField, Zero};
 use ark_poly::EvaluationDomain;
@@ -32,8 +33,7 @@ use poly_commitment::{
     srs::{endos, SRS},
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
-use std::array;
-use std::sync::Arc;
+use std::{array, sync::Arc};
 type PallasField = <Pallas as AffineRepr>::BaseField;
 type VestaField = <Vesta as AffineRepr>::BaseField;
 

--- a/kimchi/src/tests/generic.rs
+++ b/kimchi/src/tests/generic.rs
@@ -1,6 +1,8 @@
 use super::framework::TestFramework;
-use crate::circuits::polynomials::generic::testing::{create_circuit, fill_in_witness};
-use crate::circuits::wires::COLUMNS;
+use crate::circuits::{
+    polynomials::generic::testing::{create_circuit, fill_in_witness},
+    wires::COLUMNS,
+};
 use ark_ff::Zero;
 use mina_curves::pasta::{Fp, Vesta, VestaParameters};
 use mina_poseidon::{

--- a/kimchi/src/tests/lookup.rs
+++ b/kimchi/src/tests/lookup.rs
@@ -14,8 +14,7 @@ use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
-use rand::prelude::*;
-use rand::Rng;
+use rand::{prelude::*, Rng};
 use std::array;
 
 type SpongeParams = PlonkSpongeConstantsKimchi;

--- a/kimchi/src/tests/range_check.rs
+++ b/kimchi/src/tests/range_check.rs
@@ -27,8 +27,7 @@ use o1_utils::{
 };
 use rand::{rngs::StdRng, SeedableRng};
 
-use std::array;
-use std::sync::Arc;
+use std::{array, sync::Arc};
 
 use crate::{prover_index::ProverIndex, verifier::verify};
 use groupmap::GroupMap;

--- a/kimchi/src/tests/recursion.rs
+++ b/kimchi/src/tests/recursion.rs
@@ -1,10 +1,13 @@
 use super::framework::TestFramework;
-use crate::circuits::polynomials::generic::testing::{create_circuit, fill_in_witness};
-use crate::circuits::wires::COLUMNS;
-use crate::proof::RecursionChallenge;
+use crate::{
+    circuits::{
+        polynomials::generic::testing::{create_circuit, fill_in_witness},
+        wires::COLUMNS,
+    },
+    proof::RecursionChallenge,
+};
 use ark_ff::{UniformRand, Zero};
-use ark_poly::univariate::DensePolynomial;
-use ark_poly::DenseUVPolynomial;
+use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial};
 use mina_curves::pasta::{Fp, Vesta, VestaParameters};
 use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi,

--- a/kimchi/src/tests/serde.rs
+++ b/kimchi/src/tests/serde.rs
@@ -18,8 +18,7 @@ use mina_poseidon::{
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use poly_commitment::{commitment::CommitmentCurve, evaluation_proof::OpeningProof, srs::SRS};
-use std::array;
-use std::time::Instant;
+use std::{array, time::Instant};
 
 type SpongeParams = PlonkSpongeConstantsKimchi;
 type BaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;

--- a/kimchi/src/tests/varbasemul.rs
+++ b/kimchi/src/tests/varbasemul.rs
@@ -1,9 +1,11 @@
-use crate::circuits::{
-    gate::{CircuitGate, GateType},
-    polynomials::varbasemul,
-    wires::*,
+use crate::{
+    circuits::{
+        gate::{CircuitGate, GateType},
+        polynomials::varbasemul,
+        wires::*,
+    },
+    tests::framework::TestFramework,
 };
-use crate::tests::framework::TestFramework;
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{BigInteger, BitIteratorLE, Field, One, PrimeField, UniformRand, Zero};
 use colored::Colorize;
@@ -13,9 +15,7 @@ use mina_poseidon::{
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use rand::{rngs::StdRng, SeedableRng};
-use std::array;
-use std::ops::Mul;
-use std::time::Instant;
+use std::{array, ops::Mul, time::Instant};
 
 type SpongeParams = PlonkSpongeConstantsKimchi;
 type BaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -22,8 +22,8 @@ use poly_commitment::{
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
-use std::array;
 use std::{
+    array,
     fs::{File, OpenOptions},
     io::{BufReader, BufWriter, Seek, SeekFrom::Start},
     path::Path,

--- a/poly-commitment/src/chunked.rs
+++ b/poly-commitment/src/chunked.rs
@@ -2,8 +2,7 @@ use ark_ec::CurveGroup;
 use ark_ff::{Field, Zero};
 use std::ops::AddAssign;
 
-use crate::commitment::CommitmentCurve;
-use crate::PolyComm;
+use crate::{commitment::CommitmentCurve, PolyComm};
 
 impl<C> PolyComm<C>
 where

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -6,9 +6,11 @@
 //!     producing the batched opening proof
 //! 3. Verify batch of batched opening proofs
 
-use crate::srs::endos;
-use crate::SRS as SRSTrait;
-use crate::{error::CommitmentError, srs::SRS};
+use crate::{
+    error::CommitmentError,
+    srs::{endos, SRS},
+    SRS as SRSTrait,
+};
 use ark_ec::{
     models::short_weierstrass::Affine as SWJAffine, short_weierstrass::SWCurveConfig, AffineRepr,
     CurveGroup, VariableBaseMSM,
@@ -21,8 +23,7 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use core::ops::{Add, AddAssign, Sub};
 use groupmap::{BWParameters, GroupMap};
 use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
-use o1_utils::math;
-use o1_utils::ExtendedDensePolynomial as _;
+use o1_utils::{math, ExtendedDensePolynomial as _};
 use rand_core::{CryptoRng, RngCore};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -815,8 +816,7 @@ mod tests {
     use crate::srs::SRS;
     use ark_poly::{DenseUVPolynomial, Polynomial, Radix2EvaluationDomain};
     use mina_curves::pasta::{Fp, Vesta as VestaG};
-    use mina_poseidon::constants::PlonkSpongeConstantsKimchi as SC;
-    use mina_poseidon::sponge::DefaultFqSponge;
+    use mina_poseidon::{constants::PlonkSpongeConstantsKimchi as SC, sponge::DefaultFqSponge};
     use rand::{rngs::StdRng, SeedableRng};
     use std::array;
 

--- a/poly-commitment/src/evaluation_proof.rs
+++ b/poly-commitment/src/evaluation_proof.rs
@@ -1,9 +1,11 @@
-use crate::{commitment::*, srs::endos};
-use crate::{srs::SRS, PolynomialsToCombine, SRS as _};
+use crate::{
+    commitment::*,
+    srs::{endos, SRS},
+    PolynomialsToCombine, SRS as _,
+};
 use ark_ec::{AffineRepr, CurveGroup, VariableBaseMSM};
 use ark_ff::{FftField, Field, One, PrimeField, UniformRand, Zero};
-use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial};
-use ark_poly::{EvaluationDomain, Evaluations};
+use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, Evaluations};
 use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
 use o1_utils::{math, ExtendedDensePolynomial};
 use rand_core::{CryptoRng, RngCore};

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -11,9 +11,11 @@ mod tests;
 
 pub use commitment::PolyComm;
 
-use crate::commitment::{BatchEvaluationProof, BlindedCommitment, CommitmentCurve};
-use crate::error::CommitmentError;
-use crate::evaluation_proof::DensePolynomialOrEvaluations;
+use crate::{
+    commitment::{BatchEvaluationProof, BlindedCommitment, CommitmentCurve},
+    error::CommitmentError,
+    evaluation_proof::DensePolynomialOrEvaluations,
+};
 use ark_ec::AffineRepr;
 use ark_ff::UniformRand;
 use ark_poly::{

--- a/poly-commitment/src/pairing_proof.rs
+++ b/poly-commitment/src/pairing_proof.rs
@@ -1,7 +1,7 @@
-use crate::commitment::*;
-use crate::evaluation_proof::combine_polys;
-use crate::srs::SRS;
-use crate::{CommitmentError, PolynomialsToCombine, SRS as SRSTrait};
+use crate::{
+    commitment::*, evaluation_proof::combine_polys, srs::SRS, CommitmentError,
+    PolynomialsToCombine, SRS as SRSTrait,
+};
 use ark_ec::{pairing::Pairing, AffineRepr, VariableBaseMSM};
 use ark_ff::{PrimeField, Zero};
 use ark_poly::{
@@ -329,12 +329,10 @@ impl<
 #[cfg(test)]
 mod tests {
     use super::{PairingProof, PairingSRS};
-    use crate::commitment::Evaluation;
-    use crate::evaluation_proof::DensePolynomialOrEvaluations;
-    use crate::srs::SRS;
-    use crate::SRS as _;
-    use ark_bn254::Fr as ScalarField;
-    use ark_bn254::{Config, G1Affine as G1, G2Affine as G2};
+    use crate::{
+        commitment::Evaluation, evaluation_proof::DensePolynomialOrEvaluations, srs::SRS, SRS as _,
+    };
+    use ark_bn254::{Config, Fr as ScalarField, G1Affine as G1, G2Affine as G2};
     use ark_ec::bn::Bn;
     use ark_ff::UniformRand;
     use ark_poly::{

--- a/poly-commitment/src/srs.rs
+++ b/poly-commitment/src/srs.rs
@@ -1,7 +1,6 @@
 //! This module implements the Marlin structured reference string primitive
 
-use crate::commitment::CommitmentCurve;
-use crate::PolyComm;
+use crate::{commitment::CommitmentCurve, PolyComm};
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{BigInteger, Field, One, PrimeField, Zero};
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as D};
@@ -11,9 +10,7 @@ use groupmap::GroupMap;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::array;
-use std::cmp::min;
-use std::collections::HashMap;
+use std::{array, cmp::min, collections::HashMap};
 
 #[serde_as]
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Eq)]

--- a/poly-commitment/src/tests/batch_15_wires.rs
+++ b/poly-commitment/src/tests/batch_15_wires.rs
@@ -12,9 +12,9 @@ use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, Radix2EvaluationD
 use colored::Colorize;
 use groupmap::GroupMap;
 use mina_curves::pasta::{Fp, Vesta, VestaParameters};
-use mina_poseidon::constants::PlonkSpongeConstantsKimchi as SC;
-use mina_poseidon::sponge::DefaultFqSponge;
-use mina_poseidon::FqSponge;
+use mina_poseidon::{
+    constants::PlonkSpongeConstantsKimchi as SC, sponge::DefaultFqSponge, FqSponge,
+};
 use o1_utils::ExtendedDensePolynomial as _;
 use rand::Rng;
 use std::time::{Duration, Instant};

--- a/poly-commitment/src/tests/commitment.rs
+++ b/poly-commitment/src/tests/commitment.rs
@@ -12,9 +12,9 @@ use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, Radix2EvaluationD
 use colored::Colorize;
 use groupmap::GroupMap;
 use mina_curves::pasta::{Fp, Vesta, VestaParameters};
-use mina_poseidon::constants::PlonkSpongeConstantsKimchi as SC;
-use mina_poseidon::sponge::DefaultFqSponge;
-use mina_poseidon::FqSponge as _;
+use mina_poseidon::{
+    constants::PlonkSpongeConstantsKimchi as SC, sponge::DefaultFqSponge, FqSponge as _,
+};
 use o1_utils::ExtendedDensePolynomial as _;
 use rand::{CryptoRng, Rng, SeedableRng};
 use std::time::{Duration, Instant};

--- a/poseidon/export_test_vectors/src/main.rs
+++ b/poseidon/export_test_vectors/src/main.rs
@@ -8,10 +8,12 @@ fn main() {
 
 mod inner {
     use super::vectors;
-    use std::env;
-    use std::fs::File;
-    use std::io::{self, Write};
-    use std::str::FromStr;
+    use std::{
+        env,
+        fs::File,
+        io::{self, Write},
+        str::FromStr,
+    };
 
     #[derive(Debug)]
     pub enum Mode {

--- a/poseidon/src/permutation.rs
+++ b/poseidon/src/permutation.rs
@@ -1,7 +1,9 @@
 //! The permutation module contains the function implementing the permutation used in Poseidon
 
-use crate::constants::SpongeConstants;
-use crate::poseidon::{sbox, ArithmeticSpongeParams};
+use crate::{
+    constants::SpongeConstants,
+    poseidon::{sbox, ArithmeticSpongeParams},
+};
 use ark_ff::Field;
 
 fn apply_mds_matrix<F: Field, SC: SpongeConstants>(

--- a/poseidon/src/poseidon.rs
+++ b/poseidon/src/poseidon.rs
@@ -1,7 +1,9 @@
 //! This module implements Poseidon Hash Function primitive
 
-use crate::constants::SpongeConstants;
-use crate::permutation::{full_round, poseidon_block_cipher};
+use crate::{
+    constants::SpongeConstants,
+    permutation::{full_round, poseidon_block_cipher},
+};
 use ark_ff::Field;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use serde::{Deserialize, Serialize};

--- a/poseidon/src/sponge.rs
+++ b/poseidon/src/sponge.rs
@@ -1,5 +1,7 @@
-use crate::constants::SpongeConstants;
-use crate::poseidon::{ArithmeticSponge, ArithmeticSpongeParams, Sponge};
+use crate::{
+    constants::SpongeConstants,
+    poseidon::{ArithmeticSponge, ArithmeticSpongeParams, Sponge},
+};
 use ark_ec::models::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ff::{BigInteger, Field, One, PrimeField, Zero};
 

--- a/poseidon/src/tests/poseidon_tests.rs
+++ b/poseidon/src/tests/poseidon_tests.rs
@@ -1,15 +1,12 @@
 use crate::{
     constants::{PlonkSpongeConstantsKimchi, PlonkSpongeConstantsLegacy},
-    pasta::fp_kimchi as SpongeParametersKimchi,
-    pasta::fp_legacy as SpongeParametersLegacy,
-    poseidon::ArithmeticSponge as Poseidon,
-    poseidon::Sponge as _,
+    pasta::{fp_kimchi as SpongeParametersKimchi, fp_legacy as SpongeParametersLegacy},
+    poseidon::{ArithmeticSponge as Poseidon, Sponge as _},
 };
 use mina_curves::pasta::Fp;
 use o1_utils::FieldHelpers;
 use serde::Deserialize;
-use std::fs::File;
-use std::path::PathBuf; // needed for ::new() sponge
+use std::{fs::File, path::PathBuf}; // needed for ::new() sponge
 
 //
 // Helpers for test vectors

--- a/turshi/src/memory.rs
+++ b/turshi/src/memory.rs
@@ -1,11 +1,12 @@
 //! This module represents the Cairo memory, containing the
 //! compiled Cairo program that occupies the first few entries
 
-use std::fmt::{Display, Formatter, Result};
-use std::ops::{Index, IndexMut};
+use std::{
+    fmt::{Display, Formatter, Result},
+    ops::{Index, IndexMut},
+};
 
-use crate::helper::*;
-use crate::word::CairoWord;
+use crate::{helper::*, word::CairoWord};
 use ark_ff::Field;
 use core::iter::repeat;
 

--- a/turshi/src/runner.rs
+++ b/turshi/src/runner.rs
@@ -1,9 +1,11 @@
 //! This module represents a run of a Cairo program as a series of consecutive
 //! execution steps, each of which define the execution logic of Cairo instructions
 
-use crate::flags::*;
-use crate::memory::CairoMemory;
-use crate::word::{CairoWord, FlagBits, FlagSets, Offsets};
+use crate::{
+    flags::*,
+    memory::CairoMemory,
+    word::{CairoWord, FlagBits, FlagSets, Offsets},
+};
 use ark_ff::Field;
 
 /// A structure to store program counter, allocation pointer and frame pointer

--- a/turshi/src/word.rs
+++ b/turshi/src/word.rs
@@ -4,8 +4,7 @@
 //! Our Pallas curves have 255 bits, so Cairo native instructions will fit.
 //! This means that our Cairo implementation can admit a larger domain for immediate values than theirs.
 
-use crate::flags::*;
-use crate::helper::CairoFieldHelpers;
+use crate::{flags::*, helper::CairoFieldHelpers};
 use ark_ff::Field;
 use o1_utils::field_helpers::FieldHelpers;
 
@@ -244,8 +243,10 @@ impl<F: Field> FlagSets<F> for CairoWord<F> {
 
 #[cfg(test)]
 mod tests {
-    use crate::flags::*;
-    use crate::word::{FlagBits, FlagSets, Offsets};
+    use crate::{
+        flags::*,
+        word::{FlagBits, FlagSets, Offsets},
+    };
     use ark_ff::{One, Zero};
     use mina_curves::pasta::Fp as F;
 

--- a/utils/src/foreign_field.rs
+++ b/utils/src/foreign_field.rs
@@ -4,9 +4,11 @@ use crate::field_helpers::FieldHelpers;
 use ark_ff::{Field, PrimeField};
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
-use std::array;
-use std::fmt::{Debug, Formatter};
-use std::ops::{Index, IndexMut};
+use std::{
+    array,
+    fmt::{Debug, Formatter},
+    ops::{Index, IndexMut},
+};
 
 /// Index of low limb (in 3-limb foreign elements)
 pub const LO: usize = 0;

--- a/utils/src/serialization.rs
+++ b/utils/src/serialization.rs
@@ -93,8 +93,7 @@ mod tests {
 
     use ark_ec::short_weierstrass::SWCurveConfig;
     use ark_serialize::Write;
-    use mina_curves::pasta::{Pallas, Vesta};
-    use mina_curves::pasta::{PallasParameters, VestaParameters};
+    use mina_curves::pasta::{Pallas, PallasParameters, Vesta, VestaParameters};
     use serde::{Deserialize, Serialize};
     use serde_with::serde_as;
     use std::io::BufReader;


### PR DESCRIPTION
This was done half a year ago in `master` but never reached `develop` which is a big source of annoying diffs. 

https://github.com/o1-labs/proof-systems/pull/2044