### PR TITLE
MVPoly/PBT: remove a flaky test for multilinearity

### DIFF
--- a/mvpoly/src/pbt.rs
+++ b/mvpoly/src/pbt.rs
@@ -556,12 +556,6 @@ pub fn test_is_multilinear<F: PrimeField, const N: usize, const D: usize, T: MVP
         p.add_monomial(monomials_exponents, c);
         assert!(p.is_multilinear());
     }
-
-    // Test with a random polynomial (very unlikely to be multilinear)
-    {
-        let p = unsafe { T::random(&mut rng, None) };
-        assert!(!p.is_multilinear());
-    }
 }
 
 pub fn test_is_constant<F: PrimeField, const N: usize, const D: usize, T: MVPoly<F, N, D>>() {


### PR DESCRIPTION
It does depend on maximum degree given in parameter. The probability is not negligible if 2 is given.

Cherry-picking from https://github.com/o1-labs/proof-systems/pull/2702/commits