### PR TITLE
Use make_test_rng in develop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
  "mina-curves",
  "mina-poseidon",
  "num-bigint",
+ "o1-utils",
  "rand",
  "serde",
  "serde_json",

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -2965,7 +2965,6 @@ pub mod test {
         evaluation_proof::OpeningProof,
         srs::{endos, SRS},
     };
-    use rand::{prelude::StdRng, SeedableRng};
     use std::{array, sync::Arc};
 
     #[test]
@@ -3052,7 +3051,7 @@ pub mod test {
         let zk_rows = 3;
         let domain = EvaluationDomains::<Fp>::create(2usize.pow(10) + zk_rows)
             .expect("failed to create evaluation domain");
-        let rng = &mut StdRng::from_seed([17u8; 32]);
+        let rng = &mut o1_utils::tests::make_test_rng(None);
 
         // Check that both ways of computing lagrange basis give the same result
         let d1_size: i32 = domain.d1.size().try_into().expect("domain size too big");

--- a/kimchi/src/circuits/polynomials/turshi.rs
+++ b/kimchi/src/circuits/polynomials/turshi.rs
@@ -91,7 +91,6 @@ use crate::{
     proof::ProofEvaluations,
 };
 use ark_ff::{FftField, Field, PrimeField};
-use rand::{prelude::StdRng, SeedableRng};
 use std::{array, marker::PhantomData};
 use turshi::{
     runner::{CairoInstruction, CairoProgram, Pointers},
@@ -214,7 +213,7 @@ impl<F: PrimeField> CircuitGate<F> {
         let linearized = constraints.linearize(polys).unwrap();
 
         // Setup proof evaluations
-        let rng = &mut StdRng::from_seed([0u8; 32]);
+        let rng = &mut o1_utils::tests::make_test_rng(None);
         let evals = ProofEvaluations::dummy_with_witness_evaluations(curr, next);
 
         // Setup circuit constants

--- a/kimchi/src/lagrange_basis_evaluations.rs
+++ b/kimchi/src/lagrange_basis_evaluations.rs
@@ -153,13 +153,12 @@ mod tests {
     use ark_ff::{One, UniformRand, Zero};
     use ark_poly::{Polynomial, Radix2EvaluationDomain};
     use mina_curves::pasta::Fp;
-    use rand::{rngs::StdRng, SeedableRng};
 
     #[test]
     fn test_lagrange_evaluations() {
         let n = 1 << 4;
         let domain = Radix2EvaluationDomain::new(n).unwrap();
-        let rng = &mut StdRng::from_seed([0u8; 32]);
+        let rng = &mut o1_utils::tests::make_test_rng(None);
         let x = Fp::rand(rng);
         let evaluator = LagrangeBasisEvaluations::new(domain.size(), domain, x);
 
@@ -184,7 +183,7 @@ mod tests {
     fn test_new_with_chunked_segments() {
         let n = 1 << 4;
         let domain = Radix2EvaluationDomain::new(n).unwrap();
-        let rng = &mut StdRng::from_seed([0u8; 32]);
+        let rng = &mut o1_utils::tests::make_test_rng(None);
         let x = Fp::rand(rng);
         let evaluator = LagrangeBasisEvaluations::new(domain.size(), domain, x);
         let evaluator_chunked =
@@ -205,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_evaluation() {
-        let rng = &mut StdRng::from_seed([0u8; 32]);
+        let rng = &mut o1_utils::tests::make_test_rng(None);
         let n = 1 << 10;
         let domain = Radix2EvaluationDomain::new(n).unwrap();
 
@@ -228,7 +227,7 @@ mod tests {
 
     #[test]
     fn test_evaluation_boolean() {
-        let rng = &mut StdRng::from_seed([0u8; 32]);
+        let rng = &mut o1_utils::tests::make_test_rng(None);
         let n = 1 << 1;
         let domain = Radix2EvaluationDomain::new(n).unwrap();
 

--- a/kimchi/src/tests/and.rs
+++ b/kimchi/src/tests/and.rs
@@ -20,7 +20,6 @@ use mina_poseidon::{
 };
 use num_bigint::BigUint;
 use o1_utils::{BitwiseOps, FieldHelpers, RandomField};
-use rand::{rngs::StdRng, SeedableRng};
 
 use super::framework::TestFramework;
 
@@ -31,11 +30,6 @@ type VestaBaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;
 type VestaScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
 type PallasBaseSponge = DefaultFqSponge<PallasParameters, SpongeParams>;
 type PallasScalarSponge = DefaultFrSponge<Fq, SpongeParams>;
-
-const RNG_SEED: [u8; 32] = [
-    255, 27, 111, 55, 22, 200, 10, 1, 0, 136, 56, 16, 2, 30, 31, 77, 18, 11, 40, 53, 5, 8, 189, 92,
-    97, 25, 21, 12, 13, 44, 14, 12,
-];
 
 fn create_test_gates_and<G: KimchiCurve>(bytes: usize) -> Vec<CircuitGate<G::ScalarField>>
 where
@@ -79,7 +73,7 @@ fn setup_and<G: KimchiCurve>(
 where
     G::BaseField: PrimeField,
 {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     let gates = create_test_gates_and::<G>(bytes);
     let cs = ConstraintSystem::create(gates).build().unwrap();
@@ -122,7 +116,7 @@ where
     EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
     EFrSponge: FrSponge<G::ScalarField>,
 {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     // Create
     let mut gates = vec![];
@@ -152,7 +146,11 @@ fn prove_and_check_serialization_regression<G: KimchiCurve, EFqSponge, EFrSponge
     EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
     EFrSponge: FrSponge<G::ScalarField>,
 {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    const RNG_SEED: [u8; 32] = [
+        255, 27, 111, 55, 22, 200, 10, 1, 0, 136, 56, 16, 2, 30, 31, 77, 18, 11, 40, 53, 5, 8, 189,
+        92, 97, 25, 21, 12, 13, 44, 14, 12,
+    ];
+    let rng = &mut o1_utils::tests::make_test_rng(Some(RNG_SEED));
 
     // Create
     let mut gates = vec![];
@@ -328,7 +326,7 @@ fn test_and_bad_decomposition() {
 #[test]
 // Test AND when the decomposition of the inner XOR is incorrect
 fn test_bad_and() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     let bytes = 2;
     let gates = create_test_gates_and::<Vesta>(bytes);

--- a/kimchi/src/tests/ec.rs
+++ b/kimchi/src/tests/ec.rs
@@ -9,7 +9,6 @@ use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
-use rand::{rngs::StdRng, SeedableRng};
 use std::{array, ops::Mul};
 
 use super::framework::TestFramework;
@@ -21,6 +20,8 @@ type ScalarSponge = DefaultFrSponge<F, SpongeParams>;
 // Tests add and double gates
 #[test]
 fn ec_test() {
+    let rng = &mut o1_utils::tests::make_test_rng(None);
+
     let num_doubles = 100;
     let num_additions = 100;
     let num_infs = 100;
@@ -36,8 +37,6 @@ fn ec_test() {
     }
 
     let mut witness: [Vec<F>; COLUMNS] = array::from_fn(|_| vec![]);
-
-    let rng = &mut StdRng::from_seed([0; 32]);
 
     let ps: Vec<Other> = {
         let p = Other::generator()

--- a/kimchi/src/tests/endomul.rs
+++ b/kimchi/src/tests/endomul.rs
@@ -14,7 +14,6 @@ use mina_poseidon::{
     sponge::{DefaultFqSponge, DefaultFrSponge, ScalarChallenge},
 };
 use poly_commitment::srs::endos;
-use rand::{rngs::StdRng, SeedableRng};
 use std::{array, ops::Mul};
 
 type SpongeParams = PlonkSpongeConstantsKimchi;
@@ -54,7 +53,7 @@ fn endomul_test() {
     let mut witness: [Vec<F>; COLUMNS] =
         array::from_fn(|_| vec![F::zero(); rows_per_scalar * num_scalars]);
 
-    let rng = &mut StdRng::from_seed([0; 32]);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     // let start = Instant::now();
     for i in 0..num_scalars {

--- a/kimchi/src/tests/endomul_scalar.rs
+++ b/kimchi/src/tests/endomul_scalar.rs
@@ -13,7 +13,6 @@ use mina_poseidon::{
     sponge::{DefaultFqSponge, DefaultFrSponge, ScalarChallenge},
 };
 use poly_commitment::srs::endos;
-use rand::{rngs::StdRng, SeedableRng};
 use std::array;
 
 type SpongeParams = PlonkSpongeConstantsKimchi;
@@ -47,7 +46,7 @@ fn endomul_scalar_test() {
 
     let mut witness: [Vec<F>; COLUMNS] = array::from_fn(|_| vec![]);
 
-    let rng = &mut StdRng::from_seed([0; 32]);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     //let start = Instant::now();
     for _ in 0..num_scalars {

--- a/kimchi/src/tests/foreign_field_add.rs
+++ b/kimchi/src/tests/foreign_field_add.rs
@@ -26,13 +26,14 @@ use num_bigint::{BigUint, RandBigInt};
 use num_traits::FromPrimitive;
 use o1_utils::{
     foreign_field::{BigUintForeignFieldHelpers, ForeignElement, HI, LO, MI, TWO_TO_LIMB},
+    tests::make_test_rng,
     FieldHelpers, Two,
 };
 use poly_commitment::{
     evaluation_proof::OpeningProof,
     srs::{endos, SRS},
 };
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, Rng};
 use std::{array, sync::Arc};
 type PallasField = <Pallas as AffineRepr>::BaseField;
 type VestaField = <Vesta as AffineRepr>::BaseField;
@@ -51,11 +52,6 @@ fn secp256k1_modulus() -> BigUint {
 fn secp256k1_max() -> BigUint {
     secp256k1_modulus() - BigUint::from(1u32)
 }
-
-const RNG_SEED: [u8; 32] = [
-    0, 131, 43, 175, 229, 252, 206, 26, 67, 193, 86, 160, 1, 90, 131, 86, 168, 4, 95, 50, 48, 9,
-    192, 13, 250, 215, 172, 130, 24, 164, 162, 221,
-];
 
 // A value that produces a negative low carry when added to itself
 static OVF_NEG_LO: &[u8] = &[
@@ -889,7 +885,7 @@ fn test_pasta_sub_max_pallas() {
 #[test]
 // Test with a random addition
 fn test_random_add() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut make_test_rng(None);
     let foreign_mod = secp256k1_modulus();
     let left_input = random_input(rng, foreign_mod.clone(), true);
     let right_input = random_input(rng, foreign_mod.clone(), true);
@@ -910,7 +906,7 @@ fn test_random_add() {
 // Test with a random subtraction
 fn test_random_sub() {
     let foreign_mod = secp256k1_modulus();
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut make_test_rng(None);
     let left_input = random_input(rng, foreign_mod.clone(), true);
     let right_input = random_input(rng, foreign_mod.clone(), true);
     let left_big = BigUint::from_bytes_be(&left_input);
@@ -932,7 +928,7 @@ fn test_random_sub() {
 #[test]
 // Random test with foreign field being the native field add
 fn test_foreign_is_native_add() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut make_test_rng(None);
     let pallas = PallasField::modulus_biguint();
     let left_input = random_input(rng, pallas.clone(), true);
     let right_input = random_input(rng, pallas.clone(), true);
@@ -965,7 +961,7 @@ fn test_foreign_is_native_add() {
 #[test]
 // Random test with foreign field being the native field add
 fn test_foreign_is_native_sub() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut make_test_rng(None);
     let pallas = PallasField::modulus_biguint();
     let left_input = random_input(rng, pallas.clone(), true);
     let right_input = random_input(rng, pallas.clone(), true);
@@ -998,7 +994,7 @@ fn test_foreign_is_native_sub() {
 #[test]
 // Test with a random addition
 fn test_random_small_add() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut make_test_rng(None);
     // 2^200 - 75 is prime with 200 bits (3 limbs but smaller than Pallas)
     let prime = BigUint::from_u128(2u128.pow(100)).unwrap().pow(2) - BigUint::from_u32(75).unwrap();
     let foreign_mod = prime.clone();
@@ -1023,7 +1019,8 @@ fn test_random_small_add() {
 #[test]
 // Test with a random subtraction
 fn test_random_small_sub() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut make_test_rng(None);
+
     // 2^200 - 75 is prime with 200 bits (3 limbs but smaller than Pallas)
     let prime = BigUint::from_u128(2u128.pow(100)).unwrap().pow(2) - BigUint::from_u32(75).unwrap();
     let foreign_mod = prime.clone();
@@ -1048,7 +1045,8 @@ fn test_random_small_sub() {
 #[test]
 // Test with bad parameters in bound check
 fn test_bad_bound() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut make_test_rng(None);
+
     let foreign_mod = secp256k1_modulus();
     let left_input = BigUint::from_bytes_be(&random_input(rng, foreign_mod.clone(), false));
     let right_input = BigUint::from_bytes_be(&random_input(rng, foreign_mod.clone(), false));
@@ -1107,7 +1105,7 @@ fn test_bad_bound() {
 #[test]
 // Test with bad left input
 fn test_random_bad_input() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut make_test_rng(None);
     let foreign_mod = secp256k1_modulus();
     let left_input = random_input(rng, foreign_mod.clone(), false);
     let right_input = random_input(rng, foreign_mod, false);
@@ -1151,7 +1149,7 @@ fn test_random_bad_input() {
 #[test]
 // Test with bad parameters
 fn test_random_bad_parameters() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut make_test_rng(None);
     let foreign_mod = secp256k1_modulus();
     let left_input = random_input(rng, foreign_mod.clone(), false);
     let right_input = random_input(rng, foreign_mod, false);
@@ -1215,7 +1213,7 @@ fn test_random_bad_parameters() {
 #[test]
 // Test with chain of random operations
 fn test_random_chain() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut make_test_rng(None);
 
     let nops = 20;
     let foreign_mod = secp256k1_modulus();
@@ -1247,7 +1245,7 @@ fn test_random_chain() {
 
 // Prove and verify used for end-to-end tests
 fn prove_and_verify(operation_count: usize) {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut make_test_rng(None);
 
     // Create random operations
     let operations = (0..operation_count)
@@ -1312,7 +1310,7 @@ fn extend_witness_bound_rc(witness: &mut [Vec<PallasField>; COLUMNS]) {
 #[test]
 fn test_ffadd_no_rc() {
     let operation_count = 3;
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut make_test_rng(None);
 
     // Create foreign modulus
     let foreign_mod = secp256k1_modulus();
@@ -1385,7 +1383,7 @@ where
     G::BaseField: PrimeField,
     G: KimchiCurve,
 {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut make_test_rng(None);
 
     // Create foreign field addition gates
     let (_next_row, gates) = short_circuit(&[FFOps::Add], foreign_field_modulus);

--- a/kimchi/src/tests/foreign_field_mul.rs
+++ b/kimchi/src/tests/foreign_field_mul.rs
@@ -25,7 +25,6 @@ use mina_poseidon::{
     FqSponge,
 };
 use num_bigint::RandBigInt;
-use rand::{rngs::StdRng, SeedableRng};
 
 type PallasField = <Pallas as AffineRepr>::BaseField;
 type VestaField = <Vesta as AffineRepr>::BaseField;
@@ -35,11 +34,6 @@ type VestaBaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;
 type VestaScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
 type PallasBaseSponge = DefaultFqSponge<PallasParameters, SpongeParams>;
 type PallasScalarSponge = DefaultFrSponge<Fq, SpongeParams>;
-
-const RNG_SEED: [u8; 32] = [
-    211, 31, 143, 75, 29, 255, 0, 126, 237, 193, 86, 160, 1, 90, 131, 221, 186, 168, 4, 95, 50, 48,
-    89, 29, 13, 250, 215, 172, 130, 24, 164, 162,
-];
 
 // The secp256k1 base field modulus
 fn secp256k1_modulus() -> BigUint {
@@ -290,7 +284,7 @@ where
     EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
     EFrSponge: FrSponge<G::ScalarField>,
 {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     for _ in 0..3 {
         let left_input = rng.gen_biguint_range(&BigUint::zero(), foreign_field_modulus);
@@ -639,7 +633,7 @@ fn test_max_foreign_multiplicands() {
 #[test]
 // Test with nonzero carry0 bits
 fn test_nonzero_carry0() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     for _ in 0..4 {
         let mut a = rng.gen_biguint_below(&secp256k1_modulus()).to_limbs();
@@ -805,7 +799,7 @@ fn test_nonzero_carry1_hi() {
 #[test]
 // Test with nonzero second bit of carry1_hi
 fn test_nonzero_second_bit_carry1_hi() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
     let a = rng.gen_biguint_range(
         &(secp256k1_modulus() - BigUint::two().pow(64)),
         &secp256k1_modulus(),
@@ -1062,7 +1056,7 @@ fn test_mul_invalid_remainder() {
 #[test]
 // Test multiplying some random values and invalidating carry1_lo
 fn test_random_multiplicands_carry1_lo() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     for _ in 0..10 {
         let left_input = rng.gen_biguint_range(&BigUint::zero(), &secp256k1_max());
@@ -1227,7 +1221,7 @@ fn test_random_multiplicands_carry1_lo() {
 #[test]
 // Test multiplying some random values with secp256k1 foreign modulus
 fn test_random_multiplicands_valid() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     for _ in 0..10 {
         let left_input = rng.gen_biguint_range(&BigUint::zero(), &secp256k1_max());
@@ -1255,7 +1249,7 @@ fn test_random_multiplicands_valid() {
 fn test_smaller_foreign_field_modulus() {
     let foreign_field_modulus = BigUint::two().pow(252u32) - BigUint::one();
 
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     for _ in 0..10 {
         let left_input = rng.gen_biguint_range(&BigUint::zero(), &foreign_field_modulus);
@@ -1342,7 +1336,7 @@ fn test_custom_constraints_small_foreign_field_modulus_on_pallas() {
 
 #[test]
 fn test_native_modulus_constraint() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
     let left_input = rng.gen_biguint_range(
         &(secp256k1_modulus() - BigUint::two().pow(96)),
         &secp256k1_modulus(),

--- a/kimchi/src/tests/lookup.rs
+++ b/kimchi/src/tests/lookup.rs
@@ -135,7 +135,7 @@ fn setup_successfull_runtime_table_test(
 ) {
     let seed: [u8; 32] = thread_rng().gen();
     eprintln!("Seed: {:?}", seed);
-    let mut rng = StdRng::from_seed(seed);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
     let nb_lookups = lookups.len();
 
     // circuit
@@ -200,7 +200,7 @@ fn test_runtime_table() {
     let num = 5;
     let seed: [u8; 32] = thread_rng().gen();
     eprintln!("Seed: {:?}", seed);
-    let mut rng = StdRng::from_seed(seed);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     let first_column = [8u32, 9, 8, 7, 1];
     let len = first_column.len();
@@ -456,7 +456,7 @@ fn test_negative_test_runtime_table_prover_uses_undefined_id_in_index_and_witnes
 fn test_runtime_table_with_more_than_one_runtime_table_data_given_by_prover() {
     let seed: [u8; 32] = thread_rng().gen();
     eprintln!("Seed: {:?}", seed);
-    let mut rng = StdRng::from_seed(seed);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     let first_column = [0, 1, 2, 3, 4];
     let len = first_column.len();
@@ -561,7 +561,7 @@ fn test_runtime_table_only_one_table_with_id_zero_with_non_zero_entries_fixed_va
 fn test_runtime_table_only_one_table_with_id_zero_with_non_zero_entries_random_values() {
     let seed: [u8; 32] = thread_rng().gen();
     eprintln!("Seed: {:?}", seed);
-    let mut rng = StdRng::from_seed(seed);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     let len = rng.gen_range(1usize..1000);
     let first_column: Vec<i32> = (0..len as i32).collect();
@@ -575,7 +575,7 @@ fn test_runtime_table_only_one_table_with_id_zero_with_non_zero_entries_random_v
 
     let data: Vec<Fp> = first_column
         .into_iter()
-        .map(|_| UniformRand::rand(&mut rng))
+        .map(|_| UniformRand::rand(rng))
         .collect();
     let runtime_table = RuntimeTable { id: table_id, data };
 
@@ -595,7 +595,7 @@ fn test_lookup_with_a_table_with_id_zero_but_no_zero_entry() {
     let max_len: u32 = 100u32;
     let seed: [u8; 32] = thread_rng().gen();
     eprintln!("Seed: {:?}", seed);
-    let mut rng = StdRng::from_seed(seed);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     // Non zero-length table
     let len = 1u32 + rng.gen_range(0u32..max_len);
@@ -645,7 +645,7 @@ fn test_lookup_with_a_table_with_id_zero_but_no_zero_entry() {
 fn test_dummy_value_is_added_in_an_arbitraly_created_table_when_no_table_with_id_0() {
     let seed: [u8; 32] = thread_rng().gen();
     eprintln!("Seed: {:?}", seed);
-    let mut rng = StdRng::from_seed(seed);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
     let max_len: u32 = 100u32;
     let max_table_id: i32 = 100;
 
@@ -692,7 +692,7 @@ fn test_dummy_value_is_added_in_an_arbitraly_created_table_when_no_table_with_id
 fn test_dummy_zero_entry_is_counted_while_computing_domain_size() {
     let seed: [u8; 32] = thread_rng().gen();
     eprintln!("Seed: {:?}", seed);
-    let mut rng = StdRng::from_seed(seed);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     let power_of_2: u32 = rng.gen_range(3..16);
     // 4 = zk_rows + 1 for the closing constraint on the polynomial.
@@ -700,9 +700,7 @@ fn test_dummy_zero_entry_is_counted_while_computing_domain_size() {
     // We want to create a table with an ID different than 0.
     let table_id: i32 = rng.gen_range(1..1_000);
     let idx: Vec<Fp> = (1..(len + 1) as i32).map(Into::into).collect();
-    let values: Vec<Fp> = (1..(len + 1))
-        .map(|_| UniformRand::rand(&mut rng))
-        .collect();
+    let values: Vec<Fp> = (1..(len + 1)).map(|_| UniformRand::rand(rng)).collect();
     let lt = LookupTable {
         id: table_id,
         data: vec![idx, values],

--- a/kimchi/src/tests/not.rs
+++ b/kimchi/src/tests/not.rs
@@ -24,7 +24,6 @@ use mina_poseidon::{
 use num_bigint::BigUint;
 use o1_utils::{BigUintHelpers, BitwiseOps, FieldHelpers, RandomField};
 use poly_commitment::evaluation_proof::OpeningProof;
-use rand::{rngs::StdRng, SeedableRng};
 
 type PallasField = <Pallas as AffineRepr>::BaseField;
 type VestaField = <Vesta as AffineRepr>::BaseField;
@@ -33,11 +32,6 @@ type VestaBaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;
 type VestaScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
 
 const NOT: bool = false;
-
-const RNG_SEED: [u8; 32] = [
-    211, 31, 143, 75, 29, 255, 0, 126, 237, 193, 86, 160, 1, 90, 131, 221, 186, 168, 4, 95, 50, 48,
-    89, 29, 13, 250, 215, 172, 130, 24, 164, 162,
-];
 
 // Creates as many negations as the number of inputs. The inputs must fit in the native field.
 // We start at the row 0 using generic gates to perform the negations.
@@ -122,7 +116,7 @@ fn setup_not_xor<G: KimchiCurve>(
 where
     G::BaseField: PrimeField,
 {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     let input = rng.gen(input, bits);
 
@@ -171,7 +165,7 @@ fn setup_not_gnrc<G: KimchiCurve>(
 where
     G::BaseField: PrimeField,
 {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     let inputs = if let Some(inps) = inputs {
         assert!(len.is_none());
@@ -256,7 +250,7 @@ fn check_not_gnrc<G: KimchiCurve>(
 // End-to-end test of NOT using XOR gadget
 fn test_prove_and_verify_not_xor() {
     let bits = 64;
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     // Create circuit
     let gates = {
@@ -289,7 +283,7 @@ fn test_prove_and_verify_not_xor() {
 // End-to-end test of NOT using generic gadget
 fn test_prove_and_verify_five_not_gnrc() {
     let bits = 64;
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     // Create circuit
     let gates = {
@@ -339,7 +333,7 @@ fn test_not_xor_all_crumb() {
 fn test_not_xor_crumbs_random() {
     for i in 2..=7 {
         let bits = 2u32.pow(i) as usize;
-        let rng = &mut StdRng::from_seed(RNG_SEED);
+        let rng = &mut o1_utils::tests::make_test_rng(None);
         let input = rng.gen_field_with_bits(bits);
         test_not_xor::<Vesta>(Some(input), Some(bits));
         test_not_xor::<Vesta>(Some(input), None);
@@ -349,7 +343,7 @@ fn test_not_xor_crumbs_random() {
 #[test]
 // Tests a NOT for a random-length big input
 fn test_not_xor_big_random() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
     let input = rng.gen_field_with_bits(200);
     test_not_xor::<Vesta>(Some(input), None);
     let input = rng.gen_field_with_bits(200);
@@ -373,7 +367,7 @@ fn test_not_gnrc_single() {
 #[test]
 // Tests a chain of 5 NOTs with different lengths but padded to 254 bits with the generic builder
 fn test_not_gnrc_vector() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
     // up to 2^16, 2^32, 2^64, 2^128, 2^254
     let inputs = (0..5)
         .map(|i| rng.gen_field_with_bits(4 + i))

--- a/kimchi/src/tests/range_check.rs
+++ b/kimchi/src/tests/range_check.rs
@@ -25,7 +25,6 @@ use o1_utils::{
     },
     FieldHelpers,
 };
-use rand::{rngs::StdRng, SeedableRng};
 
 use std::{array, sync::Arc};
 
@@ -47,11 +46,6 @@ type BaseSponge = DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>;
 type ScalarSponge = DefaultFrSponge<Fp, PlonkSpongeConstantsKimchi>;
 
 type PallasField = <Pallas as AffineRepr>::BaseField;
-
-const RNG_SEED: [u8; 32] = [
-    22, 4, 34, 75, 29, 255, 0, 126, 237, 19, 86, 160, 1, 90, 131, 221, 186, 168, 40, 59, 0, 4, 9,
-    0, 33, 210, 215, 172, 130, 24, 164, 12,
-];
 
 fn create_test_prover_index(
     public_size: usize,
@@ -1143,7 +1137,7 @@ fn verify_64_bit_range_check() {
 
 #[test]
 fn compact_multi_range_check() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     // Create prover index
     let index = create_test_prover_index(0, true);
@@ -1230,7 +1224,7 @@ fn verify_range_check_valid_proof1() {
 
 #[test]
 fn verify_compact_multi_range_check_proof() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     let limbs: [PallasField; 3] =
         array::from_fn(|_| rng.gen_biguint_below(&BigUint::two_to_limb())).to_fields();

--- a/kimchi/src/tests/recursion.rs
+++ b/kimchi/src/tests/recursion.rs
@@ -15,7 +15,6 @@ use mina_poseidon::{
 };
 use o1_utils::math;
 use poly_commitment::{commitment::b_poly_coefficients, SRS as _};
-use rand::prelude::*;
 use std::array;
 
 type SpongeParams = PlonkSpongeConstantsKimchi;
@@ -39,7 +38,7 @@ fn test_recursion() {
 
     // previous opening for recursion
     let index = test_runner.prover_index();
-    let rng = &mut StdRng::from_seed([0u8; 32]);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
     let prev_challenges = {
         let k = math::ceil_log2(index.srs.g.len());
         let chals: Vec<_> = (0..k).map(|_| Fp::rand(rng)).collect();

--- a/kimchi/src/tests/rot.rs
+++ b/kimchi/src/tests/rot.rs
@@ -30,7 +30,7 @@ use poly_commitment::{
     evaluation_proof::OpeningProof,
     srs::{endos, SRS},
 };
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::Rng;
 
 type PallasField = <Pallas as AffineRepr>::BaseField;
 type SpongeParams = PlonkSpongeConstantsKimchi;
@@ -41,11 +41,6 @@ type PallasScalarSponge = DefaultFrSponge<Fq, SpongeParams>;
 
 type BaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;
 type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
-
-const RNG_SEED: [u8; 32] = [
-    211, 31, 143, 75, 29, 255, 0, 126, 237, 193, 86, 160, 1, 90, 131, 221, 186, 168, 4, 95, 50, 48,
-    89, 29, 13, 250, 215, 172, 130, 24, 164, 162,
-];
 
 fn create_rot_gadget<G: KimchiCurve>(rot: u32, side: RotMode) -> Vec<CircuitGate<G::ScalarField>>
 where
@@ -96,7 +91,7 @@ where
     EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
     EFrSponge: FrSponge<G::ScalarField>,
 {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
     let rot = rng.gen_range(1..64);
     // Create
     let gates = create_rot_gadget::<G>(rot, RotMode::Left);
@@ -163,7 +158,7 @@ where
 #[test]
 // Test that a random offset between 1 and 63 work as expected, both left and right
 fn test_rot_random() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
     let rot = rng.gen_range(1..=63);
     let word = rng.gen_range(0..2u128.pow(64)) as u64;
     test_rot::<Vesta>(word, rot, RotMode::Left);
@@ -176,7 +171,7 @@ fn test_rot_random() {
 #[test]
 // Test that a bad rotation fails as expected
 fn test_zero_rot() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
     let word = rng.gen_range(0..2u128.pow(64)) as u64;
     create_rot_witness::<Vesta>(word, 0, RotMode::Left);
 }
@@ -185,7 +180,7 @@ fn test_zero_rot() {
 #[test]
 // Test that a bad rotation fails as expected
 fn test_large_rot() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
     let word = rng.gen_range(0..2u128.pow(64)) as u64;
     create_rot_witness::<Vesta>(word, 64, RotMode::Left);
 }
@@ -193,7 +188,7 @@ fn test_large_rot() {
 #[test]
 // Test bad rotation
 fn test_bad_constraints() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
     let rot = rng.gen_range(1..=63);
     let word = rng.gen_range(0..2u128.pow(64)) as u64;
     let (mut witness, cs) = setup_rot::<Vesta>(word, rot, RotMode::Left);

--- a/kimchi/src/tests/varbasemul.rs
+++ b/kimchi/src/tests/varbasemul.rs
@@ -14,7 +14,6 @@ use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
-use rand::{rngs::StdRng, SeedableRng};
 use std::{array, ops::Mul, time::Instant};
 
 type SpongeParams = PlonkSpongeConstantsKimchi;
@@ -50,7 +49,7 @@ fn varbase_mul_test() {
     let mut witness: [Vec<F>; COLUMNS] =
         array::from_fn(|_| vec![F::zero(); rows_per_scalar * num_scalars]);
 
-    let rng = &mut StdRng::from_seed([0; 32]);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     let start = Instant::now();
     for i in 0..num_scalars {

--- a/kimchi/src/tests/xor.rs
+++ b/kimchi/src/tests/xor.rs
@@ -25,7 +25,6 @@ use poly_commitment::{
     evaluation_proof::OpeningProof,
     srs::{endos, SRS},
 };
-use rand::{rngs::StdRng, SeedableRng};
 
 use super::framework::TestFramework;
 
@@ -38,11 +37,6 @@ type BaseSponge = DefaultFqSponge<VestaParameters, SpongeParams>;
 type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
 
 const XOR: bool = true;
-
-const RNG_SEED: [u8; 32] = [
-    211, 31, 143, 75, 29, 255, 0, 126, 237, 193, 86, 160, 1, 90, 131, 221, 186, 168, 4, 95, 50, 48,
-    89, 29, 13, 250, 215, 172, 130, 24, 164, 162,
-];
 
 fn create_test_constraint_system_xor<G: KimchiCurve>(
     bits: usize,
@@ -110,8 +104,8 @@ fn setup_xor<G: KimchiCurve>(
 where
     G::BaseField: PrimeField,
 {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
-    // Initalize inputs
+    let rng = &mut o1_utils::tests::make_test_rng(None);
+    // Initialize inputs
     // If some input was given then use that one, otherwise generate a random one with the given bits
     let input1 = rng.gen(in1, bits);
     let input2 = rng.gen(in2, bits);
@@ -153,7 +147,7 @@ where
 #[test]
 // End-to-end test of XOR
 fn test_prove_and_verify_xor() {
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
 
     let bits = 64;
     // Create
@@ -276,7 +270,7 @@ fn test_bad_xor_decompsition() {
 // Tests that the extend xor function works as expected
 fn test_extend_xor() {
     let bits = Some(16);
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
     let input1: PallasField = rng.gen(None, bits);
     let input2: PallasField = rng.gen(None, bits);
 
@@ -318,7 +312,7 @@ fn test_extend_xor() {
 #[test]
 fn test_bad_xor() {
     let bits = Some(16);
-    let rng = &mut StdRng::from_seed(RNG_SEED);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
     let input1: PallasField = rng.gen(None, bits);
     let input2: PallasField = rng.gen(None, bits);
 

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -817,7 +817,6 @@ mod tests {
     use ark_poly::{DenseUVPolynomial, Polynomial, Radix2EvaluationDomain};
     use mina_curves::pasta::{Fp, Vesta as VestaG};
     use mina_poseidon::{constants::PlonkSpongeConstantsKimchi as SC, sponge::DefaultFqSponge};
-    use rand::{rngs::StdRng, SeedableRng};
     use std::array;
 
     #[test]
@@ -922,7 +921,7 @@ mod tests {
 
         // create an SRS
         let srs = SRS::<VestaG>::create(20);
-        let rng = &mut StdRng::from_seed([0u8; 32]);
+        let rng = &mut o1_utils::tests::make_test_rng(None);
 
         // commit the two polynomials
         let commitment1 = srs.commit(&poly1, 1, rng);

--- a/poly-commitment/src/pairing_proof.rs
+++ b/poly-commitment/src/pairing_proof.rs
@@ -340,14 +340,12 @@ mod tests {
         Radix2EvaluationDomain as D,
     };
 
-    use rand::{rngs::StdRng, SeedableRng};
-
     #[test]
     fn test_pairing_proof() {
         let n = 64;
         let domain = D::<ScalarField>::new(n).unwrap();
 
-        let rng = &mut StdRng::from_seed([0u8; 32]);
+        let rng = &mut o1_utils::tests::make_test_rng(None);
 
         let x = ScalarField::rand(rng);
 

--- a/poly-commitment/src/tests/commitment.rs
+++ b/poly-commitment/src/tests/commitment.rs
@@ -257,7 +257,7 @@ where
     <Fp as std::str::FromStr>::Err: std::fmt::Debug,
 {
     // setup
-    let mut rng = rand::thread_rng();
+    let mut rng = o1_utils::tests::make_test_rng(None);
     test_randomised(&mut rng)
 }
 

--- a/poly-commitment/src/tests/serialization.rs
+++ b/poly-commitment/src/tests/serialization.rs
@@ -3,13 +3,12 @@
 use crate::{commitment::CommitmentCurve, srs::SRS, SRS as _};
 use ark_ff::UniformRand;
 use o1_utils::serialization::test_generic_serialization_regression_serde;
-use rand::{rngs::StdRng, SeedableRng};
 
 #[test]
 pub fn ser_regression_canonical_srs() {
     use mina_curves::pasta::{Fp, Fq, Pallas, Vesta};
 
-    let rng = &mut StdRng::from_seed([0u8; 32]);
+    let rng = &mut o1_utils::tests::make_test_rng(Some([0u8; 32]));
 
     let td1 = Fp::rand(rng);
     let data_expected = SRS::<Vesta>::create_trusted_setup(td1, 1 << 3);
@@ -67,7 +66,7 @@ pub fn ser_regression_canonical_polycomm() {
     use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial};
     use mina_curves::pasta::{Fp, Vesta};
 
-    let rng = &mut StdRng::from_seed([0u8; 32]);
+    let rng = &mut o1_utils::tests::make_test_rng(Some([0u8; 32]));
 
     let srs = SRS::<Vesta>::create(1 << 7);
 
@@ -108,7 +107,7 @@ pub fn ser_regression_canonical_opening_proof() {
     use groupmap::GroupMap;
     use mina_curves::pasta::Vesta;
 
-    let rng = &mut StdRng::from_seed([0u8; 32]);
+    let rng = &mut o1_utils::tests::make_test_rng(Some([0u8; 32]));
 
     let group_map = <Vesta as CommitmentCurve>::Map::setup();
     let srs = SRS::<Vesta>::create(1 << 7);

--- a/poseidon/export_test_vectors/Cargo.toml
+++ b/poseidon/export_test_vectors/Cargo.toml
@@ -12,12 +12,13 @@ license = "Apache-2.0"
 [dependencies]
 ark-ff.workspace = true
 num-bigint.workspace = true
-serde_json.workspace = true 
-hex.workspace = true 
-ark-serialize.workspace = true 
-rand.workspace = true 
-serde.workspace = true 
-serde_with.workspace = true 
+serde_json.workspace = true
+hex.workspace = true
+ark-serialize.workspace = true
+rand.workspace = true
+serde.workspace = true
+serde_with.workspace = true
 
-mina-curves.workspace = true 
-mina-poseidon.workspace = true 
+mina-curves.workspace = true
+mina-poseidon.workspace = true
+o1-utils.workspace = true

--- a/poseidon/export_test_vectors/src/vectors.rs
+++ b/poseidon/export_test_vectors/src/vectors.rs
@@ -8,7 +8,7 @@ use mina_poseidon::{
     poseidon::{ArithmeticSponge as Poseidon, ArithmeticSpongeParams, Sponge as _},
 };
 use num_bigint::BigUint;
-use rand::{prelude::*, Rng};
+use rand::Rng;
 use serde::Serialize;
 
 //
@@ -55,13 +55,13 @@ fn rand_fields(rng: &mut impl Rng, length: u8) -> Vec<Fp> {
 
 /// creates a set of test vectors
 pub fn generate(mode: Mode, param_type: ParamType) -> TestVectors {
-    let mut rng = &mut rand::rngs::StdRng::from_seed([0u8; 32]);
+    let rng = &mut o1_utils::tests::make_test_rng(Some([0u8; 32]));
     let mut test_vectors = vec![];
 
     // generate inputs of different lengths
     for length in 0..6 {
         // generate input & hash
-        let input = rand_fields(&mut rng, length);
+        let input = rand_fields(rng, length);
         let output = match param_type {
             ParamType::Legacy => poseidon::<constants::PlonkSpongeConstantsLegacy>(
                 &input,
@@ -121,7 +121,7 @@ mod tests {
     #[test]
     fn poseidon_test_vectors_regression() {
         use mina_poseidon::pasta;
-        let mut rng = &mut rand::rngs::StdRng::from_seed([0u8; 32]);
+        let rng = &mut o1_utils::tests::make_test_rng(Some([0u8; 32]));
 
         // Values are generated w.r.t. the following commit:
         // 1494cf973d40fb276465929eb7db1952c5de7bdc
@@ -194,7 +194,7 @@ mod tests {
 
             for length in 0..6 {
                 // generate input & hash
-                let input = rand_fields(&mut rng, length);
+                let input = rand_fields(rng, length);
                 let output = match param_type {
                     ParamType::Legacy => poseidon::<constants::PlonkSpongeConstantsLegacy>(
                         &input,

--- a/utils/src/foreign_field.rs
+++ b/utils/src/foreign_field.rs
@@ -396,15 +396,9 @@ mod tests {
     use ark_ff::One;
     use mina_curves::pasta::Pallas as CurvePoint;
     use num_bigint::RandBigInt;
-    use rand::{rngs::StdRng, SeedableRng};
 
     /// Base field element type
     pub type BaseField = <CurvePoint as AffineRepr>::BaseField;
-
-    const RNG_SEED: [u8; 32] = [
-        12, 31, 143, 75, 29, 255, 206, 26, 67, 193, 86, 160, 1, 90, 131, 221, 86, 168, 4, 95, 50,
-        48, 89, 29, 13, 250, 215, 172, 130, 24, 164, 162,
-    ];
 
     fn secp256k1_modulus() -> BigUint {
         BigUint::from_bytes_be(&secp256k1::constants::FIELD_SIZE)
@@ -479,7 +473,7 @@ mod tests {
 
     #[test]
     fn check_negation() {
-        let rng = &mut StdRng::from_seed(RNG_SEED);
+        let rng = &mut crate::tests::make_test_rng(None);
         for _ in 0..10 {
             rng.gen_biguint(256).negate();
         }
@@ -487,7 +481,7 @@ mod tests {
 
     #[test]
     fn check_good_limbs() {
-        let rng = &mut StdRng::from_seed(RNG_SEED);
+        let rng = &mut crate::tests::make_test_rng(None);
         for _ in 0..100 {
             let x = rng.gen_biguint(264);
             assert_eq!(x.to_limbs().len(), 3);
@@ -513,28 +507,28 @@ mod tests {
     #[test]
     #[should_panic]
     fn check_bad_limbs_1() {
-        let rng = &mut StdRng::from_seed(RNG_SEED);
+        let rng = &mut crate::tests::make_test_rng(None);
         assert_ne!(rng.gen_biguint(265).to_limbs().len(), 3);
     }
 
     #[test]
     #[should_panic]
     fn check_bad_limbs_2() {
-        let rng = &mut StdRng::from_seed(RNG_SEED);
+        let rng = &mut crate::tests::make_test_rng(None);
         assert_ne!(rng.gen_biguint(265).to_compact_limbs().len(), 2);
     }
 
     #[test]
     #[should_panic]
     fn check_bad_limbs_3() {
-        let rng = &mut StdRng::from_seed(RNG_SEED);
+        let rng = &mut crate::tests::make_test_rng(None);
         assert_ne!(rng.gen_biguint(265).to_field_limbs::<BaseField>().len(), 3);
     }
 
     #[test]
     #[should_panic]
     fn check_bad_limbs_4() {
-        let rng = &mut StdRng::from_seed(RNG_SEED);
+        let rng = &mut crate::tests::make_test_rng(None);
         assert_ne!(
             rng.gen_biguint(265)
                 .to_compact_field_limbs::<BaseField>()


### PR DESCRIPTION
Using `o1_utils::tests::make_test_rng` everywhere.

Porting the following from master to develop:
- PR https://github.com/o1-labs/proof-systems/pull/1942
- Commit 47aa2608a905786b207447dd064681cfa4d7292f

Continuing:
- https://github.com/o1-labs/proof-systems/pull/2614