### PR TITLE
CI: dropping support for Rust 1.71

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       RUST_TOOLCHAIN_COVERAGE_VERSION: "1.74"
     strategy:
       matrix:
-        rust_toolchain_version: ["1.71", "1.72", "1.73", "1.74", "1.75", "1.76", "1.77"]
+        rust_toolchain_version: ["1.72", "1.73", "1.74", "1.75", "1.76", "1.77"]
         # FIXME: currently not available for 5.0.0.
         # It might be related to boxroot dependency, and we would need to bump
         # up the ocaml-rs dependency


### PR DESCRIPTION
Mina does use 1.72, therefore we have to support at minima 1.72