### PR TITLE
Revert "add elf parser test"

### DIFF
--- a/o1vm/tests/test_riscv_elf.rs
+++ b/o1vm/tests/test_riscv_elf.rs
@@ -6,23 +6,6 @@ use o1vm::interpreters::riscv32im::{
 };
 
 #[test]
-// This test is used to check that the elf loader is working correctly.
-// We must export the code used in this test in a function that can be called by
-// the o1vm at load time.
-fn test_correctly_parsing_elf() {
-    let curr_dir = std::env::current_dir().unwrap();
-    let path = curr_dir.join(std::path::PathBuf::from(
-        "resources/programs/riscv32i/fibonacci",
-    ));
-    let state = o1vm::elf_loader::parse_riscv32i(&path).unwrap();
-    // This is the output we get by running objdump -d fibonacci
-    assert_eq!(state.pc, 69932);
-
-    assert_eq!(state.memory.len(), 1);
-    assert_eq!(state.memory[0].index, 17);
-}
-
-#[test]
 // Checking an instruction can be converted into a string.
 // It is mostly because we would want to use it to debug or write better error
 // messages.


### PR DESCRIPTION
This reverts commit 3fdda8e30889167cbd355d26ebf7685f279b5132.

I accepted https://github.com/o1-labs/proof-systems/pull/2759/, but:
1. The test is already present in master in `test_elf_loader.rs`
2. The code wasn't compiling.

Reverting as it is useless.