### PR TITLE
Support Rust 1.77

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       RUST_TOOLCHAIN_COVERAGE_VERSION: "1.74"
     strategy:
       matrix:
-        rust_toolchain_version: ["1.71", "1.72", "1.73", "1.74", "1.75", "1.76"]
+        rust_toolchain_version: ["1.71", "1.72", "1.73", "1.74", "1.75", "1.76", "1.77"]
         # FIXME: currently not available for 5.0.0.
         # It might be related to boxroot dependency, and we would need to bump
         # up the ocaml-rs dependency

--- a/kimchi/src/precomputed_srs.rs
+++ b/kimchi/src/precomputed_srs.rs
@@ -185,6 +185,7 @@ mod tests {
         if std::env::var("SRS_OVERWRITE").is_ok() {
             let mut file = std::fs::OpenOptions::new()
                 .create(true)
+                .truncate(true)
                 .write(true)
                 .open(srs_path)
                 .expect("failed to open SRS file");

--- a/msm/src/precomputed_srs.rs
+++ b/msm/src/precomputed_srs.rs
@@ -89,6 +89,7 @@ fn create_and_store_srs_with_path(
         // Open/create the file
         let mut file = std::fs::OpenOptions::new()
             .create(true)
+            .truncate(true)
             .write(true)
             .open(srs_path.clone())
             .expect("failed to open SRS file");


### PR DESCRIPTION
Previous versions will be dropped step by step. Upgrading step by step to avoid big diffs.