### PR TITLE
o1vm/pickles remove error

### DIFF
--- a/o1vm/src/pickles/main.rs
+++ b/o1vm/src/pickles/main.rs
@@ -1,4 +1,3 @@
-use ark_ff::UniformRand;
 use kimchi::circuits::domains::EvaluationDomains;
 use kimchi_msm::expr::E;
 use log::debug;
@@ -125,8 +124,6 @@ pub fn main() -> ExitCode {
             .evaluations
             .instruction_counter
             .push(Fp::from(mips_wit_env.instruction_counter));
-        // FIXME: Might be another value
-        curr_proof_inputs.evaluations.error.push(Fp::rand(&mut rng));
 
         curr_proof_inputs
             .evaluations

--- a/o1vm/src/pickles/proof.rs
+++ b/o1vm/src/pickles/proof.rs
@@ -7,7 +7,6 @@ use crate::interpreters::mips::column::N_MIPS_SEL_COLS;
 pub struct WitnessColumns<G, S> {
     pub scratch: [G; crate::interpreters::mips::witness::SCRATCH_SIZE],
     pub instruction_counter: G,
-    pub error: G,
     pub selector: S,
 }
 
@@ -21,7 +20,6 @@ impl<G: KimchiCurve> ProofInputs<G> {
             evaluations: WitnessColumns {
                 scratch: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
                 instruction_counter: Vec::with_capacity(domain_size),
-                error: Vec::with_capacity(domain_size),
                 selector: Vec::with_capacity(domain_size),
             },
         }

--- a/o1vm/src/pickles/prover.rs
+++ b/o1vm/src/pickles/prover.rs
@@ -85,7 +85,6 @@ where
         let WitnessColumns {
             scratch,
             instruction_counter,
-            error,
             selector,
         } = evaluations;
 
@@ -115,7 +114,6 @@ where
         WitnessColumns {
             scratch: scratch.try_into().unwrap(),
             instruction_counter: eval_col(instruction_counter),
-            error: eval_col(error.clone()),
             selector: selector.try_into().unwrap(),
         }
     };
@@ -125,7 +123,6 @@ where
         let WitnessColumns {
             scratch,
             instruction_counter,
-            error,
             selector,
         } = &polys;
         // Note: We add a constant blinder in case we have a column with only zeroes.
@@ -144,7 +141,6 @@ where
         WitnessColumns {
             scratch: scratch.try_into().unwrap(),
             instruction_counter: comm(instruction_counter),
-            error: comm(error),
             selector: selector.try_into().unwrap(),
         }
     };
@@ -158,7 +154,6 @@ where
         let WitnessColumns {
             scratch,
             instruction_counter,
-            error,
             selector,
         } = &polys;
         let eval_d8 =
@@ -169,7 +164,6 @@ where
         WitnessColumns {
             scratch: scratch.try_into().unwrap(),
             instruction_counter: eval_d8(instruction_counter),
-            error: eval_d8(error),
             selector: selector.try_into().unwrap(),
         }
     };
@@ -180,7 +174,6 @@ where
         absorb_commitment(&mut fq_sponge, comm)
     }
     absorb_commitment(&mut fq_sponge, &commitments.instruction_counter);
-    absorb_commitment(&mut fq_sponge, &commitments.error);
     for comm in commitments.selector.iter() {
         absorb_commitment(&mut fq_sponge, comm)
     }
@@ -294,7 +287,6 @@ where
         let WitnessColumns {
             scratch,
             instruction_counter,
-            error,
             selector,
         } = &polys;
         let eval = |poly: &DensePolynomial<G::ScalarField>| poly.evaluate(point);
@@ -303,7 +295,6 @@ where
         WitnessColumns {
             scratch: scratch.try_into().unwrap(),
             instruction_counter: eval(instruction_counter),
-            error: eval(error),
             selector: selector.try_into().unwrap(),
         }
     };
