### PR TITLE
Arrabiata/main: add multiple FIXME to remind the next steps

### DIFF
--- a/arrabiata/src/main.rs
+++ b/arrabiata/src/main.rs
@@ -123,6 +123,9 @@ pub fn main() {
         // Compute the accumulation of the public inputs/selectors
 
         // FIXME:
+        // Compute the accumulation of the blinders for the PCS
+
+        // FIXME:
         // Compute the accumulated error
 
         debug!(

--- a/arrabiata/src/main.rs
+++ b/arrabiata/src/main.rs
@@ -92,6 +92,39 @@ pub fn main() {
         // FIXME: Check twice the updated commitments
         env.compute_and_update_previous_commitments();
 
+        // FIXME:
+        // Absorb all commitments in the sponge.
+
+        // FIXME:
+        // Coin chalenges β and γ for the permutation argument
+
+        // FIXME:
+        // Compute the accumulator for the permutation argument
+
+        // FIXME:
+        // Compute the cross-terms
+
+        // FIXME:
+        // Absorb the cross-terms
+
+        // FIXME:
+        // Coin challenge r to fold
+
+        // FIXME:
+        // Compute the accumulated witness
+
+        // FIXME:
+        // Compute the accumulation of the commitments to the witness columns
+
+        // FIXME:
+        // Compute the accumulation of the challenges
+
+        // FIXME:
+        // Compute the accumulation of the public inputs/selectors
+
+        // FIXME:
+        // Compute the accumulated error
+
         debug!(
             "Iteration {i} fully proven in {elapsed} μs",
             i = env.current_iteration,


### PR DESCRIPTION
Might not be complete. Only to keep it in the master branch for external contributors.

Eventually, all steps will be moved into a single method in the witness environment.