### PR TITLE
Kimchi: move more berkeley expr related code into berkeley_columns

### DIFF
--- a/kimchi/src/circuits/argument.rs
+++ b/kimchi/src/circuits/argument.rs
@@ -13,8 +13,8 @@ use serde::{Deserialize, Serialize};
 
 //TODO use generic challenge
 use super::{
-    berkeley_columns::{BerkeleyChallengeTerm, BerkeleyChallenges},
-    expr::{constraints::ExprOps, Cache, ConstantExpr, ConstantTerm, Constants},
+    berkeley_columns::{constraints::ExprOps, BerkeleyChallengeTerm, BerkeleyChallenges},
+    expr::{Cache, ConstantExpr, ConstantTerm, Constants},
     gate::{CurrOrNext, GateType},
     polynomial::COLUMNS,
 };

--- a/kimchi/src/circuits/berkeley_columns.rs
+++ b/kimchi/src/circuits/berkeley_columns.rs
@@ -28,14 +28,18 @@ use crate::{
         },
         gate::{CurrOrNext, GateType},
         lookup::{index::LookupSelectors, lookups::LookupPattern},
+        polynomials::foreign_field_common::KimchiForeignElement,
         wires::COLUMNS,
     },
     proof::{PointEvaluations, ProofEvaluations},
 };
-use ark_ff::FftField;
+use ark_ff::{FftField, Field, One, PrimeField, Zero};
 use ark_poly::{Evaluations, Radix2EvaluationDomain as D};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub},
