### PR TITLE
fix: typos in documentation files

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -17,7 +17,7 @@
 - [Commitments](./fundamentals/zkbook_commitment.md)
 - [Polynomial Commitments](./plonk/polynomial_commitments.md)
   - [Inner Product Argument](./plonk/inner_product.md)
-  - [Different Functionnalities](./plonk/inner_product_api.md)
+  - [Different Functionalities](./plonk/inner_product_api.md)
 - [Two Party Computation](./fundamentals/zkbook_2pc/overview.md)
   - [Garbled Circuits](./fundamentals/zkbook_2pc/gc.md)
     - [Basics](./fundamentals/zkbook_2pc/basics.md)

--- a/book/src/plonk/zkpm.md
+++ b/book/src/plonk/zkpm.md
@@ -58,7 +58,7 @@ $$
   = Z(\omega h)[(a(h) + \beta S_{\sigma1}(h) + \gamma)(b(h) + \beta S_{\sigma2}(h) + \gamma)(c(h) + \beta S_{\sigma3}(h) + \gamma)]$$
 
 
-The modified permuation checks that ensures that the check is performed only on all the values except the last $k$ elements in the witness polynomials are as follows.
+The modified permutation checks that ensures that the check is performed only on all the values except the last $k$ elements in the witness polynomials are as follows.
 
 * For all $h \in H$, $L_1(h)(Z(h) - 1) = 0$
 * For all $h \in \blue{H\setminus \{h_{n-k}, \ldots, h_n\}}$, $$\begin{aligned}  & Z(h)[(a(h) + \beta h + \gamma)(b(h) + \beta k_1 h + \gamma)(c(h) + \beta k_2 h + \gamma)] \\

--- a/o1vm/README-optimism.md
+++ b/o1vm/README-optimism.md
@@ -3,7 +3,7 @@
 Install the first dependencies:
 ```
 sudo apt update
-# chrony will ensure the system clock is open to date
+# chrony will ensure the system clock is up to date
 sudo apt install build-essential git vim chrony ufw -y
 ```
 


### PR DESCRIPTION
Corrected `Functionnalities` to `Functionalities`
Corrected `permuation` to `permutation`
Corrected `clock is open to date` to `clock is up to date`