### PR TITLE
Compute the necessarry inversions of the witness in batch after it's creation

### DIFF
--- a/o1vm/src/interpreters/mips/tests_helpers.rs
+++ b/o1vm/src/interpreters/mips/tests_helpers.rs
@@ -8,6 +8,7 @@ use crate::{
     preimage_oracle::PreImageOracleT,
 };
 use rand::{CryptoRng, Rng, RngCore};
+use std::collections::HashSet;
 use std::{fs, path::PathBuf};
 
 // FIXME: we should parametrize the tests with different fields.
@@ -98,6 +99,7 @@ where
         preimage_key: None,
         keccak_env: None,
         hash_counter: 0,
+        scratch_to_inverse: HashSet::new(),
     };
     // Initialize general purpose registers with random values
     for reg in env.registers.general_purpose.iter_mut() {

--- a/o1vm/src/interpreters/mips/tests_helpers.rs
+++ b/o1vm/src/interpreters/mips/tests_helpers.rs
@@ -8,8 +8,7 @@ use crate::{
     preimage_oracle::PreImageOracleT,
 };
 use rand::{CryptoRng, Rng, RngCore};
-use std::collections::HashSet;
-use std::{fs, path::PathBuf};
+use std::{collections::HashSet, fs, path::PathBuf};
 
 // FIXME: we should parametrize the tests with different fields.
 use ark_bn254::Fr as Fp;

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -962,6 +962,22 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
         }
     }
 
+    pub fn write_inverse_column(&mut self, column: Column, value: Fp) {
+        assert!(value != Fp::zero());
+        match column {
+            Column::ScratchState(idx) => {
+                self.scratch_to_inverse.insert(idx);
+                self.scratch_state[idx] = value
+            }
+            Column::InstructionCounter | Column::Selector(_) => {
+                panic!(
+                    "inverse only supported in scratch state, not in {:?}",
+                    column
+                )
+            }
+        }
+    }
+
     pub fn update_last_memory_access(&mut self, i: usize) {
         let [i_0, i_1, _] = self.last_memory_accesses;
         self.last_memory_accesses = [i, i_0, i_1]

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -358,7 +358,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
             self.write_column(position, 0);
             0
         } else {
-            self.write_field_column(position, Fp::from(*x).inverse().unwrap());
+            self.write_inverse_column(position, Fp::from(*x));
             1 // Placeholder value
         }
     }
@@ -370,12 +370,11 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
         self.write_column(pos, res);
         // write the non deterministic advice inv_or_zero
         let pos = self.alloc_scratch();
-        let inv_or_zero = if *x == 0 {
-            Fp::zero()
+        if *x == 0 {
+            self.write_column(pos, 0);
         } else {
-            Fp::inverse(&Fp::from(*x)).unwrap()
+            self.write_inverse_column(pos, Fp::from(*x));
         };
-        self.write_field_column(pos, inv_or_zero);
         // return the result
         res
     }
@@ -392,12 +391,11 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
         };
         let _to_zero_test_inv_or_zero = {
             let pos = self.alloc_scratch();
-            let inv_or_zero = if to_zero_test == Fp::zero() {
-                Fp::zero()
+            if to_zero_test == Fp::zero() {
+                self.write_column(pos, 0);
             } else {
-                Fp::inverse(&to_zero_test).unwrap()
+                self.write_inverse_column(pos, to_zero_test);
             };
-            self.write_field_column(pos, inv_or_zero);
             1 // Placeholder value
         };
         res

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -29,6 +29,7 @@ use kimchi::o1_utils::Two;
 use log::{debug, info};
 use std::{
     array,
+    collections::HashSet,
     fs::File,
     io::{BufWriter, Write},
 };
@@ -90,6 +91,7 @@ pub struct Env<Fp, PreImageOracle: PreImageOracleT> {
     pub preimage_key: Option<[u8; 32]>,
     pub keccak_env: Option<KeccakEnv<Fp>>,
     pub hash_counter: u64,
+    pub scratch_to_inverse: HashSet<usize>,
 }
 
 fn fresh_scratch_state<Fp: Field, const N: usize>() -> [Fp; N] {
@@ -937,6 +939,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
             preimage_key: None,
             keccak_env: None,
             hash_counter: 0,
+            scratch_to_inverse: HashSet::new(),
         }
     }
 
@@ -944,6 +947,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
         self.scratch_state_idx = 0;
         self.scratch_state = fresh_scratch_state();
         self.selector = N_MIPS_SEL_COLS;