+};
 
 /// The challenge terms used in Berkeley.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -367,4 +371,252 @@ pub fn index<F>(g: GateType) -> E<F> {
 
 pub fn coeff<F>(i: usize) -> E<F> {
     E::<F>::cell(Column::Coefficient(i), CurrOrNext::Curr)
+}
+
+/// A number of useful constraints
+pub mod constraints {
+    use o1_utils::{foreign_field::ForeignFieldHelpers, Two};
+
+    use crate::circuits::argument::ArgumentData;
+    use std::fmt;
+
+    use super::*;
+    use crate::circuits::berkeley_columns::{coeff, witness};
+
+    /// This trait defines a common arithmetic operations interface
+    /// that can be used by constraints.  It allows us to reuse
+    /// constraint code for witness computation.
+    pub trait ExprOps<F, ChallengeTerm>:
+        Add<Output = Self>
+        + Sub<Output = Self>
+        + Neg<Output = Self>
+        + Mul<Output = Self>
+        + AddAssign<Self>
+        + MulAssign<Self>
+        + Clone
+        + Zero
+        + One
+        + From<u64>
+        + fmt::Debug
+        + fmt::Display
+    // Add more as necessary
+    where
+        Self: std::marker::Sized,
+    {
+        /// 2^pow
+        fn two_pow(pow: u64) -> Self;
+
+        /// 2^{LIMB_BITS}
+        fn two_to_limb() -> Self;
+
+        /// 2^{2 * LIMB_BITS}
+        fn two_to_2limb() -> Self;
+
+        /// 2^{3 * LIMB_BITS}
+        fn two_to_3limb() -> Self;
+
+        /// Double the value
+        fn double(&self) -> Self;
+
+        /// Compute the square of this value
+        fn square(&self) -> Self;
+
+        /// Raise the value to the given power
+        fn pow(&self, p: u64) -> Self;
+
+        /// Constrain to boolean
+        fn boolean(&self) -> Self;
+
+        /// Constrain to crumb (i.e. two bits)
+        fn crumb(&self) -> Self;
+
+        /// Create a literal
+        fn literal(x: F) -> Self;
+
+        // Witness variable
+        fn witness(row: CurrOrNext, col: usize, env: Option<&ArgumentData<F>>) -> Self;
+
+        /// Coefficient
+        fn coeff(col: usize, env: Option<&ArgumentData<F>>) -> Self;
+
+        /// Create a constant
+        fn constant(expr: ConstantExpr<F, ChallengeTerm>, env: Option<&ArgumentData<F>>) -> Self;
+
+        /// Cache item
+        fn cache(&self, cache: &mut Cache) -> Self;
+    }
+
+    // TODO generalize with generic Column/challengeterm
+    // We need to create a trait for berkeley_columns::Environment
+    impl<F> ExprOps<F, BerkeleyChallengeTerm>
+        for Expr<ConstantExpr<F, BerkeleyChallengeTerm>, super::Column>
+    where
+        F: PrimeField,
+        // TODO remove
+        Expr<ConstantExpr<F, BerkeleyChallengeTerm>, super::Column>: std::fmt::Display,
+    {
+        fn two_pow(pow: u64) -> Self {
+            Expr::<ConstantExpr<F, BerkeleyChallengeTerm>, super::Column>::literal(
+                <F as Two<F>>::two_pow(pow),
+            )
+        }
+
+        fn two_to_limb() -> Self {
+            Expr::<ConstantExpr<F, BerkeleyChallengeTerm>, super::Column>::literal(
+                KimchiForeignElement::<F>::two_to_limb(),
+            )
+        }
+
+        fn two_to_2limb() -> Self {
+            Expr::<ConstantExpr<F, BerkeleyChallengeTerm>, super::Column>::literal(
+                KimchiForeignElement::<F>::two_to_2limb(),
+            )
+        }
+
+        fn two_to_3limb() -> Self {
+            Expr::<ConstantExpr<F, BerkeleyChallengeTerm>, super::Column>::literal(
+                KimchiForeignElement::<F>::two_to_3limb(),
+            )
+        }
+
+        fn double(&self) -> Self {
+            Expr::double(self.clone())
+        }
+
+        fn square(&self) -> Self {
+            Expr::square(self.clone())
+        }
+
+        fn pow(&self, p: u64) -> Self {
+            Expr::pow(self.clone(), p)
+        }
+
+        fn boolean(&self) -> Self {
+            crate::circuits::constraints::boolean(self)
+        }
+
+        fn crumb(&self) -> Self {
+            crate::circuits::constraints::crumb(self)
+        }
+
+        fn literal(x: F) -> Self {
+            ConstantTerm::Literal(x).into()
+        }
+
+        fn witness(row: CurrOrNext, col: usize, _: Option<&ArgumentData<F>>) -> Self {
+            witness(col, row)
+        }
+
+        fn coeff(col: usize, _: Option<&ArgumentData<F>>) -> Self {
+            coeff(col)
+        }
+
+        fn constant(
+            expr: ConstantExpr<F, BerkeleyChallengeTerm>,
+            _: Option<&ArgumentData<F>>,
+        ) -> Self {
+            Expr::from(expr)
+        }
+
+        fn cache(&self, cache: &mut Cache) -> Self {
+            Expr::Cache(cache.next_id(), Box::new(self.clone()))
+        }
+    }
+
+    // TODO generalize with generic Column/challengeterm
+    // We need to generalize argument.rs
+    impl<F: Field> ExprOps<F, BerkeleyChallengeTerm> for F {
+        fn two_pow(pow: u64) -> Self {
+            <F as Two<F>>::two_pow(pow)
+        }
+
+        fn two_to_limb() -> Self {
+            KimchiForeignElement::<F>::two_to_limb()
+        }
+
+        fn two_to_2limb() -> Self {
+            KimchiForeignElement::<F>::two_to_2limb()
+        }
+
+        fn two_to_3limb() -> Self {
+            KimchiForeignElement::<F>::two_to_3limb()
+        }
+
+        fn double(&self) -> Self {
+            *self * F::from(2u64)
+        }
+
+        fn square(&self) -> Self {
+            *self * *self
+        }
+
+        fn pow(&self, p: u64) -> Self {
+            self.pow([p])
+        }
+
+        fn boolean(&self) -> Self {
+            self.clone().square() - self.clone()
+        }
+
+        fn crumb(&self) -> Self {
+            self.clone()
+                * (self.clone() - 1u64.into())
+                * (self.clone() - 2u64.into())
+                * (self.clone() - 3u64.into())
+        }
+
+        fn literal(x: F) -> Self {
+            x
+        }
+
+        fn witness(row: CurrOrNext, col: usize, env: Option<&ArgumentData<F>>) -> Self {
+            match env {
+                Some(data) => data.witness[(row, col)],
+                None => panic!("Missing witness"),
+            }
+        }
+
+        fn coeff(col: usize, env: Option<&ArgumentData<F>>) -> Self {
+            match env {
+                Some(data) => data.coeffs[col],
+                None => panic!("Missing coefficients"),
+            }
+        }
+
+        fn constant(
+            expr: ConstantExpr<F, BerkeleyChallengeTerm>,
+            env: Option<&ArgumentData<F>>,
+        ) -> Self {
+            match env {
+                Some(data) => expr.value(&data.constants, &data.challenges),
+                None => panic!("Missing constants"),
+            }
+        }
+
+        fn cache(&self, _: &mut Cache) -> Self {
+            *self
+        }
+    }
+
+    /// Creates a constraint to enforce that b is either 0 or 1.
+    pub fn boolean<F: Field, ChallengeTerm, T: ExprOps<F, ChallengeTerm>>(b: &T) -> T {
+        b.square() - b.clone()
+    }
+
+    /// Crumb constraint for 2-bit value x
+    pub fn crumb<F: Field, ChallengeTerm, T: ExprOps<F, ChallengeTerm>>(x: &T) -> T {
+        // Assert x \in [0,3] i.e. assert x*(x - 1)*(x - 2)*(x - 3) == 0
+        x.clone()
+            * (x.clone() - 1u64.into())
+            * (x.clone() - 2u64.into())
+            * (x.clone() - 3u64.into())
+    }
+
+    /// lo + mi * 2^{LIMB_BITS}
+    pub fn compact_limb<F: Field, ChallengeTerm, T: ExprOps<F, ChallengeTerm>>(
+        lo: &T,
+        mi: &T,
+    ) -> T {
+        lo.clone() + mi.clone() * T::two_to_limb()
+    }
 }

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -29,8 +29,6 @@ use std::{
 use thiserror::Error;
 use CurrOrNext::{Curr, Next};
 
-use self::constraints::ExprOps;
-
 #[derive(Debug, Error)]
 pub enum ExprError<Column> {
     #[error("Empty stack")]
@@ -555,7 +553,10 @@ impl Cache {
         CacheId(id)
     }
 
-    pub fn cache<F: Field, ChallengeTerm, T: ExprOps<F, ChallengeTerm>>(&mut self, e: T) -> T {
+    pub fn cache<F: Field, ChallengeTerm, Column>(
+        &mut self,
+        e: Expr<ConstantExpr<F, ChallengeTerm>, Column>,
+    ) -> Expr<ConstantExpr<F, ChallengeTerm>, Column> {
         e.cache(self)
     }
 }
@@ -3178,253 +3179,6 @@ where
     }
 }
 
