### PR TITLE
CI/Arrabbiata: make the main file running for continuous testing

### DIFF
--- a/arrabbiata/README.md
+++ b/arrabbiata/README.md
@@ -67,7 +67,7 @@ environment variable `RUST_LOG=debug`.
 ### Run tests
 
 ```
-cargo nextest run --all-features --release --nocapture -p arrabiata
+cargo nextest run --all-features --release --nocapture -p arrabbiata
 ```
 
 ### Registry of zkApps

--- a/arrabbiata/src/interpreter.rs
+++ b/arrabbiata/src/interpreter.rs
@@ -28,6 +28,7 @@
 //! - [Handle the combinaison of constraints](#handle-the-combinaison-of-constraints)
 //! - [Permutation argument](#permutation-argument)
 //! - [Fiat-Shamir challenges](#fiat-shamir-challenges)
+//! - [Folding](#folding)
 //!
 //! ## Gadgets implemented
 //!

--- a/arrabbiata/src/interpreter.rs
+++ b/arrabbiata/src/interpreter.rs
@@ -1017,7 +1017,6 @@ pub fn run_ivc<E: InterpreterEnv>(env: &mut E, instr: Instruction) {
                         state.iter().enumerate().for_each(|(i, x)| {
                             unsafe { env.save_poseidon_state(x.clone(), i) };
                         });
-                        env.reset();
                     };
                     state
                 });

--- a/arrabbiata/src/lib.rs
+++ b/arrabbiata/src/lib.rs
@@ -1,3 +1,5 @@
+use curve::PlonkSpongeConstants;
+use mina_poseidon::constants::SpongeConstants;
 use strum::EnumCount as _;
 
 pub mod column_env;
@@ -21,12 +23,16 @@ pub const MAX_DEGREE: u64 = 5;
 /// Requiring at least 2^16 to perform 16bits range checks.
 pub const MIN_SRS_LOG2_SIZE: usize = 16;
 
-/// The number of rows the IVC circuit requires.
-// FIXME: that might change. We use a vertical layout for now.
-pub const IVC_CIRCUIT_SIZE: usize = 1 << 13;
-
 /// The maximum number of columns that can be used in the circuit.
 pub const NUMBER_OF_COLUMNS: usize = 15;
+
+/// The number of rows the IVC circuit requires.
+// FIXME:
+// We will increase the IVC circuit size step by step, while we are finishing
+// the implementation.
+// 1. We start by absorbing all the accumulators of each column.
+pub const IVC_CIRCUIT_SIZE: usize =
+    (PlonkSpongeConstants::PERM_ROUNDS_FULL / 5) * NUMBER_OF_COLUMNS;
 
 /// The maximum number of public inputs the circuit can use per row
 /// We do have 15 for now as we want to compute 5 rounds of poseidon per row

