### PR TITLE
Mina_curves: activating ADX instructions by default

### DIFF
--- a/curves/Cargo.toml
+++ b/curves/Cargo.toml
@@ -19,3 +19,7 @@ rand.workspace = true
 ark-algebra-test-templates.workspace = true
 ark-std.workspace = true
 ark-serialize.workspace = true
+
+[features]
+asm = []
+default = ["asm"]


### PR DESCRIPTION
Spotted by @sebastiencs.

ADX instructions are not activated otherwise. However, this change activates it all the time, and compiling on machines not supporting ADX will fail. Is it what we want? 