### PR TITLE
o1vm/riscv32: remove unused mul_hi_lo.

### DIFF
--- a/o1vm/src/interpreters/riscv32im/constraints.rs
+++ b/o1vm/src/interpreters/riscv32im/constraints.rs
@@ -353,16 +353,6 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         self.variable(position)
     }
 
-    unsafe fn mul_hi_lo(
-        &mut self,
-        _x: &Self::Variable,
-        _y: &Self::Variable,
-        position_hi: Self::Position,
-        position_lo: Self::Position,
-    ) -> (Self::Variable, Self::Variable) {
-        (self.variable(position_hi), self.variable(position_lo))
-    }
-
     unsafe fn divmod_signed(
         &mut self,
         _x: &Self::Variable,

--- a/o1vm/src/interpreters/riscv32im/interpreter.rs
+++ b/o1vm/src/interpreters/riscv32im/interpreter.rs
@@ -1257,22 +1257,6 @@ pub trait InterpreterEnv {
         position: Self::Position,
     ) -> Self::Variable;
 
-    /// Returns `((x * y) >> 32, (x * y) & ((1 << 32) - 1))`, storing the results in `position_hi`
-    /// and `position_lo` respectively.
-    ///
-    /// # Safety
-    ///
-    /// There are no constraints on the returned values; callers must manually add constraints to
-    /// ensure that the pair of returned values correspond to the given values `x` and `y`, and
-    /// that they fall within the desired range.
-    unsafe fn mul_hi_lo(
-        &mut self,
-        x: &Self::Variable,
-        y: &Self::Variable,
-        position_hi: Self::Position,
-        position_lo: Self::Position,
-    ) -> (Self::Variable, Self::Variable);
-
     /// Returns `(x / y, x % y)`, storing the results in `position_quotient` and
     /// `position_remainder` respectively.
     ///

--- a/o1vm/src/interpreters/riscv32im/witness.rs
+++ b/o1vm/src/interpreters/riscv32im/witness.rs
@@ -501,25 +501,6 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         res
     }
 
-    unsafe fn mul_hi_lo(
-        &mut self,
-        x: &Self::Variable,
-        y: &Self::Variable,
-        position_hi: Self::Position,
-        position_lo: Self::Position,
-    ) -> (Self::Variable, Self::Variable) {
-        let x: u32 = (*x).try_into().unwrap();
-        let y: u32 = (*y).try_into().unwrap();
-        let mul = (x as u64) * (y as u64);
-        let hi = (mul >> 32) as u32;
-        let lo = (mul & ((1 << 32) - 1)) as u32;
-        let hi = hi as u64;
-        let lo = lo as u64;
-        self.write_column(position_hi, hi);
-        self.write_column(position_lo, lo);
-        (hi, lo)
-    }
-
     unsafe fn divmod_signed(
         &mut self,
         x: &Self::Variable,


### PR DESCRIPTION
Like mul_hi_lo_signed, the method is splitted in two different methods: mul_hi and mul_lo.