### PR TITLE
o1vm/mips: remove inverse_or_zero from interpreter trait

### DIFF
--- a/o1vm/src/interpreters/mips/constraints.rs
+++ b/o1vm/src/interpreters/mips/constraints.rs
@@ -220,21 +220,13 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         };
         let x_inv_or_zero = {
             let pos = self.alloc_scratch();
-            unsafe { self.inverse_or_zero(x, pos) }
+            self.variable(pos)
         };
         // If x = 0, then res = 1 and x_inv_or_zero = 0
         // If x <> 0, then res = 0 and x_inv_or_zero = x^(-1)
         self.add_constraint(x.clone() * x_inv_or_zero.clone() + res.clone() - Self::constant(1));
         self.add_constraint(x.clone() * res.clone());
         res
-    }
-
-    unsafe fn inverse_or_zero(
-        &mut self,
-        _x: &Self::Variable,
-        position: Self::Position,
-    ) -> Self::Variable {
-        self.variable(position)
     }
 
     fn equal(&mut self, x: &Self::Variable, y: &Self::Variable) -> Self::Variable {

--- a/o1vm/src/interpreters/mips/interpreter.rs
+++ b/o1vm/src/interpreters/mips/interpreter.rs
@@ -683,21 +683,6 @@ pub trait InterpreterEnv {
     /// `x`.
     unsafe fn test_zero(&mut self, x: &Self::Variable, position: Self::Position) -> Self::Variable;
 
-    /// Returns `x^(-1)`, or `0` if `x` is `0`, storing the result in `position`.
-    ///
-    /// # Safety
-    ///
-    /// There are no constraints on the returned value; callers must assert the relationship with
-    /// `x`.
-    ///
-    /// The value returned may be a placeholder; callers should be careful not to depend directly
-    /// on the value stored in the variable.
-    unsafe fn inverse_or_zero(
-        &mut self,
-        x: &Self::Variable,
-        position: Self::Position,
-    ) -> Self::Variable;
-
     fn is_zero(&mut self, x: &Self::Variable) -> Self::Variable;
 
     /// Returns 1 if `x` is equal to `y`, or 0 otherwise, storing the result in `position`.

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -312,20 +312,6 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
         res
     }
 
-    unsafe fn inverse_or_zero(
-        &mut self,
-        x: &Self::Variable,
-        position: Self::Position,
-    ) -> Self::Variable {
-        if *x == 0 {
-            self.write_column(position, 0);
-            0
-        } else {
-            self.write_field_column(position, Fp::from(*x).inverse().unwrap());
-            1 // Placeholder value
-        }
-    }
-
     fn is_zero(&mut self, x: &Self::Variable) -> Self::Variable {
         // write the result
         let pos = self.alloc_scratch();


### PR DESCRIPTION
It was only used by `constraints.rs`, not in the witness nor the interpreter. Inline the method.