### PR TITLE
Arrabiata: prepare constraints for cross-terms computation

### DIFF
--- a/arrabbiata/src/columns.rs
+++ b/arrabbiata/src/columns.rs
@@ -36,6 +36,22 @@ pub enum Column {
     X(usize),
 }
 
+/// Convert a column to a usize. This is used by the library [mvpoly] when we
+/// need to compute the cross-terms.
+/// For now, we only support the conversion of the private inputs, i.e. the `X`
+/// variant.
+/// Also, for now, the [mvpoly] library expects the columns to be mapped to a
+/// prime number as the prime representation is used under the hood. This must
+/// be changed.
+impl From<Column> for usize {
+    fn from(val: Column) -> usize {
+        match val {
+            Column::X(i) => i,
+            _ => unimplemented!("Only the private inputs are supported for now"),
+        }
+    }
+}
+
 pub struct Challenges<F: Field> {
     /// Challenge used to aggregate the constraints
     pub alpha: F,

--- a/arrabbiata/src/columns.rs
+++ b/arrabbiata/src/columns.rs
@@ -8,6 +8,8 @@ use std::{
 };
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 
+use crate::NUMBER_OF_COLUMNS;
+
 /// This enum represents the different gadgets that can be used in the circuit.
 /// The selectors are defined at setup time, can take only the values `0` or
 /// `1` and are public.
@@ -38,16 +40,21 @@ pub enum Column {
 
 /// Convert a column to a usize. This is used by the library [mvpoly] when we
 /// need to compute the cross-terms.
-/// For now, we only support the conversion of the private inputs, i.e. the `X`
-/// variant.
-/// Also, for now, the [mvpoly] library expects the columns to be mapped to a
-/// prime number as the prime representation is used under the hood. This must
-/// be changed.
+/// For now, only the private inputs and the public inputs are converted,
+/// because there might not need to treat the selectors in the polynomial while
+/// computing the cross-terms (FIXME: check this later, but pretty sure it's the
+/// case).
+///
+/// Also, the [mvpoly::monomials] implementation of the trait [mvpoly::MVPoly]
+/// will be used, and the mapping here is consistent with the one expected by
+/// this implementation, i.e. we simply map to an increasing number starting at
+/// 0, without any gap.
 impl From<Column> for usize {
     fn from(val: Column) -> usize {
         match val {
             Column::X(i) => i,
-            _ => unimplemented!("Only the private inputs are supported for now"),
+            Column::PublicInput(i) => NUMBER_OF_COLUMNS + i,
+            Column::Selector(_) => unimplemented!("Selectors are not supported. This method is supposed to be called only to compute the cross-term and an optimisation is in progress to avoid the inclusion of the selectors in the multi-variate polynomial."),
         }
     }
 }

--- a/arrabbiata/src/main.rs
+++ b/arrabbiata/src/main.rs
@@ -102,6 +102,12 @@ pub fn main() {
         // Compute the accumulator for the permutation argument
 
         // FIXME:
+        // Commit to the accumulator and absorb the commitment
+
+        // FIXME:
+        // Coin challenge α for combining the constraints
+
+        // FIXME:
         // Compute the cross-terms
 
         // FIXME:

--- a/mvpoly/src/lib.rs
+++ b/mvpoly/src/lib.rs
@@ -254,6 +254,45 @@ pub trait MVPoly<F: PrimeField, const N: usize, const D: usize>:
         u2: F,
     ) -> HashMap<usize, F>;
 
+    /// Compute the cross-terms of the given polynomial, scaled by the given
+    /// scalar.
+    ///
+    /// More explicitly, given a polynomial `P(X1, ..., Xn)` and a scalar α, the
+    /// method computes the the cross-terms of the polynomial `Q(X1, ..., Xn, α)
+    /// = α * P(X1, ..., Xn)`. For this reason, the method takes as input the
+    /// two different scalars `scalar1` and `scalar2` as we are considering the
+    /// scaling factor as a variable.
+    ///
+    /// This method is particularly useful when you need to compute a
+    /// (possibly random) combinaison of polynomials `P1(X1, ..., Xn), ...,
+    /// Pm(X1, ..., Xn)`, like when computing a quotient polynomial in the PlonK
+    /// PIOP, as the result is the sum of individual "scaled" polynomials:
+    /// ```text
+    /// Q(X_1, ..., X_n, α_1, ..., α_m) =
+    ///   α_1 P1(X_1, ..., X_n) +
+    ///   ...
+    ///   α_m Pm(X_1, ..., X_n) +
+    /// ```
+    ///
+    /// The polynomial must not necessarily be homogeneous. For this reason, the
+    /// values `u1` and `u2` represents the extra variable that is used to make
+    /// the polynomial homogeneous.
+    ///
+    /// The homogeneous degree is supposed to be the one defined by the type of
+    /// the polynomial `P`, i.e. `D`.
+    ///
+    /// The output is a map of `D` values that represents the cross-terms
+    /// for each power of `r`.
+    fn compute_cross_terms_scaled(
+        &self,
+        eval1: &[F; N],
+        eval2: &[F; N],
+        u1: F,
+        u2: F,
+        scalar1: F,
+        scalar2: F,
+    ) -> HashMap<usize, F>;
+
     /// Modify the monomial in the polynomial to the new value `coeff`.
     fn modify_monomial(&mut self, exponents: [usize; N], coeff: F);
 

--- a/mvpoly/src/monomials.rs
+++ b/mvpoly/src/monomials.rs
@@ -554,12 +554,19 @@ impl<F: PrimeField, const N: usize, const D: usize> From<F> for Sparse<F, N, D> 
     }
 }
 
