### PR TITLE
Re-enable updated specification CI check for `develop`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,9 @@ jobs:
           cd book/specifications/poly-commitment
           make build
 
-      # TODO: re-enable this check once proper specs are in place (broken links were fixed and needs to be under the version control to produce proper Git diff)
-      # - name: Check that up-to-date specification is checked in
-      #   run: |
-      #     git diff --exit-code ":(exclude)rust-toolchain"
+      - name: Check that up-to-date specification is checked in
+        run: |
+          git diff --exit-code ":(exclude)rust-toolchain"
 
       - name: Build cargo docs
         run: |


### PR DESCRIPTION
Closes #2582.