### PR TITLE
PolyComm/KZG: use is_empty directly instead of accessing field

### DIFF
--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -599,10 +599,7 @@ pub fn combine_commitments<G: CommitmentCurve>(
     // will contain the power of polyscale
     let mut xi_i = G::ScalarField::one();
 
-    for Evaluation { commitment, .. } in evaluations
-        .iter()
-        .filter(|x| !x.commitment.chunks.is_empty())
-    {
+    for Evaluation { commitment, .. } in evaluations.iter().filter(|x| !x.commitment.is_empty()) {
         // iterating over the polynomial segments
         for comm_ch in &commitment.chunks {
             scalars.push(rand_base * xi_i);

--- a/poly-commitment/src/kzg.rs
+++ b/poly-commitment/src/kzg.rs
@@ -64,10 +64,7 @@ pub fn combine_evaluations<G: CommitmentCurve>(
         vec![G::ScalarField::zero(); num_evals]
     };
 
-    for Evaluation { evaluations, .. } in evaluations
-        .iter()
-        .filter(|x| !x.commitment.chunks.is_empty())
-    {
+    for Evaluation { evaluations, .. } in evaluations.iter().filter(|x| !x.commitment.is_empty()) {
         // IMPROVEME: we could have a flat array that would contain all the
         // evaluations and all the chunks. It would avoid fetching the memory
         // and avoid indirection into RAM.


### PR DESCRIPTION
is_empty is exactly an alias for chunks.is_empty