### PR TITLE
fix: typos in documentation files

### DIFF
--- a/book/src/kimchi/gates.md
+++ b/book/src/kimchi/gates.md
@@ -186,7 +186,7 @@ Finally, providing $q(X) = \text{gates}(X)/v_{\mathbb{G}}(X)$ and performing the
 
 _The prover knows a polynomial_ $\text{gates}(X)$ _that equals zero on any_ $x\in\{1,g,g^2,g^3\}$.
 
-Nonetheless, it would still remain to verify that $\text{gates}(X)$ actually corresponds to the encoding of the actual constraints. Meaning, checking that this polynomial encodes the column witnesses, and the agreed circuit. So instead of providing just $\text{gates}(X)$ (actually, a commitment to it), the prover can send commitments to each of th $15$ witness polynomials, so that the verifier can reconstruct the huge constraint using the encodings of the circuit (which is known ahead). 
+Nonetheless, it would still remain to verify that $\text{gates}(X)$ actually corresponds to the encoding of the actual constraints. Meaning, checking that this polynomial encodes the column witnesses, and the agreed circuit. So instead of providing just $\text{gates}(X)$ (actually, a commitment to it), the prover can send commitments to each of the $15$ witness polynomials, so that the verifier can reconstruct the huge constraint using the encodings of the circuit (which is known ahead). 
 
 <!--- TO-DO (anais): check how the verifier merges both things, as they are quite intertwined and the degrees of the products may could too large for pairings? --->
 

--- a/book/src/kimchi/lookup.md
+++ b/book/src/kimchi/lookup.md
@@ -217,7 +217,7 @@ The denominator thus becomes $\prod_{k=1}^{5} (\gamma (1+\beta) + s_{kn+i-1} + \
 
 There are two things that we haven't touched on:
 
-* The vector $t$ representing the **combined lookup table** (after its columns have been combined with a joint combiner $j$). The **non-combined loookup table** is fixed at setup time and derived based on the lookup tables used in the circuit.
+* The vector $t$ representing the **combined lookup table** (after its columns have been combined with a joint combiner $j$). The **non-combined lookup table** is fixed at setup time and derived based on the lookup tables used in the circuit.
 * The vector $s$ representing the sorted multiset of both the queries and the lookup table. This is created by the prover and sent as commitment to the verifier.
 
 The first vector $t$ is quite straightforward to think about:


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "each of th $15$" to "each of the $15$".
Corrected "loookup" to "lookup".

Please review the changes and let me know if any additional changes are needed.

