### PR TITLE
Poly-commitment: move combine_evaluations in kzg module

### DIFF
--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -10,7 +10,7 @@ use ark_ec::{
     models::short_weierstrass::Affine as SWJAffine, short_weierstrass::SWCurveConfig, AffineRepr,
     CurveGroup, VariableBaseMSM,
 };
-use ark_ff::{BigInteger, Field, One, PrimeField, Zero};
+use ark_ff::{BigInteger, Field, One, PrimeField};
 use ark_poly::univariate::DensePolynomial;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use core::ops::{Add, Sub};
@@ -548,64 +548,6 @@ pub fn combine_commitments<G: CommitmentCurve>(
             xi_i *= polyscale;
         }
     }
-}
-
-/// Combine the (chunked) evaluations of multiple polynomials.
-/// This function returns the accumulation of the evaluations, scaled by
-/// `polyscale`.
-/// If no evaluation is given, the function returns an empty vector.
-/// It does also suppose that for each evaluation, the number of evaluations is
-/// the same. It is not constrained yet in the interface, but it should be. If
-/// one list has not the same size, it will be shrunk to the size of the first
-/// element of the list.
-/// For instance, if we have 3 polynomials P1, P2, P3 evaluated at the points
-/// ζ and ζω (like in vanilla PlonK), and for each polynomial, we have two
-/// chunks, i.e. we have
-/// ```text
-///         2 chunks of P1
-///        /---------------\
-/// E1 = [(P1_1(ζ), P1_2(ζ)), (P1_1(ζω), P1_2(ζω))]
-/// E2 = [(P2_1(ζ), P2_2(ζ)), (P2_1(ζω), P2_2(ζω))]
-/// E3 = [(P3_1(ζ), P3_2(ζ)), (P3_1(ζω), P3_2(ζω))]
-/// ```
-/// The output will be a list of 3 elements, equal to:
-/// ```text
-/// P1_1(ζ) + P1_2(ζ) * polyscale + P1_1(ζω) polyscale^2 + P1_2(ζω) * polyscale^3
-/// P2_1(ζ) + P2_2(ζ) * polyscale + P2_1(ζω) polyscale^2 + P2_2(ζω) * polyscale^3
-/// ```
-pub fn combine_evaluations<G: CommitmentCurve>(
-    evaluations: &Vec<Evaluation<G>>,
-    polyscale: G::ScalarField,
-) -> Vec<G::ScalarField> {
-    let mut xi_i = G::ScalarField::one();
-    let mut acc = {
-        let num_evals = if !evaluations.is_empty() {
-            evaluations[0].evaluations.len()
-        } else {
-            0
-        };
-        vec![G::ScalarField::zero(); num_evals]
-    };
-
-    for Evaluation { evaluations, .. } in evaluations
-        .iter()
-        .filter(|x| !x.commitment.elems.is_empty())
-    {
-        // IMPROVEME: we could have a flat array that would contain all the
-        // evaluations and all the chunks. It would avoid fetching the memory
-        // and avoid indirection into RAM.
-        // We could have a single flat array.
-        // iterating over the polynomial segments
-        for chunk_idx in 0..evaluations[0].len() {
-            // supposes that all evaluations are of the same size
-            for eval_pt_idx in 0..evaluations.len() {
-                acc[eval_pt_idx] += evaluations[eval_pt_idx][chunk_idx] * xi_i;
-            }
-            xi_i *= polyscale;
-        }
-    }
-
-    acc
 }
 
 #[cfg(feature = "ocaml_types")]

