### PR TITLE
o1vm/pickles: using new instead of elems - fixing master

### DIFF
--- a/o1vm/src/pickles/prover.rs
+++ b/o1vm/src/pickles/prover.rs
@@ -209,9 +209,7 @@ where
             (
                 DensePolynomialOrEvaluations::DensePolynomial(poly),
                 // We do not have any blinder, therefore we set to 0.
-                PolyComm {
-                    elems: vec![G::ScalarField::zero()],
-                },
+                PolyComm::new(vec![G::ScalarField::zero()]),
             )
         })
         .collect();


### PR DESCRIPTION
elems has been renamed in chunks previously (cf https://github.com/o1-labs/proof-systems/pull/2658), to map the actual meaning of the field of the structure