### PR TITLE
Fix typos and grammar issues in documentation files

### DIFF
--- a/book/specifications/README.md
+++ b/book/specifications/README.md
@@ -49,4 +49,4 @@ The idea is to keep as much of the specification close to the source, so that mo
 
 The specifications are built into the Mina book, and deployed to Github pages, via [this Github Action](/.github/workflows/website.yml).
 
-The Github Action ensures that the generated specifications that are pushed to the remote repository are also up to date.
+The Github Action ensures that the generated specifications that are pushed to the remote repository are also up-to-date.

--- a/book/src/fundamentals/zkbook_2pc/pap.md
+++ b/book/src/fundamentals/zkbook_2pc/pap.md
@@ -24,7 +24,7 @@ The point-and-permute optimization of garbled circuit in [BMR90](https://www.cs.
 |$(\one,\zero,\one)$|$\enc_{X_a^1,X_b^1}(X_c^1)$|
 |$(\one,\one,\zero)$|$\enc_{X_a^1,X_b^0}(X_c^0)$|
 
-- When the evaluator gets the input label, say $X_a^1,X_b^1$, the evaluator first extracts the `color` bits $(\lsb(X_a^1),\lsb(X_b^1)) = (\one,\zero)$ and decrypts the corresponding ciphertext (the third one in the above example) to get a output label.
+- When the evaluator gets the input label, say $X_a^1,X_b^1$, the evaluator first extracts the `color` bits $(\lsb(X_a^1),\lsb(X_b^1)) = (\one,\zero)$ and decrypts the corresponding ciphertext (the third one in the above example) to get an output label.
 
 ## Encryption Instantiation
 The encryption algorithm is instantiated with hash function (modeled as random oracle) and one-time pad.

--- a/book/src/kimchi/final_check.md
+++ b/book/src/kimchi/final_check.md
@@ -73,7 +73,7 @@ $$
 \end{align}
 $$
 
-So at the end, when we have to check for the identity $f(\zeta) = Z_H(\zeta) t(\zeta)$ we'll actually have to check something like this (I colored the missing parts on the left hand side of the equation):
+So at the end, when we have to check for the identity $f(\zeta) = Z_H(\zeta) t(\zeta)$ we'll actually have to check something like this (I colored the missing parts on the left-hand side of the equation):
 
 $$
 \begin{align}


### PR DESCRIPTION
This pull request addresses minor typos and grammar issues in the following documentation files:  

1. **`README.md`**  
   - Corrected the phrase "up to date" to "up-to-date" to follow proper hyphenation for compound adjectives.  

2. **`pap.md`**  
   - Replaced "a output label" with "an output label" to align with correct article usage before a word starting with a vowel sound.  

3. **`final_check.md`**  
   - Updated "left hand side" to "left-hand side" to fix the missing hyphen in the compound adjective.  

### Summary of Changes  
- Improved grammatical correctness and consistency.  
- Enhanced the readability of the documentation.  

These changes are minor but contribute to maintaining high-quality documentation standards for the project.  

### Commit Summary  
- `README.md`: Fixed "up to date" → "up-to-date".  
- `pap.md`: Fixed "a output label" → "an output label".  
- `final_check.md`: Fixed "left hand side" → "left-hand side".  