### PR TITLE
o1vm/riscv32im: decrease the number of required columns

### DIFF
--- a/o1vm/src/interpreters/riscv32im/mod.rs
+++ b/o1vm/src/interpreters/riscv32im/mod.rs
@@ -1,7 +1,5 @@
 /// The minimal number of columns required for the VM
-// FIXME: the value will be updated when the interpreter is fully
-// implemented. Using a small value for now.
-pub const SCRATCH_SIZE: usize = 80;
+pub const SCRATCH_SIZE: usize = 39;
 
 /// Number of instructions in the ISA
 pub const INSTRUCTION_SET_SIZE: usize = 48;


### PR DESCRIPTION
Try with 38, and fibonacci will fail.
It might need to be increased in the future if you see that the current testsuite doesn't cover the whole instruction set.