### PR TITLE
o1vm/riscv32i: split interpret_instruction in subroutines

### DIFF
--- a/o1vm/src/interpreters/riscv32i/interpreter.rs
+++ b/o1vm/src/interpreters/riscv32i/interpreter.rs
@@ -1043,6 +1043,36 @@ pub trait InterpreterEnv {
 pub fn interpret_instruction<Env: InterpreterEnv>(env: &mut Env, instr: Instruction) {
     env.activate_selector(instr);
 
-    // TODO: match on instructions
-    unimplemented!("TODO");
+    match instr {
+        Instruction::RType(rtype) => interpret_rtype(env, rtype),
+        Instruction::IType(itype) => interpret_itype(env, itype),
+        Instruction::SType(stype) => interpret_stype(env, stype),
+        Instruction::SBType(sbtype) => interpret_sbtype(env, sbtype),
+        Instruction::UType(utype) => interpret_utype(env, utype),
+        Instruction::UJType(ujtype) => interpret_ujtype(env, ujtype),
+    }
+}
+
+pub fn interpret_rtype<Env: InterpreterEnv>(_env: &mut Env, _instr: RInstruction) {
+    unimplemented!("TODO")
+}
+
+pub fn interpret_itype<Env: InterpreterEnv>(_env: &mut Env, _instr: IInstruction) {
+    unimplemented!("TODO")
+}
+
+pub fn interpret_stype<Env: InterpreterEnv>(_env: &mut Env, _instr: SInstruction) {
+    unimplemented!("TODO")
+}
+
+pub fn interpret_sbtype<Env: InterpreterEnv>(_env: &mut Env, _instr: SBInstruction) {
+    unimplemented!("TODO")
+}
+
+pub fn interpret_utype<Env: InterpreterEnv>(_env: &mut Env, _instr: UInstruction) {
+    unimplemented!("TODO")
+}
+
+pub fn interpret_ujtype<Env: InterpreterEnv>(_env: &mut Env, _instr: UJInstruction) {
+    unimplemented!("TODO")
 }


### PR DESCRIPTION
Leaving the implementation details for @svv232 