### PR TITLE
CI/o1vm: deactivating path dependent execution

### DIFF
--- a/.github/workflows/o1vm-ci.yml
+++ b/.github/workflows/o1vm-ci.yml
@@ -3,37 +3,9 @@ name: o1vm CI
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      [
-        "o1vm/**",
-        "folding/**",
-        "groupmap/**",
-        "kimchi/**",
-        "msm/**",
-        "curves/**",
-        "poseidon/**",
-        "poly-commitment/",
-        "internal-tracing/**",
-        "srs/**",
-        "utils/**",
-      ]
   push:
     branches:
       - master
-    paths:
-      [
-        "o1vm/**",
-        "folding/**",
-        "groupmap/**",
-        "kimchi/**",
-        "msm/**",
-        "curves/**",
-        "poseidon/**",
-        "poly-commitment/",
-        "internal-tracing/**",
-        "srs/**",
-        "utils/**",
-      ]
 
 env:
   # https://doc.rust-lang.org/cargo/reference/profiles.html#release


### PR DESCRIPTION
As we enforce some GH actions to pass when targeting master, it can make PR stalled and unmergeable. I do not see any options in GH settings at the moment to include these conditions.

cc @shimkiv: this blocks https://github.com/o1-labs/proof-systems/pull/2755 and https://github.com/o1-labs/proof-systems/pull/2761. Do you have a better option?