### PR TITLE
CI: stop generating doc for each Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,11 +131,6 @@ jobs:
         run: |
           git diff --exit-code ":(exclude)rust-toolchain"
 
-      - name: Build cargo docs
-        run: |
-          eval $(opam env)
-          make generate-doc
-
       #
       # Coding guidelines
       #


### PR DESCRIPTION
We do only care for one, and it is the one running in gh-page.yml

Also, getting a compiler error from Rust 1.75, might be related to https://github.com/rust-lang/rust/issues/119529