### PR TITLE
o1vm: move memory_size into a top-level utils module

### DIFF
--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -22,6 +22,7 @@ use crate::{
     },
     lookups::Lookup,
     preimage_oracle::PreImageOracleT,
+    utils::memory_size,
 };
 use ark_ff::Field;
 use core::panic;
@@ -94,42 +95,6 @@ pub struct Env<Fp, PreImageOracle: PreImageOracleT> {
 
 fn fresh_scratch_state<Fp: Field, const N: usize>() -> [Fp; N] {
     array::from_fn(|_| Fp::zero())
-}
-
-const KUNIT: usize = 1024; // a kunit of memory is 1024 things (bytes, kilobytes, ...)
-const PREFIXES: &str = "KMGTPE"; // prefixes for memory quantities KiB, MiB, GiB, ...
-
-// Create a human-readable string representation of the memory size
-fn memory_size(total: usize) -> String {
-    if total < KUNIT {
-        format!("{total} B")
-    } else {
-        // Compute the index in the prefixes string above
-        let mut idx = 0;
-        let mut d = KUNIT;
-        let mut n = total / KUNIT;
-
-        while n >= KUNIT {
-            d *= KUNIT;
-            idx += 1;
-            n /= KUNIT;
-        }
-
-        let value = total as f64 / d as f64;
-
-        let prefix =
-        ////////////////////////////////////////////////////////////////////////
-        // Famous last words: 1023 exabytes ought to be enough for anybody    //
-        //                                                                    //
-        // Corollary:                                                         //
-        // unwrap() below shouldn't fail                                      //
-        // The maximum representation for usize corresponds to 16 exabytes    //
-        // anyway                                                             //
-        ////////////////////////////////////////////////////////////////////////
-            PREFIXES.chars().nth(idx).unwrap();
-
-        format!("{:.1} {}iB", value, prefix)
-    }
 }
 
 impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreImageOracle> {
@@ -1333,20 +1298,5 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
                 step, pc, insn, ips, pages, mem, name
             );
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-
-    use super::*;
-
-    #[test]
-    fn test_memory_size() {
-        assert_eq!(memory_size(1023_usize), "1023 B");
-        assert_eq!(memory_size(1024_usize), "1.0 KiB");
-        assert_eq!(memory_size(1024 * 1024_usize), "1.0 MiB");
-        assert_eq!(memory_size(2100 * 1024 * 1024_usize), "2.1 GiB");
-        assert_eq!(memory_size(std::usize::MAX), "16.0 EiB");
     }
 }

--- a/o1vm/src/lib.rs
+++ b/o1vm/src/lib.rs
@@ -26,6 +26,8 @@ pub mod preimage_oracle;
 /// The RAM lookup argument.
 pub mod ramlookup;
 
+pub mod utils;
+
 use kimchi::circuits::{
     berkeley_columns::BerkeleyChallengeTerm,
     expr::{ConstantExpr, Expr},

--- a/o1vm/src/utils.rs
+++ b/o1vm/src/utils.rs
@@ -1,0 +1,50 @@
+const KUNIT: usize = 1024; // a kunit of memory is 1024 things (bytes, kilobytes, ...)
+const PREFIXES: &str = "KMGTPE"; // prefixes for memory quantities KiB, MiB, GiB, ...
+
+// Create a human-readable string representation of the memory size
+pub fn memory_size(total: usize) -> String {
+    if total < KUNIT {
+        format!("{total} B")
+    } else {
+        // Compute the index in the prefixes string above
+        let mut idx = 0;
+        let mut d = KUNIT;
+        let mut n = total / KUNIT;
+
+        while n >= KUNIT {
+            d *= KUNIT;
+            idx += 1;
+            n /= KUNIT;
+        }
+
+        let value = total as f64 / d as f64;
+
+        let prefix =
+        ////////////////////////////////////////////////////////////////////////
+        // Famous last words: 1023 exabytes ought to be enough for anybody    //
+        //                                                                    //
+        // Corollary:                                                         //
+        // unwrap() below shouldn't fail                                      //
+        // The maximum representation for usize corresponds to 16 exabytes    //
+        // anyway                                                             //
+        ////////////////////////////////////////////////////////////////////////
+            PREFIXES.chars().nth(idx).unwrap();
+
+        format!("{:.1} {}iB", value, prefix)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_memory_size() {
+        assert_eq!(memory_size(1023_usize), "1023 B");
+        assert_eq!(memory_size(1024_usize), "1.0 KiB");
+        assert_eq!(memory_size(1024 * 1024_usize), "1.0 MiB");
+        assert_eq!(memory_size(2100 * 1024 * 1024_usize), "2.1 GiB");
+        assert_eq!(memory_size(std::usize::MAX), "16.0 EiB");
+    }
+}


### PR DESCRIPTION
It will be shared by the MIPS and the RISC-V 32i ISA.
Cherry-picked from https://github.com/o1-labs/proof-systems/pull/2727/