### PR TITLE
Poly_commitment: move CamlOpeningProof into eval_proof where defined

### DIFF
--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1508,8 +1508,8 @@ pub mod caml {
     use crate::proof::caml::{CamlProofEvaluations, CamlRecursionChallenge};
     use ark_ec::AffineRepr;
     use poly_commitment::{
-        commitment::caml::{CamlOpeningProof, CamlPolyComm},
-        evaluation_proof::OpeningProof,
+        commitment::caml::CamlPolyComm,
+        evaluation_proof::{caml::CamlOpeningProof, OpeningProof},
     };
 
     #[cfg(feature = "internal_tracing")]
@@ -1533,7 +1533,8 @@ pub mod caml {
         pub evals: CamlProofEvaluations<CamlF>,
         pub ft_eval1: CamlF,
         pub public: Vec<CamlF>,
-        pub prev_challenges: Vec<CamlRecursionChallenge<CamlG, CamlF>>, //Vec<(Vec<CamlF>, CamlPolyComm<CamlG>)>,
+        //Vec<(Vec<CamlF>, CamlPolyComm<CamlG>)>,
+        pub prev_challenges: Vec<CamlRecursionChallenge<CamlG, CamlF>>,
     }
 
     //
@@ -1585,8 +1586,10 @@ pub mod caml {
     // ProverCommitments<G> -> CamlProverCommitments<CamlG>
     // we need to know how to convert G to CamlG.
     // we don't know that information, unless we implemented some trait (e.g. ToCaml)
-    // we can do that, but instead we implemented the From trait for the reverse operations (From<G> for CamlG).
-    // it reduces the complexity, but forces us to do the conversion in two phases instead of one.
+    // we can do that, but instead we implemented the From trait for the reverse
+    // operations (From<G> for CamlG).
+    // it reduces the complexity, but forces us to do the conversion in two
+    // phases instead of one.
 
     //
     // CamlLookupCommitments<CamlG> <-> LookupCommitments<G>

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -966,9 +966,9 @@ pub fn inner_prod<F: Field>(xs: &[F], ys: &[F]) -> F {
 
 #[cfg(feature = "ocaml_types")]
 pub mod caml {
-    use super::*;
-
     // polynomial commitment
+    use super::PolyComm;
+    use ark_ec::AffineRepr;
 
     #[derive(Clone, Debug, ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
     pub struct CamlPolyComm<CamlG> {
@@ -1035,60 +1035,6 @@ pub mod caml {
             PolyComm {
                 //FIXME something with as_ref()
                 elems: camlpolycomm.unshifted.iter().map(Into::into).collect(),
-            }
-        }
-    }
-
-    // opening proof
-
-    #[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
-    pub struct CamlOpeningProof<G, F> {
-        /// vector of rounds of L & R commitments
-        pub lr: Vec<(G, G)>,
-        pub delta: G,
-        pub z1: F,
-        pub z2: F,
-        pub sg: G,
-    }
-
-    impl<G, CamlF, CamlG> From<OpeningProof<G>> for CamlOpeningProof<CamlG, CamlF>
-    where
-        G: AffineRepr,
-        CamlG: From<G>,
-        CamlF: From<G::ScalarField>,
-    {
-        fn from(opening_proof: OpeningProof<G>) -> Self {
-            Self {
-                lr: opening_proof
-                    .lr
-                    .into_iter()
-                    .map(|(g1, g2)| (CamlG::from(g1), CamlG::from(g2)))
-                    .collect(),
-                delta: CamlG::from(opening_proof.delta),
-                z1: opening_proof.z1.into(),
-                z2: opening_proof.z2.into(),
-                sg: CamlG::from(opening_proof.sg),
-            }
-        }
-    }
-
-    impl<G, CamlF, CamlG> From<CamlOpeningProof<CamlG, CamlF>> for OpeningProof<G>
-    where
-        G: AffineRepr,
-        CamlG: Into<G>,
-        CamlF: Into<G::ScalarField>,
-    {
-        fn from(caml: CamlOpeningProof<CamlG, CamlF>) -> Self {
-            Self {
-                lr: caml
-                    .lr
-                    .into_iter()
-                    .map(|(g1, g2)| (g1.into(), g2.into()))
-                    .collect(),
-                delta: caml.delta.into(),
-                z1: caml.z1.into(),
-                z2: caml.z2.into(),
-                sg: caml.sg.into(),
             }
         }
     }


### PR DESCRIPTION
It is more logical to move where OpeningProof is defined. This way, it follows the convention.