--- a/poly-commitment/src/kzg.rs
+++ b/poly-commitment/src/kzg.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 use ark_ec::{pairing::Pairing, AffineRepr, VariableBaseMSM};
-use ark_ff::{PrimeField, Zero};
+use ark_ff::{One, PrimeField, Zero};
 use ark_poly::{
     univariate::{DenseOrSparsePolynomial, DensePolynomial},
     DenseUVPolynomial, EvaluationDomain, Evaluations, Polynomial, Radix2EvaluationDomain as D,
@@ -26,6 +26,64 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::ops::Neg;
+
+/// Combine the (chunked) evaluations of multiple polynomials.
+/// This function returns the accumulation of the evaluations, scaled by
+/// `polyscale`.
+/// If no evaluation is given, the function returns an empty vector.
+/// It does also suppose that for each evaluation, the number of evaluations is
+/// the same. It is not constrained yet in the interface, but it should be. If
+/// one list has not the same size, it will be shrunk to the size of the first
+/// element of the list.
+/// For instance, if we have 3 polynomials P1, P2, P3 evaluated at the points
+/// ζ and ζω (like in vanilla PlonK), and for each polynomial, we have two
+/// chunks, i.e. we have
+/// ```text
+///         2 chunks of P1
+///        /---------------\
+/// E1 = [(P1_1(ζ), P1_2(ζ)), (P1_1(ζω), P1_2(ζω))]
+/// E2 = [(P2_1(ζ), P2_2(ζ)), (P2_1(ζω), P2_2(ζω))]
+/// E3 = [(P3_1(ζ), P3_2(ζ)), (P3_1(ζω), P3_2(ζω))]
+/// ```
+/// The output will be a list of 3 elements, equal to:
+/// ```text
+/// P1_1(ζ) + P1_2(ζ) * polyscale + P1_1(ζω) polyscale^2 + P1_2(ζω) * polyscale^3
+/// P2_1(ζ) + P2_2(ζ) * polyscale + P2_1(ζω) polyscale^2 + P2_2(ζω) * polyscale^3
+/// ```
+pub fn combine_evaluations<G: CommitmentCurve>(
+    evaluations: &Vec<Evaluation<G>>,
+    polyscale: G::ScalarField,
+) -> Vec<G::ScalarField> {
+    let mut xi_i = G::ScalarField::one();
+    let mut acc = {
+        let num_evals = if !evaluations.is_empty() {
+            evaluations[0].evaluations.len()
+        } else {
+            0
+        };
+        vec![G::ScalarField::zero(); num_evals]
+    };
+
+    for Evaluation { evaluations, .. } in evaluations
+        .iter()
+        .filter(|x| !x.commitment.elems.is_empty())
+    {
+        // IMPROVEME: we could have a flat array that would contain all the
+        // evaluations and all the chunks. It would avoid fetching the memory
+        // and avoid indirection into RAM.
+        // We could have a single flat array.
+        // iterating over the polynomial segments
+        for chunk_idx in 0..evaluations[0].len() {
+            // supposes that all evaluations are of the same size
+            for eval_pt_idx in 0..evaluations.len() {
+                acc[eval_pt_idx] += evaluations[eval_pt_idx][chunk_idx] * xi_i;
+            }
+            xi_i *= polyscale;
+        }
+    }
+
+    acc
+}
 
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize)]