--- a/arrabbiata/src/main.rs
+++ b/arrabbiata/src/main.rs
@@ -1,3 +1,9 @@
+//! This file contains an entry point to run a zkApp written in Rust.
+//! Until the first version is complete, this file will contain code that
+//! will need to be moved later into the Arrabbiata library.
+//! The end goal is to allow the end-user to simply select the zkApp they want,
+//! specify the number of iterations, and keep this file relatively simple.
+
 use arrabbiata::{
     curve::PlonkSpongeConstants,
     interpreter::{self, InterpreterEnv},

--- a/arrabbiata/src/main.rs
+++ b/arrabbiata/src/main.rs
@@ -73,16 +73,23 @@ pub fn main() {
         info!("Run iteration: {}/{}", env.current_iteration, n_iteration);
 
         // Build the application circuit
-        info!("Running N iterations of the application circuit");
+        info!("Running {n_iteration_per_fold} iterations of the application circuit");
         for _i in 0..n_iteration_per_fold {
             interpreter::run_app(&mut env);
             env.reset();
         }
 
-        info!("Building the IVC circuit");
+        info!(
+            "Building the IVC circuit. A total number of {} rows will be filled from the witness row {}",
+            IVC_CIRCUIT_SIZE, env.current_row,
+        );
         // Build the IVC circuit
-        for _i in 0..IVC_CIRCUIT_SIZE {
+        for i in 0..IVC_CIRCUIT_SIZE {
             let instr = env.fetch_instruction();
+            debug!(
+                "Running IVC row {} (instruction = {:?}, witness row = {})",
+                i, instr, env.current_row
+            );
             interpreter::run_ivc(&mut env, instr);
             env.current_instruction = env.fetch_next_instruction();
             env.reset();

--- a/arrabbiata/src/witness.rs
+++ b/arrabbiata/src/witness.rs
@@ -19,6 +19,8 @@ use crate::{
     NUMBER_OF_VALUES_TO_ABSORB_PUBLIC_IO,
 };
 
+/// The first instruction in the IVC is the Poseidon permutation. It is used to
+/// start hashing the public input.
 pub const IVC_STARTING_INSTRUCTION: Instruction = Instruction::Poseidon(0);
 
 /// An environment that can be shared between IVC instances.

--- a/arrabbiata/src/witness.rs
+++ b/arrabbiata/src/witness.rs
@@ -990,9 +990,6 @@ impl<
     /// z_(i + 1) = F(w_i, z_i)
     /// ```
     ///
-    /// - We decompose the scalar `r`, the random combiner, into bits to compute
-    /// the MSM for the next step.
-    ///
     /// - We compute the MSM (verifier)
     ///
     /// ```text

--- a/arrabbiata/tests/cli.rs
+++ b/arrabbiata/tests/cli.rs
@@ -1,0 +1,33 @@
+use std::{path::PathBuf, process::Command};
+
+#[test]
+fn test_arrabbiata_binary() {
+    // Build the binary path
+    let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    // Build the path to the binary. It is assumed that no package is selected
+    // when running the test, i.e. no `-p arrabbiata` in the `cargo test`
+    // command. It is the behavior in the CI.
+    let binary_path = project_root
+        .join("..")
+        .join("target")
+        .join("release")
+        .join("arrabbiata");
+
+    // Build the command
+    let output = Command::new(binary_path)
+        .arg("square-root")
+        .arg("--n")
+        .arg("10")
+        .arg("--srs-size")
+        .arg("16")
+        .output()
+        .expect("Failed to execute binary");
+
+    // Assert the test results
+    assert!(
+        output.status.success(),
+        "Binary did not exit successfully: {:?}",
+        output
+    );
+}

--- a/arrabbiata/tests/witness.rs
+++ b/arrabbiata/tests/witness.rs
@@ -56,7 +56,7 @@ fn test_unit_witness_poseidon_next_row_gadget_one_full_hash() {
     assert_eq!(env.sponge_e2, sponge.clone());
 
     // Number of rows used by one full hash
-    assert_eq!(env.current_row, 13);
+    assert_eq!(env.current_row, 12);
 }
 
 #[test]


### PR DESCRIPTION
The steps to finish a first PoC of Arrabbiata are listed in this file `arrabbiata/main.rs`. The plan for the next weeks is to make a list of consecutive PR implementing the different FIXME. At the end of this list, a user should be able to execute `main.rs` with a pre-defined list of zkApp written in Rust using the "interpreter" interface.
The diagram might not be totally correct, nor complete. It will be edited step by step, while the code is being written and tested.

PR in progress are:
- permutation argument (https://github.com/o1-labs/proof-systems/pull/2593)
- Fiat-Shamir (https://github.com/o1-labs/proof-systems/pull/2720 + https://github.com/o1-labs/proof-systems/pull/2686)

This PR only makes the binary `arrabbiata` (defined in `main.rs`) executable and ending with a success status, to run it in the CI and be convinced we're making good progress in the following PRs.
 
This PR also includes changes to the documentation. As I am coming back into the codebase, I'm cleaning outdated descriptions and ideas. More would come.