### PR TITLE
Poly-commitment/IPA: additional tests regarding expected nb chunks

### DIFF
--- a/o1vm/src/pickles/prover.rs
+++ b/o1vm/src/pickles/prover.rs
@@ -209,9 +209,7 @@ where
             (
                 DensePolynomialOrEvaluations::DensePolynomial(poly),
                 // We do not have any blinder, therefore we set to 0.
-                PolyComm {
-                    elems: vec![G::ScalarField::zero()],
-                },
+                PolyComm::new(vec![G::ScalarField::zero()]),
             )
         })
         .collect();

--- a/poly-commitment/src/ipa.rs
+++ b/poly-commitment/src/ipa.rs
@@ -584,11 +584,6 @@ where
         })
     }
 
-    /// This function commits a polynomial using the SRS' basis of size `n`.
-    /// - `plnm`: polynomial to commit to with max size of sections
-    /// - `num_chunks`: the number of commitments to be included in the output polynomial commitment
-    /// The function returns an unbounded commitment vector
-    /// (which splits the commitment into several commitments of size at most `n`).
     fn commit_non_hiding(
         &self,
         plnm: &DensePolynomial<G::ScalarField>,

--- a/poly-commitment/src/ipa.rs
+++ b/poly-commitment/src/ipa.rs
@@ -564,7 +564,6 @@ where
         self.mask_custom(comm, &blinders).unwrap()
     }
 
-    /// Same as [SRS::mask] except that you can pass the blinders manually.
     fn mask_custom(
         &self,
         com: PolyComm<G>,
@@ -611,8 +610,6 @@ where
         PolyComm::<G> { chunks }
     }
 