-impl<F: PrimeField, const N: usize, const D: usize, const M: usize> From<Sparse<F, N, D>>
-    for Result<Sparse<F, M, D>, String>
+impl<F: PrimeField, const N: usize, const D: usize, const M: usize, const D_PRIME: usize>
+    From<Sparse<F, N, D>> for Result<Sparse<F, M, D_PRIME>, String>
 {
-    fn from(poly: Sparse<F, N, D>) -> Result<Sparse<F, M, D>, String> {
+    fn from(poly: Sparse<F, N, D>) -> Result<Sparse<F, M, D_PRIME>, String> {
         if M < N {
-            return Err("The number of variables must be greater than N".to_string());
+            return Err(format!(
+                "The final number of variables {M} must be greater than {N}"
+            ));
+        }
+        if D_PRIME < D {
+            return Err(format!(
+                "The final degree {D_PRIME} must be greater than initial degree {D}"
+            ));
         }
         let mut monomials = HashMap::new();
         poly.monomials.iter().for_each(|(exponents, coeff)| {

--- a/mvpoly/src/prime.rs
+++ b/mvpoly/src/prime.rs
@@ -432,6 +432,18 @@ impl<F: PrimeField, const N: usize, const D: usize> MVPoly<F, N, D> for Dense<F,
         unimplemented!()
     }
 
+    fn compute_cross_terms_scaled(
+        &self,
+        _eval1: &[F; N],
+        _eval2: &[F; N],
+        _u1: F,
+        _u2: F,
+        _scalar1: F,
+        _scalar2: F,
+    ) -> HashMap<usize, F> {
+        unimplemented!()
+    }
+
     fn modify_monomial(&mut self, exponents: [usize; N], coeff: F) {
         let mut prime_gen = PrimeNumberGenerator::new();
         let primes = prime_gen.get_first_nth_primes(N);


### PR DESCRIPTION
This pull request prepares the constraints to compute the cross-terms after the different columns and arguments have been computed. Challenges must be treated as a variable, and will be in a future PR.

Previous attempt: https://github.com/o1-labs/proof-systems/pull/2695