### PR TITLE
PolyComm: use method len directly instead of chunks.len

### DIFF
--- a/folding/src/decomposable_folding.rs
+++ b/folding/src/decomposable_folding.rs
@@ -112,8 +112,8 @@ impl<'a, CF: FoldingConfig> DecomposableFoldingScheme<'a, CF> {
 
         // sanity check to verify that we only have one commitment in polycomm
         // (i.e. domain = poly size)
-        assert_eq!(error_commitments[0].chunks.len(), 1);
-        assert_eq!(error_commitments[1].chunks.len(), 1);
+        assert_eq!(error_commitments[0].len(), 1);
+        assert_eq!(error_commitments[1].len(), 1);
 
         let t0 = &error_commitments[0].chunks[0];
         let t1 = &error_commitments[1].chunks[0];
@@ -175,8 +175,8 @@ impl<'a, CF: FoldingConfig> DecomposableFoldingScheme<'a, CF> {
 
         // sanity check to verify that we only have one commitment in polycomm
         // (i.e. domain = poly size)
-        assert_eq!(error_commitments[0].chunks.len(), 1);
-        assert_eq!(error_commitments[1].chunks.len(), 1);
+        assert_eq!(error_commitments[0].len(), 1);
+        assert_eq!(error_commitments[1].len(), 1);
 
         let to_absorb = {
             let mut left = a.to_absorb();

--- a/folding/src/instance_witness.rs
+++ b/folding/src/instance_witness.rs
@@ -209,7 +209,7 @@ impl<G: CommitmentCurve, I: Instance<G>> Instance<G> for ExtendedInstance<G, I> 
     fn to_absorb(&self) -> (Vec<G::ScalarField>, Vec<G>) {
         let mut elements = self.instance.to_absorb();
         let extended_commitments = self.extended.iter().map(|commit| {
-            assert_eq!(commit.chunks.len(), 1);
+            assert_eq!(commit.len(), 1);
             commit.chunks[0]
         });
         elements.1.extend(extended_commitments);
@@ -256,7 +256,7 @@ impl<G: CommitmentCurve, I: Instance<G>> RelaxedInstance<G, I> {
     pub fn to_absorb(&self) -> (Vec<G::ScalarField>, Vec<G>) {
         let mut elements = self.extended_instance.to_absorb();
         elements.0.push(self.u);
-        assert_eq!(self.error_commitment.chunks.len(), 1);
+        assert_eq!(self.error_commitment.len(), 1);
         elements.1.push(self.error_commitment.chunks[0]);
         elements
     }

--- a/folding/src/lib.rs
+++ b/folding/src/lib.rs
@@ -235,8 +235,8 @@ impl<'a, CF: FoldingConfig> FoldingScheme<'a, CF> {
 
         // sanity check to verify that we only have one commitment in polycomm
         // (i.e. domain = poly size)
-        assert_eq!(error_commitments[0].chunks.len(), 1);
-        assert_eq!(error_commitments[1].chunks.len(), 1);
+        assert_eq!(error_commitments[0].len(), 1);
+        assert_eq!(error_commitments[1].len(), 1);
 
         let t_0 = &error_commitments[0].chunks[0];
         let t_1 = &error_commitments[1].chunks[0];
@@ -300,8 +300,8 @@ impl<'a, CF: FoldingConfig> FoldingScheme<'a, CF> {
 
         // sanity check to verify that we only have one commitment in polycomm
         // (i.e. domain = poly size)
-        assert_eq!(error_commitments[0].chunks.len(), 1);
-        assert_eq!(error_commitments[1].chunks.len(), 1);
+        assert_eq!(error_commitments[0].len(), 1);
+        assert_eq!(error_commitments[1].len(), 1);
 
         let to_absorb = {
             let mut left = a.to_absorb();

--- a/ivc/src/plonkish_lang.rs
+++ b/ivc/src/plonkish_lang.rs
@@ -177,7 +177,7 @@ impl<G: CommitmentCurve, const N_COL: usize, const N_ALPHAS: usize>
 
         // Absorbing commitments
         (&commitments).into_iter().for_each(|c| {
-            assert!(c.chunks.len() == 1);
+            assert!(c.len() == 1);
             absorb_commitment(fq_sponge, c)
         });
 

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1201,7 +1201,7 @@ where
             .map(|RecursionChallenge { chals, comm }| {
                 (
                     DensePolynomial::from_coefficients_vec(b_poly_coefficients(chals)),
-                    comm.chunks.len(),
+                    comm.len(),
                 )
             })
             .collect::<Vec<_>>();

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -239,11 +239,11 @@ where
         let alpha = alpha_chal.to_field(endo_r);
 
         //~ 1. Enforce that the length of the $t$ commitment is of size 7.
-        if self.commitments.t_comm.chunks.len() > chunk_size * 7 {
+        if self.commitments.t_comm.len() > chunk_size * 7 {
             return Err(VerifyError::IncorrectCommitmentLength(
                 "t",
                 chunk_size * 7,
-                self.commitments.t_comm.chunks.len(),
+                self.commitments.t_comm.len(),
             ));
         }
 

--- a/poly-commitment/src/ipa.rs
+++ b/poly-commitment/src/ipa.rs
@@ -162,7 +162,7 @@ pub fn combine_polys<G: CommitmentCurve, D: EvaluationDomain<G::ScalarField>>(
                     .for_each(|(i, x)| {
                         *x += scale * evals[i * stride];
                     });
-                for j in 0..omegas.chunks.len() {
+                for j in 0..omegas.len() {
                     omega += &(omegas.chunks[j] * scale);
                     scale *= &polyscale;
                 }
@@ -172,7 +172,7 @@ pub fn combine_polys<G: CommitmentCurve, D: EvaluationDomain<G::ScalarField>>(
             DensePolynomialOrEvaluations::DensePolynomial(p_i) => {
                 let mut offset = 0;
                 // iterating over chunks of the polynomial
-                for j in 0..omegas.chunks.len() {
+                for j in 0..omegas.len() {
                     let segment = &p_i.coeffs[std::cmp::min(offset, p_i.coeffs.len())
                         ..std::cmp::min(offset + srs_length, p_i.coeffs.len())];
                     plnm_coefficients.add_poly(scale, segment);
@@ -1065,9 +1065,8 @@ impl<G: CommitmentCurve> SRS<G> {
                         (*evals).clone().interpolate()
                     }
                 };
-                let chunked_polynomial =
-                    poly.to_chunked_polynomial(blinders.chunks.len(), self.g.len());
-                let chunked_commitment = { self.commit_non_hiding(&poly, blinders.chunks.len()) };
+                let chunked_polynomial = poly.to_chunked_polynomial(blinders.len(), self.g.len());
+                let chunked_commitment = { self.commit_non_hiding(&poly, blinders.len()) };
                 let masked_commitment = match self.mask_custom(chunked_commitment, blinders) {
                     Ok(comm) => comm,
                     Err(err) => panic!("Error at index {i}: {err}"),


### PR DESCRIPTION
`len()` on PolyComm is exactly implemented as `chunks.len()` It is part of a work abstracting the structure `PolyComm`, and remove the access to the field `chunks`.