### PR TITLE
o1vm/constraint : add a missing constraint for sel

### DIFF
--- a/o1vm/src/pickles/mod.rs
+++ b/o1vm/src/pickles/mod.rs
@@ -30,7 +30,7 @@ pub const DEGREE_QUOTIENT_POLYNOMIAL: u64 = 7;
 
 /// Total number of constraints for all instructions, including the constraints
 /// added for the selectors.
-pub const TOTAL_NUMBER_OF_CONSTRAINTS: usize = 463;
+pub const TOTAL_NUMBER_OF_CONSTRAINTS: usize = 464;
 
 #[cfg(test)]
 mod tests;

--- a/o1vm/src/pickles/tests.rs
+++ b/o1vm/src/pickles/tests.rs
@@ -43,13 +43,16 @@ fn test_regression_selectors_for_instructions() {
     let mips_con_env = mips_constraints::Env::<Fp>::default();
     let constraints = mips_con_env.get_selector_constraints();
     assert_eq!(
-        constraints.len(),
+        // We substract 1 as we have one boolean check per sel
+        // and 1 constraint to check that one and only one
+        // sel is activated
+        constraints.len() - 1,
         // We could use N_MIPS_SEL_COLS, but sanity check in case this value is
         // changed.
         RTypeInstruction::COUNT + JTypeInstruction::COUNT + ITypeInstruction::COUNT
     );
-    // All instructions are degree 2.
+    // All instructions are degree 1 or 2.
     constraints
         .iter()
-        .for_each(|c| assert_eq!(c.degree(1, 0), 2));
+        .for_each(|c| assert!(c.degree(1, 0) == 2 || c.degree(1, 0) == 1));
 }


### PR DESCRIPTION
the selectors were only constrained to be boolean
We add the constraint that one and only one
of them is activated.