--- a/poly-commitment/tests/ipa_commitment.rs
+++ b/poly-commitment/tests/ipa_commitment.rs
@@ -1,4 +1,3 @@
-use ark_ec::AffineRepr;
 use ark_ff::{One, UniformRand, Zero};
 use ark_poly::{
     univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, Evaluations, Polynomial,
@@ -11,134 +10,12 @@ use mina_poseidon::{
 };
 use o1_utils::ExtendedDensePolynomial;
 use poly_commitment::{
-    commitment::{
-        combine_evaluations, combined_inner_product, BatchEvaluationProof, CommitmentCurve,
-        Evaluation,
-    },
+    commitment::{combined_inner_product, BatchEvaluationProof, CommitmentCurve, Evaluation},
     ipa::{DensePolynomialOrEvaluations, SRS},
     PolyComm, SRS as _,
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::array;
-
-#[test]
-fn test_combine_evaluations() {
-    let nb_of_chunks = 1;
-
-    // we ignore commitments
-    let dummy_commitments = PolyComm::<VestaG> {
-        elems: vec![VestaG::zero(); nb_of_chunks],
-    };
-
-    let polyscale = Fp::from(2);
-    // Using only one evaluation. Starting with eval_p1
-    {
-        let eval_p1 = Evaluation {
-            commitment: dummy_commitments.clone(),
-            evaluations: vec![
-                // Eval at first point. Only one chunk.
-                vec![Fp::from(1)],
-                // Eval at second point. Only one chunk.
-                vec![Fp::from(2)],
-            ],
-        };
-
-        let output = combine_evaluations::<VestaG>(&vec![eval_p1], polyscale);
-        // We have 2 evaluation points.
-        assert_eq!(output.len(), 2);
-        // polyscale is not used.
-        let exp_output = [Fp::from(1), Fp::from(2)];
-        output.iter().zip(exp_output.iter()).for_each(|(o, e)| {
-            assert_eq!(o, e);
-        });
-    }
-
-    // And after that eval_p2
-    {
-        let eval_p2 = Evaluation {
-            commitment: dummy_commitments.clone(),
-            evaluations: vec![
-                // Eval at first point. Only one chunk.
-                vec![Fp::from(3)],
-                // Eval at second point. Only one chunk.
-                vec![Fp::from(4)],
-            ],
-        };
-
-        let output = combine_evaluations::<VestaG>(&vec![eval_p2], polyscale);
-        // We have 2 evaluation points
-        assert_eq!(output.len(), 2);
-        // polyscale is not used.
-        let exp_output = [Fp::from(3), Fp::from(4)];
-        output.iter().zip(exp_output.iter()).for_each(|(o, e)| {
-            assert_eq!(o, e);
-        });
-    }
-
-    // Now with two evaluations
-    {
-        let eval_p1 = Evaluation {
-            commitment: dummy_commitments.clone(),
-            evaluations: vec![
-                // Eval at first point. Only one chunk.
-                vec![Fp::from(1)],
-                // Eval at second point. Only one chunk.
-                vec![Fp::from(2)],
-            ],
-        };
-
-        let eval_p2 = Evaluation {
-            commitment: dummy_commitments.clone(),
-            evaluations: vec![
-                // Eval at first point. Only one chunk.
-                vec![Fp::from(3)],
-                // Eval at second point. Only one chunk.
-                vec![Fp::from(4)],
-            ],
-        };
-
-        let output = combine_evaluations::<VestaG>(&vec![eval_p1, eval_p2], polyscale);
-        // We have 2 evaluation points
-        assert_eq!(output.len(), 2);
-        let exp_output = [Fp::from(1 + 3 * 2), Fp::from(2 + 4 * 2)];
-        output.iter().zip(exp_output.iter()).for_each(|(o, e)| {
-            assert_eq!(o, e);
-        });
-    }
-
-    // Now with two evaluations and two chunks
-    {
-        let eval_p1 = Evaluation {
-            commitment: dummy_commitments.clone(),
-            evaluations: vec![
-                // Eval at first point.
-                vec![Fp::from(1), Fp::from(3)],
-                // Eval at second point.
-                vec![Fp::from(2), Fp::from(4)],
-            ],
-        };
-
-        let eval_p2 = Evaluation {
-            commitment: dummy_commitments.clone(),
-            evaluations: vec![
-                // Eval at first point.
-                vec![Fp::from(5), Fp::from(7)],
-                // Eval at second point.
-                vec![Fp::from(6), Fp::from(8)],
-            ],
-        };
-
-        let output = combine_evaluations::<VestaG>(&vec![eval_p1, eval_p2], polyscale);
-        // We have 2 evaluation points
-        assert_eq!(output.len(), 2);
-        let o1 = Fp::from(1 + 3 * 2 + 5 * 4 + 7 * 8);
-        let o2 = Fp::from(2 + 4 * 2 + 6 * 4 + 8 * 8);
-        let exp_output = [o1, o2];
-        output.iter().zip(exp_output.iter()).for_each(|(o, e)| {
-            assert_eq!(o, e);
-        });
-    }
-}
 
 #[test]
 fn test_lagrange_commitments() {

--- a/poly-commitment/tests/kzg.rs
+++ b/poly-commitment/tests/kzg.rs
@@ -6,12 +6,132 @@ use ark_poly::{
     Radix2EvaluationDomain as D,
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use mina_curves::pasta::{Fp, Vesta as VestaG};
 use poly_commitment::{
     commitment::Evaluation,
     ipa::{DensePolynomialOrEvaluations, SRS},
-    kzg::{KZGProof, PairingSRS},
-    SRS as _,
+    kzg::{combine_evaluations, KZGProof, PairingSRS},
+    PolyComm, SRS as _,
 };
+
+#[test]
+fn test_combine_evaluations() {
+    let nb_of_chunks = 1;
+
+    // we ignore commitments
+    let dummy_commitments = PolyComm::<VestaG> {
+        elems: vec![VestaG::zero(); nb_of_chunks],
+    };
+
+    let polyscale = Fp::from(2);
+    // Using only one evaluation. Starting with eval_p1
+    {
+        let eval_p1 = Evaluation {
+            commitment: dummy_commitments.clone(),
+            evaluations: vec![
+                // Eval at first point. Only one chunk.
+                vec![Fp::from(1)],
+                // Eval at second point. Only one chunk.
+                vec![Fp::from(2)],
+            ],
+        };
+
+        let output = combine_evaluations::<VestaG>(&vec![eval_p1], polyscale);
+        // We have 2 evaluation points.
+        assert_eq!(output.len(), 2);
+        // polyscale is not used.
+        let exp_output = [Fp::from(1), Fp::from(2)];
+        output.iter().zip(exp_output.iter()).for_each(|(o, e)| {
+            assert_eq!(o, e);
+        });
+    }
+
+    // And after that eval_p2
+    {
+        let eval_p2 = Evaluation {
+            commitment: dummy_commitments.clone(),
+            evaluations: vec![
+                // Eval at first point. Only one chunk.
+                vec![Fp::from(3)],
+                // Eval at second point. Only one chunk.
+                vec![Fp::from(4)],
+            ],
+        };
+
+        let output = combine_evaluations::<VestaG>(&vec![eval_p2], polyscale);
+        // We have 2 evaluation points
+        assert_eq!(output.len(), 2);
+        // polyscale is not used.
+        let exp_output = [Fp::from(3), Fp::from(4)];
+        output.iter().zip(exp_output.iter()).for_each(|(o, e)| {
+            assert_eq!(o, e);
+        });
+    }
+
+    // Now with two evaluations
+    {
+        let eval_p1 = Evaluation {
+            commitment: dummy_commitments.clone(),
+            evaluations: vec![
+                // Eval at first point. Only one chunk.
+                vec![Fp::from(1)],
+                // Eval at second point. Only one chunk.
+                vec![Fp::from(2)],
+            ],
+        };
+
+        let eval_p2 = Evaluation {
+            commitment: dummy_commitments.clone(),
+            evaluations: vec![
+                // Eval at first point. Only one chunk.
+                vec![Fp::from(3)],
+                // Eval at second point. Only one chunk.
+                vec![Fp::from(4)],
+            ],
+        };
+
+        let output = combine_evaluations::<VestaG>(&vec![eval_p1, eval_p2], polyscale);
+        // We have 2 evaluation points
+        assert_eq!(output.len(), 2);
+        let exp_output = [Fp::from(1 + 3 * 2), Fp::from(2 + 4 * 2)];
+        output.iter().zip(exp_output.iter()).for_each(|(o, e)| {
+            assert_eq!(o, e);
+        });
+    }
+
+    // Now with two evaluations and two chunks
+    {
+        let eval_p1 = Evaluation {
+            commitment: dummy_commitments.clone(),
+            evaluations: vec![
+                // Eval at first point.
+                vec![Fp::from(1), Fp::from(3)],
+                // Eval at second point.
+                vec![Fp::from(2), Fp::from(4)],
+            ],
+        };
+
+        let eval_p2 = Evaluation {
+            commitment: dummy_commitments.clone(),
+            evaluations: vec![
+                // Eval at first point.
+                vec![Fp::from(5), Fp::from(7)],
+                // Eval at second point.
+                vec![Fp::from(6), Fp::from(8)],
+            ],
+        };
+
+        let output = combine_evaluations::<VestaG>(&vec![eval_p1, eval_p2], polyscale);
+        // We have 2 evaluation points
+        assert_eq!(output.len(), 2);
+        let o1 = Fp::from(1 + 3 * 2 + 5 * 4 + 7 * 8);
+        let o2 = Fp::from(2 + 4 * 2 + 6 * 4 + 8 * 8);
+        let exp_output = [o1, o2];
+        output.iter().zip(exp_output.iter()).for_each(|(o, e)| {
+            assert_eq!(o, e);
+        });
+    }
+}
 
 #[test]
 fn test_kzg_proof() {


### PR DESCRIPTION
The routine isn't used for IPA, it is only used by the KZG PCS.