### PR TITLE
Compute the necessarry inversions of the witness in batch after it's creation

### DIFF
--- a/o1vm/src/interpreters/mips/tests_helpers.rs
+++ b/o1vm/src/interpreters/mips/tests_helpers.rs
@@ -3,7 +3,7 @@ use crate::{
     interpreters::mips::{
         interpreter::{debugging::InstructionParts, InterpreterEnv},
         registers::Registers,
-        witness::{Env as WEnv, SyscallEnv, SCRATCH_SIZE},
+        witness::{Env as WEnv, SyscallEnv, ToInverseOrNot, SCRATCH_SIZE},
     },
     preimage_oracle::PreImageOracleT,
 };
@@ -87,7 +87,7 @@ where
         registers: Registers::default(),
         registers_write_index: Registers::default(),
         scratch_state_idx: 0,
-        scratch_state: [Fp::from(0); SCRATCH_SIZE],
+        scratch_state: [ToInverseOrNot::NotToInverse(Fp::from(0)); SCRATCH_SIZE],
         selector: crate::interpreters::mips::column::N_MIPS_SEL_COLS,
         halt: false,
         // Keccak related

--- a/o1vm/src/legacy/main.rs
+++ b/o1vm/src/legacy/main.rs
@@ -159,7 +159,7 @@ pub fn main() -> ExitCode {
         for i in 0..N_MIPS_REL_COLS {
             match i.cmp(&SCRATCH_SIZE) {
                 Ordering::Less => mips_trace.trace.get_mut(&instr).unwrap().witness.cols[i]
-                    .push(mips_wit_env.scratch_state[i]),
+                    .push(mips_wit_env.scratch_state[i].to_field()),
                 Ordering::Equal => mips_trace.trace.get_mut(&instr).unwrap().witness.cols[i]
                     .push(Fp::from(mips_wit_env.instruction_counter)),
                 Ordering::Greater => {

--- a/o1vm/src/pickles/main.rs
+++ b/o1vm/src/pickles/main.rs
@@ -98,7 +98,7 @@ pub fn main() -> ExitCode {
         constraints
     };
 
-    let mut curr_proof_inputs: ProofInputs<Vesta> = ProofInputs::new(DOMAIN_SIZE);
+    let mut curr_proof_inputs: ProofInputs<Fp> = ProofInputs::new(DOMAIN_SIZE);
     while !mips_wit_env.halt {
         let _instr: Instruction = mips_wit_env.step(&configuration, &meta, &start);
         for (scratch, scratch_chunk) in mips_wit_env

--- a/o1vm/src/pickles/main.rs
+++ b/o1vm/src/pickles/main.rs
@@ -106,7 +106,7 @@ pub fn main() -> ExitCode {
             .iter()
             .zip(curr_proof_inputs.evaluations.scratch.iter_mut())
         {
-            scratch_chunk.push(*scratch);
+            scratch_chunk.push(scratch.to_field());
         }
         curr_proof_inputs
             .evaluations

--- a/o1vm/src/pickles/proof.rs
+++ b/o1vm/src/pickles/proof.rs
@@ -15,7 +15,10 @@ pub struct ProofInputs<F: Field> {
 }
 
 pub struct NotInversedProofInputs<F: Field> {
-    pub evaluations: WitnessColumns<Vec<ToInverseOrNot<F>>, Vec<F>>,
+    pub scratch: [Vec<ToInverseOrNot<F>>; crate::interpreters::mips::witness::SCRATCH_SIZE],
+    pub instruction_counter: Vec<F>,
+    pub error: Vec<F>,
+    pub selector: Vec<F>,
 }
 
 impl<G: KimchiCurve> ProofInputs<G> {

--- a/o1vm/src/pickles/proof.rs
+++ b/o1vm/src/pickles/proof.rs
@@ -80,6 +80,17 @@ impl<F: ark_ff::Field> From<NotInversedProofInputs<F>> for ProofInputs<F> {
     }
 }
 
+impl<F: Field> NotInversedProofInputs<F> {
+    pub fn new(domain_size: usize) -> Self {
+        NotInversedProofInputs {
+            scratch: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
+            instruction_counter: Vec::with_capacity(domain_size),
+            error: Vec::with_capacity(domain_size),
+            selector: Vec::with_capacity(domain_size),
+        }
+    }
+}
+
 impl<F: Field> ProofInputs<F> {
     pub fn new(domain_size: usize) -> Self {
         ProofInputs {

--- a/o1vm/src/pickles/proof.rs
+++ b/o1vm/src/pickles/proof.rs
@@ -1,7 +1,8 @@
+use crate::interpreters::mips::{column::N_MIPS_SEL_COLS, witness::ToInverseOrNot};
+use ark_ff::Field;
 use kimchi::curve::KimchiCurve;
 use poly_commitment::{ipa::OpeningProof, PolyComm};
-
-use crate::interpreters::mips::{column::N_MIPS_SEL_COLS, witness::ToInverseOrNot};
+use std::collections::HashMap;
 
 pub struct WitnessColumns<G, S> {
     pub scratch: [G; crate::interpreters::mips::witness::SCRATCH_SIZE],
@@ -21,7 +22,65 @@ pub struct NotInversedProofInputs<F: Field> {
     pub selector: Vec<F>,
 }
 
-impl<G: KimchiCurve> ProofInputs<G> {
+impl<F: ark_ff::Field> From<NotInversedProofInputs<F>> for ProofInputs<F> {
+    // This function collects the values marked as to inverse from
+    // the proof input, performs a batch inversion on them,
+    // and returns a usable proof input
+    fn from(not_inversed: NotInversedProofInputs<F>) -> ProofInputs<F> {
+        // Initialising the result
+        let mut res = ProofInputs::new(not_inversed.scratch[1].len());
+        res.evaluations.error = not_inversed.error;
+        res.evaluations.instruction_counter = not_inversed.instruction_counter;
+        res.evaluations.selector = not_inversed.selector;
+
+        // Collecting the values to inverse
+        let to_inverse_map: &mut HashMap<_, F> = &mut HashMap::new();
+        for (i, scratch_i) in not_inversed.scratch.iter().enumerate() {
+            for (j, ref x_j) in scratch_i.iter().enumerate() {
+                match x_j {
+                    ToInverseOrNot::NotToInverse(_) => (),
+                    ToInverseOrNot::ToInverse(x) => {
+                        // the result is none as this key has not been inserted yet
+                        let _none = HashMap::insert(to_inverse_map, (i, j), *x);
+                    }
+                }
+            }
+        }
+
+        // Perform the inversion
+        // FIXME: we go trough vec to get the array required by arkworks
+        // This is ugly
+        let mut to_inverse_vec: Vec<F> = Vec::with_capacity(to_inverse_map.len());
+        for v in to_inverse_map.values() {
+            to_inverse_vec.push(*v);
+        }
+        let to_inverse_slice = to_inverse_vec.as_mut_slice();
+
+        ark_ff::batch_inversion::<F>(to_inverse_slice);
+        // Collecting the inverses and putting them back in the map
+        // we need to create a second map to collect the inverses.
+        // FIXME: We should not need to do this
+        let mut inversed_map = HashMap::new();
+        for (i, (k, _)) in to_inverse_map.iter().enumerate() {
+            // We ignore the old value
+            let _ = inversed_map.insert(*k, to_inverse_slice[i]);
+        }
+
+        //Writting the inverses in the proof input
+        for (i, scratch_i) in not_inversed.scratch.iter().enumerate() {
+            for (j, ref x_j) in scratch_i.iter().enumerate() {
+                match x_j {
+                    ToInverseOrNot::NotToInverse(x) => res.evaluations.scratch[i].push(*x),
+                    ToInverseOrNot::ToInverse(_) => res.evaluations.scratch[i]
+                        .push(*inversed_map.get(&(i, j)).expect("This function is buggy")),
+                }
+            }
+        }
+        res
+    }
+}
+
+impl<F: Field> ProofInputs<F> {
     pub fn new(domain_size: usize) -> Self {
         ProofInputs {
             evaluations: WitnessColumns {

--- a/o1vm/src/pickles/proof.rs
+++ b/o1vm/src/pickles/proof.rs
@@ -1,7 +1,7 @@
 use kimchi::curve::KimchiCurve;
 use poly_commitment::{ipa::OpeningProof, PolyComm};
 
-use crate::interpreters::mips::column::N_MIPS_SEL_COLS;
+use crate::interpreters::mips::{column::N_MIPS_SEL_COLS, witness::ToInverseOrNot};
 
 pub struct WitnessColumns<G, S> {
     pub scratch: [G; crate::interpreters::mips::witness::SCRATCH_SIZE],
@@ -12,6 +12,10 @@ pub struct WitnessColumns<G, S> {
 
 pub struct ProofInputs<G: KimchiCurve> {
     pub evaluations: WitnessColumns<Vec<G::ScalarField>, Vec<G::ScalarField>>,
+}
+
+pub struct NotInversedProofInputs<G: KimchiCurve> {
+    pub evaluations: WitnessColumns<Vec<ToInverseOrNot<G::ScalarField>>, Vec<G::ScalarField>>,
 }
 
 impl<G: KimchiCurve> ProofInputs<G> {

--- a/o1vm/src/pickles/proof.rs
+++ b/o1vm/src/pickles/proof.rs
@@ -10,12 +10,12 @@ pub struct WitnessColumns<G, S> {
     pub selector: S,
 }
 
-pub struct ProofInputs<G: KimchiCurve> {
-    pub evaluations: WitnessColumns<Vec<G::ScalarField>, Vec<G::ScalarField>>,
+pub struct ProofInputs<F: Field> {
+    pub evaluations: WitnessColumns<Vec<F>, Vec<F>>,
 }
 
-pub struct NotInversedProofInputs<G: KimchiCurve> {
-    pub evaluations: WitnessColumns<Vec<ToInverseOrNot<G::ScalarField>>, Vec<G::ScalarField>>,
+pub struct NotInversedProofInputs<F: Field> {
+    pub evaluations: WitnessColumns<Vec<ToInverseOrNot<F>>, Vec<F>>,
 }
 
 impl<G: KimchiCurve> ProofInputs<G> {

--- a/o1vm/src/pickles/prover.rs
+++ b/o1vm/src/pickles/prover.rs
@@ -59,7 +59,7 @@ pub fn prove<
 >(
     domain: EvaluationDomains<G::ScalarField>,
     srs: &SRS<G>,
-    inputs: ProofInputs<G>,
+    inputs: ProofInputs<G::ScalarField>,
     constraints: &[E<G::ScalarField>],
     rng: &mut RNG,
 ) -> Result<Proof<G>, ProverError>


### PR DESCRIPTION
                    
Follow-up of https://github.com/o1-labs/proof-systems/pull/2047
but we proceed differently.
The scratch state now contains field element which are marked to be inversed or not, using a variant.
The Batch inversion is then done when creating the ProofInput.
We first create an intermediary type NotInversedProofInput, containing the same variant as the scratch state, and implement a conversion to ProofInput  which does the batch inversion