### PR TITLE
o1vm/riscv32: remove unused divmod_signed

### DIFF
--- a/o1vm/src/interpreters/riscv32im/constraints.rs
+++ b/o1vm/src/interpreters/riscv32im/constraints.rs
@@ -371,19 +371,6 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         self.variable(position)
     }
 
-    unsafe fn divmod_signed(
-        &mut self,
-        _x: &Self::Variable,
-        _y: &Self::Variable,
-        position_quotient: Self::Position,
-        position_remainder: Self::Position,
-    ) -> (Self::Variable, Self::Variable) {
-        (
-            self.variable(position_quotient),
-            self.variable(position_remainder),
-        )
-    }
-
     unsafe fn divmod(
         &mut self,
         _x: &Self::Variable,

--- a/o1vm/src/interpreters/riscv32im/interpreter.rs
+++ b/o1vm/src/interpreters/riscv32im/interpreter.rs
@@ -1293,22 +1293,6 @@ pub trait InterpreterEnv {
     /// There are no constraints on the returned values; callers must manually add constraints to
     /// ensure that the pair of returned values correspond to the given values `x` and `y`, and
     /// that they fall within the desired range.
-    unsafe fn divmod_signed(
-        &mut self,
-        x: &Self::Variable,
-        y: &Self::Variable,
-        position_quotient: Self::Position,
-        position_remainder: Self::Position,
-    ) -> (Self::Variable, Self::Variable);
-
-    /// Returns `(x / y, x % y)`, storing the results in `position_quotient` and
-    /// `position_remainder` respectively.
-    ///
-    /// # Safety
-    ///
-    /// There are no constraints on the returned values; callers must manually add constraints to
-    /// ensure that the pair of returned values correspond to the given values `x` and `y`, and
-    /// that they fall within the desired range.
     unsafe fn divmod(
         &mut self,
         x: &Self::Variable,

--- a/o1vm/src/interpreters/riscv32im/witness.rs
+++ b/o1vm/src/interpreters/riscv32im/witness.rs
@@ -529,24 +529,6 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         res
     }
 
-    unsafe fn divmod_signed(
-        &mut self,
-        x: &Self::Variable,
-        y: &Self::Variable,
-        position_quotient: Self::Position,
-        position_remainder: Self::Position,
-    ) -> (Self::Variable, Self::Variable) {
-        let x: u32 = (*x).try_into().unwrap();
-        let y: u32 = (*y).try_into().unwrap();
-        let q = ((x as i32) / (y as i32)) as u32;
-        let r = ((x as i32) % (y as i32)) as u32;
-        let q = q as u64;
-        let r = r as u64;
-        self.write_column(position_quotient, q);
-        self.write_column(position_remainder, r);
-        (q, r)
-    }
-
     unsafe fn divmod(
         &mut self,
         x: &Self::Variable,


### PR DESCRIPTION
As for mul_hi_lo(_signed), the method is splitted.