### PR TITLE
Poly-commitment: rename elems field into chunks

### DIFF
--- a/arrabiata/src/witness.rs
+++ b/arrabiata/src/witness.rs
@@ -496,7 +496,7 @@ where
                 let idx_col = idx / 2;
                 debug!("Absorbing the accumulator for the column index {idx_col}. After this, there will still be {} elements to absorb", NUMBER_OF_VALUES_TO_ABSORB_PUBLIC_IO - idx - 1);
                 if self.current_iteration % 2 == 0 {
-                    let (pt_x, pt_y) = self.ivc_accumulator_e2[idx_col].elems[0]
+                    let (pt_x, pt_y) = self.ivc_accumulator_e2[idx_col].chunks[0]
                         .to_coordinates()
                         .unwrap();
                     if idx % 2 == 0 {
@@ -505,7 +505,7 @@ where
                         self.write_public_input(pos, pt_y.to_biguint().into())
                     }
                 } else {
-                    let (pt_x, pt_y) = self.ivc_accumulator_e1[idx_col].elems[0]
+                    let (pt_x, pt_y) = self.ivc_accumulator_e1[idx_col].chunks[0]
                         .to_coordinates()
                         .unwrap();
                     if idx % 2 == 0 {
@@ -544,7 +544,7 @@ where
                     if self.current_iteration % 2 == 0 {
                         match side {
                             Side::Left => {
-                                let pt = self.previous_commitments_e2[i_comm].elems[0];
+                                let pt = self.previous_commitments_e2[i_comm].chunks[0];
                                 // We suppose we never have a commitment equals to the
                                 // point at infinity
                                 let (pt_x, pt_y) = pt.to_coordinates().unwrap();
@@ -570,7 +570,7 @@ where
                     } else {
                         match side {
                             Side::Left => {
-                                let pt = self.previous_commitments_e1[i_comm].elems[0];
+                                let pt = self.previous_commitments_e1[i_comm].chunks[0];
                                 // We suppose we never have a commitment equals to the
                                 // point at infinity
                                 let (pt_x, pt_y) = pt.to_coordinates().unwrap();
@@ -603,22 +603,22 @@ where
                 let (pt_x, pt_y): (BigInt, BigInt) = match side {
                     Side::Left => {
                         if self.current_iteration % 2 == 0 {
-                            let pt = self.ivc_accumulator_e2[i_comm].elems[0];
+                            let pt = self.ivc_accumulator_e2[i_comm].chunks[0];
                             let (x, y) = pt.to_coordinates().unwrap();
                             (x.to_biguint().into(), y.to_biguint().into())
                         } else {
-                            let pt = self.ivc_accumulator_e1[i_comm].elems[0];
+                            let pt = self.ivc_accumulator_e1[i_comm].chunks[0];
                             let (x, y) = pt.to_coordinates().unwrap();
                             (x.to_biguint().into(), y.to_biguint().into())
                         }
                     }
                     Side::Right => {
                         if self.current_iteration % 2 == 0 {
-                            let pt = self.previous_commitments_e2[i_comm].elems[0];
+                            let pt = self.previous_commitments_e2[i_comm].chunks[0];
                             let (x, y) = pt.to_coordinates().unwrap();
                             (x.to_biguint().into(), y.to_biguint().into())
                         } else {
-                            let pt = self.previous_commitments_e1[i_comm].elems[0];
+                            let pt = self.previous_commitments_e1[i_comm].chunks[0];
                             let (x, y) = pt.to_coordinates().unwrap();
                             (x.to_biguint().into(), y.to_biguint().into())
                         }

--- a/arrabiata/tests/witness.rs
+++ b/arrabiata/tests/witness.rs
@@ -162,7 +162,7 @@ fn test_unit_witness_elliptic_curve_addition() {
     assert_eq!(env.current_iteration, 0);
     let (exp_x3, exp_y3) = {
         let res: Pallas =
-            (env.ivc_accumulator_e2[0].elems[0] + env.previous_commitments_e2[0].elems[0]).into();
+            (env.ivc_accumulator_e2[0].chunks[0] + env.previous_commitments_e2[0].chunks[0]).into();
         let (x3, y3) = res.to_coordinates().unwrap();
         (
             x3.to_biguint().to_bigint().unwrap(),
@@ -181,7 +181,7 @@ fn test_unit_witness_elliptic_curve_addition() {
     assert_eq!(env.current_iteration, 1);
     let (exp_x3, exp_y3) = {
         let res: Vesta =
-            (env.ivc_accumulator_e1[0].elems[0] + env.previous_commitments_e1[0].elems[0]).into();
+            (env.ivc_accumulator_e1[0].chunks[0] + env.previous_commitments_e1[0].chunks[0]).into();
         let (x3, y3) = res.to_coordinates().unwrap();
         (
             x3.to_biguint().to_bigint().unwrap(),
@@ -200,7 +200,7 @@ fn test_unit_witness_elliptic_curve_addition() {
     assert_eq!(env.current_iteration, 2);
     let (exp_x3, exp_y3) = {
         let res: Pallas =
-            (env.ivc_accumulator_e2[0].elems[0] + env.previous_commitments_e2[0].elems[0]).into();
+            (env.ivc_accumulator_e2[0].chunks[0] + env.previous_commitments_e2[0].chunks[0]).into();
         let (x3, y3) = res.to_coordinates().unwrap();
         (
             x3.to_biguint().to_bigint().unwrap(),

--- a/folding/src/decomposable_folding.rs
+++ b/folding/src/decomposable_folding.rs
@@ -112,11 +112,11 @@ impl<'a, CF: FoldingConfig> DecomposableFoldingScheme<'a, CF> {
 
         // sanity check to verify that we only have one commitment in polycomm
         // (i.e. domain = poly size)
-        assert_eq!(error_commitments[0].elems.len(), 1);
-        assert_eq!(error_commitments[1].elems.len(), 1);
+        assert_eq!(error_commitments[0].chunks.len(), 1);
+        assert_eq!(error_commitments[1].chunks.len(), 1);
 
-        let t0 = &error_commitments[0].elems[0];
-        let t1 = &error_commitments[1].elems[0];
+        let t0 = &error_commitments[0].chunks[0];
+        let t1 = &error_commitments[1].chunks[0];
 
         let to_absorb = env.to_absorb(t0, t1);
         fq_sponge.absorb_fr(&to_absorb.0);
@@ -175,16 +175,18 @@ impl<'a, CF: FoldingConfig> DecomposableFoldingScheme<'a, CF> {
 
         // sanity check to verify that we only have one commitment in polycomm
         // (i.e. domain = poly size)
-        assert_eq!(error_commitments[0].elems.len(), 1);
-        assert_eq!(error_commitments[1].elems.len(), 1);
+        assert_eq!(error_commitments[0].chunks.len(), 1);
+        assert_eq!(error_commitments[1].chunks.len(), 1);
 
         let to_absorb = {
             let mut left = a.to_absorb();
             let right = b.to_absorb();
             left.0.extend(right.0);
             left.1.extend(right.1);
-            left.1
-                .extend([error_commitments[0].elems[0], error_commitments[1].elems[0]]);
+            left.1.extend([
+                error_commitments[0].chunks[0],
+                error_commitments[1].chunks[0],
+            ]);
             left
         };
 

--- a/folding/src/instance_witness.rs
+++ b/folding/src/instance_witness.rs
@@ -209,8 +209,8 @@ impl<G: CommitmentCurve, I: Instance<G>> Instance<G> for ExtendedInstance<G, I> 
     fn to_absorb(&self) -> (Vec<G::ScalarField>, Vec<G>) {
         let mut elements = self.instance.to_absorb();
         let extended_commitments = self.extended.iter().map(|commit| {
-            assert_eq!(commit.elems.len(), 1);
-            commit.elems[0]
+            assert_eq!(commit.chunks.len(), 1);
+            commit.chunks[0]
         });
         elements.1.extend(extended_commitments);
         elements
@@ -256,8 +256,8 @@ impl<G: CommitmentCurve, I: Instance<G>> RelaxedInstance<G, I> {
     pub fn to_absorb(&self) -> (Vec<G::ScalarField>, Vec<G>) {
         let mut elements = self.extended_instance.to_absorb();
         elements.0.push(self.u);
-        assert_eq!(self.error_commitment.elems.len(), 1);
-        elements.1.push(self.error_commitment.elems[0]);
+        assert_eq!(self.error_commitment.chunks.len(), 1);
+        elements.1.push(self.error_commitment.chunks[0]);
         elements
     }
 

--- a/folding/src/lib.rs
+++ b/folding/src/lib.rs
@@ -235,11 +235,11 @@ impl<'a, CF: FoldingConfig> FoldingScheme<'a, CF> {
 
         // sanity check to verify that we only have one commitment in polycomm
         // (i.e. domain = poly size)
-        assert_eq!(error_commitments[0].elems.len(), 1);
-        assert_eq!(error_commitments[1].elems.len(), 1);
+        assert_eq!(error_commitments[0].chunks.len(), 1);
+        assert_eq!(error_commitments[1].chunks.len(), 1);
 
-        let t_0 = &error_commitments[0].elems[0];
-        let t_1 = &error_commitments[1].elems[0];
+        let t_0 = &error_commitments[0].chunks[0];
+        let t_1 = &error_commitments[1].chunks[0];
 
         // Absorbing the commitments into the sponge
         let to_absorb = env.to_absorb(t_0, t_1);
@@ -300,16 +300,18 @@ impl<'a, CF: FoldingConfig> FoldingScheme<'a, CF> {
 
         // sanity check to verify that we only have one commitment in polycomm
         // (i.e. domain = poly size)
-        assert_eq!(error_commitments[0].elems.len(), 1);
-        assert_eq!(error_commitments[1].elems.len(), 1);
+        assert_eq!(error_commitments[0].chunks.len(), 1);
+        assert_eq!(error_commitments[1].chunks.len(), 1);
 
         let to_absorb = {
             let mut left = a.to_absorb();
             let right = b.to_absorb();
             left.0.extend(right.0);
             left.1.extend(right.1);
-            left.1
-                .extend([error_commitments[0].elems[0], error_commitments[1].elems[0]]);
+            left.1.extend([
+                error_commitments[0].chunks[0],
+                error_commitments[1].chunks[0],
+            ]);
             left
         };
 
@@ -341,7 +343,7 @@ impl<'a, CF: FoldingConfig> FoldingScheme<'a, CF> {
             let right = right_instance.to_absorb();
             left.0.extend(right.0);
             left.1.extend(right.1);
-            left.1.extend([t_0.elems[0], t_1.elems[0]]);
+            left.1.extend([t_0.chunks[0], t_1.chunks[0]]);
             left
         };
 

--- a/folding/tests/test_decomposable_folding.rs
+++ b/folding/tests/test_decomposable_folding.rs
@@ -258,7 +258,7 @@ fn instance_from_witness(
         .0
         .iter()
         .map(|w| srs.commit_evaluations_non_hiding(domain, w))
-        .map(|c| c.elems[0])
+        .map(|c| c.chunks[0])
         .collect_vec();
     let commitments: [_; 5] = commitments.try_into().unwrap();
 
@@ -465,8 +465,8 @@ fn test_decomposable_folding() {
         // show that there is some non trivial computation.
         assert_eq!(t_0.len(), 1);
         assert_eq!(t_1.len(), 1);
-        assert!(!t_0.elems[0].is_zero());
-        assert!(!t_1.elems[0].is_zero());
+        assert!(!t_0.chunks[0].is_zero());
+        assert!(!t_1.chunks[0].is_zero());
 
         let checker = ExtendedProvider::new(folded_instance, folded_witness);
         debug!("exp: \n {:#?}", final_constraint.to_string());

--- a/folding/tests/test_folding_with_quadriticization.rs
+++ b/folding/tests/test_folding_with_quadriticization.rs
@@ -258,7 +258,7 @@ fn instance_from_witness(
         .0
         .iter()
         .map(|w| srs.commit_evaluations_non_hiding(domain, w))
-        .map(|c| c.elems[0])
+        .map(|c| c.chunks[0])
         .collect_vec();
     let commitments: [_; 5] = commitments.try_into().unwrap();
 
@@ -503,8 +503,8 @@ fn test_quadriticization() {
         // show that there is some non trivial computation.
         assert_eq!(t_0.len(), 1);
         assert_eq!(t_1.len(), 1);
-        assert!(!t_0.elems[0].is_zero());
-        assert!(!t_1.elems[0].is_zero());
+        assert!(!t_0.chunks[0].is_zero());
+        assert!(!t_1.chunks[0].is_zero());
 
         let checker = ExtendedProvider::new(folded_instance, folded_witness);
 

--- a/folding/tests/test_vanilla_folding.rs
+++ b/folding/tests/test_vanilla_folding.rs
@@ -224,7 +224,7 @@ fn instance_from_witness(
         .0
         .iter()
         .map(|w| srs.commit_evaluations_non_hiding(domain, w))
-        .map(|c| c.elems[0])
+        .map(|c| c.chunks[0])
         .collect_vec();
     let commitments: [_; 3] = commitments.try_into().unwrap();
 
@@ -493,8 +493,8 @@ fn test_folding_instance() {
     // show that there is some non trivial computation.
     assert_eq!(t_0.len(), 1);
     assert_eq!(t_1.len(), 1);
-    assert!(!t_0.elems[0].is_zero());
-    assert!(!t_1.elems[0].is_zero());
+    assert!(!t_0.chunks[0].is_zero());
+    assert!(!t_1.chunks[0].is_zero());
 
     // checking that we have the expected number of elements to absorb
     // 3+2 from each instance + 1 from u, times 2 instances

--- a/ivc/src/plonkish_lang.rs
+++ b/ivc/src/plonkish_lang.rs
@@ -177,13 +177,13 @@ impl<G: CommitmentCurve, const N_COL: usize, const N_ALPHAS: usize>
 
         // Absorbing commitments
         (&commitments).into_iter().for_each(|c| {
-            assert!(c.elems.len() == 1);
+            assert!(c.chunks.len() == 1);
             absorb_commitment(fq_sponge, c)
         });
 
         let commitments: [G; N_COL] = commitments
             .into_iter()
-            .map(|c| c.elems[0])
+            .map(|c| c.chunks[0])
             .collect_vec()
             .try_into()
             .unwrap();
@@ -215,7 +215,7 @@ impl<G: CommitmentCurve, const N_COL: usize, const N_ALPHAS: usize>
         // Absorbing commitments
         self.commitments
             .iter()
-            .for_each(|c| absorb_commitment(fq_sponge, &PolyComm { elems: vec![*c] }));
+            .for_each(|c| absorb_commitment(fq_sponge, &PolyComm { chunks: vec![*c] }));
 
         let beta = fq_sponge.challenge();
         let gamma = fq_sponge.challenge();

--- a/ivc/src/prover.rs
+++ b/ivc/src/prover.rs
@@ -234,7 +234,7 @@ where
 
     let witness_comms: Witness<N_WIT_QUAD, PolyComm<G>> = {
         let blinders = PolyComm {
-            elems: vec![Fp::one()],
+            chunks: vec![Fp::one()],
         };
         let comm = {
             |poly: &DensePolynomial<Fp>| {
@@ -438,10 +438,10 @@ where
 
     let coefficients_form = DensePolynomialOrEvaluations::DensePolynomial;
     let non_hiding = |d1_size| PolyComm {
-        elems: vec![Fp::zero(); d1_size],
+        chunks: vec![Fp::zero(); d1_size],
     };
     let hiding = |d1_size| PolyComm {
-        elems: vec![Fp::one(); d1_size],
+        chunks: vec![Fp::one(); d1_size],
     };
 
     // Gathering all polynomials_to_open to use in the opening proof

--- a/ivc/tests/simple.rs
+++ b/ivc/tests/simple.rs
@@ -491,8 +491,8 @@ pub fn heavy_test_simple_add() {
 
     // The polynomial of the computation is linear, therefore, the error terms
     // are zero
-    assert_ne!(folding_output_one.t_0.elems[0], Curve::zero());
-    assert_ne!(folding_output_one.t_1.elems[0], Curve::zero());
+    assert_ne!(folding_output_one.t_0.chunks[0], Curve::zero());
+    assert_ne!(folding_output_one.t_1.chunks[0], Curve::zero());
 
     // Sanity check that the u values are the same. The u value is there to
     // homogeneoize the polynomial describing the NP relation.
@@ -518,7 +518,7 @@ pub fn heavy_test_simple_add() {
             .relaxed_extended_left_instance
             .extended_instance
             .extended;
-        let extended_comms: Vec<_> = extended.iter().map(|x| x.elems[0]).collect();
+        let extended_comms: Vec<_> = extended.iter().map(|x| x.chunks[0]).collect();
         comms_left.extend(extended_comms.clone());
         extended_comms.iter().enumerate().for_each(|(i, x)| {
             assert_ne!(
@@ -553,7 +553,7 @@ pub fn heavy_test_simple_add() {
             .relaxed_extended_right_instance
             .extended_instance
             .extended;
-        comms_right.extend(extended.iter().map(|x| x.elems[0]));
+        comms_right.extend(extended.iter().map(|x| x.chunks[0]));
     }
     assert_eq!(comms_right.len(), N_COL_TOTAL_QUAD);
     // Checking they are all not zero.
@@ -571,7 +571,7 @@ pub fn heavy_test_simple_add() {
     comms_out.extend(folded_instance_one.extended_instance.instance.commitments);
     {
         let extended = folded_instance_one.extended_instance.extended.clone();
-        comms_out.extend(extended.iter().map(|x| x.elems[0]));
+        comms_out.extend(extended.iter().map(|x| x.chunks[0]));
     }
     // Checking they are all not zero.
     comms_out.iter().for_each(|c| {
@@ -607,9 +607,9 @@ pub fn heavy_test_simple_add() {
         .commitment;
 
     let error_terms = [
-        left_error_term.elems[0],
-        right_error_term.elems[0],
-        folded_instance_one.error_commitment.elems[0],
+        left_error_term.chunks[0],
+        right_error_term.chunks[0],
+        folded_instance_one.error_commitment.chunks[0],
     ];
     error_terms.iter().for_each(|c| {
         assert_ne!(c, &Curve::zero());
@@ -618,8 +618,8 @@ pub fn heavy_test_simple_add() {
     let error_terms: [(Fq, Fq); 3] = std::array::from_fn(|i| (error_terms[i].x, error_terms[i].y));
 
     let t_terms = [
-        folding_output_one.t_0.elems[0],
-        folding_output_one.t_1.elems[0],
+        folding_output_one.t_0.chunks[0],
+        folding_output_one.t_1.chunks[0],
     ];
     t_terms.iter().for_each(|c| {
         assert_ne!(c, &Curve::zero());

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1165,7 +1165,7 @@ where
 
             PolyComm {
                 // blinding_f - Z_H(zeta) * blinding_t
-                elems: vec![
+                chunks: vec![
                     blinding_f - (zeta_to_domain_size - G::ScalarField::one()) * blinding_t,
                 ],
             }
@@ -1201,7 +1201,7 @@ where
             .map(|RecursionChallenge { chals, comm }| {
                 (
                     DensePolynomial::from_coefficients_vec(b_poly_coefficients(chals)),
-                    comm.elems.len(),
+                    comm.chunks.len(),
                 )
             })
             .collect::<Vec<_>>();
@@ -1236,7 +1236,7 @@ where
         //~    (and evaluation proofs) in the protocol.
         //~    First, include the previous challenges, in case we are in a recursive prover.
         let non_hiding = |d1_size: usize| PolyComm {
-            elems: vec![G::ScalarField::zero(); d1_size],
+            chunks: vec![G::ScalarField::zero(); d1_size],
         };
 
         let coefficients_form = DensePolynomialOrEvaluations::DensePolynomial;
@@ -1248,7 +1248,7 @@ where
             .collect::<Vec<_>>();
 
         let fixed_hiding = |d1_size: usize| PolyComm {
-            elems: vec![G::ScalarField::one(); d1_size],
+            chunks: vec![G::ScalarField::one(); d1_size],
         };
 
         //~ 1. Then, include:
@@ -1395,17 +1395,17 @@ where
                 if lcs.runtime_selector.is_some() {
                     let runtime_comm = lookup_context.runtime_table_comm.as_ref().unwrap();
 
-                    let elems = runtime_comm
+                    let chunks = runtime_comm
                         .blinders
-                        .elems
+                        .chunks
                         .iter()
                         .map(|blinding| *joint_combiner * blinding + base_blinding)
                         .collect();
 
-                    PolyComm { elems }
+                    PolyComm { chunks }
                 } else {
-                    let elems = vec![base_blinding; num_chunks];
-                    PolyComm { elems }
+                    let chunks = vec![base_blinding; num_chunks];
+                    PolyComm { chunks }
                 }
             };
 

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -239,11 +239,11 @@ where
         let alpha = alpha_chal.to_field(endo_r);
 
         //~ 1. Enforce that the length of the $t$ commitment is of size 7.
-        if self.commitments.t_comm.elems.len() > chunk_size * 7 {
+        if self.commitments.t_comm.chunks.len() > chunk_size * 7 {
             return Err(VerifyError::IncorrectCommitmentLength(
                 "t",
                 chunk_size * 7,
-                self.commitments.t_comm.elems.len(),
+                self.commitments.t_comm.chunks.len(),
             ));
         }
 

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -441,42 +441,42 @@ impl<G: KimchiCurve, OpeningProof: OpenProof<G>> VerifierIndex<G, OpeningProof> 
         // Always present
 
         for comm in sigma_comm.iter() {
-            fq_sponge.absorb_g(&comm.elems);
+            fq_sponge.absorb_g(&comm.chunks);
         }
         for comm in coefficients_comm.iter() {
-            fq_sponge.absorb_g(&comm.elems);
+            fq_sponge.absorb_g(&comm.chunks);
         }
-        fq_sponge.absorb_g(&generic_comm.elems);
-        fq_sponge.absorb_g(&psm_comm.elems);
-        fq_sponge.absorb_g(&complete_add_comm.elems);
-        fq_sponge.absorb_g(&mul_comm.elems);
-        fq_sponge.absorb_g(&emul_comm.elems);
-        fq_sponge.absorb_g(&endomul_scalar_comm.elems);
+        fq_sponge.absorb_g(&generic_comm.chunks);
+        fq_sponge.absorb_g(&psm_comm.chunks);
+        fq_sponge.absorb_g(&complete_add_comm.chunks);
+        fq_sponge.absorb_g(&mul_comm.chunks);
+        fq_sponge.absorb_g(&emul_comm.chunks);
+        fq_sponge.absorb_g(&endomul_scalar_comm.chunks);
 
         // Optional gates
 
         if let Some(range_check0_comm) = range_check0_comm {
-            fq_sponge.absorb_g(&range_check0_comm.elems);
+            fq_sponge.absorb_g(&range_check0_comm.chunks);
         }
 
         if let Some(range_check1_comm) = range_check1_comm {
-            fq_sponge.absorb_g(&range_check1_comm.elems);
+            fq_sponge.absorb_g(&range_check1_comm.chunks);
         }
 
         if let Some(foreign_field_mul_comm) = foreign_field_mul_comm {
-            fq_sponge.absorb_g(&foreign_field_mul_comm.elems);
+            fq_sponge.absorb_g(&foreign_field_mul_comm.chunks);
         }
 
         if let Some(foreign_field_add_comm) = foreign_field_add_comm {
-            fq_sponge.absorb_g(&foreign_field_add_comm.elems);
+            fq_sponge.absorb_g(&foreign_field_add_comm.chunks);
         }
 
         if let Some(xor_comm) = xor_comm {
-            fq_sponge.absorb_g(&xor_comm.elems);
+            fq_sponge.absorb_g(&xor_comm.chunks);
         }
 
         if let Some(rot_comm) = rot_comm {
-            fq_sponge.absorb_g(&rot_comm.elems);
+            fq_sponge.absorb_g(&rot_comm.chunks);
         }
 
         // Lookup index; optional
@@ -498,26 +498,26 @@ impl<G: KimchiCurve, OpeningProof: OpenProof<G>> VerifierIndex<G, OpeningProof> 
         }) = lookup_index
         {
             for entry in lookup_table {
-                fq_sponge.absorb_g(&entry.elems);
+                fq_sponge.absorb_g(&entry.chunks);
             }
             if let Some(table_ids) = table_ids {
-                fq_sponge.absorb_g(&table_ids.elems);
+                fq_sponge.absorb_g(&table_ids.chunks);
             }
             if let Some(runtime_tables_selector) = runtime_tables_selector {
-                fq_sponge.absorb_g(&runtime_tables_selector.elems);
+                fq_sponge.absorb_g(&runtime_tables_selector.chunks);
             }
 
             if let Some(xor) = xor {
-                fq_sponge.absorb_g(&xor.elems);
+                fq_sponge.absorb_g(&xor.chunks);
             }
             if let Some(lookup) = lookup {
-                fq_sponge.absorb_g(&lookup.elems);
+                fq_sponge.absorb_g(&lookup.chunks);
             }
             if let Some(range_check) = range_check {
-                fq_sponge.absorb_g(&range_check.elems);
+                fq_sponge.absorb_g(&range_check.chunks);
             }
             if let Some(ffmul) = ffmul {
-                fq_sponge.absorb_g(&ffmul.elems);
+                fq_sponge.absorb_g(&ffmul.chunks);
             }
         }
         fq_sponge.digest_fq()

--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -138,7 +138,7 @@ where
 
     let witness_comms: Witness<N_WIT, PolyComm<G>> = {
         let blinders = PolyComm {
-            elems: vec![G::ScalarField::one()],
+            chunks: vec![G::ScalarField::one()],
         };
         let comm = {
             |poly: &DensePolynomial<G::ScalarField>| {
@@ -490,10 +490,10 @@ where
 
     let coefficients_form = DensePolynomialOrEvaluations::DensePolynomial;
     let non_hiding = |d1_size| PolyComm {
-        elems: vec![G::ScalarField::zero(); d1_size],
+        chunks: vec![G::ScalarField::zero(); d1_size],
     };
     let hiding = |d1_size| PolyComm {
-        elems: vec![G::ScalarField::one(); d1_size],
+        chunks: vec![G::ScalarField::one(); d1_size],
     };
 
     // Gathering all polynomials to use in the opening proof

--- a/msm/src/test/generic.rs
+++ b/msm/src/test/generic.rs
@@ -108,7 +108,7 @@ pub fn test_completeness_generic<
         // Checking that none of the commitments are zero
         (&proof.proof_comms.witness_comms)
             .into_iter()
-            .for_each(|v| v.elems.iter().for_each(|x| assert!(!x.is_zero())));
+            .for_each(|v| v.chunks.iter().for_each(|x| assert!(!x.is_zero())));
 
         // Checking the number of chunks of the quotient polynomial
         let max_degree = {

--- a/o1vm/src/legacy/trace.rs
+++ b/o1vm/src/legacy/trace.rs
@@ -179,7 +179,7 @@ where
 
         let commitments: [C::Curve; N] = commitments
             .into_iter()
-            .map(|c| c.elems[0])
+            .map(|c| c.chunks[0])
             .collect_vec()
             .try_into()
             .unwrap();

--- a/poly-commitment/src/chunked.rs
+++ b/poly-commitment/src/chunked.rs
@@ -15,13 +15,13 @@ where
         // use Horner's to compute chunk[0] + z^n chunk[1] + z^2n chunk[2] + ...
         // as ( chunk[-1] * z^n + chunk[-2] ) * z^n + chunk[-3]
         // (https://en.wikipedia.org/wiki/Horner%27s_method)
-        for chunk in self.elems.iter().rev() {
+        for chunk in self.chunks.iter().rev() {
             res *= zeta_n;
             res.add_assign(chunk);
         }
 
         PolyComm {
-            elems: vec![res.into_affine()],
+            chunks: vec![res.into_affine()],
         }
     }
 }
@@ -37,7 +37,7 @@ where
         // use Horner's to compute chunk[0] + z^n chunk[1] + z^2n chunk[2] + ...
         // as ( chunk[-1] * z^n + chunk[-2] ) * z^n + chunk[-3]
         // (https://en.wikipedia.org/wiki/Horner%27s_method)
-        for chunk in self.elems.iter().rev() {
+        for chunk in self.chunks.iter().rev() {
             res *= zeta_n;
             res += chunk
         }

--- a/poly-commitment/src/kzg.rs
+++ b/poly-commitment/src/kzg.rs
@@ -66,7 +66,7 @@ pub fn combine_evaluations<G: CommitmentCurve>(
 
     for Evaluation { evaluations, .. } in evaluations
         .iter()
-        .filter(|x| !x.commitment.elems.is_empty())
+        .filter(|x| !x.commitment.chunks.is_empty())
     {
         // IMPROVEME: we could have a flat array that would contain all the
         // evaluations and all the chunks. It would avoid fetching the memory
@@ -414,7 +414,7 @@ impl<
             quotient
         };
 
-        let quotient = srs.full_srs.commit_non_hiding(&quotient_poly, 1).elems[0];
+        let quotient = srs.full_srs.commit_non_hiding(&quotient_poly, 1).chunks[0];
 
         Some(KZGProof {
             quotient,
@@ -455,12 +455,12 @@ impl<
         let divisor_commitment = srs
             .verifier_srs
             .commit_non_hiding(&divisor_polynomial(elm), 1)
-            .elems[0];
+            .chunks[0];
         // Taking the first element of the commitment, i.e. no support for chunking.
         let eval_commitment = srs
             .full_srs
             .commit_non_hiding(&eval_polynomial(elm, &evals), 1)
-            .elems[0]
+            .chunks[0]
             .into_group();
         let numerator_commitment = { poly_commitment - eval_commitment - blinding_commitment };
         // We compute the result of the multiplication of two miller loop,

--- a/poly-commitment/tests/kzg.rs
+++ b/poly-commitment/tests/kzg.rs
@@ -20,7 +20,7 @@ fn test_combine_evaluations() {
 
     // we ignore commitments
     let dummy_commitments = PolyComm::<VestaG> {
-        elems: vec![VestaG::zero(); nb_of_chunks],
+        chunks: vec![VestaG::zero(); nb_of_chunks],
     };
 
     let polyscale = Fp::from(2);


### PR DESCRIPTION
It is more meaningful because it is actually chunks. In following pull requests, the abstraction over PolyComm will be changed, to avoid erroneous usage of PolyComm.

It is part of the implementation of the prover into pickles, as I noticed I made a small error while splitting the quotient polynomial in chunks.

I am breaking the usage of PolyComm in develop, and in Mina, cc @volhovm as you will work on merging develop into master for proof-systems.