### PR TITLE
Mina-signer: make secret field of KeyPair public

### DIFF
--- a/signer/src/keypair.rs
+++ b/signer/src/keypair.rs
@@ -27,7 +27,7 @@ pub type Result<T> = std::result::Result<T, KeypairError>;
 #[derive(Clone, PartialEq, Eq)]
 pub struct Keypair {
     /// Secret key
-    pub(crate) secret: SecKey,
+    pub secret: SecKey,
     /// Public key
     pub public: PubKey,
 }


### PR DESCRIPTION
Can be used by the upstream OpenMina. See https://github.com/o1-labs/proof-systems/pull/2750/files.