### PR TITLE
Refactoring: Improve poly-commitment docs & decrease confusing variable names

### DIFF
--- a/ivc/src/prover.rs
+++ b/ivc/src/prover.rs
@@ -437,11 +437,11 @@ where
     let u = u_chal.to_field(endo_r);
 
     let coefficients_form = DensePolynomialOrEvaluations::DensePolynomial;
-    let non_hiding = |d1_size| PolyComm {
-        chunks: vec![Fp::zero(); d1_size],
+    let non_hiding = |n_chunks| PolyComm {
+        chunks: vec![Fp::zero(); n_chunks],
     };
-    let hiding = |d1_size| PolyComm {
-        chunks: vec![Fp::one(); d1_size],
+    let hiding = |n_chunks| PolyComm {
+        chunks: vec![Fp::one(); n_chunks],
     };
 
     // Gathering all polynomials_to_open to use in the opening proof

--- a/ivc/src/prover.rs
+++ b/ivc/src/prover.rs
@@ -31,8 +31,8 @@ use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
 use o1_utils::ExtendedDensePolynomial;
 use poly_commitment::{
     commitment::{absorb_commitment, CommitmentCurve, PolyComm},
-    ipa::DensePolynomialOrEvaluations,
     kzg::{KZGProof, PairingSRS},
+    utils::DensePolynomialOrEvaluations,
     OpenProof, SRS,
 };
 use rand::{CryptoRng, RngCore};

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1238,8 +1238,12 @@ where
         //~ 1. Create a list of all polynomials that will require evaluations
         //~    (and evaluation proofs) in the protocol.
         //~    First, include the previous challenges, in case we are in a recursive prover.
-        let non_hiding = |d1_size: usize| PolyComm {
-            chunks: vec![G::ScalarField::zero(); d1_size],
+        let non_hiding = |n_chunks: usize| PolyComm {
+            chunks: vec![G::ScalarField::zero(); n_chunks],
+        };
+
+        let fixed_hiding = |n_chunks: usize| PolyComm {
+            chunks: vec![G::ScalarField::one(); n_chunks],
         };
 
         let coefficients_form = DensePolynomialOrEvaluations::DensePolynomial;
@@ -1247,12 +1251,8 @@ where
 
         let mut polynomials = polys
             .iter()
-            .map(|(p, d1_size)| (coefficients_form(p), non_hiding(*d1_size)))
+            .map(|(p, n_chunks)| (coefficients_form(p), non_hiding(*n_chunks)))
             .collect::<Vec<_>>();
-
-        let fixed_hiding = |d1_size: usize| PolyComm {
-            chunks: vec![G::ScalarField::one(); d1_size],
-        };
 
         //~ 1. Then, include:
         //~~ * the negated public polynomial

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -46,7 +46,7 @@ use poly_commitment::{
     commitment::{
         absorb_commitment, b_poly_coefficients, BlindedCommitment, CommitmentCurve, PolyComm,
     },
-    ipa::DensePolynomialOrEvaluations,
+    utils::DensePolynomialOrEvaluations,
     OpenProof, SRS as _,
 };
 use rand_core::{CryptoRng, RngCore};

--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -490,11 +490,11 @@ where
     let u = u_chal.to_field(endo_r);
 
     let coefficients_form = DensePolynomialOrEvaluations::DensePolynomial;
-    let non_hiding = |d1_size| PolyComm {
-        chunks: vec![G::ScalarField::zero(); d1_size],
+    let non_hiding = |n_chunks| PolyComm {
+        chunks: vec![G::ScalarField::zero(); n_chunks],
     };
-    let hiding = |d1_size| PolyComm {
-        chunks: vec![G::ScalarField::one(); d1_size],
+    let hiding = |n_chunks| PolyComm {
+        chunks: vec![G::ScalarField::one(); n_chunks],
     };
 
     // Gathering all polynomials to use in the opening proof

--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -30,7 +30,7 @@ use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
 use o1_utils::ExtendedDensePolynomial;
 use poly_commitment::{
     commitment::{absorb_commitment, PolyComm},
-    ipa::DensePolynomialOrEvaluations,
+    utils::DensePolynomialOrEvaluations,
     OpenProof, SRS,
 };
 use rand::{CryptoRng, RngCore};

--- a/o1vm/src/pickles/prover.rs
+++ b/o1vm/src/pickles/prover.rs
@@ -18,7 +18,8 @@ use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
 use o1_utils::ExtendedDensePolynomial;
 use poly_commitment::{
     commitment::{absorb_commitment, PolyComm},
-    ipa::{DensePolynomialOrEvaluations, OpeningProof, SRS},
+    ipa::{OpeningProof, SRS},
+    utils::DensePolynomialOrEvaluations,
     OpenProof as _, SRS as _,
 };
 use rand::{CryptoRng, RngCore};

--- a/poly-commitment/benches/ipa.rs
+++ b/poly-commitment/benches/ipa.rs
@@ -5,9 +5,7 @@ use groupmap::GroupMap;
 use mina_curves::pasta::{Fp, Vesta, VestaParameters};
 use mina_poseidon::{constants::PlonkSpongeConstantsKimchi, sponge::DefaultFqSponge, FqSponge};
 use poly_commitment::{
-    commitment::CommitmentCurve,
-    ipa::{DensePolynomialOrEvaluations, SRS},
-    PolyComm, SRS as _,
+    commitment::CommitmentCurve, ipa::SRS, utils::DensePolynomialOrEvaluations, PolyComm, SRS as _,
 };
 
 fn benchmark_ipa_open(c: &mut Criterion) {

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -511,7 +511,7 @@ pub fn combined_inner_product<F: PrimeField>(
     // final combined evaluation result
     let mut res = F::zero();
     // polyscale^i
-    let mut xi_i = F::one();
+    let mut polyscale_i = F::one();
 
     for evals_tr in polys.iter().filter(|evals_tr| !evals_tr[0].is_empty()) {
         // Transpose the evaluations.
@@ -523,7 +523,7 @@ pub fn combined_inner_product<F: PrimeField>(
 
         // Iterating over the polynomial segments.
         // Each segment gets its own polyscale^i, each segment element j is multiplied by evalscale^j.
-        // Given that xi_i = polyscale^i0 at this point, after this loop we have:
+        // Given that polyscale_i = polyscale^i0 at this point, after this loop we have:
         //
         //    res += Σ polyscale^{i0+i} ( Σ evals_tr[j][i] * evalscale^j )
         //           i                    j
@@ -531,8 +531,8 @@ pub fn combined_inner_product<F: PrimeField>(
         for eval in &evals {
             // p_i(evalscale)
             let term = DensePolynomial::<F>::eval_polynomial(eval, *evalscale);
-            res += &(xi_i * term);
-            xi_i *= polyscale;
+            res += &(polyscale_i * term);
+            polyscale_i *= polyscale;
         }
     }
     res
@@ -607,16 +607,16 @@ pub fn combine_commitments<G: CommitmentCurve>(
     rand_base: G::ScalarField,
 ) {
     // will contain the power of polyscale
-    let mut xi_i = G::ScalarField::one();
+    let mut polyscale_i = G::ScalarField::one();
 
     for Evaluation { commitment, .. } in evaluations.iter().filter(|x| !x.commitment.is_empty()) {
         // iterating over the polynomial segments
         for comm_ch in &commitment.chunks {
-            scalars.push(rand_base * xi_i);
+            scalars.push(rand_base * polyscale_i);
             points.push(*comm_ch);
 
             // compute next power of polyscale
-            xi_i *= polyscale;
+            polyscale_i *= polyscale;
         }
     }
 }

--- a/poly-commitment/src/ipa.rs
+++ b/poly-commitment/src/ipa.rs
@@ -745,7 +745,7 @@ impl<G: CommitmentCurve> SRS<G> {
         let r_delta = <G::ScalarField as UniformRand>::rand(rng);
 
         // Compute delta, the commitment
-        // delta = G0^d * U_base^{b0*d} * H^r_delta   (as a group element, in multiplicative notation)
+        // delta = [d] G0 + [b0*d] U_base + [r_delta] H^r   (as a group element, in additive notation)
         let delta = ((g0.into_group() + (u_base.mul(b0))).into_affine().mul(d)
             + self.h.mul(r_delta))
         .into_affine();

--- a/poly-commitment/src/ipa.rs
+++ b/poly-commitment/src/ipa.rs
@@ -568,15 +568,17 @@ impl<G: CommitmentCurve> SRS<G> {
         // Combines polynomials roughly as follows: p(X) := ∑_i polyscale^i p_i(X)
         //
         // `blinding_factor` is a combined set of commitments that are
-        // paired with polynomials in `plnms`.
+        // paired with polynomials in `plnms`. In kimchi, these input commitments
+        // are blinders, so often `[G::ScalarField::one(); num_chunks]` or zeroes.
         let (p, blinding_factor) = combine_polys::<G, D>(plnms, polyscale, self.g.len());
 
         // The initial evaluation vector for polynomial commitment b_init is not
-        // just the powers of a single point as in the original IPA, but rather
-        // a vector of linearly combined powers with `evalscale` as recombiner.
+        // just the powers of a single point as in the original IPA (1,ζ,ζ^2,...)
+        //
+        // but rather a vector of linearly combined powers with `evalscale` as recombiner.
         //
         // b_init[j] = Σ_i evalscale^i elm_i^j
-        //          = ζ^j + evalscale * ζ^j ω^j (in the specific case of opening)
+        //           = ζ^j + evalscale * ζ^j ω^j (in the specific case of challenges (ζ,ζω))
         let b_init = {
             // randomise/scale the eval powers
             let mut scale = G::ScalarField::one();

--- a/poly-commitment/src/ipa.rs
+++ b/poly-commitment/src/ipa.rs
@@ -5,18 +5,18 @@
 
 use crate::{
     commitment::{
-        b_poly, b_poly_coefficients, combine_commitments, shift_scalar, BatchEvaluationProof,
-        CommitmentCurve, *,
+        b_poly, b_poly_coefficients, combine_commitments, shift_scalar, squeeze_challenge,
+        squeeze_prechallenge, BatchEvaluationProof, CommitmentCurve, EndoCurve,
     },
     error::CommitmentError,
     hash_map_cache::HashMapCache,
+    utils::combine_polys,
     BlindedCommitment, PolyComm, PolynomialsToCombine, SRS as SRSTrait,
 };
 use ark_ec::{AffineRepr, CurveGroup, VariableBaseMSM};
-use ark_ff::{BigInteger, FftField, Field, One, PrimeField, UniformRand, Zero};
+use ark_ff::{BigInteger, Field, One, PrimeField, UniformRand, Zero};
 use ark_poly::{
-    univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, Evaluations,
-    Radix2EvaluationDomain as D,
+    univariate::DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as D,
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use blake2::{Blake2b512, Digest};
@@ -24,195 +24,13 @@ use groupmap::GroupMap;
 use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
 use o1_utils::{
     field_helpers::{inner_prod, pows},
-    math, ExtendedDensePolynomial,
+    math,
 };
 use rand::{CryptoRng, RngCore};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::{cmp::min, iter::Iterator, ops::AddAssign};
-
-/// A formal sum of the form
-/// `s_0 * p_0 + ... s_n * p_n`
-/// where each `s_i` is a scalar and each `p_i` is a polynomial.
-/// The parameter `P` is expected to be the coefficients of the polynomial
-/// `p_i`, even though we could treat it as the evaluations.
-///
-/// This hypothesis is important if `to_dense_polynomial` is called.
-#[derive(Default)]
-struct ScaledChunkedPolynomial<F, P>(Vec<(F, P)>);
-
-/// Represent a polynomial either with its coefficients or its evaluations
-pub enum DensePolynomialOrEvaluations<'a, F: FftField, D: EvaluationDomain<F>> {
-    /// Polynomial represented by its coefficients
-    DensePolynomial(&'a DensePolynomial<F>),
-    /// Polynomial represented by its evaluations over a domain D
-    Evaluations(&'a Evaluations<F, D>, D),
-}
-
-impl<F, P> ScaledChunkedPolynomial<F, P> {
-    fn add_poly(&mut self, scale: F, p: P) {
-        self.0.push((scale, p))
-    }
-}
-
-impl<'a, F: Field> ScaledChunkedPolynomial<F, &'a [F]> {
-    /// Compute the resulting scaled polynomial.
-    /// Example:
-    /// Given the two polynomials `1 + 2X` and `3 + 4X`, and the scaling
-    /// factors `2` and `3`, the result is the polynomial `11 + 16X`.
-    /// ```text
-    /// 2 * [1, 2] + 3 * [3, 4] = [2, 4] + [9, 12] = [11, 16]
-    /// ```
-    fn to_dense_polynomial(&self) -> DensePolynomial<F> {
-        // Note: using a reference to avoid reallocation of the result.
-        let mut res = DensePolynomial::<F>::zero();
-
-        let scaled: Vec<_> = self
-            .0
-            .par_iter()
-            .map(|(scale, segment)| {
-                let scale = *scale;
-                // We simply scale each coefficients.
-                // It is simply because DensePolynomial doesn't have a method
-                // `scale`.
-                let v = segment.par_iter().map(|x| scale * *x).collect();
-                DensePolynomial::from_coefficients_vec(v)
-            })
-            .collect();
-
-        for p in scaled {
-            res += &p;
-        }
-
-        res
-    }
-}
-
-/// Combine the polynomials using a scalar (`polyscale`), creating a single
-/// unified polynomial to open. This function also accepts polynomials in
-/// evaluations form. In this case it applies an IFFT, and, if necessarry,
-/// applies chunking to it (ie. split it in multiple polynomials of
-/// degree less than the SRS size).
-/// Parameters:
-/// - plnms: vector of polynomials, either in evaluations or coefficients form.
-/// The order of the output follows the order of this structure.
-/// - polyscale: scalar to combine the polynomials, which will be scaled based
-/// on the number of polynomials to combine.
-///
-/// Example:
-/// Given the three polynomials `p1(X)`, and `p3(X)` in coefficients
-/// forms, p2(X) in evaluation form,
-/// and the scaling factor `polyscale`, the result will be the polynomial:
-///
-/// ```text
-/// p1(X) + polyscale * i_fft(chunks(p2))(X) + polyscale^2 p3(X)
-/// ```
-///
-/// Additional complexity is added to handle chunks.
-// TODO: move into utils? It is useful for multiple PCS
-pub fn combine_polys<G: CommitmentCurve, D: EvaluationDomain<G::ScalarField>>(
-    plnms: PolynomialsToCombine<G, D>,
-    polyscale: G::ScalarField,
-    srs_length: usize,
-) -> (DensePolynomial<G::ScalarField>, G::ScalarField) {
-    // Initialising the output for the combined coefficients forms
-    let mut plnm_coefficients =
-        ScaledChunkedPolynomial::<G::ScalarField, &[G::ScalarField]>::default();
-    // Initialising the output for the combined evaluations forms
-    let mut plnm_evals_part = {
-        // For now just check that all the evaluation polynomials are the same
-        // degree so that we can do just a single FFT.
-        // If/when we change this, we can add more complicated code to handle
-        // different degrees.
-        let degree = plnms
-            .iter()
-            .fold(None, |acc, (p, _)| match p {
-                DensePolynomialOrEvaluations::DensePolynomial(_) => acc,
-                DensePolynomialOrEvaluations::Evaluations(_, d) => {
-                    if let Some(n) = acc {
-                        assert_eq!(n, d.size());
-                    }
-                    Some(d.size())
-                }
-            })
-            .unwrap_or(0);
-        vec![G::ScalarField::zero(); degree]
-    };
-
-    // Will contain ∑ comm_chunk * polyscale^i
-    let mut combined_comm = G::ScalarField::zero();
-
-    // Will contain polyscale^i
-    let mut polyscale_to_i = G::ScalarField::one();
-
-    // Iterating over polynomials in the batch.
-    // Note that the chunks in the commitment `p_i_comm` are given as `PolyComm<G::ScalarField>`. They are
-    // evaluations.
-    // We do modify two different structures depending on the form of the
-    // polynomial we are currently processing: `plnm` and `plnm_evals_part`.
-    // We do need to treat both forms separately.
-    for (p_i, p_i_comm) in plnms {
-        match p_i {
-            // Here we scale the polynomial in evaluations forms
-            // Note that based on the check above, sub_domain.size() always give
-            // the same value
-            DensePolynomialOrEvaluations::Evaluations(evals_i, sub_domain) => {
-                let stride = evals_i.evals.len() / sub_domain.size();
-                let evals = &evals_i.evals;
-                plnm_evals_part
-                    .par_iter_mut()
-                    .enumerate()
-                    .for_each(|(i, x)| {
-                        *x += polyscale_to_i * evals[i * stride];
-                    });
-                for comm_chunk in p_i_comm.into_iter() {
-                    combined_comm += &(*comm_chunk * polyscale_to_i);
-                    polyscale_to_i *= &polyscale;
-                }
-            }
-
-            // Here we scale the polynomial in coefficient forms
-            DensePolynomialOrEvaluations::DensePolynomial(p_i) => {
-                let mut offset = 0;
-                // iterating over chunks of the polynomial
-                for comm_chunk in p_i_comm.into_iter() {
-                    let segment = &p_i.coeffs[std::cmp::min(offset, p_i.coeffs.len())
-                        ..std::cmp::min(offset + srs_length, p_i.coeffs.len())];
-                    plnm_coefficients.add_poly(polyscale_to_i, segment);
-
-                    combined_comm += &(*comm_chunk * polyscale_to_i);
-                    polyscale_to_i *= &polyscale;
-                    offset += srs_length;
-                }
-            }
-        }
-    }
-
-    // Now, we will combine both evaluations and coefficients forms
-
-    // plnm will be our final combined polynomial. We first treat the
-    // polynomials in coefficients forms, which is simply scaling the
-    // coefficients and add them.
-    let mut combined_plnm = plnm_coefficients.to_dense_polynomial();
-
-    if !plnm_evals_part.is_empty() {
-        // n is the number of evaluations, which is a multiple of the
-        // domain size.
-        // We treat now each chunk.
-        let n = plnm_evals_part.len();
-        let max_poly_size = srs_length;
-        // equiv to divceil, but unstable in rust < 1.73.
-        let num_chunks = n / max_poly_size + if n % max_poly_size == 0 { 0 } else { 1 };
-        // Interpolation on the whole domain, i.e. it can be d2, d4, etc.
-        combined_plnm += &Evaluations::from_vec_and_domain(plnm_evals_part, D::new(n).unwrap())
-            .interpolate()
-            .to_chunked_polynomial(num_chunks, max_poly_size)
-            .linearize(polyscale);
-    }
-
-    (combined_plnm, combined_comm)
-}
 
 #[serde_as]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/poly-commitment/src/kzg.rs
+++ b/poly-commitment/src/kzg.rs
@@ -55,7 +55,7 @@ pub fn combine_evaluations<G: CommitmentCurve>(
     evaluations: &Vec<Evaluation<G>>,
     polyscale: G::ScalarField,
 ) -> Vec<G::ScalarField> {
-    let mut xi_i = G::ScalarField::one();
+    let mut polyscale_i = G::ScalarField::one();
     let mut acc = {
         let num_evals = if !evaluations.is_empty() {
             evaluations[0].evaluations.len()
@@ -74,9 +74,9 @@ pub fn combine_evaluations<G: CommitmentCurve>(
         for chunk_idx in 0..evaluations[0].len() {
             // supposes that all evaluations are of the same size
             for eval_pt_idx in 0..evaluations.len() {
-                acc[eval_pt_idx] += evaluations[eval_pt_idx][chunk_idx] * xi_i;
+                acc[eval_pt_idx] += evaluations[eval_pt_idx][chunk_idx] * polyscale_i;
             }
-            xi_i *= polyscale;
+            polyscale_i *= polyscale;
         }
     }
 

--- a/poly-commitment/src/kzg.rs
+++ b/poly-commitment/src/kzg.rs
@@ -10,9 +10,8 @@
 //! parameter.
 
 use crate::{
-    commitment::*,
-    ipa::{combine_polys, SRS},
-    CommitmentError, PolynomialsToCombine, SRS as SRSTrait,
+    commitment::*, ipa::SRS, utils::combine_polys, CommitmentError, PolynomialsToCombine,
+    SRS as SRSTrait,
 };
 
 use ark_ec::{pairing::Pairing, AffineRepr, VariableBaseMSM};

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -169,8 +169,9 @@ pub trait SRS<G: CommitmentCurve>: Clone + Sized {
 }
 
 #[allow(type_alias_bounds)]
-/// Simply an alias to represent a polynomial with its commitment, possibly with
-/// a blinder.
+/// An alias to represent a polynomial (in either coefficient or
+/// evaluation form), with a set of *scalar field* elements that
+/// represent the exponent of its blinder.
 // TODO: add a string to name the polynomial
 type PolynomialsToCombine<'a, G: CommitmentCurve, D: EvaluationDomain<G::ScalarField>> = &'a [(
     DensePolynomialOrEvaluations<'a, G::ScalarField, D>,

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod hash_map_cache;
 pub mod ipa;
 pub mod kzg;
+pub mod utils;
 
 // Exposing property based tests for the SRS trait
 pub mod pbt_srs;
@@ -13,7 +14,7 @@ pub use commitment::PolyComm;
 use crate::{
     commitment::{BatchEvaluationProof, BlindedCommitment, CommitmentCurve},
     error::CommitmentError,
-    ipa::DensePolynomialOrEvaluations,
+    utils::DensePolynomialOrEvaluations,
 };
 use ark_ec::AffineRepr;
 use ark_ff::UniformRand;

--- a/poly-commitment/src/utils.rs
+++ b/poly-commitment/src/utils.rs
@@ -1,0 +1,186 @@
+use crate::{commitment::CommitmentCurve, PolynomialsToCombine};
+use ark_ff::{FftField, Field, One, Zero};
+use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, Evaluations};
+use o1_utils::ExtendedDensePolynomial;
+use rayon::prelude::*;
+
+/// Represent a polynomial either with its coefficients or its evaluations
+pub enum DensePolynomialOrEvaluations<'a, F: FftField, D: EvaluationDomain<F>> {
+    /// Polynomial represented by its coefficients
+    DensePolynomial(&'a DensePolynomial<F>),
+    /// Polynomial represented by its evaluations over a domain D
+    Evaluations(&'a Evaluations<F, D>, D),
+}
+
+/// A formal sum of the form
+/// `s_0 * p_0 + ... s_n * p_n`
+/// where each `s_i` is a scalar and each `p_i` is a polynomial.
+/// The parameter `P` is expected to be the coefficients of the polynomial
+/// `p_i`, even though we could treat it as the evaluations.
+///
+/// This hypothesis is important if `to_dense_polynomial` is called.
+#[derive(Default)]
+struct ScaledChunkedPolynomial<F, P>(Vec<(F, P)>);
+
+impl<F, P> ScaledChunkedPolynomial<F, P> {
+    fn add_poly(&mut self, scale: F, p: P) {
+        self.0.push((scale, p))
+    }
+}
+
+impl<'a, F: Field> ScaledChunkedPolynomial<F, &'a [F]> {
+    /// Compute the resulting scaled polynomial.
+    /// Example:
+    /// Given the two polynomials `1 + 2X` and `3 + 4X`, and the scaling
+    /// factors `2` and `3`, the result is the polynomial `11 + 16X`.
+    /// ```text
+    /// 2 * [1, 2] + 3 * [3, 4] = [2, 4] + [9, 12] = [11, 16]
+    /// ```
+    fn to_dense_polynomial(&self) -> DensePolynomial<F> {
+        // Note: using a reference to avoid reallocation of the result.
+        let mut res = DensePolynomial::<F>::zero();
+
+        let scaled: Vec<_> = self
+            .0
+            .par_iter()
+            .map(|(scale, segment)| {
+                let scale = *scale;
+                // We simply scale each coefficients.
+                // It is simply because DensePolynomial doesn't have a method
+                // `scale`.
+                let v = segment.par_iter().map(|x| scale * *x).collect();
+                DensePolynomial::from_coefficients_vec(v)
+            })
+            .collect();
+
+        for p in scaled {
+            res += &p;
+        }
+
+        res
+    }
+}
+
+/// Combine the polynomials using a scalar (`polyscale`), creating a single
+/// unified polynomial to open. This function also accepts polynomials in
+/// evaluations form. In this case it applies an IFFT, and, if necessarry,
+/// applies chunking to it (ie. split it in multiple polynomials of
+/// degree less than the SRS size).
+/// Parameters:
+/// - plnms: vector of polynomials, either in evaluations or coefficients form.
+/// The order of the output follows the order of this structure.
+/// - polyscale: scalar to combine the polynomials, which will be scaled based
+/// on the number of polynomials to combine.
+///
+/// Example:
+/// Given the three polynomials `p1(X)`, and `p3(X)` in coefficients
+/// forms, p2(X) in evaluation form,
+/// and the scaling factor `polyscale`, the result will be the polynomial:
+///
+/// ```text
+/// p1(X) + polyscale * i_fft(chunks(p2))(X) + polyscale^2 p3(X)
+/// ```
+///
+/// Additional complexity is added to handle chunks.
+pub fn combine_polys<G: CommitmentCurve, D: EvaluationDomain<G::ScalarField>>(
+    plnms: PolynomialsToCombine<G, D>,
+    polyscale: G::ScalarField,
+    srs_length: usize,
+) -> (DensePolynomial<G::ScalarField>, G::ScalarField) {
+    // Initialising the output for the combined coefficients forms
+    let mut plnm_coefficients =
+        ScaledChunkedPolynomial::<G::ScalarField, &[G::ScalarField]>::default();
+    // Initialising the output for the combined evaluations forms
+    let mut plnm_evals_part = {
+        // For now just check that all the evaluation polynomials are the same
+        // degree so that we can do just a single FFT.
+        // If/when we change this, we can add more complicated code to handle
+        // different degrees.
+        let degree = plnms
+            .iter()
+            .fold(None, |acc, (p, _)| match p {
+                DensePolynomialOrEvaluations::DensePolynomial(_) => acc,
+                DensePolynomialOrEvaluations::Evaluations(_, d) => {
+                    if let Some(n) = acc {
+                        assert_eq!(n, d.size());
+                    }
+                    Some(d.size())
+                }
+            })
+            .unwrap_or(0);
+        vec![G::ScalarField::zero(); degree]
+    };
+
+    // Will contain ∑ comm_chunk * polyscale^i
+    let mut combined_comm = G::ScalarField::zero();
+
+    // Will contain polyscale^i
+    let mut polyscale_to_i = G::ScalarField::one();
+
+    // Iterating over polynomials in the batch.
+    // Note that the chunks in the commitment `p_i_comm` are given as `PolyComm<G::ScalarField>`. They are
+    // evaluations.
+    // We do modify two different structures depending on the form of the
+    // polynomial we are currently processing: `plnm` and `plnm_evals_part`.
+    // We do need to treat both forms separately.
+    for (p_i, p_i_comm) in plnms {
+        match p_i {
+            // Here we scale the polynomial in evaluations forms
+            // Note that based on the check above, sub_domain.size() always give
+            // the same value
+            DensePolynomialOrEvaluations::Evaluations(evals_i, sub_domain) => {
+                let stride = evals_i.evals.len() / sub_domain.size();
+                let evals = &evals_i.evals;
+                plnm_evals_part
+                    .par_iter_mut()
+                    .enumerate()
+                    .for_each(|(i, x)| {
+                        *x += polyscale_to_i * evals[i * stride];
+                    });
+                for comm_chunk in p_i_comm.into_iter() {
+                    combined_comm += &(*comm_chunk * polyscale_to_i);
+                    polyscale_to_i *= &polyscale;
+                }
+            }
+
+            // Here we scale the polynomial in coefficient forms
+            DensePolynomialOrEvaluations::DensePolynomial(p_i) => {
+                let mut offset = 0;
+                // iterating over chunks of the polynomial
+                for comm_chunk in p_i_comm.into_iter() {
+                    let segment = &p_i.coeffs[std::cmp::min(offset, p_i.coeffs.len())
+                        ..std::cmp::min(offset + srs_length, p_i.coeffs.len())];
+                    plnm_coefficients.add_poly(polyscale_to_i, segment);
+
+                    combined_comm += &(*comm_chunk * polyscale_to_i);
+                    polyscale_to_i *= &polyscale;
+                    offset += srs_length;
+                }
+            }
+        }
+    }
+
+    // Now, we will combine both evaluations and coefficients forms
+
+    // plnm will be our final combined polynomial. We first treat the
+    // polynomials in coefficients forms, which is simply scaling the
+    // coefficients and add them.
+    let mut combined_plnm = plnm_coefficients.to_dense_polynomial();
+
+    if !plnm_evals_part.is_empty() {
+        // n is the number of evaluations, which is a multiple of the
+        // domain size.
+        // We treat now each chunk.
+        let n = plnm_evals_part.len();
+        let max_poly_size = srs_length;
+        // equiv to divceil, but unstable in rust < 1.73.
+        let num_chunks = n / max_poly_size + if n % max_poly_size == 0 { 0 } else { 1 };
+        // Interpolation on the whole domain, i.e. it can be d2, d4, etc.
+        combined_plnm += &Evaluations::from_vec_and_domain(plnm_evals_part, D::new(n).unwrap())
+            .interpolate()
+            .to_chunked_polynomial(num_chunks, max_poly_size)
+            .linearize(polyscale);
+    }
+
+    (combined_plnm, combined_comm)
+}

--- a/poly-commitment/src/utils.rs
+++ b/poly-commitment/src/utils.rs
@@ -66,11 +66,16 @@ impl<'a, F: Field> ScaledChunkedPolynomial<F, &'a [F]> {
 /// evaluations form. In this case it applies an IFFT, and, if necessarry,
 /// applies chunking to it (ie. split it in multiple polynomials of
 /// degree less than the SRS size).
+///
 /// Parameters:
-/// - plnms: vector of polynomials, either in evaluations or coefficients form.
-/// The order of the output follows the order of this structure.
-/// - polyscale: scalar to combine the polynomials, which will be scaled based
-/// on the number of polynomials to combine.
+/// - `plnms`: vector of polynomials, either in evaluations or coefficients form, together with
+///    a set of scalars representing their blinders.
+/// - `polyscale`: scalar to combine the polynomials, which will be scaled based on the number of
+///    polynomials to combine.
+///
+/// Output:
+/// - `combined_poly`: combined polynomial. The order of the output follows the order of `plnms`.
+/// - `combined_comm`: combined scalars representing the blinder commitment.
 ///
 /// Example:
 /// Given the three polynomials `p1(X)`, and `p3(X)` in coefficients

--- a/poly-commitment/tests/batch_15_wires.rs
+++ b/poly-commitment/tests/batch_15_wires.rs
@@ -12,7 +12,8 @@ use mina_poseidon::{
 use o1_utils::ExtendedDensePolynomial as _;
 use poly_commitment::{
     commitment::{combined_inner_product, BatchEvaluationProof, CommitmentCurve, Evaluation},
-    ipa::{DensePolynomialOrEvaluations, SRS},
+    ipa::SRS,
+    utils::DensePolynomialOrEvaluations,
     SRS as _,
 };
 use rand::Rng;

--- a/poly-commitment/tests/commitment.rs
+++ b/poly-commitment/tests/commitment.rs
@@ -14,7 +14,8 @@ use poly_commitment::{
         combined_inner_product, BatchEvaluationProof, BlindedCommitment, CommitmentCurve,
         Evaluation, PolyComm,
     },
-    ipa::{DensePolynomialOrEvaluations, OpeningProof, SRS},
+    ipa::{OpeningProof, SRS},
+    utils::DensePolynomialOrEvaluations,
     SRS as _,
 };
 use rand::{CryptoRng, Rng, SeedableRng};

--- a/poly-commitment/tests/ipa_commitment.rs
+++ b/poly-commitment/tests/ipa_commitment.rs
@@ -11,8 +11,10 @@ use mina_poseidon::{
 use o1_utils::ExtendedDensePolynomial;
 use poly_commitment::{
     commitment::{combined_inner_product, BatchEvaluationProof, CommitmentCurve, Evaluation},
-    ipa::{DensePolynomialOrEvaluations, SRS},
-    pbt_srs, PolyComm, SRS as _,
+    ipa::SRS,
+    pbt_srs,
+    utils::DensePolynomialOrEvaluations,
+    PolyComm, SRS as _,
 };
 use rand::Rng;
 use std::array;

--- a/poly-commitment/tests/kzg.rs
+++ b/poly-commitment/tests/kzg.rs
@@ -9,9 +9,11 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use mina_curves::pasta::{Fp, Vesta as VestaG};
 use poly_commitment::{
     commitment::Evaluation,
-    ipa::{DensePolynomialOrEvaluations, SRS},
+    ipa::SRS,
     kzg::{combine_evaluations, KZGProof, PairingSRS},
-    pbt_srs, PolyComm, SRS as _,
+    pbt_srs,
+    utils::DensePolynomialOrEvaluations,
+    PolyComm, SRS as _,
 };
 
 #[test]


### PR DESCRIPTION
This is a **no-op** docs/naming refactoring commit that does the following:
- Moves `combine_polys` to `poly-commitment/src/utils.rs` (there was a comment left by someone that this is a good idea; I agree)
- Improves docs for `combine_polys` and related structs,  like `PolynomialsToCombine`.
- Renames some variables inside `combine_polys`: "omegas" was used which is (1) only used once in the whole repo, and (2) is absolutely not descriptive, since it has no r. Was replaced by 
- Fixed some typos/bad argument names for `hiding/non_hiding` functions, that are actually operating over the integer expressing the number of chunks, not the size of the domain as the previous variable implied.
- Importantly: gets rid of `"xi"`, which was a very rarely used term to call `polyscale`, also known as `u` (not to be confused with the three other `u`s int he code). Used `polyscale` instead.
    -  `xi` is used more on the ocaml side, but my plan is to remove it from there too. See the justification below.
- Improves docs/disambiguates variable names in IPA commitment creation and verification.

Parent `mina` PR:
- https://github.com/MinaProtocol/mina/pull/16376
    - _(strictly speaking, these are independent; mina's PR targets p-s develop, while p-s PR is towards p-s master)_

On `xi` and justification for not using it:
- Throughout the codebase, we use `xi = polyscale = v` and `r = evalscale = u` which is a /pain/ for someone trying to make sense of what's happening. What's even worse, the term `u` means at least two other things: a generator in the IPA procedure, and the IPA challenge.
- I decided to get rid of the `xi/r` pair of these three, for the following reasons:
    - The original plonk paper uses `u` and `v`.
    - Our o1labs book on pickles uses `u` and `v` (with references to `polyscale` and `evalscale`).
    - Most of `proof-systems` except some 10 lines uses `u/v` or `polyscale/evalscale`.
    - `r` is a terribly overloaded variable name, which probably means about 5 things across the codebase already (e.g. `r` in `schnorr.ml` or `signature.ml`, e.g. `l` and `r` in `plonk_constraint_system.ml`). So I'm strongly against using it as a global identifier if possible. 
    - I think it would be better to stick with globally identifiable handles, like `polyscale`. I think it's _acceptable_ to keep two notations, one concise-mathematical, one globally-identifiable and code-friendly. So one mathematical notation should  go, and `xi / r` is the most ambiguous of the two and least used.