-    /// Commits a polynomial, potentially splitting the result in multiple
-    /// commitments.
     fn commit(
         &self,
         plnm: &DensePolynomial<G::ScalarField>,

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -68,7 +68,7 @@ pub trait SRS<G: CommitmentCurve>: Clone + Sized {
     /// - `num_chunks`: the minimal number of commitments to be included in the
     /// output polynomial commitment.
     ///
-    /// The function returns the commitments to the chunks (of at most `n`) of
+    /// The function returns the commitments to the chunks (of size at most `n`) of
     /// the polynomials.
     ///
     /// The function will also pad with zeroes if the polynomial has a degree

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -7,6 +7,9 @@ pub mod ipa;
 /// KZG polynomial commitment scheme
 pub mod kzg;
 
+// Exposing property based tests for the SRS trait
+pub mod pbt_srs;
+
 pub use commitment::PolyComm;
 
 use crate::{
@@ -76,8 +79,8 @@ pub trait SRS<G: CommitmentCurve>: Clone + Sized {
     /// also contain the additional chunks.
     ///
     /// See the test
-    /// `test_regression_commit_non_hiding_expected_number_of_chunks` for an
-    /// example of the number of chunks returned.
+    /// [crate::pbt_srs::test_regression_commit_non_hiding_expected_number_of_chunks]
+    /// for an example of the number of chunks returned.
     fn commit_non_hiding(
         &self,
         plnm: &DensePolynomial<G::ScalarField>,

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -60,13 +60,24 @@ pub trait SRS<G: CommitmentCurve>: Clone + Sized {
     }
 
     /// This function commits a polynomial using the SRS' basis of size `n`.
-    /// - `plnm`: polynomial to commit to with max size of sections
-    /// - `num_chunks`: the number of commitments to be included in the output
-    /// polynomial commitment
-    /// The function returns an unbounded commitment vector (which splits the
-    /// commitment into several commitments of size at most `n`).
-    /// It is analogous to [SRS::commit_evaluations_non_hiding] but for
-    /// polynomials.
+    /// - `plnm`: polynomial to commit to. The polynomial can be of any degree,
+    /// including higher than `n`.
+    /// - `num_chunks`: the minimal number of commitments to be included in the
+    /// output polynomial commitment.
+    ///
+    /// The function returns the commitments to the chunks (of at most `n`) of
+    /// the polynomials.
+    ///
+    /// The function will also pad with zeroes if the polynomial has a degree
+    /// smaller than `n * num_chunks`.
+    ///
+    /// Note that if the polynomial has a degree higher than `n * num_chunks`,
+    /// the output will contain more than `num_chunks` commitments as it will
+    /// also contain the additional chunks.
+    ///
+    /// See the test
+    /// `test_regression_commit_non_hiding_expected_number_of_chunks` for an
+    /// example of the number of chunks returned.
     fn commit_non_hiding(
         &self,
         plnm: &DensePolynomial<G::ScalarField>,

--- a/poly-commitment/src/pbt_srs.rs
+++ b/poly-commitment/src/pbt_srs.rs
@@ -1,0 +1,77 @@
+//! This module defines Property-based tests for the SRS trait.
+//! It includes tests regarding methods the SRS trait should implement.
+//! It aims to verify the implementation respects the properties described in
+//! the documentation of the methods.
+
+use ark_ff::Zero;
+use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial};
+use rand::Rng;
+
+use crate::{commitment::CommitmentCurve, SRS};
+
+// Testing how many chunks are generated with different polynomial sizes and
+// different number of chunks requested.
+pub fn test_regression_commit_non_hiding_expected_number_of_chunks<
+    G: CommitmentCurve,
+    Srs: SRS<G>,
+>() {
+    let mut rng = &mut o1_utils::tests::make_test_rng(None);
+    // maximum random srs size is 64
+    let log2_srs_size = rng.gen_range(1..6);
+    let srs_size = 1 << log2_srs_size;
+    let srs = Srs::create(srs_size);
+
+    // If we have a polynomial of the size of the SRS (i.e. of degree `srs_size -
+    // 1`), and we request 1 chunk, we should get 1 chunk.
+    {
+        // srs_size is the number of evaluation degree
+        let poly_degree = srs_size - 1;
+        let poly = DensePolynomial::<G::ScalarField>::rand(poly_degree, &mut rng);
+        let commitment = srs.commit_non_hiding(&poly, 1);
+        assert_eq!(commitment.len(), 1);
+    }
+
+    // If we have a polynomial of the size of the SRS (i.e. of degree `srs_size -
+    // 1`), and we request k chunks (k > 1), we should get k chunk.
+    {
+        // srs_size is the number of evaluation degree
+        let poly_degree = srs_size - 1;
+        // maximum 10 chunks for the test
+        let k = rng.gen_range(2..10);
+        let poly = DensePolynomial::<G::ScalarField>::rand(poly_degree, &mut rng);
+        let commitment = srs.commit_non_hiding(&poly, k);
+        assert_eq!(commitment.len(), k);
+    }
+
+    // Same than the two previous cases, but with the special polynomial equals to zero.
+    {
+        let k = rng.gen_range(1..10);
+        let poly = DensePolynomial::<G::ScalarField>::zero();
+        let commitment = srs.commit_non_hiding(&poly, k);
+        assert_eq!(commitment.len(), k);
+    }
+
+    // Polynomial of exactly a multiple of the SRS size, i.e degree is k *
+    // srs_size - 1.
+    {
+        let k = rng.gen_range(2..5);
+        let poly_degree = k * srs_size - 1;
+        let poly = DensePolynomial::<G::ScalarField>::rand(poly_degree, &mut rng);
+        // if we request a number of chunks smaller than the multiple, we will
+        // still get a number of chunks equals to the multiple.
+        let requested_num_chunks = rng.gen_range(1..k);
+        let commitment = srs.commit_non_hiding(&poly, requested_num_chunks);
+        assert_eq!(commitment.len(), k);
+
+        // if we request a number of chunks equals to the multiple, we will get
+        // the exact number of chunks.
+        let commitment = srs.commit_non_hiding(&poly, k);
+        assert_eq!(commitment.len(), k);
+
+        // if we request a number of chunks greater than the multiple, we will
+        // get the exact number of chunks requested.
+        let requested_num_chunks = rng.gen_range(k + 1..10);
+        let commitment = srs.commit_non_hiding(&poly, requested_num_chunks);
+        assert_eq!(commitment.len(), requested_num_chunks);
+    }
+}

--- a/poly-commitment/tests/ipa_commitment.rs
+++ b/poly-commitment/tests/ipa_commitment.rs
@@ -4,7 +4,7 @@ use ark_poly::{
     Radix2EvaluationDomain as D, Radix2EvaluationDomain,
 };
 use groupmap::GroupMap;
-use mina_curves::pasta::{Fp, Vesta as VestaG};
+use mina_curves::pasta::{Fp, Pallas, Vesta as VestaG};
 use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi as SC, sponge::DefaultFqSponge, FqSponge,
 };
@@ -12,7 +12,7 @@ use o1_utils::ExtendedDensePolynomial;
 use poly_commitment::{
     commitment::{combined_inner_product, BatchEvaluationProof, CommitmentCurve, Evaluation},
     ipa::{DensePolynomialOrEvaluations, SRS},
-    PolyComm, SRS as _,
+    pbt_srs, PolyComm, SRS as _,
 };
 use rand::Rng;
 use std::array;
@@ -220,63 +220,6 @@ fn test_opening_proof() {
 // different number of chunks requested.
 #[test]
 fn test_regression_commit_non_hiding_expected_number_of_chunks() {
-    let mut rng = &mut o1_utils::tests::make_test_rng(None);
-    // maximum random srs size is 64
-    let log2_srs_size = rng.gen_range(1..6);
-    let srs_size = 1 << log2_srs_size;
-    let srs = SRS::<VestaG>::create(srs_size);
-
-    // If we have a polynomial of the size of the SRS (i.e. of degree `srs_size -
-    // 1`), and we request 1 chunk, we should get 1 chunk.
-    {
-        // srs_size is the number of evaluation degree
-        let poly_degree = srs_size - 1;
-        let poly = DensePolynomial::<Fp>::rand(poly_degree, &mut rng);
-        let commitment = srs.commit_non_hiding(&poly, 1);
-        assert_eq!(commitment.len(), 1);
-    }
-
-    // If we have a polynomial of the size of the SRS (i.e. of degree `srs_size -
-    // 1`), and we request k chunks (k > 1), we should get k chunk.
-    {
-        // srs_size is the number of evaluation degree
-        let poly_degree = srs_size - 1;
-        // maximum 10 chunks for the test
-        let k = rng.gen_range(2..10);
-        let poly = DensePolynomial::<Fp>::rand(poly_degree, &mut rng);
-        let commitment = srs.commit_non_hiding(&poly, k);
-        assert_eq!(commitment.len(), k);
-    }
-
-    // Same than the two previous cases, but with the special polynomial equals to zero.
-    {
-        let k = rng.gen_range(1..10);
-        let poly = DensePolynomial::<Fp>::zero();
-        let commitment = srs.commit_non_hiding(&poly, k);
-        assert_eq!(commitment.len(), k);
-    }
-
-    // Polynomial of exactly a multiple of the SRS size, i.e degree is k *
-    // srs_size - 1.
-    {
-        let k = rng.gen_range(2..5);
-        let poly_degree = k * srs_size - 1;
-        let poly = DensePolynomial::<Fp>::rand(poly_degree, &mut rng);
-        // if we request a number of chunks smaller than the multiple, we will
-        // still get a number of chunks equals to the multiple.
-        let requested_num_chunks = rng.gen_range(1..k);
-        let commitment = srs.commit_non_hiding(&poly, requested_num_chunks);
-        assert_eq!(commitment.len(), k);
-
-        // if we request a number of chunks equals to the multiple, we will get
-        // the exact number of chunks.
-        let commitment = srs.commit_non_hiding(&poly, k);
-        assert_eq!(commitment.len(), k);
-
-        // if we request a number of chunks greater than the multiple, we will
-        // get the exact number of chunks requested.
-        let requested_num_chunks = rng.gen_range(k + 1..10);
-        let commitment = srs.commit_non_hiding(&poly, requested_num_chunks);
-        assert_eq!(commitment.len(), requested_num_chunks);
-    }
+    pbt_srs::test_regression_commit_non_hiding_expected_number_of_chunks::<VestaG, SRS<VestaG>>();
+    pbt_srs::test_regression_commit_non_hiding_expected_number_of_chunks::<Pallas, SRS<Pallas>>()
 }

--- a/poly-commitment/tests/ipa_commitment.rs
+++ b/poly-commitment/tests/ipa_commitment.rs
@@ -60,9 +60,11 @@ fn test_chunked_lagrange_commitments() {
 
     let expected_lagrange_commitments: Vec<_> = (0..n)
         .map(|i| {
+            // Generating the i-th element of the lagrange basis
             let mut e = vec![Fp::zero(); n];
             e[i] = Fp::one();
             let p = Evaluations::<Fp, D<Fp>>::from_vec_and_domain(e, domain).interpolate();
+            // Committing, and requesting [num_chunks] chunks.
             srs.commit_non_hiding(&p, num_chunks)
         })
         .collect();
@@ -211,5 +213,70 @@ fn test_opening_proof() {
         }];
 
         assert!(srs.verify(&group_map, &mut batch, rng));
+    }
+}
+
+// Testing how many chunks are generated with different polynomial sizes and
+// different number of chunks requested.
+#[test]
+fn test_regression_commit_non_hiding_expected_number_of_chunks() {
+    let mut rng = &mut o1_utils::tests::make_test_rng(None);
+    // maximum random srs size is 64
+    let log2_srs_size = rng.gen_range(1..6);
+    let srs_size = 1 << log2_srs_size;
+    let srs = SRS::<VestaG>::create(srs_size);
+
+    // If we have a polynomial of the size of the SRS (i.e. of degree `srs_size -
+    // 1`), and we request 1 chunk, we should get 1 chunk.
+    {
+        // srs_size is the number of evaluation degree
+        let poly_degree = srs_size - 1;
+        let poly = DensePolynomial::<Fp>::rand(poly_degree, &mut rng);
+        let commitment = srs.commit_non_hiding(&poly, 1);
+        assert_eq!(commitment.len(), 1);
+    }
+
+    // If we have a polynomial of the size of the SRS (i.e. of degree `srs_size -
+    // 1`), and we request k chunks (k > 1), we should get k chunk.
+    {
+        // srs_size is the number of evaluation degree
+        let poly_degree = srs_size - 1;
+        // maximum 10 chunks for the test
+        let k = rng.gen_range(2..10);
+        let poly = DensePolynomial::<Fp>::rand(poly_degree, &mut rng);
+        let commitment = srs.commit_non_hiding(&poly, k);
+        assert_eq!(commitment.len(), k);
+    }
+
+    // Same than the two previous cases, but with the special polynomial equals to zero.
+    {
+        let k = rng.gen_range(1..10);
+        let poly = DensePolynomial::<Fp>::zero();
+        let commitment = srs.commit_non_hiding(&poly, k);
+        assert_eq!(commitment.len(), k);
+    }
+
+    // Polynomial of exactly a multiple of the SRS size, i.e degree is k *
+    // srs_size - 1.
+    {
+        let k = rng.gen_range(2..5);
+        let poly_degree = k * srs_size - 1;
+        let poly = DensePolynomial::<Fp>::rand(poly_degree, &mut rng);
+        // if we request a number of chunks smaller than the multiple, we will
+        // still get a number of chunks equals to the multiple.
+        let requested_num_chunks = rng.gen_range(1..k);
+        let commitment = srs.commit_non_hiding(&poly, requested_num_chunks);
+        assert_eq!(commitment.len(), k);
+
+        // if we request a number of chunks equals to the multiple, we will get
+        // the exact number of chunks.
+        let commitment = srs.commit_non_hiding(&poly, k);
+        assert_eq!(commitment.len(), k);
+
+        // if we request a number of chunks greater than the multiple, we will
+        // get the exact number of chunks requested.
+        let requested_num_chunks = rng.gen_range(k + 1..10);
+        let commitment = srs.commit_non_hiding(&poly, requested_num_chunks);
+        assert_eq!(commitment.len(), requested_num_chunks);
     }
 }


### PR DESCRIPTION
While working on the prover for o1vm/pickles, I was wondering the number of chunks `commit_non_hiding` was supposed to return in different cases, in particular when the polynomial has a degree higher than the number of chunks requested. This test clarifies it.
I hope it doesn't duplicate another test - I didn't look for.

As @querolita is (was?) working on chunking, cc'ing her as she might be interested in.