### PR TITLE
Poly-commitment: modestly improve documentation

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,6 @@
+# Default is 7. However, it seems to be arbitrary. Some protocols do require
+# many parameters, like polynomial commitment scheme when we want to make an
+# opening.
+# Note that we should not use too much this threshold, and stay clean in the
+# choice of our routine parameters.
+too-many-arguments-threshold = 8

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -515,7 +515,7 @@ where
     pub polyscale: G::ScalarField,
     /// A challenge to aggregate multiple evaluation points.
     pub evalscale: G::ScalarField,
-    /// The actual opening proof.
+    /// The opening proof.
     pub opening: &'a OpeningProof,
     pub combined_inner_product: G::ScalarField,
 }

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -500,19 +500,24 @@ where
     G: AffineRepr,
     EFqSponge: FqSponge<G::BaseField, G, G::ScalarField>,
 {
-    /// The sponge used to generate/absorb the challenges.
+    /// Sponge used to coin and absorb values and simulate
+    /// non-interactivity using the Fiat-Shamir transformation.
     pub sponge: EFqSponge,
     /// A list of evaluations, each supposed to correspond to a different
     /// polynomial.
     pub evaluations: Vec<Evaluation<G>>,
     /// The actual evaluation points. Each field `evaluations` of each structure
     /// of `Evaluation` should have the same (outer) length.
+    /// A randomized folded challenge will be built using `evalscale`.
     pub evaluation_points: Vec<G::ScalarField>,
-    /// scaling factor for evaluation point powers
+    /// A challenge to combine polynomials. Powers of this point will be used,
+    /// hence the name.
     pub polyscale: G::ScalarField,
-    /// scaling factor for polynomials
+    /// A challenge to build a randomized folded challenge (often named u) in
+    /// case of multiple evaluation points. In the case of multiple evaluation
+    /// points, powers of this point will be used, hence the name.
     pub evalscale: G::ScalarField,
-    /// batched opening proof
+    /// The actual opening proof.
     pub opening: &'a OpeningProof,
     pub combined_inner_product: G::ScalarField,
 }

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -508,7 +508,6 @@ where
     pub evaluations: Vec<Evaluation<G>>,
     /// The actual evaluation points. Each field `evaluations` of each structure
     /// of `Evaluation` should have the same (outer) length.
-    /// A randomized folded challenge will be built using `evalscale`.
     pub evaluation_points: Vec<G::ScalarField>,
     /// A challenge to combine polynomials. Powers of this point will be used,
     /// hence the name.

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -513,9 +513,7 @@ where
     /// A challenge to combine polynomials. Powers of this point will be used,
     /// hence the name.
     pub polyscale: G::ScalarField,
-    /// A challenge to build a randomized folded challenge (often named u) in
-    /// case of multiple evaluation points. In the case of multiple evaluation
-    /// points, powers of this point will be used, hence the name.
+    /// A challenge to aggregate multiple evaluation points.
     pub evalscale: G::ScalarField,
     /// The actual opening proof.
     pub opening: &'a OpeningProof,

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -495,7 +495,6 @@ where
 }
 
 /// Contains the batch evaluation
-// TODO: I think we should really change this name to something more correct
 pub struct BatchEvaluationProof<'a, G, EFqSponge, OpeningProof>
 where
     G: AffineRepr,