-//
-// Constraints
-//
-
-/// A number of useful constraints
-pub mod constraints {
-    use o1_utils::Two;
-
-    use crate::circuits::argument::ArgumentData;
-    use std::fmt;
-
-    use super::*;
-    use crate::circuits::berkeley_columns::{coeff, witness};
-
-    /// This trait defines a common arithmetic operations interface
-    /// that can be used by constraints.  It allows us to reuse
-    /// constraint code for witness computation.
-    pub trait ExprOps<F, ChallengeTerm>:
-        Add<Output = Self>
-        + Sub<Output = Self>
-        + Neg<Output = Self>
-        + Mul<Output = Self>
-        + AddAssign<Self>
-        + MulAssign<Self>
-        + Clone
-        + Zero
-        + One
-        + From<u64>
-        + fmt::Debug
-        + fmt::Display
-    // Add more as necessary
-    where
-        Self: std::marker::Sized,
-    {
-        /// 2^pow
-        fn two_pow(pow: u64) -> Self;
-
-        /// 2^{LIMB_BITS}
-        fn two_to_limb() -> Self;
-
-        /// 2^{2 * LIMB_BITS}
-        fn two_to_2limb() -> Self;
-
-        /// 2^{3 * LIMB_BITS}
-        fn two_to_3limb() -> Self;
-
-        /// Double the value
-        fn double(&self) -> Self;
-
-        /// Compute the square of this value
-        fn square(&self) -> Self;
-
-        /// Raise the value to the given power
-        fn pow(&self, p: u64) -> Self;
-
-        /// Constrain to boolean
-        fn boolean(&self) -> Self;
-
-        /// Constrain to crumb (i.e. two bits)
-        fn crumb(&self) -> Self;
-
-        /// Create a literal
-        fn literal(x: F) -> Self;
-
-        // Witness variable
-        fn witness(row: CurrOrNext, col: usize, env: Option<&ArgumentData<F>>) -> Self;
-
-        /// Coefficient
-        fn coeff(col: usize, env: Option<&ArgumentData<F>>) -> Self;
-
-        /// Create a constant
-        fn constant(expr: ConstantExpr<F, ChallengeTerm>, env: Option<&ArgumentData<F>>) -> Self;
-
-        /// Cache item
-        fn cache(&self, cache: &mut Cache) -> Self;
-    }
-    // TODO generalize with generic Column/challengeterm
-    // We need to create a trait for berkeley_columns::Environment
-    impl<F> ExprOps<F, BerkeleyChallengeTerm>
-        for Expr<ConstantExpr<F, BerkeleyChallengeTerm>, berkeley_columns::Column>
-    where
-        F: PrimeField,
-        // TODO remove
-        Expr<ConstantExpr<F, BerkeleyChallengeTerm>, berkeley_columns::Column>: std::fmt::Display,
-    {
-        fn two_pow(pow: u64) -> Self {
-            Expr::<ConstantExpr<F, BerkeleyChallengeTerm>, berkeley_columns::Column>::literal(
-                <F as Two<F>>::two_pow(pow),
-            )
-        }
-
-        fn two_to_limb() -> Self {
-            Expr::<ConstantExpr<F, BerkeleyChallengeTerm>, berkeley_columns::Column>::literal(
-                KimchiForeignElement::<F>::two_to_limb(),
-            )
-        }
-
-        fn two_to_2limb() -> Self {
-            Expr::<ConstantExpr<F, BerkeleyChallengeTerm>, berkeley_columns::Column>::literal(
-                KimchiForeignElement::<F>::two_to_2limb(),
-            )
-        }
-
-        fn two_to_3limb() -> Self {
-            Expr::<ConstantExpr<F, BerkeleyChallengeTerm>, berkeley_columns::Column>::literal(
-                KimchiForeignElement::<F>::two_to_3limb(),
-            )
-        }
-
-        fn double(&self) -> Self {
-            Expr::double(self.clone())
-        }
-
-        fn square(&self) -> Self {
-            Expr::square(self.clone())
-        }
-
-        fn pow(&self, p: u64) -> Self {
-            Expr::pow(self.clone(), p)
-        }
-
-        fn boolean(&self) -> Self {
-            constraints::boolean(self)
-        }
-
-        fn crumb(&self) -> Self {
-            constraints::crumb(self)
-        }
-
-        fn literal(x: F) -> Self {
-            ConstantTerm::Literal(x).into()
-        }
-
-        fn witness(row: CurrOrNext, col: usize, _: Option<&ArgumentData<F>>) -> Self {
-            witness(col, row)
-        }
-
-        fn coeff(col: usize, _: Option<&ArgumentData<F>>) -> Self {
-            coeff(col)
-        }
-
-        fn constant(
-            expr: ConstantExpr<F, BerkeleyChallengeTerm>,
-            _: Option<&ArgumentData<F>>,
-        ) -> Self {
-            Expr::from(expr)
-        }
-
-        fn cache(&self, cache: &mut Cache) -> Self {
-            Expr::Cache(cache.next_id(), Box::new(self.clone()))
-        }
-    }
-    // TODO generalize with generic Column/challengeterm
-    // We need to generalize argument.rs
-    impl<F: Field> ExprOps<F, BerkeleyChallengeTerm> for F {
-        fn two_pow(pow: u64) -> Self {
-            <F as Two<F>>::two_pow(pow)
-        }
-
-        fn two_to_limb() -> Self {
-            KimchiForeignElement::<F>::two_to_limb()
-        }
-
-        fn two_to_2limb() -> Self {
-            KimchiForeignElement::<F>::two_to_2limb()
-        }
-
-        fn two_to_3limb() -> Self {
-            KimchiForeignElement::<F>::two_to_3limb()
-        }
-
-        fn double(&self) -> Self {
-            *self * F::from(2u64)
-        }
-
-        fn square(&self) -> Self {
-            *self * *self
-        }
-
-        fn pow(&self, p: u64) -> Self {
-            self.pow([p])
-        }
-
-        fn boolean(&self) -> Self {
-            constraints::boolean(self)
-        }
-
-        fn crumb(&self) -> Self {
-            constraints::crumb(self)
-        }
-
-        fn literal(x: F) -> Self {
-            x
-        }
-
-        fn witness(row: CurrOrNext, col: usize, env: Option<&ArgumentData<F>>) -> Self {
-            match env {
-                Some(data) => data.witness[(row, col)],
-                None => panic!("Missing witness"),
-            }
-        }
-
-        fn coeff(col: usize, env: Option<&ArgumentData<F>>) -> Self {
-            match env {
-                Some(data) => data.coeffs[col],
-                None => panic!("Missing coefficients"),
-            }
-        }
-
-        fn constant(
-            expr: ConstantExpr<F, BerkeleyChallengeTerm>,
-            env: Option<&ArgumentData<F>>,
-        ) -> Self {
-            match env {
-                Some(data) => expr.value(&data.constants, &data.challenges),
-                None => panic!("Missing constants"),
-            }
-        }
-
-        fn cache(&self, _: &mut Cache) -> Self {
-            *self
-        }
-    }
-
-    /// Creates a constraint to enforce that b is either 0 or 1.
-    pub fn boolean<F: Field, ChallengeTerm, T: ExprOps<F, ChallengeTerm>>(b: &T) -> T {
-        b.square() - b.clone()
-    }
-
-    /// Crumb constraint for 2-bit value x
-    pub fn crumb<F: Field, ChallengeTerm, T: ExprOps<F, ChallengeTerm>>(x: &T) -> T {
-        // Assert x \in [0,3] i.e. assert x*(x - 1)*(x - 2)*(x - 3) == 0
-        x.clone()
-            * (x.clone() - 1u64.into())
-            * (x.clone() - 2u64.into())
-            * (x.clone() - 3u64.into())
-    }
-
-    /// lo + mi * 2^{LIMB_BITS}
-    pub fn compact_limb<F: Field, ChallengeTerm, T: ExprOps<F, ChallengeTerm>>(
-        lo: &T,
-        mi: &T,
-    ) -> T {
-        lo.clone() + mi.clone() * T::two_to_limb()
-    }
-}
-
 /// Auto clone macro - Helps make constraints more readable
 /// by eliminating requirement to .clone() all the time
 #[macro_export]
