### PR TITLE
typo README.md

### DIFF
--- a/arrabbiata/README.md
+++ b/arrabbiata/README.md
@@ -54,7 +54,7 @@ activated gate on each row.
 
 Different built-in examples are provided. For instance:
 ```
-cargo run --bin arrabiata --release -- square-root --n 10 --srs-size 16
+cargo run --bin arrabbiata --release -- square-root --n 10 --srs-size 16
 ```
 
 will generate 10 full folding iterations of the polynomial-time function `f(X, Y) =


### PR DESCRIPTION
The correct spelling of the word is "arrabbiata," as it refers to the Italian term for a spicy tomato-based pasta sauce. The project uses "Arrabbiata" in the title, but the binary name is incorrectly spelled as "arrabiata." Maintaining consistent spelling aligns with the title and avoids confusion, ensuring clarity and professionalism in the project documentation and implementation.