@@ -350,8 +341,6 @@ where
     }
     fr_sponge.absorb(&zeta_evaluations.instruction_counter);
     fr_sponge.absorb(&zeta_omega_evaluations.instruction_counter);
-    fr_sponge.absorb(&zeta_evaluations.error);
-    fr_sponge.absorb(&zeta_omega_evaluations.error);
     for (zeta_eval, zeta_omega_eval) in zeta_evaluations
         .selector
         .iter()
@@ -374,7 +363,6 @@ where
 
     let mut polynomials: Vec<_> = polys.scratch.into_iter().collect();
     polynomials.push(polys.instruction_counter);
-    polynomials.push(polys.error);
     polynomials.extend(polys.selector);
 
     // Preparing the polynomials for the opening proof

--- a/o1vm/src/pickles/tests.rs
+++ b/o1vm/src/pickles/tests.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     pickles::{verifier::verify, MAXIMUM_DEGREE_CONSTRAINTS, TOTAL_NUMBER_OF_CONSTRAINTS},
 };
-use ark_ff::{One, Zero};
+use ark_ff::Zero;
 use interpreter::{ITypeInstruction, JTypeInstruction, RTypeInstruction};
 use kimchi::circuits::{domains::EvaluationDomains, expr::Expr, gate::CurrOrNext};
 use kimchi_msm::{columns::Column, expr::E};
@@ -82,18 +82,18 @@ fn test_small_circuit() {
     let proof_input = ProofInputs::<Pallas> {
         evaluations: WitnessColumns {
             scratch: std::array::from_fn(|_| zero_to_n_minus_one(8)),
-            instruction_counter: zero_to_n_minus_one(8)
-                .into_iter()
-                .map(|x| x + Fq::one())
-                .collect(),
-            error: (0..8)
-                .map(|i| -Fq::from((i * SCRATCH_SIZE + (i + 1)) as u64))
-                .collect(),
+            // Note that the instruction counter is not
+            // used as intended.
+            // See the constraint we apply.
+            instruction_counter: (0..8).map(|i| -Fq::from(i * SCRATCH_SIZE as u64)).collect(),
+            // Selector will be ignored
             selector: zero_to_n_minus_one(8),
         },
     };
+    // The constraint we check adds the scratch
+    // and the instruction counter together.
     let mut expr = Expr::zero();
-    for i in 0..SCRATCH_SIZE + 2 {
+    for i in 0..SCRATCH_SIZE + 1 {
         expr += Expr::cell(Column::Relation(i), CurrOrNext::Curr);
     }
     let mut rng = make_test_rng(None);

--- a/o1vm/src/pickles/verifier.rs
+++ b/o1vm/src/pickles/verifier.rs
@@ -2,7 +2,6 @@
 
 use ark_ec::{AffineRepr, Group};
 use ark_ff::{Field, One, PrimeField, Zero};
-use itertools::Itertools;
 use rand::thread_rng;
 
 use kimchi::{
@@ -104,7 +103,6 @@ where
         absorb_commitment(&mut fq_sponge, comm)
     }
     absorb_commitment(&mut fq_sponge, &commitments.instruction_counter);
-    absorb_commitment(&mut fq_sponge, &commitments.error);
     for comm in commitments.selector.iter() {
         absorb_commitment(&mut fq_sponge, comm)
     }
@@ -146,8 +144,6 @@ where
     }
     fr_sponge.absorb(&zeta_evaluations.instruction_counter);
     fr_sponge.absorb(&zeta_omega_evaluations.instruction_counter);
-    fr_sponge.absorb(&zeta_evaluations.error);
-    fr_sponge.absorb(&zeta_omega_evaluations.error);
     for (zeta_eval, zeta_omega_eval) in zeta_evaluations
         .selector
         .iter()


### PR DESCRIPTION
The error field in a proof was a leftover from folding.
We remove it when using pickles.