--- a/poly-commitment/src/ipa.rs
+++ b/poly-commitment/src/ipa.rs
@@ -825,22 +825,14 @@ where
 }
 
 impl<G: CommitmentCurve> SRS<G> {
-    /// This function opens polynomials in batch at several points
-    /// - plnms: batch of polynomials to open commitments for
-    /// - elm: evaluation point vector to open the commitments at
-    /// - polyscale: used to combine polynomials for opening commitments in batch
-    /// (we will open the \sum_i polyscale^i * plnms.(i))
-    /// - evalscale: used to combine evaluations to open on only one point
-    /// - sponge: parameters for the random oracle argument
-    /// - rng: used for blinders for the zk property
-    /// A slight modification to the original protocol is done
-    /// when absorbing the first prover message.
     #[allow(clippy::type_complexity)]
     #[allow(clippy::many_single_char_names)]
+    // NB: a slight modification to the original protocol is done when absorbing
+    // the first prover message to improve the efficiency in a recursive
+    // setting.
     pub fn open<EFqSponge, RNG, D: EvaluationDomain<G::ScalarField>>(
         &self,
         group_map: &G::Map,
-        // TODO(mimoo): create a type for that entry
         plnms: PolynomialsToCombine<G, D>,
         elm: &[G::ScalarField],
         polyscale: G::ScalarField,

--- a/poly-commitment/src/ipa.rs
+++ b/poly-commitment/src/ipa.rs
@@ -835,7 +835,6 @@ impl<G: CommitmentCurve> SRS<G> {
     /// - rng: used for blinders for the zk property
     /// A slight modification to the original protocol is done
     /// when absorbing the first prover message.
-    #[allow(clippy::too_many_arguments)]
     #[allow(clippy::type_complexity)]
     #[allow(clippy::many_single_char_names)]
     pub fn open<EFqSponge, RNG, D: EvaluationDomain<G::ScalarField>>(

--- a/poly-commitment/src/kzg.rs
+++ b/poly-commitment/src/kzg.rs
@@ -385,12 +385,14 @@ impl<
 {
     /// Create a KZG proof.
     /// Parameters:
-    /// - `srs`: the structured reference string
-    /// - `plnms`: vector of polynomials with optional degree bound and
-    /// commitment randomness
+    /// - `srs`: the structured reference string used to commit
+    /// to the polynomials
+    /// - `plnms`: the list of polynomials to commit to, with possible blinders.
+    /// The type is simply an alias to handle the polynomials in evaluations or
+    /// coefficients forms.
     /// - `elm`: vector of evaluation points. Note that it only works for two
-    /// elements for now, i.e. elm must be of size 2.
-    /// - `polyscale`: scaling factor
+    /// elements for now.
+    /// - `polyscale`: a challenge to combine the polynomials.
     pub fn create<D: EvaluationDomain<F>>(
         srs: &PairingSRS<Pair>,
         plnms: PolynomialsToCombine<G, D>,
@@ -401,6 +403,7 @@ impl<
         let evals: Vec<_> = elm.iter().map(|pt| p.evaluate(pt)).collect();
 
         let quotient_poly = {
+            // This is where the condition on two points is enforced.
             let eval_polynomial = eval_polynomial(elm, &evals);
             let divisor_polynomial = divisor_polynomial(elm);
             let numerator_polynomial = &p - &eval_polynomial;

--- a/poly-commitment/src/kzg.rs
+++ b/poly-commitment/src/kzg.rs
@@ -392,7 +392,7 @@ impl<
     /// coefficients forms.
     /// - `elm`: vector of evaluation points. Note that it only works for two
     /// elements for now.
-    /// - `polyscale`: a challenge to combine the polynomials.
+    /// - `polyscale`: a challenge to batch the polynomials.
     pub fn create<D: EvaluationDomain<F>>(
         srs: &PairingSRS<Pair>,
         plnms: PolynomialsToCombine<G, D>,

--- a/poly-commitment/src/kzg.rs
+++ b/poly-commitment/src/kzg.rs
@@ -387,7 +387,7 @@ impl<
     /// Parameters:
     /// - `srs`: the structured reference string used to commit
     /// to the polynomials
-    /// - `plnms`: the list of polynomials to commit to, with possible blinders.
+    /// - `plnms`: the list of polynomials to open.
     /// The type is simply an alias to handle the polynomials in evaluations or
     /// coefficients forms.
     /// - `elm`: vector of evaluation points. Note that it only works for two

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -171,7 +171,7 @@ pub trait OpenProof<G: CommitmentCurve>: Sized + Clone {
     /// name.
     /// - `sponge`: Sponge used to coin and absorb values and simulate
     /// non-interactivity using the Fiat-Shamir transformation.
-    /// - `rng`: a pseudo random number generator in case blinding is needed
+    /// - `rng`: a pseudo random number generator used for zero-knowledge
     fn open<EFqSponge, RNG, D: EvaluationDomain<<G as AffineRepr>::ScalarField>>(
         srs: &Self::SRS,
         group_map: &<G as CommitmentCurve>::Map,

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -164,7 +164,7 @@ pub trait OpenProof<G: CommitmentCurve>: Sized + Clone {
     /// The type is simply an alias to handle the polynomials in evaluations or
     /// coefficients forms.
     /// - `elm`: the evaluation points
-    /// - `polyscale`: a challenge to combine the polynomials.
+    /// - `polyscale`: a challenge to bacth the polynomials.
     /// - `evalscale`: a challenge to build a randomized folded challenge (often
     /// refered as u) in case of multiple evaluation points. In the case of
     /// multiple evaluation points, powers of this point will be used, hence the

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -165,10 +165,7 @@ pub trait OpenProof<G: CommitmentCurve>: Sized + Clone {
     /// coefficients forms.
     /// - `elm`: the evaluation points
     /// - `polyscale`: a challenge to bacth the polynomials.
-    /// - `evalscale`: a challenge to build a randomized folded challenge (often
-    /// refered as u) in case of multiple evaluation points. In the case of
-    /// multiple evaluation points, powers of this point will be used, hence the
-    /// name.
+    /// - `evalscale`: a challenge to bacth the evaluation points
     /// - `sponge`: Sponge used to coin and absorb values and simulate
     /// non-interactivity using the Fiat-Shamir transformation.
     /// - `rng`: a pseudo random number generator used for zero-knowledge

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -160,7 +160,7 @@ pub trait OpenProof<G: CommitmentCurve>: Sized + Clone {
     /// - `srs`: the structured reference string used to commit
     /// to the polynomials
     /// - `group_map`: the group map
-    /// - `plnms`: the list of polynomials to commit to, with possible blinders.
+    /// - `plnms`: the list of polynomials to open, with possible blinders.
     /// The type is simply an alias to handle the polynomials in evaluations or
     /// coefficients forms.
     /// - `elm`: the evaluation points

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -172,7 +172,6 @@ pub trait OpenProof<G: CommitmentCurve>: Sized + Clone {
     /// - `sponge`: Sponge used to coin and absorb values and simulate
     /// non-interactivity using the Fiat-Shamir transformation.
     /// - `rng`: a pseudo random number generator in case blinding is needed
-    #[allow(clippy::too_many_arguments)]
     fn open<EFqSponge, RNG, D: EvaluationDomain<<G as AffineRepr>::ScalarField>>(
         srs: &Self::SRS,
         group_map: &<G as CommitmentCurve>::Map,


### PR DESCRIPTION
These are changes I was making while writing the prover in o1vm/pickles, and it is a follow-up on the pair-coding session we had early this week with @marcbeunardeau88

The changes are mostly esthetics for the online documentation generation, see https://o1-labs.github.io/proof-systems/rustdoc/