### PR TITLE
Make lagrange basis handling safe

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -611,16 +611,16 @@ every input (thinking of a two-bit input as a number in $\{0, 1, 2, 3\}$), one f
 are given by
 
 * `c_func(x)`, defined by
-     * `c_func(0) = 0`
-     * `c_func(1) = 0`
-     * `c_func(2) = -1`
-     * `c_func(3) = 1`
+	 * `c_func(0) = 0`
+	 * `c_func(1) = 0`
+	 * `c_func(2) = -1`
+	 * `c_func(3) = 1`
 
 * `d_func(x)`, defined by
-     * `d_func(0) = -1`
-     * `d_func(1) = 1`
-     * `d_func(2) = 0`
-     * `d_func(3) = 0`
+	 * `d_func(0) = -1`
+	 * `d_func(1) = 1`
+	 * `d_func(2) = 0`
+	 * `d_func(3) = 0`
 
 One can then interpolate to find polynomials that implement these functions on $\{0, 1, 2, 3\}$.
 
@@ -1687,10 +1687,10 @@ To create the index, follow these steps:
 
    To do this, for each table:
 
-    * Update the corresponding entries in a table id vector (of size the domain as well)
+	* Update the corresponding entries in a table id vector (of size the domain as well)
    with the table ID of the table.
-    * Copy the entries from the table to new rows in the corresponding columns of the concatenated table.
-    * Fill in any unused columns with 0 (to match the dummy value)
+	* Copy the entries from the table to new rows in the corresponding columns of the concatenated table.
+	* Fill in any unused columns with 0 (to match the dummy value)
 6. Pad the end of the concatened table with the dummy value.
 7. Pad the end of the table id vector with 0s.
 8. pre-compute polynomial and evaluation form for the look up tables