+        self.scratch_to_inverse = HashSet::new();
     }
 
     pub fn write_column(&mut self, column: Column, value: u64) {

--- a/o1vm/src/pickles/proof.rs
+++ b/o1vm/src/pickles/proof.rs
@@ -10,11 +10,11 @@ pub struct WitnessColumns<G, S> {
     pub selector: S,
 }
 
-pub struct ProofInputs<G: KimchiCurve> {
-    pub evaluations: WitnessColumns<Vec<G::ScalarField>, Vec<G::ScalarField>>,
+pub struct ProofInputs<F: Field> {
+    pub evaluations: WitnessColumns<Vec<F>, Vec<F>>,
 }
 
-impl<G: KimchiCurve> ProofInputs<G> {
+impl<F: Field> ProofInputs<F> {
     pub fn new(domain_size: usize) -> Self {
         ProofInputs {
             evaluations: WitnessColumns {

--- a/o1vm/src/pickles/proof.rs
+++ b/o1vm/src/pickles/proof.rs
@@ -1,7 +1,9 @@
-use kimchi::{curve::KimchiCurve, proof::PointEvaluations};
-use poly_commitment::{ipa::OpeningProof, PolyComm};
-
 use crate::interpreters::mips::{column::N_MIPS_SEL_COLS, witness::SCRATCH_SIZE};
+use ark_ff::Field;
+use kimchi::curve::KimchiCurve;
+use kimchi::proof::PointEvaluations;
+use poly_commitment::{ipa::OpeningProof, PolyComm};
+use std::collections::{HashMap, HashSet};
 
 pub struct WitnessColumns<G, S> {
     pub scratch: [G; SCRATCH_SIZE],
@@ -24,6 +26,62 @@ impl<F: Field> ProofInputs<F> {
                 selector: Vec::with_capacity(domain_size),
             },
         }
+    }
+}
+
+pub struct NotInversedProofInputs<F: Field> {
+    pub evaluations: WitnessColumns<Vec<F>, Vec<F>>,
+    pub idx_to_inverse: Vec<HashSet<usize>>,
+}
+
+impl<F: Field> NotInversedProofInputs<F> {
+    pub fn new(domain_size: usize) -> Self {
+        NotInversedProofInputs {
+            evaluations: ProofInputs::new(domain_size).evaluations,
+            idx_to_inverse: Vec::with_capacity(domain_size),
+        }
+    }
+}
+
+impl<F: Field> From<NotInversedProofInputs<F>> for ProofInputs<F> {
+    fn from(not_inversed: NotInversedProofInputs<F>) -> ProofInputs<F> {
+        // Initialising the result
+        let mut res = ProofInputs::new(not_inversed.evaluations.scratch[1].len());
+        res.evaluations = not_inversed.evaluations;
+        // Collecting the values to inverse
+        let to_inverse_map: &mut HashMap<_, F> = &mut HashMap::new();
+        for (i, set_i) in not_inversed.idx_to_inverse.iter().enumerate() {
+            for &j in set_i.iter() {
+                assert!(res.evaluations.scratch[j][i] != F::zero());
+                // the result is none as this key has not been inserted yet
+                let _none = HashMap::insert(to_inverse_map, (i, j), res.evaluations.scratch[j][i]);
+            }
+        }
+        // Perform the inversion
+        let mut to_inverse_vec: Vec<F> = Vec::with_capacity(to_inverse_map.len());
+        for v in to_inverse_map.values() {
+            to_inverse_vec.push(*v);
+        }
+        for v in &to_inverse_vec {
+            assert!(v != &F::zero());
+        }
+        let to_inverse_slice = to_inverse_vec.as_mut_slice();
+
+        ark_ff::batch_inversion::<F>(to_inverse_slice);
+        // Collecting the inverses and putting them back in the map
+        // we need to create a second map to collect the inverses.
+        // IMPROVEME: We should not need to do this
+        let mut inversed_map = HashMap::new();
+        for (i, (k, _)) in to_inverse_map.iter().enumerate() {
+            // We ignore the old value
+            let _ = inversed_map.insert(*k, to_inverse_slice[i]);
+        }
+
+        // Writting the inversed values in res
+        for (&(i, j), &inv) in inversed_map.iter() {
+            res.evaluations.scratch[j][i] = inv;
+        }
+        res
     }
 }
 

--- a/o1vm/src/pickles/proof.rs
+++ b/o1vm/src/pickles/proof.rs
@@ -1,7 +1,6 @@
 use crate::interpreters::mips::{column::N_MIPS_SEL_COLS, witness::SCRATCH_SIZE};
 use ark_ff::Field;
-use kimchi::curve::KimchiCurve;
-use kimchi::proof::PointEvaluations;
+use kimchi::{curve::KimchiCurve, proof::PointEvaluations};
 use poly_commitment::{ipa::OpeningProof, PolyComm};
 use std::collections::{HashMap, HashSet};
 

--- a/o1vm/src/pickles/prover.rs
+++ b/o1vm/src/pickles/prover.rs
@@ -59,7 +59,7 @@ pub fn prove<
 >(
     domain: EvaluationDomains<G::ScalarField>,
     srs: &SRS<G>,
-    inputs: ProofInputs<G>,
+    inputs: ProofInputs<G::ScalarField>,
     constraints: &[E<G::ScalarField>],
     rng: &mut RNG,
 ) -> Result<Proof<G>, ProverError>

--- a/o1vm/src/pickles/tests.rs
+++ b/o1vm/src/pickles/tests.rs
@@ -81,7 +81,7 @@ fn zero_to_n_minus_one(n: usize) -> Vec<Fq> {
 fn test_small_circuit() {
     let domain = EvaluationDomains::<Fq>::create(8).unwrap();
     let srs = SRS::create(8);
-    let proof_input = ProofInputs::<Pallas> {
+    let proof_input = ProofInputs::<Fq> {
         evaluations: WitnessColumns {
             scratch: std::array::from_fn(|_| zero_to_n_minus_one(8)),
             instruction_counter: zero_to_n_minus_one(8)


### PR DESCRIPTION
Follow-up of https://github.com/o1-labs/proof-systems/pull/2047
but we proceed differently.
The witness env now contains a set marking which element are to be inverted.
The Batch inversion is then done when creating the ProofInput.
We first create an intermediary type NotInversedProofInput, and implement a conversion to ProofInput which does the batch inversion