### PR TITLE
CI: adding Rust 1.75

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       RUST_TOOLCHAIN_COVERAGE_VERSION: "1.74"
     strategy:
       matrix:
-        rust_toolchain_version: ["1.71", "1.72", "1.73", "1.74"]
+        rust_toolchain_version: ["1.71", "1.72", "1.73", "1.74", "1.75"]
         # FIXME: currently not available for 5.0.0.
         # It might be related to boxroot dependency, and we would need to bump
         # up the ocaml-rs dependency


### PR DESCRIPTION
Previous versions will be dropped step by step. Upgrading step by step to avoid big diffs.