@@ -1940,7 +1940,7 @@ A proof consists of the following data structures:
 ```rs
 /// Evaluations of a polynomial at 2 points
 #[serde_as]
-#[derive(Copy, Clone, Serialize, Deserialize, Default, Debug)]
+#[derive(Copy, Clone, Serialize, Deserialize, Default, Debug, PartialEq)]
 #[cfg_attr(
     feature = "ocaml_types",
     derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)
@@ -1963,7 +1963,7 @@ pub struct PointEvaluations<Evals> {
 /// - **Chunked evaluations** `Field` is instantiated with vectors with a length that equals the length of the chunk
 /// - **Non chunked evaluations** `Field` is instantiated with a field, so they are single-sized#[serde_as]
 #[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ProofEvaluations<Evals> {
     /// public input polynomials
     pub public: Option<Evals>,
@@ -2028,7 +2028,7 @@ pub struct ProofEvaluations<Evals> {
 
 /// Commitments linked to the lookup feature
 #[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(bound = "G: ark_serialize::CanonicalDeserialize + ark_serialize::CanonicalSerialize")]
 pub struct LookupCommitments<G: AffineRepr> {
     /// Commitments to the sorted lookup table polynomial (may have chunks)
@@ -2041,7 +2041,7 @@ pub struct LookupCommitments<G: AffineRepr> {
 
 /// All the commitments that the prover creates as part of the proof.
 #[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(bound = "G: ark_serialize::CanonicalDeserialize + ark_serialize::CanonicalSerialize")]
 pub struct ProverCommitments<G: AffineRepr> {
     /// The commitments to the witness (execution trace)
@@ -2056,7 +2056,7 @@ pub struct ProverCommitments<G: AffineRepr> {
 
 /// The proof that the prover creates from a [ProverIndex](super::prover_index::ProverIndex) and a `witness`.
 #[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(bound = "G: ark_serialize::CanonicalDeserialize + ark_serialize::CanonicalSerialize")]
 pub struct ProverProof<G: AffineRepr, OpeningProof> {
     /// All the polynomial commitments required in the proof
@@ -2082,7 +2082,7 @@ pub struct ProverProof<G: AffineRepr, OpeningProof> {
 
 /// A struct to store the challenges inside a `ProverProof`
 #[serde_as]
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(bound = "G: ark_serialize::CanonicalDeserialize + ark_serialize::CanonicalSerialize")]
 pub struct RecursionChallenge<G>
 where
@@ -2151,32 +2151,32 @@ The prover then follows the following steps to create the proof:
    form so we can take advantage of the sparsity of the evaluations (i.e., there are many
    0 entries and entries that have less-than-full-size field elemnts.)
 1. If using lookup:
-    * if using runtime table:
-        * check that all the provided runtime tables have length and IDs that match the runtime table configuration of the index
-          we expect the given runtime tables to be sorted as configured, this makes it easier afterwards
-        * calculate the contribution to the second column of the lookup table
-          (the runtime vector)
-    * If queries involve a lookup table with multiple columns
-      then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
-      otherwise set the joint combiner challenge $j'$ to $0$.
-    * Derive the scalar joint combiner $j$ from $j'$ using the endomorphism (TOOD: specify)
-    * If multiple lookup tables are involved,
-      set the `table_id_combiner` as the $j^i$ with $i$ the maximum width of any used table.
-      Essentially, this is to add a last column of table ids to the concatenated lookup tables.
-    * Compute the dummy lookup value as the combination of the last entry of the XOR table (so `(0, 0, 0)`).
-      Warning: This assumes that we always use the XOR table when using lookups.
-    * Compute the lookup table values as the combination of the lookup table entries.
-    * Compute the sorted evaluations.
-    * Randomize the last `EVALS` rows in each of the sorted polynomials
-      in order to add zero-knowledge to the protocol.
-    * Commit each of the sorted polynomials.
-    * Absorb each commitments to the sorted polynomials.
+	* if using runtime table:
+		* check that all the provided runtime tables have length and IDs that match the runtime table configuration of the index
+		  we expect the given runtime tables to be sorted as configured, this makes it easier afterwards
+		* calculate the contribution to the second column of the lookup table
+		  (the runtime vector)
+	* If queries involve a lookup table with multiple columns
+	  then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
+	  otherwise set the joint combiner challenge $j'$ to $0$.
+	* Derive the scalar joint combiner $j$ from $j'$ using the endomorphism (TOOD: specify)
+	* If multiple lookup tables are involved,
+	  set the `table_id_combiner` as the $j^i$ with $i$ the maximum width of any used table.
+	  Essentially, this is to add a last column of table ids to the concatenated lookup tables.
+	* Compute the dummy lookup value as the combination of the last entry of the XOR table (so `(0, 0, 0)`).
+	  Warning: This assumes that we always use the XOR table when using lookups.
+	* Compute the lookup table values as the combination of the lookup table entries.
+	* Compute the sorted evaluations.
+	* Randomize the last `EVALS` rows in each of the sorted polynomials
+	  in order to add zero-knowledge to the protocol.
+	* Commit each of the sorted polynomials.
+	* Absorb each commitments to the sorted polynomials.
 1. Sample $\beta$ with the Fq-Sponge.
 1. Sample $\gamma$ with the Fq-Sponge.
 1. If using lookup:
-    * Compute the lookup aggregation polynomial.
-    * Commit to the aggregation polynomial.
-    * Absorb the commitment to the aggregation polynomial with the Fq-Sponge.
+	* Compute the lookup aggregation polynomial.
+	* Commit to the aggregation polynomial.
+	* Absorb the commitment to the aggregation polynomial with the Fq-Sponge.
 1. Compute the permutation aggregation polynomial $z$.
 1. Commit (hidding) to the permutation aggregation polynomial $z$.
 1. Absorb the permutation aggregation polynomial $z$ with the Fq-Sponge.
@@ -2185,10 +2185,10 @@ The prover then follows the following steps to create the proof:
 1. TODO: instantiate alpha?
 1. Compute the quotient polynomial (the $t$ in $f = Z_H \cdot t$).
    The quotient polynomial is computed by adding all these polynomials together:
-    * the combined constraints for all the gates
-    * the combined constraints for the permutation
-    * TODO: lookup
-    * the negated public polynomial
+	* the combined constraints for all the gates
+	* the combined constraints for the permutation
+	* TODO: lookup
+	* the negated public polynomial
    and by then dividing the resulting polynomial with the vanishing polynomial $Z_H$.
    TODO: specify the split of the permutation polynomial into perm and bnd?
 1. commit (hiding) to the quotient polynomial $t$
@@ -2196,16 +2196,16 @@ The prover then follows the following steps to create the proof:
 1. Sample $\zeta'$ with the Fq-Sponge.
 1. Derive $\zeta$ from $\zeta'$ using the endomorphism (TODO: specify)
 1. If lookup is used, evaluate the following polynomials at $\zeta$ and $\zeta \omega$:
-    * the aggregation polynomial
-    * the sorted polynomials
-    * the table polynonial
+	* the aggregation polynomial
+	* the sorted polynomials
+	* the table polynonial
 1. Chunk evaluate the following polynomials at both $\zeta$ and $\zeta \omega$:
-    * $s_i$
-    * $w_i$
-    * $z$
-    * lookup (TODO, see [this issue](https://github.com/MinaProtocol/mina/issues/13886))
-    * generic selector
-    * poseidon selector
+	* $s_i$
+	* $w_i$
+	* $z$
+	* lookup (TODO, see [this issue](https://github.com/MinaProtocol/mina/issues/13886))
+	* generic selector
+	* poseidon selector
 
    By "chunk evaluate" we mean that the evaluation of each polynomial can potentially be a vector of values.
    This is because the index's `max_poly_size` parameter dictates the maximum size of a polynomial in the protocol.
@@ -2230,12 +2230,12 @@ The prover then follows the following steps to create the proof:
 1. Compute evaluations for the previous recursion challenges.
 1. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
 1. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
-    * the public polynomial
-    * z
-    * generic selector
-    * poseidon selector
-    * the 15 register/witness
-    * 6 sigmas evaluations (the last one is not evaluated)
+	* the public polynomial
+	* z
+	* generic selector
+	* poseidon selector
+	* the 15 register/witness
+	* 6 sigmas evaluations (the last one is not evaluated)
 1. Sample $v'$ with the Fr-Sponge
 1. Derive $v$ from $v'$ using the endomorphism (TODO: specify)
 1. Sample $u'$ with the Fr-Sponge
@@ -2244,21 +2244,21 @@ The prover then follows the following steps to create the proof:
    (and evaluation proofs) in the protocol.
    First, include the previous challenges, in case we are in a recursive prover.
 1. Then, include:
-    * the negated public polynomial
-    * the ft polynomial
-    * the permutation aggregation polynomial z polynomial
-    * the generic selector
-    * the poseidon selector
-    * the 15 registers/witness columns
-    * the 6 sigmas
-    * the optional gates
-    * optionally, the runtime table
+	* the negated public polynomial
+	* the ft polynomial
+	* the permutation aggregation polynomial z polynomial
+	* the generic selector
+	* the poseidon selector
+	* the 15 registers/witness columns
+	* the 6 sigmas
+	* the optional gates
+	* optionally, the runtime table
 1. if using lookup:
-    * add the lookup sorted polynomials
-    * add the lookup aggreg polynomial
-    * add the combined table polynomial
-    * if present, add the runtime table polynomial
-    * the lookup selectors
+	* add the lookup sorted polynomials
+	* add the lookup aggreg polynomial
+	* add the combined table polynomial
+	* if present, add the runtime table polynomial
+	* the lookup selectors
 1. Create an aggregated evaluation proof for all of these polynomials at $\zeta$ and $\zeta\omega$ using $u$ and $v$.
 
 
@@ -2279,12 +2279,12 @@ We run the following algorithm:
 1. Absorb the commitment of the public input polynomial with the Fq-Sponge.
 1. Absorb the commitments to the registers / witness columns with the Fq-Sponge.
 1. If lookup is used:
-    * If it involves queries to a multiple-column lookup table,
-      then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
-      otherwise set the joint combiner challenge $j'$ to $0$.
-    * Derive the scalar joint combiner challenge $j$ from $j'$ using the endomorphism.
-      (TODO: specify endomorphism)
-    * absorb the commitments to the sorted polynomials.
+	* If it involves queries to a multiple-column lookup table,
+	  then squeeze the Fq-Sponge to obtain the joint combiner challenge $j'$,
+	  otherwise set the joint combiner challenge $j'$ to $0$.
+	* Derive the scalar joint combiner challenge $j$ from $j'$ using the endomorphism.
+	  (TODO: specify endomorphism)
+	* absorb the commitments to the sorted polynomials.
 1. Sample the first permutation challenge $\beta$ with the Fq-Sponge.
 1. Sample the second permutation challenge $\gamma$ with the Fq-Sponge.
 1. If using lookup, absorb the commitment to the aggregation lookup polynomial.
@@ -2304,12 +2304,12 @@ We run the following algorithm:
    NOTE: this works only in the case when the poly segment size is not smaller than that of the domain.
 1. Absorb the unique evaluation of ft: $ft(\zeta\omega)$.
 1. Absorb all the polynomial evaluations in $\zeta$ and $\zeta\omega$:
-    * the public polynomial
-    * z
-    * generic selector
-    * poseidon selector
-    * the 15 register/witness
-    * 6 sigmas evaluations (the last one is not evaluated)
+	* the public polynomial
+	* z
+	* generic selector
+	* poseidon selector
+	* the 15 register/witness
+	* 6 sigmas evaluations (the last one is not evaluated)
 1. Sample $v'$ with the Fr-Sponge.
 1. Derive $v$ from $v'$ using the endomorphism (TODO: specify).
 1. Sample $u'$ with the Fr-Sponge.
@@ -2341,16 +2341,16 @@ Essentially, this steps verifies that $f(\zeta) = t(\zeta) * Z_H(\zeta)$.
    (see [Maller's optimization](../kimchi/maller_15.md)).
 1. List the polynomial commitments, and their associated evaluations,
    that are associated to the aggregated evaluation proof in the proof:
-    * recursion
-    * public input commitment
-    * ft commitment (chunks of it)
-    * permutation commitment
-    * index commitments that use the coefficients
-    * witness commitments
-    * coefficient commitments
-    * sigma commitments
-    * optional gate commitments
-    * lookup commitments
+	* recursion
+	* public input commitment
+	* ft commitment (chunks of it)
+	* permutation commitment
+	* index commitments that use the coefficients
+	* witness commitments
+	* coefficient commitments
+	* sigma commitments
+	* optional gate commitments
+	* lookup commitments
 
 #### Batch verification of proofs
 

--- a/circuit-construction/src/tests/example_proof.rs
+++ b/circuit-construction/src/tests/example_proof.rs
@@ -53,7 +53,7 @@ fn test_example_circuit() {
     // create SRS
     let srs = {
         let mut srs = SRS::<Vesta>::create(1 << 7); // 2^7 = 128
-        srs.add_lagrange_basis(Radix2EvaluationDomain::new(srs.g.len()).unwrap());
+        srs.get_lagrange_basis_from_domain_size(Radix2EvaluationDomain::new(srs.g.len()));
         Arc::new(srs)
     };
 

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -3008,8 +3008,8 @@ pub mod test {
         ];
         let index = {
             let constraint_system = ConstraintSystem::fp_for_testing(gates);
-            let mut srs = SRS::<Vesta>::create(constraint_system.domain.d1.size());
-            srs.add_lagrange_basis(constraint_system.domain.d1);
+            let srs = SRS::<Vesta>::create(constraint_system.domain.d1.size());
+            srs.get_lagrange_basis(constraint_system.domain.d1);
             let srs = Arc::new(srs);
 
             let (endo_q, _endo_r) = endos::<Pallas>();

--- a/kimchi/src/lagrange_basis_evaluations.rs
+++ b/kimchi/src/lagrange_basis_evaluations.rs
@@ -129,7 +129,7 @@ impl<F: FftField> LagrangeBasisEvaluations<F> {
                 chunked_evals[i * max_poly_size + j] = x_pow;
                 x_pow *= x;
             }
-            // This uses the same trick as `poly_commitment::srs::SRS::add_lagrange_basis`, but
+            // This uses the same trick as `poly_commitment::srs::SRS::lagrange_basis`, but
             // applied to field elements instead of group elements.
             domain.ifft_in_place(&mut chunked_evals);
             evals.push(chunked_evals);

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -210,7 +210,7 @@ pub mod testing {
             override_srs_size,
             |d1: D<G::ScalarField>, size: usize| {
                 let log2_size = size.ilog2();
-                let mut srs = if log2_size <= precomputed_srs::SERIALIZED_SRS_SIZE {
+                let srs = if log2_size <= precomputed_srs::SERIALIZED_SRS_SIZE {
                     // TODO: we should trim it if it's smaller
                     precomputed_srs::get_srs()
                 } else {
@@ -218,7 +218,7 @@ pub mod testing {
                     SRS::<G>::create(size)
                 };
 
-                srs.add_lagrange_basis(d1);
+                srs.get_lagrange_basis(d1);
                 srs
             },
         )

--- a/kimchi/src/tests/foreign_field_add.rs
+++ b/kimchi/src/tests/foreign_field_add.rs
@@ -324,8 +324,8 @@ fn create_test_constraint_system_ffadd(
     };
 
     let cs = ConstraintSystem::create(gates).public(1).build().unwrap();
-    let mut srs = SRS::<Vesta>::create(cs.domain.d1.size());
-    srs.add_lagrange_basis(cs.domain.d1);
+    let srs = SRS::<Vesta>::create(cs.domain.d1.size());
+    srs.get_lagrange_basis(cs.domain.d1);
     let srs = Arc::new(srs);
 
     let (endo_q, _endo_r) = endos::<Pallas>();
@@ -1493,8 +1493,8 @@ fn test_ffadd_finalization() {
             .public(num_public_inputs)
             .build()
             .unwrap();
-        let mut srs = SRS::<Vesta>::create(cs.domain.d1.size());
-        srs.add_lagrange_basis(cs.domain.d1);
+        let srs = SRS::<Vesta>::create(cs.domain.d1.size());
+        srs.get_lagrange_basis(cs.domain.d1);
         let srs = Arc::new(srs);
 
         let (endo_q, _endo_r) = endos::<Pallas>();

--- a/kimchi/src/tests/generic.rs
+++ b/kimchi/src/tests/generic.rs
@@ -118,8 +118,8 @@ fn test_generic_gate_pairing() {
     .witness(witness)
     .public_inputs(public)
     .setup_with_custom_srs(|d1, usize| {
-        let mut srs = poly_commitment::pairing_proof::PairingSRS::create(x, usize);
-        srs.full_srs.add_lagrange_basis(d1);
+        let srs = poly_commitment::pairing_proof::PairingSRS::create(x, usize);
+        srs.full_srs.get_lagrange_basis(d1);
         srs
     })
     .prove_and_verify::<BaseSponge, ScalarSponge>()

--- a/kimchi/src/tests/range_check.rs
+++ b/kimchi/src/tests/range_check.rs
@@ -1082,8 +1082,8 @@ fn verify_64_bit_range_check() {
             .unwrap();
 
     let index = {
-        let mut srs = SRS::<Vesta>::create(cs.domain.d1.size());
-        srs.add_lagrange_basis(cs.domain.d1);
+        let srs = SRS::<Vesta>::create(cs.domain.d1.size());
+        srs.get_lagrange_basis(cs.domain.d1);
         let srs = Arc::new(srs);
 
         let (endo_q, _endo_r) = endos::<Pallas>();

--- a/kimchi/src/tests/rot.rs
+++ b/kimchi/src/tests/rot.rs
@@ -330,8 +330,8 @@ fn test_rot_finalization() {
             .public(num_public_inputs)
             .build()
             .unwrap();
-        let mut srs = SRS::<Vesta>::create(cs.domain.d1.size());
-        srs.add_lagrange_basis(cs.domain.d1);
+        let srs = SRS::<Vesta>::create(cs.domain.d1.size());
+        srs.get_lagrange_basis(cs.domain.d1);
         let srs = Arc::new(srs);
 
         let (endo_q, _endo_r) = endos::<Pallas>();

--- a/kimchi/src/tests/serde.rs
+++ b/kimchi/src/tests/serde.rs
@@ -81,8 +81,8 @@ mod tests {
             serde_json::from_str(&verifier_index_serialize).unwrap();
 
         // add srs with lagrange bases
-        let mut srs = SRS::<Affine<VestaParameters>>::create(verifier_index.max_poly_size);
-        srs.add_lagrange_basis(verifier_index.domain);
+        let srs = SRS::<Affine<VestaParameters>>::create(verifier_index.max_poly_size);
+        srs.get_lagrange_basis(verifier_index.domain);
         verifier_index_deserialize.powers_of_alpha = index.powers_of_alpha;
         verifier_index_deserialize.linearization = index.linearization;
         verifier_index_deserialize.srs = std::sync::Arc::new(srs);

--- a/kimchi/src/tests/xor.rs
+++ b/kimchi/src/tests/xor.rs
@@ -395,8 +395,8 @@ fn test_xor_finalization() {
             .public(num_inputs)
             .build()
             .unwrap();
-        let mut srs = SRS::<Vesta>::create(cs.domain.d1.size());
-        srs.add_lagrange_basis(cs.domain.d1);
+        let srs = SRS::<Vesta>::create(cs.domain.d1.size());
+        srs.get_lagrange_basis(cs.domain.d1);
         let srs = Arc::new(srs);
 
         let (endo_q, _endo_r) = endos::<Pallas>();

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -34,6 +34,7 @@ use rand::thread_rng;
 /// The result of a proof verification.
 pub type Result<T> = std::result::Result<T, VerifyError>;
 
+#[derive(Debug)]
 pub struct Context<'a, G: KimchiCurve, OpeningProof: OpenProof<G>> {
     /// The [VerifierIndex] associated to the proof
     pub verifier_index: &'a VerifierIndex<G, OpeningProof>,
@@ -797,8 +798,7 @@ where
         }
         let lgr_comm = verifier_index
             .srs()
-            .get_lagrange_basis(verifier_index.domain.size())
-            .expect("pre-computed committed lagrange bases not found");
+            .get_lagrange_basis(verifier_index.domain.size());
         let com: Vec<_> = lgr_comm.iter().take(verifier_index.public).collect();
         if public_input.is_empty() {
             PolyComm::new(vec![verifier_index.srs().blinding_commitment(); chunk_size])

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -506,8 +506,8 @@ impl<G: CommitmentCurve> SRSTrait<G> for SRS<G> {
         self.g.len()
     }
 
-    fn get_lagrange_basis(&self, domain_size: usize) -> Option<&Vec<PolyComm<G>>> {
-        self.lagrange_bases.get(&domain_size)
+    fn get_lagrange_basis(&self, domain_size: usize) -> &Vec<PolyComm<G>> {
+        self.get_lagrange_basis_from_domain_size(domain_size)
     }
 
     fn blinding_commitment(&self) -> G {
@@ -591,10 +591,7 @@ impl<G: CommitmentCurve> SRSTrait<G> for SRS<G> {
         domain: D<G::ScalarField>,
         plnm: &Evaluations<G::ScalarField, D<G::ScalarField>>,
     ) -> PolyComm<G> {
-        let basis = self
-            .lagrange_bases
-            .get(&domain.size())
-            .unwrap_or_else(|| panic!("lagrange bases for size {} not found", domain.size()));
+        let basis = self.get_lagrange_basis(domain);
         let commit_evaluations = |evals: &Vec<G::ScalarField>, basis: &Vec<PolyComm<G>>| {
             PolyComm::<G>::multi_scalar_mul(&basis.iter().collect::<Vec<_>>()[..], &evals[..])
         };

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -822,8 +822,8 @@ mod tests {
         let n = 64;
         let domain = D::<Fp>::new(n).unwrap();
 
-        let mut srs = SRS::<VestaG>::create(n);
-        srs.add_lagrange_basis(domain);
+        let srs = SRS::<VestaG>::create(n);
+        srs.get_lagrange_basis(domain);
 
         let num_chunks = domain.size() / srs.g.len();
 
@@ -836,7 +836,7 @@ mod tests {
             })
             .collect();
 
-        let computed_lagrange_commitments = srs.lagrange_bases.get(&domain.size()).unwrap();
+        let computed_lagrange_commitments = srs.get_lagrange_basis_from_domain_size(domain.size());
         for i in 0..n {
             assert_eq!(
                 computed_lagrange_commitments[i],
@@ -852,8 +852,8 @@ mod tests {
         let divisor = 4;
         let domain = D::<Fp>::new(n).unwrap();
 
-        let mut srs = SRS::<VestaG>::create(n / divisor);
-        srs.add_lagrange_basis(domain);
+        let srs = SRS::<VestaG>::create(n / divisor);
+        srs.get_lagrange_basis(domain);
 
         let num_chunks = domain.size() / srs.g.len();
         assert!(num_chunks == divisor);
@@ -867,7 +867,7 @@ mod tests {
             })
             .collect();
 
-        let computed_lagrange_commitments = srs.lagrange_bases.get(&domain.size()).unwrap();
+        let computed_lagrange_commitments = srs.get_lagrange_basis_from_domain_size(domain.size());
         for i in 0..n {
             assert_eq!(
                 computed_lagrange_commitments[i],
@@ -885,8 +885,8 @@ mod tests {
         let n = 64;
         let domain = D::<Fp>::new(n).unwrap();
 
-        let mut srs = SRS::<VestaG>::create(n / 2 + 1);
-        srs.add_lagrange_basis(domain);
+        let srs = SRS::<VestaG>::create(n / 2 + 1);
+        srs.get_lagrange_basis(domain);
 
         // Is this even taken into account?...
         let num_chunks = (domain.size() + srs.g.len() - 1) / srs.g.len();
@@ -901,7 +901,7 @@ mod tests {
             })
             .collect();
 
-        let computed_lagrange_commitments = srs.lagrange_bases.get(&domain.size()).unwrap();
+        let computed_lagrange_commitments = srs.get_lagrange_basis_from_domain_size(domain.size());
         for i in 0..n {
             assert_eq!(
                 computed_lagrange_commitments[i],

--- a/poly-commitment/src/hash_map_cache.rs
+++ b/poly-commitment/src/hash_map_cache.rs
@@ -16,11 +16,11 @@ impl<Key: Hash + std::cmp::Eq, Value> HashMapCache<Key, Value> {
         }
     }
 
-    pub fn get_or_generate<'a, F: FnOnce() -> Value>(
-        &'a self,
+    pub fn get_or_generate<F: FnOnce() -> Value>(
+        &self,
         key: Key,
         generator: F,
-    ) -> &'a Value {
+    ) -> &Value {
         let mut hashmap = self.contents.lock().unwrap();
         let entry = (*hashmap).entry(key);
         let inner_ptr = match entry {

--- a/poly-commitment/src/hash_map_cache.rs
+++ b/poly-commitment/src/hash_map_cache.rs
@@ -16,11 +16,7 @@ impl<Key: Hash + std::cmp::Eq, Value> HashMapCache<Key, Value> {
         }
     }
 
-    pub fn get_or_generate<F: FnOnce() -> Value>(
-        &self,
-        key: Key,
-        generator: F,
-    ) -> &Value {
+    pub fn get_or_generate<F: FnOnce() -> Value>(&self, key: Key, generator: F) -> &Value {
         let mut hashmap = self.contents.lock().unwrap();
         let entry = (*hashmap).entry(key);
         let inner_ptr = match entry {

--- a/poly-commitment/src/hash_map_cache.rs
+++ b/poly-commitment/src/hash_map_cache.rs
@@ -38,4 +38,8 @@ impl<Key: Hash + std::cmp::Eq, Value> HashMapCache<Key, Value> {
         // must live at least at most as long as the cache value.
         unsafe { &*inner_ptr }
     }
+
+    pub fn contains_key(&self, key: &Key) -> bool {
+        self.contents.lock().unwrap().contains_key(key)
+    }
 }

--- a/poly-commitment/src/hash_map_cache.rs
+++ b/poly-commitment/src/hash_map_cache.rs
@@ -1,0 +1,41 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    hash::Hash,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct HashMapCache<Key: Hash, Value> {
+    contents: Arc<Mutex<HashMap<Key, Value>>>,
+}
+
+impl<Key: Hash + std::cmp::Eq, Value> HashMapCache<Key, Value> {
+    pub fn new() -> Self {
+        HashMapCache {
+            contents: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn get_or_generate<'a, F: FnOnce() -> Value>(
+        &'a self,
+        key: Key,
+        generator: F,
+    ) -> &'a Value {
+        let mut hashmap = self.contents.lock().unwrap();
+        let entry = (*hashmap).entry(key);
+        let inner_ptr = match entry {
+            Entry::Occupied(o) => {
+                let o_ref = o.into_mut();
+                &*o_ref as *const Value
+            }
+            Entry::Vacant(v) => {
+                let v_ref = v.insert(generator());
+                &*v_ref as *const Value
+            }
+        };
+
+        // This is safe because we never delete entries from the cache, and the value reference
+        // must live at least at most as long as the cache value.
+        unsafe { &*inner_ptr }
+    }
+}

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -3,6 +3,7 @@ mod combine;
 pub mod commitment;
 pub mod error;
 pub mod evaluation_proof;
+pub mod hash_map_cache;
 pub mod pairing_proof;
 pub mod srs;
 
@@ -29,7 +30,7 @@ pub trait SRS<G: CommitmentCurve> {
     fn max_poly_size(&self) -> usize;
 
     /// Retrieve the precomputed Lagrange basis for the given domain size
-    fn get_lagrange_basis(&self, domain_size: usize) -> Option<&Vec<PolyComm<G>>>;
+    fn get_lagrange_basis(&self, domain_size: usize) -> &Vec<PolyComm<G>>;
 
     /// Get the group element used for blinding commitments
     fn blinding_commitment(&self) -> G;
@@ -92,7 +93,7 @@ type PolynomialsToCombine<'a, G: CommitmentCurve, D: EvaluationDomain<G::ScalarF
 )];
 
 pub trait OpenProof<G: CommitmentCurve>: Sized {
-    type SRS: SRS<G>;
+    type SRS: SRS<G> + std::fmt::Debug;
 
     #[allow(clippy::too_many_arguments)]
     fn open<EFqSponge, RNG, D: EvaluationDomain<<G as AffineRepr>::ScalarField>>(

--- a/poly-commitment/src/pairing_proof.rs
+++ b/poly-commitment/src/pairing_proof.rs
@@ -352,9 +352,9 @@ mod tests {
 
         let x = ScalarField::rand(rng);
 
-        let mut srs = SRS::<G1>::create_trusted_setup(x, n);
+        let srs = SRS::<G1>::create_trusted_setup(x, n);
         let verifier_srs = SRS::<G2>::create_trusted_setup(x, 3);
-        srs.add_lagrange_basis(domain);
+        srs.get_lagrange_basis(domain);
 
         let srs = PairingSRS {
             full_srs: srs,

--- a/poly-commitment/src/pairing_proof.rs
+++ b/poly-commitment/src/pairing_proof.rs
@@ -148,8 +148,9 @@ impl<
         self.full_srs.max_poly_size()
     }
 
-    fn get_lagrange_basis(&self, domain_size: usize) -> Option<&Vec<PolyComm<G>>> {
-        self.full_srs.get_lagrange_basis(domain_size)
+    fn get_lagrange_basis(&self, domain_size: usize) -> &Vec<PolyComm<G>> {
+        self.full_srs
+            .get_lagrange_basis_from_domain_size(domain_size)
     }
 
     fn blinding_commitment(&self) -> G {


### PR DESCRIPTION
This PR adds the concept of `HashMapCache` to remove the potential for errors / panics in code. In particular, this addresses https://github.com/o1-labs/o1js/issues/1411.