### PR TITLE
Poly-commitment: revert change regarding trusted-setup

### DIFF
--- a/msm/src/precomputed_srs.rs
+++ b/msm/src/precomputed_srs.rs
@@ -2,9 +2,11 @@
 
 use crate::{Fp, BN254, DOMAIN_SIZE};
 use ark_ec::pairing::Pairing;
+use ark_ff::UniformRand;
 use ark_serialize::Write;
 use kimchi::{circuits::domains::EvaluationDomains, precomputed_srs::TestSRS};
 use poly_commitment::{kzg::PairingSRS, SRS as _};
+use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::{fs::File, io::BufReader, path::PathBuf};
 
@@ -71,7 +73,9 @@ fn create_and_store_srs_with_path(
     srs_path: PathBuf,
 ) -> PairingSRS<BN254> {
     // We generate with a fixed-seed RNG, only used for testing.
-    let mut srs = PairingSRS::create(domain_size);
+    let mut rng = &mut StdRng::from_seed([42u8; 32]);
+    let trapdoor = Fp::rand(&mut rng);
+    let mut srs = PairingSRS::create_trusted_setup(trapdoor, domain_size);
 
     for sub_domain_size in 1..=domain_size {
         let domain = EvaluationDomains::<Fp>::create(sub_domain_size).unwrap();

--- a/poly-commitment/src/kzg.rs
+++ b/poly-commitment/src/kzg.rs
@@ -139,9 +139,9 @@ impl<
     /// Create a trusted setup for the KZG protocol.
     /// The setup is created using a toxic waste `toxic_waste` and a depth
     /// `depth`.
-    fn create_trusted_setup(toxic_waste: F, depth: usize) -> Self {
+    pub fn create_trusted_setup(toxic_waste: F, depth: usize) -> Self {
         let full_srs = unsafe { SRS::create_trusted_setup(toxic_waste, depth) };
-        let verifier_srs = unsafe { SRS::create_trusted_setup(toxic_waste, depth) };
+        let verifier_srs = unsafe { SRS::create_trusted_setup(toxic_waste, 3) };
         Self {
             full_srs,
             verifier_srs,


### PR DESCRIPTION
Introduced in fa8e6a38c021d943b7cf073b686743edfc70a27f. Also, making create_and_store_srs_with_path deterministic as before. The test is exactly testing encoding of the SRS for regression.

Reviewer should run:
```
cargo nextest run "precomputed_srs::tests::heavy_test_create_or_check_srs" --all-features --release --nocapture
```
