### PR TITLE
Update book description with auto-generated stuff [1min cosmetic]

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1940,7 +1940,7 @@ A proof consists of the following data structures:
 ```rs
 /// Evaluations of a polynomial at 2 points
 #[serde_as]
-#[derive(Copy, Clone, Serialize, Deserialize, Default, Debug)]
+#[derive(Copy, Clone, Serialize, Deserialize, Default, Debug, PartialEq)]
 #[cfg_attr(
     feature = "ocaml_types",
     derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)
@@ -1963,7 +1963,7 @@ pub struct PointEvaluations<Evals> {
 /// - **Chunked evaluations** `Field` is instantiated with vectors with a length that equals the length of the chunk
 /// - **Non chunked evaluations** `Field` is instantiated with a field, so they are single-sized#[serde_as]
 #[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ProofEvaluations<Evals> {
     /// public input polynomials
     pub public: Option<Evals>,
@@ -2028,7 +2028,7 @@ pub struct ProofEvaluations<Evals> {
 
 /// Commitments linked to the lookup feature
 #[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(bound = "G: ark_serialize::CanonicalDeserialize + ark_serialize::CanonicalSerialize")]
 pub struct LookupCommitments<G: AffineRepr> {
     /// Commitments to the sorted lookup table polynomial (may have chunks)
@@ -2041,7 +2041,7 @@ pub struct LookupCommitments<G: AffineRepr> {
 
 /// All the commitments that the prover creates as part of the proof.
 #[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(bound = "G: ark_serialize::CanonicalDeserialize + ark_serialize::CanonicalSerialize")]
 pub struct ProverCommitments<G: AffineRepr> {
     /// The commitments to the witness (execution trace)
@@ -2056,7 +2056,7 @@ pub struct ProverCommitments<G: AffineRepr> {
 
 /// The proof that the prover creates from a [ProverIndex](super::prover_index::ProverIndex) and a `witness`.
 #[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(bound = "G: ark_serialize::CanonicalDeserialize + ark_serialize::CanonicalSerialize")]
 pub struct ProverProof<G: AffineRepr, OpeningProof> {
     /// All the polynomial commitments required in the proof
@@ -2082,7 +2082,7 @@ pub struct ProverProof<G: AffineRepr, OpeningProof> {
 
 /// A struct to store the challenges inside a `ProverProof`
 #[serde_as]
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(bound = "G: ark_serialize::CanonicalDeserialize + ark_serialize::CanonicalSerialize")]
 pub struct RecursionChallenge<G>
 where


### PR DESCRIPTION
After this PR was merged (https://github.com/o1-labs/proof-systems/pull/2598), the book was updated, however this was not committed in the PR itself.

I think there was a CI test before that was checking whether auto-generated book matches the commited one. We should probably have this again.