### PR TITLE
Upstream openmina changes

### DIFF
--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1736,7 +1736,7 @@ pub struct ProverIndex<G: KimchiCurve, OpeningProof: OpenProof<G>> {
 
     /// The verifier index corresponding to this prover index
     #[serde(skip)]
-    pub verifier_index: Option<VerifierIndex<G, OpeningProof>>,
+    pub verifier_index: Option<Arc<VerifierIndex<G, OpeningProof>>>,
 
     /// The verifier index digest corresponding to this prover index
     #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]

--- a/kimchi/src/bench.rs
+++ b/kimchi/src/bench.rs
@@ -1,4 +1,4 @@
-use std::array;
+use std::{array, sync::Arc};
 
 use groupmap::{BWParameters, GroupMap};
 use mina_curves::pasta::{Fp, Vesta, VestaParameters};
@@ -29,7 +29,7 @@ pub struct BenchmarkCtx {
     pub num_gates: usize,
     group_map: BWParameters<VestaParameters>,
     index: ProverIndex<Vesta, OpeningProof<Vesta>>,
-    verifier_index: VerifierIndex<Vesta, OpeningProof<Vesta>>,
+    verifier_index: Arc<VerifierIndex<Vesta, OpeningProof<Vesta>>>,
 }
 
 impl BenchmarkCtx {

--- a/kimchi/src/prover_index.rs
+++ b/kimchi/src/prover_index.rs
@@ -49,7 +49,7 @@ pub struct ProverIndex<G: KimchiCurve, OpeningProof: OpenProof<G>> {
 
     /// The verifier index corresponding to this prover index
     #[serde(skip)]
-    pub verifier_index: Option<VerifierIndex<G, OpeningProof>>,
+    pub verifier_index: Option<Arc<VerifierIndex<G, OpeningProof>>>,
 
     /// The verifier index digest corresponding to this prover index
     #[serde_as(as = "Option<o1_utils::serialization::SerdeAs>")]

--- a/kimchi/src/verifier_index.rs
+++ b/kimchi/src/verifier_index.rs
@@ -162,7 +162,7 @@ where
     /// # Panics
     ///
     /// Will panic if `srs` cannot be in `cell`.
-    pub fn verifier_index(&self) -> VerifierIndex<G, OpeningProof>
+    pub fn verifier_index(&self) -> Arc<VerifierIndex<G, OpeningProof>>
     where
         VerifierIndex<G, OpeningProof>: Clone,
     {
@@ -207,7 +207,7 @@ where
         };
 
         // TODO: Switch to commit_evaluations for all index polys
-        VerifierIndex {
+        Arc::new(VerifierIndex {
             domain,
             max_poly_size: self.max_poly_size,
             zk_rows: self.cs.zk_rows,
@@ -312,7 +312,7 @@ where
             endo: self.cs.endo,
             lookup_index,
             linearization: self.linearization.clone(),
-        }
+        })
     }
 }
 

--- a/signer/src/keypair.rs
+++ b/signer/src/keypair.rs
@@ -93,6 +93,13 @@ impl Keypair {
     pub fn to_hex(&self) -> String {
         hex::encode(self.to_bytes())
     }
+
+    /// Performs scalar multiplication with the secret key
+    pub fn secret_multiply_with_curve_point(&self, multiplicand: CurvePoint) -> CurvePoint {
+        use ark_ec::AffineCurve;
+        use ark_ec::ProjectiveCurve;
+        multiplicand.mul(self.secret.clone().into_scalar()).into_affine()
+    }
 }
 
 impl fmt::Debug for Keypair {

--- a/signer/src/pubkey.rs
+++ b/signer/src/pubkey.rs
@@ -223,7 +223,7 @@ impl fmt::Display for PubKey {
 }
 
 /// Compressed public keys consist of x-coordinate and y-coordinate parity.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CompressedPubKey {
     /// X-coordinate
     pub x: BaseField,

--- a/signer/src/pubkey.rs
+++ b/signer/src/pubkey.rs
@@ -223,13 +223,19 @@ impl fmt::Display for PubKey {
 }
 
 /// Compressed public keys consist of x-coordinate and y-coordinate parity.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct CompressedPubKey {
     /// X-coordinate
     pub x: BaseField,
 
     /// Parity of y-coordinate
     pub is_odd: bool,
+}
+
+impl fmt::Debug for CompressedPubKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{}", self.into_address()))
+    }
 }
 
 fn into_address(x: &BaseField, is_odd: bool) -> String {

--- a/signer/src/signature.rs
+++ b/signer/src/signature.rs
@@ -19,6 +19,16 @@ impl Signature {
     pub fn new(rx: BaseField, s: ScalarField) -> Self {
         Self { rx, s }
     }
+
+    /// Dummy signature
+    pub fn dummy() -> Self {
+        use ark_ff::One;
+
+        Self {
+            rx: BaseField::one(),
+            s: ScalarField::one(),
+        }
+    }
 }
 
 impl fmt::Display for Signature {


### PR DESCRIPTION
@dannywillems This contains the diffs we use for `openmina`
Merging this will allow us to depend directly on your `master` branch, without having to maintain our own fork

cc @adonagy @binier , some commits belongs to you