### PR TITLE
o1vm/riscv32: introduce tests checking the number of instructions

### DIFF
--- a/o1vm/src/interpreters/riscv32im/mod.rs
+++ b/o1vm/src/interpreters/riscv32im/mod.rs
@@ -4,12 +4,12 @@
 pub const SCRATCH_SIZE: usize = 80;
 
 /// Number of instructions in the ISA
-// FIXME: the value might not be correct. It will be updated when the
-// interpreter is fully implemented.
-pub const INSTRUCTION_SET_SIZE: usize = 40;
+pub const INSTRUCTION_SET_SIZE: usize = 48;
+
 pub const PAGE_ADDRESS_SIZE: u32 = 12;
 pub const PAGE_SIZE: u32 = 1 << PAGE_ADDRESS_SIZE;
 pub const PAGE_ADDRESS_MASK: u32 = PAGE_SIZE - 1;
+
 /// List all columns used by the interpreter
 pub mod column;
 
@@ -21,3 +21,6 @@ pub mod interpreter;
 pub mod registers;
 
 pub mod witness;
+
+#[cfg(test)]
+mod tests;

--- a/o1vm/src/interpreters/riscv32im/tests.rs
+++ b/o1vm/src/interpreters/riscv32im/tests.rs
@@ -1,0 +1,36 @@
+use crate::interpreters::riscv32im::{
+    constraints,
+    interpreter::{
+        IInstruction, MInstruction, RInstruction, SBInstruction, SInstruction, SyscallInstruction,
+        UInstruction, UJInstruction,
+    },
+};
+use mina_curves::pasta::Fp;
+use strum::EnumCount;
+
+#[test]
+// Sanity check that we have as many selector as we have instructions
+fn test_regression_selectors_for_instructions() {
+    let mips_con_env = constraints::Env::<Fp>::default();
+    let constraints = mips_con_env.get_selector_constraints();
+    assert_eq!(
+        // We substract 1 as we have one boolean check per sel
+        // and 1 constraint to check that one and only one
+        // sel is activated
+        constraints.len() - 1,
+        // This should match the list in
+        // crate::interpreters::riscv32im::interpreter::Instruction
+        RInstruction::COUNT
+            + IInstruction::COUNT
+            + SInstruction::COUNT
+            + SBInstruction::COUNT
+            + UInstruction::COUNT
+            + UJInstruction::COUNT
+            + SyscallInstruction::COUNT
+            + MInstruction::COUNT
+    );
+    // All instructions are degree 1 or 2.
+    constraints
+        .iter()
+        .for_each(|c| assert!(c.degree(1, 0) == 2 || c.degree(1, 0) == 1));
+}


### PR DESCRIPTION
In the meantime, set the correct current value.