### PR TITLE
o1vm/riscv32: sketch implementation of SB-type instr interpretation

### DIFF
--- a/o1vm/src/interpreters/riscv32im/interpreter.rs
+++ b/o1vm/src/interpreters/riscv32im/interpreter.rs
@@ -1800,8 +1800,89 @@ pub fn interpret_stype<Env: InterpreterEnv>(env: &mut Env, instr: SInstruction) 
     };
 }
 
-pub fn interpret_sbtype<Env: InterpreterEnv>(_env: &mut Env, _instr: SBInstruction) {
-    unimplemented!("TODO")
+/// Interpret an SB-type instruction.
+/// The encoding of an SB-type instruction is as follows:
+/// ```text
+/// | 31     25 | 24     20 | 19     15 | 14        12 | 11      7 | 6      0 |
+/// |   imm2    |    rs2    |    rs1    |    funct3    |    imm1   |  opcode  |
+/// ```
+/// Following the documentation found
+/// [here](https://www.cs.cornell.edu/courses/cs3410/2024fa/assignments/cpusim/riscv-instructions.pdf)
+pub fn interpret_sbtype<Env: InterpreterEnv>(env: &mut Env, instr: SBInstruction) {
+    let instruction_pointer = env.get_instruction_pointer();
+    let _next_instruction_pointer = env.get_next_instruction_pointer();
+
+    let instruction = {
+        let v0 = env.read_memory(&instruction_pointer);
+        let v1 = env.read_memory(&(instruction_pointer.clone() + Env::constant(1)));
+        let v2 = env.read_memory(&(instruction_pointer.clone() + Env::constant(2)));
+        let v3 = env.read_memory(&(instruction_pointer.clone() + Env::constant(3)));
+        (v3 * Env::constant(1 << 24))
+            + (v2 * Env::constant(1 << 16))
+            + (v1 * Env::constant(1 << 8))
+            + v0
+    };
+
+    let opcode = {
+        let pos = env.alloc_scratch();
+        unsafe { env.bitmask(&instruction, 7, 0, pos) }
+    };
+    env.range_check8(&opcode, 7);
+
+    // FIXME: trickier
+    let imm1 = {
+        let pos = env.alloc_scratch();
+        unsafe { env.bitmask(&instruction, 12, 7, pos) }
+    };
+    env.range_check8(&imm1, 5);
+
+    let funct3 = {
+        let pos = env.alloc_scratch();
+        unsafe { env.bitmask(&instruction, 15, 12, pos) }
+    };
+    env.range_check8(&funct3, 3);
+
+    let rs1 = {
+        let pos = env.alloc_scratch();
+        unsafe { env.bitmask(&instruction, 20, 15, pos) }
+    };
+    env.range_check8(&rs1, 5);
+
+    let rs2 = {
+        let pos = env.alloc_scratch();
+        unsafe { env.bitmask(&instruction, 25, 20, pos) }
+    };
+    env.range_check8(&rs2, 5);
+
+    // FIXME: trickier
+    let imm2 = {
+        let pos = env.alloc_scratch();
+        unsafe { env.bitmask(&instruction, 32, 25, pos) }
+    };
+    env.range_check16(&imm2, 12);
+
+    // FIXME: check correctness of decomposition
+
+    match instr {
+        SBInstruction::BranchEq => {
+            unimplemented!("BranchEq")
+        }
+        SBInstruction::BranchNeq => {
+            unimplemented!("BranchNeq")
+        }
+        SBInstruction::BranchLessThan => {
+            unimplemented!("BranchLessThan")
+        }
+        SBInstruction::BranchGreaterThanEqual => {
+            unimplemented!("BranchGreaterThanEqual")
+        }
+        SBInstruction::BranchLessThanUnsigned => {
+            unimplemented!("BranchLessThanUnsigned")
+        }
+        SBInstruction::BranchGreaterThanEqualUnsigned => {
+            unimplemented!("BranchGreaterThanEqualUnsigned")
+        }
+    };
 }
 
 pub fn interpret_utype<Env: InterpreterEnv>(_env: &mut Env, _instr: UInstruction) {


### PR DESCRIPTION
The immediate interpretation is trickier than the current version. It will be handled in a follow-up PR.
As for the other interpret_* method, we're building a train of PR to have small PR implementing instruction by instruction.