### PR TITLE
o1vm/riscv32: remove unused mul_hi_lo_signed

### DIFF
--- a/o1vm/src/interpreters/riscv32im/constraints.rs
+++ b/o1vm/src/interpreters/riscv32im/constraints.rs
@@ -317,16 +317,6 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         self.variable(position)
     }
 
-    unsafe fn mul_hi_lo_signed(
-        &mut self,
-        _x: &Self::Variable,
-        _y: &Self::Variable,
-        position_hi: Self::Position,
-        position_lo: Self::Position,
-    ) -> (Self::Variable, Self::Variable) {
-        (self.variable(position_hi), self.variable(position_lo))
-    }
-
     unsafe fn mul_hi_signed(
         &mut self,
         _x: &Self::Variable,

--- a/o1vm/src/interpreters/riscv32im/interpreter.rs
+++ b/o1vm/src/interpreters/riscv32im/interpreter.rs
@@ -1229,22 +1229,6 @@ pub trait InterpreterEnv {
         position: Self::Position,
     ) -> Self::Variable;
 
-    /// Returns `((x * y) >> 32, (x * y) & ((1 << 32) - 1))`, storing the results in `position_hi`
-    /// and `position_lo` respectively.
-    ///
-    /// # Safety
-    ///
-    /// There are no constraints on the returned values; callers must manually add constraints to
-    /// ensure that the pair of returned values correspond to the given values `x` and `y`, and
-    /// that they fall within the desired range.
-    unsafe fn mul_hi_lo_signed(
-        &mut self,
-        x: &Self::Variable,
-        y: &Self::Variable,
-        position_hi: Self::Position,
-        position_lo: Self::Position,
-    ) -> (Self::Variable, Self::Variable);
-
     /// Returns `((x * y) >> 32`, storing the results in `position`.
     ///
     /// # Safety

--- a/o1vm/src/interpreters/riscv32im/witness.rs
+++ b/o1vm/src/interpreters/riscv32im/witness.rs
@@ -471,25 +471,6 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         res
     }
 
-    unsafe fn mul_hi_lo_signed(
-        &mut self,
-        x: &Self::Variable,
-        y: &Self::Variable,
-        position_hi: Self::Position,
-        position_lo: Self::Position,
-    ) -> (Self::Variable, Self::Variable) {
-        let x: u32 = (*x).try_into().unwrap();
-        let y: u32 = (*y).try_into().unwrap();
-        let mul = (((x as i32) as i64) * ((y as i32) as i64)) as u64;
-        let hi = (mul >> 32) as u32;
-        let lo = (mul & ((1 << 32) - 1)) as u32;
-        let hi = hi as u64;
-        let lo = lo as u64;
-        self.write_column(position_hi, hi);
-        self.write_column(position_lo, lo);
-        (hi, lo)
-    }
-
     unsafe fn mul_hi(
         &mut self,
         x: &Self::Variable,


### PR DESCRIPTION
The method is splitted in two different methods, comparetively to MIPS.