@@ -3464,10 +3218,9 @@ pub mod test {
     use super::*;
     use crate::{
         circuits::{
-            berkeley_columns::{index, witness_curr, Environment, E},
+            berkeley_columns::{constraints::ExprOps, index, witness_curr, Environment, E},
             constraints::ConstraintSystem,
             domains::EvaluationDomains,
-            expr::constraints::ExprOps,
             gate::{CircuitGate, GateType},
             polynomials::generic::GenericGateSpec,
             wires::{Wire, COLUMNS},

--- a/kimchi/src/circuits/polynomials/complete_add.rs
+++ b/kimchi/src/circuits/polynomials/complete_add.rs
@@ -16,8 +16,8 @@
 //~
 use crate::circuits::{
     argument::{Argument, ArgumentEnv, ArgumentType},
-    berkeley_columns::BerkeleyChallengeTerm,
-    expr::{constraints::ExprOps, Cache},
+    berkeley_columns::{constraints::ExprOps, BerkeleyChallengeTerm},
+    expr::Cache,
     gate::{CircuitGate, GateType},
     wires::COLUMNS,
 };

--- a/kimchi/src/circuits/polynomials/endomul_scalar.rs
+++ b/kimchi/src/circuits/polynomials/endomul_scalar.rs
@@ -4,9 +4,9 @@
 use crate::{
     circuits::{
         argument::{Argument, ArgumentEnv, ArgumentType},
-        berkeley_columns::BerkeleyChallengeTerm,
+        berkeley_columns::{constraints::ExprOps, BerkeleyChallengeTerm},
         constraints::ConstraintSystem,
-        expr::{constraints::ExprOps, Cache},
+        expr::Cache,
         gate::{CircuitGate, GateType},
         wires::COLUMNS,
     },

--- a/kimchi/src/circuits/polynomials/endosclmul.rs
+++ b/kimchi/src/circuits/polynomials/endosclmul.rs
@@ -5,13 +5,12 @@
 use crate::{
     circuits::{
         argument::{Argument, ArgumentEnv, ArgumentType},
-        berkeley_columns::{BerkeleyChallengeTerm, BerkeleyChallenges},
-        constraints::ConstraintSystem,
-        expr::{
-            self,
+        berkeley_columns::{
             constraints::{boolean, ExprOps},
-            Cache,
+            BerkeleyChallengeTerm, BerkeleyChallenges,
         },
+        constraints::ConstraintSystem,
+        expr::{self, Cache},
         gate::{CircuitGate, GateType},
         wires::{GateWires, COLUMNS},
     },

--- a/kimchi/src/circuits/polynomials/foreign_field_add/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/circuitgates.rs
@@ -2,11 +2,11 @@
 
 use crate::circuits::{
     argument::{Argument, ArgumentEnv, ArgumentType},
-    berkeley_columns::BerkeleyChallengeTerm,
-    expr::{
+    berkeley_columns::{
         constraints::{compact_limb, ExprOps},
-        Cache,
+        BerkeleyChallengeTerm,
     },
+    expr::Cache,
     gate::GateType,
     polynomials::foreign_field_common::LIMB_COUNT,
 };

--- a/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_add/witness.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     circuits::{
-        expr::constraints::compact_limb,
+        berkeley_columns::constraints::compact_limb,
         polynomial::COLUMNS,
         polynomials::foreign_field_common::{
             BigUintForeignFieldHelpers, KimchiForeignElement, HI, LIMB_BITS, LO, MI,

--- a/kimchi/src/circuits/polynomials/foreign_field_mul/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/foreign_field_mul/circuitgates.rs
@@ -93,8 +93,8 @@ use crate::{
     auto_clone_array,
     circuits::{
         argument::{Argument, ArgumentEnv, ArgumentType},
-        berkeley_columns::BerkeleyChallengeTerm,
-        expr::{constraints::ExprOps, Cache},
+        berkeley_columns::{constraints::ExprOps, BerkeleyChallengeTerm},
+        expr::Cache,
         gate::GateType,
     },
 };

--- a/kimchi/src/circuits/polynomials/generic.rs
+++ b/kimchi/src/circuits/polynomials/generic.rs
@@ -36,8 +36,8 @@
 use crate::{
     circuits::{
         argument::{Argument, ArgumentEnv, ArgumentType},
-        berkeley_columns::BerkeleyChallengeTerm,
-        expr::{constraints::ExprOps, Cache},
+        berkeley_columns::{constraints::ExprOps, BerkeleyChallengeTerm},
+        expr::Cache,
         gate::{CircuitGate, GateType},
         polynomial::COLUMNS,
         wires::GateWires,

--- a/kimchi/src/circuits/polynomials/keccak/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/keccak/circuitgates.rs
@@ -3,11 +3,11 @@ use crate::{
     auto_clone, auto_clone_array,
     circuits::{
         argument::{Argument, ArgumentEnv, ArgumentType},
-        berkeley_columns::BerkeleyChallengeTerm,
-        expr::{
+        berkeley_columns::{
             constraints::{boolean, ExprOps},
-            Cache,
+            BerkeleyChallengeTerm,
         },
+        expr::Cache,
         gate::GateType,
         polynomials::keccak::{constants::*, OFF},
     },

--- a/kimchi/src/circuits/polynomials/keccak/mod.rs
+++ b/kimchi/src/circuits/polynomials/keccak/mod.rs
@@ -4,7 +4,7 @@ pub mod constants;
 pub mod gadget;
 pub mod witness;
 
-use crate::circuits::expr::constraints::ExprOps;
+use crate::circuits::berkeley_columns::constraints::ExprOps;
 use ark_ff::PrimeField;
 
 use self::constants::{DIM, QUARTERS, RATE_IN_BYTES, ROUNDS};

--- a/kimchi/src/circuits/polynomials/poseidon.rs
+++ b/kimchi/src/circuits/polynomials/poseidon.rs
@@ -28,8 +28,8 @@
 use crate::{
     circuits::{
         argument::{Argument, ArgumentEnv, ArgumentType},
-        berkeley_columns::BerkeleyChallengeTerm,
-        expr::{constraints::ExprOps, Cache},
+        berkeley_columns::{constraints::ExprOps, BerkeleyChallengeTerm},
+        expr::Cache,
         gate::{CircuitGate, CurrOrNext, GateType},
         polynomial::COLUMNS,
         wires::{GateWires, Wire},

--- a/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
+++ b/kimchi/src/circuits/polynomials/range_check/circuitgates.rs
@@ -118,11 +118,11 @@ use std::marker::PhantomData;
 
 use crate::circuits::{
     argument::{Argument, ArgumentEnv, ArgumentType},
-    berkeley_columns::BerkeleyChallengeTerm,
-    expr::{
+    berkeley_columns::{
         constraints::{crumb, ExprOps},
-        Cache,
+        BerkeleyChallengeTerm,
     },
+    expr::Cache,
     gate::GateType,
     polynomial::COLUMNS,
 };

--- a/kimchi/src/circuits/polynomials/rot.rs
+++ b/kimchi/src/circuits/polynomials/rot.rs
@@ -4,11 +4,11 @@ use super::range_check::witness::range_check_0_row;
 use crate::{
     circuits::{
         argument::{Argument, ArgumentEnv, ArgumentType},
-        berkeley_columns::BerkeleyChallengeTerm,
-        expr::{
+        berkeley_columns::{
             constraints::{crumb, ExprOps},
-            Cache,
+            BerkeleyChallengeTerm,
         },
+        expr::Cache,
         gate::{CircuitGate, Connect, GateType},
         lookup::{
             self,

--- a/kimchi/src/circuits/polynomials/turshi.rs
+++ b/kimchi/src/circuits/polynomials/turshi.rs
@@ -82,9 +82,11 @@ use crate::{
     alphas::Alphas,
     circuits::{
         argument::{Argument, ArgumentEnv, ArgumentType},
-        berkeley_columns::{BerkeleyChallengeTerm, BerkeleyChallenges, Column, E},
+        berkeley_columns::{
+            constraints::ExprOps, BerkeleyChallengeTerm, BerkeleyChallenges, Column, E,
+        },
         constraints::ConstraintSystem,
-        expr::{self, constraints::ExprOps, Cache},
+        expr::{self, Cache},
         gate::{CircuitGate, GateType},
         wires::{GateWires, Wire, COLUMNS},
     },

--- a/kimchi/src/circuits/polynomials/varbasemul.rs
+++ b/kimchi/src/circuits/polynomials/varbasemul.rs
@@ -12,8 +12,8 @@
 
 use crate::circuits::{
     argument::{Argument, ArgumentEnv, ArgumentType},
-    berkeley_columns::{BerkeleyChallengeTerm, Column},
-    expr::{constraints::ExprOps, Cache, Variable as VariableGen},
+    berkeley_columns::{constraints::ExprOps, BerkeleyChallengeTerm, Column},
+    expr::{Cache, Variable as VariableGen},
     gate::{CircuitGate, CurrOrNext, GateType},
     wires::{GateWires, COLUMNS},
 };

--- a/kimchi/src/circuits/polynomials/xor.rs
+++ b/kimchi/src/circuits/polynomials/xor.rs
@@ -4,8 +4,8 @@
 use crate::{
     circuits::{
         argument::{Argument, ArgumentEnv, ArgumentType},
-        berkeley_columns::BerkeleyChallengeTerm,
-        expr::{constraints::ExprOps, Cache},
+        berkeley_columns::{constraints::ExprOps, BerkeleyChallengeTerm},
+        expr::Cache,
         gate::{CircuitGate, Connect, GateType},
         lookup::{
             self,

--- a/kimchi/src/snarky/range_checks.rs
+++ b/kimchi/src/snarky/range_checks.rs
@@ -157,8 +157,8 @@ pub fn range_check<F: PrimeField>(
 #[cfg(test)]
 mod test {
     use crate::{
-        circuits::expr::constraints::ExprOps, loc, snarky::api::SnarkyCircuit, FieldVar, RunState,
-        SnarkyResult,
+        circuits::berkeley_columns::constraints::ExprOps, loc, snarky::api::SnarkyCircuit,
+        FieldVar, RunState, SnarkyResult,
     };
     use mina_curves::pasta::{Fp, Vesta, VestaParameters};
     use mina_poseidon::{


### PR DESCRIPTION
This must be done as part of the follow-up of https://github.com/o1-labs/proof-systems/pull/2566#discussion_r1764597368. cc @marcbeunardeau88 to continue

The feature flags should also be moved into berkeley_columns.rs