### PR TITLE
[easy] `develop` counterpart of PR#2590

### DIFF
--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -639,6 +639,10 @@ impl<F: PrimeField> ConstraintSystem<F> {
     }
 }
 
+//
+pub const NUM_CHUNKS_BY_DEFAULT: usize = 1;
+pub const ZK_ROWS_BY_DEFAULT: u64 = 3;
+
 pub fn zk_rows_strict_lower_bound(num_chunks: usize) -> usize {
     (2 * (PERMUTS + 1) * num_chunks - 2) / PERMUTS
 }

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -648,13 +648,13 @@ pub const ZK_ROWS_BY_DEFAULT: u64 = 3;
 /// This function computes a strict lower bound in the number of rows required
 /// for zero knowledge in circuits with `num_chunks` chunks. This means that at
 /// least one needs 1 more row than the result of this function to achieve zero
-/// knowledge. 
-/// Example: 
+/// knowledge.
+/// Example:
 ///   for 1 chunk, this function returns 2, but at least 3 rows are needed
-/// Note: 
+/// Note:
 ///   the number of zero knowledge rows is usually computed across the codebase
 ///   as the formula `(16 * num_chunks + 5) / 7`, which is precisely the formula
-///   in this function plus one. 
+///   in this function plus one.
 pub fn zk_rows_strict_lower_bound(num_chunks: usize) -> usize {
     (2 * (PERMUTS + 1) * num_chunks - 2) / PERMUTS
 }

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -639,10 +639,22 @@ impl<F: PrimeField> ConstraintSystem<F> {
     }
 }
 
-//
+/// The default number of chunks in a circuit is one (< 2^16 rows)
 pub const NUM_CHUNKS_BY_DEFAULT: usize = 1;
+
+/// The number of rows required for zero knowledge in circuits with one single chunk
 pub const ZK_ROWS_BY_DEFAULT: u64 = 3;
 
+/// This function computes a strict lower bound in the number of rows required
+/// for zero knowledge in circuits with `num_chunks` chunks. This means that at
+/// least one needs 1 more row than the result of this function to achieve zero
+/// knowledge. 
+/// Example: 
+///   for 1 chunk, this function returns 2, but at least 3 rows are needed
+/// Note: 
+///   the number of zero knowledge rows is usually computed across the codebase
+///   as the formula `(16 * num_chunks + 5) / 7`, which is precisely the formula
+///   in this function plus one. 
 pub fn zk_rows_strict_lower_bound(num_chunks: usize) -> usize {
     (2 * (PERMUTS + 1) * num_chunks - 2) / PERMUTS
 }

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -212,10 +212,10 @@ where
         let zero_knowledge_limit = zk_rows_strict_lower_bound(num_chunks);
         // Because the lower bound is strict, the result of the function above
         // is not a sufficient number of zero knowledge rows, so the error must
-        // be raised anytime the number of zero knowledge rows is not greater 
+        // be raised anytime the number of zero knowledge rows is not greater
         // than the strict lower bound.
         // Example:
-        //   for 1 chunk, `zero_knowledge_limit` is 2, and we need at least 3, 
+        //   for 1 chunk, `zero_knowledge_limit` is 2, and we need at least 3,
         //   thus the error should be raised and the message should say that the
         //   expected number of zero knowledge rows is 3 (hence the + 1).
         if (index.cs.zk_rows as usize) <= zero_knowledge_limit {

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -210,9 +210,9 @@ where
             .ok_or(ProverError::NoRoomForZkInWitness)?;
 
         let zero_knowledge_limit = zk_rows_strict_lower_bound(num_chunks);
-        if (index.cs.zk_rows as usize) < zero_knowledge_limit {
+        if (index.cs.zk_rows as usize) <= zero_knowledge_limit {
             return Err(ProverError::NotZeroKnowledge(
-                zero_knowledge_limit,
+                zero_knowledge_limit + 1,
                 index.cs.zk_rows as usize,
             ));
         }

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -210,6 +210,14 @@ where
             .ok_or(ProverError::NoRoomForZkInWitness)?;
 
         let zero_knowledge_limit = zk_rows_strict_lower_bound(num_chunks);
+        // Because the lower bound is strict, the result of the function above
+        // is not a sufficient number of zero knowledge rows, so the error must
+        // be raised anytime the number of zero knowledge rows is not greater 
+        // than the strict lower bound.
+        // Example:
+        //   for 1 chunk, `zero_knowledge_limit` is 2, and we need at least 3, 
+        //   thus the error should be raised and the message should say that the
+        //   expected number of zero knowledge rows is 3 (hence the + 1).
         if (index.cs.zk_rows as usize) <= zero_knowledge_limit {
             return Err(ProverError::NotZeroKnowledge(
                 zero_knowledge_limit + 1,


### PR DESCRIPTION
This is the `develop` counterpart of the already merged PR https://github.com/o1-labs/proof-systems/pull/2590. It has been created cherry-picking those commits. The reason that I am creating this branch now is that I have realized that the commit of `proof-systems` inside the `mina` submodule from the `o1js` repo is a `develop` ascendant, and the changes proposed in that old PR targeting `master` were never ported back to `develop`. 