### PR TITLE
o1vm/riscv32: implement mod_signed

### DIFF
--- a/o1vm/src/interpreters/riscv32im/constraints.rs
+++ b/o1vm/src/interpreters/riscv32im/constraints.rs
@@ -353,6 +353,15 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         self.variable(position)
     }
 
+    unsafe fn mod_signed(
+        &mut self,
+        _x: &Self::Variable,
+        _y: &Self::Variable,
+        position: Self::Position,
+    ) -> Self::Variable {
+        self.variable(position)
+    }
+
     unsafe fn mul_lo(
         &mut self,
         _x: &Self::Variable,

--- a/o1vm/src/interpreters/riscv32im/interpreter.rs
+++ b/o1vm/src/interpreters/riscv32im/interpreter.rs
@@ -1271,6 +1271,20 @@ pub trait InterpreterEnv {
         position: Self::Position,
     ) -> Self::Variable;
 
+    /// Returns `x % y`, storing the results in `position`.
+    ///
+    /// # Safety
+    ///
+    /// There are no constraints on the returned values; callers must manually add constraints to
+    /// ensure that the pair of returned values correspond to the given values `x` and `y`, and
+    /// that they fall within the desired range.
+    unsafe fn mod_signed(
+        &mut self,
+        x: &Self::Variable,
+        y: &Self::Variable,
+        position: Self::Position,
+    ) -> Self::Variable;
+
     /// Returns `(x / y, x % y)`, storing the results in `position_quotient` and
     /// `position_remainder` respectively.
     ///

--- a/o1vm/src/interpreters/riscv32im/witness.rs
+++ b/o1vm/src/interpreters/riscv32im/witness.rs
@@ -521,9 +521,9 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         y: &Self::Variable,
         position: Self::Position,
     ) -> Self::Variable {
-        let x: u32 = (*x).try_into().unwrap();
-        let y: u32 = (*y).try_into().unwrap();
-        let res = ((x as i32) % (y as i32)) as u32;
+        let x: i32 = (*x).try_into().unwrap();
+        let y: i32 = (*y).try_into().unwrap();
+        let res = (x % y) as u32;
         let res = res as u64;
         self.write_column(position, res);
         res

--- a/o1vm/src/interpreters/riscv32im/witness.rs
+++ b/o1vm/src/interpreters/riscv32im/witness.rs
@@ -515,6 +515,20 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         res
     }
 
+    unsafe fn mod_signed(
+        &mut self,
+        x: &Self::Variable,
+        y: &Self::Variable,
+        position: Self::Position,
+    ) -> Self::Variable {
+        let x: u32 = (*x).try_into().unwrap();
+        let y: u32 = (*y).try_into().unwrap();
+        let res = ((x as i32) % (y as i32)) as u32;
+        let res = res as u64;
+        self.write_column(position, res);
+        res
+    }
+
     unsafe fn divmod_signed(
         &mut self,
         x: &Self::Variable,


### PR DESCRIPTION
It will be used to implement MInstruction::Rem in a follow-up PR.