### PR TITLE
Fix spelling

### DIFF
--- a/kimchi/src/circuits/argument.rs
+++ b/kimchi/src/circuits/argument.rs
@@ -155,7 +155,7 @@ pub struct ArgumentData<F: 'static> {
     pub challenges: BerkeleyChallenges<F>,
 }
 
-/// Witness data for a argument
+/// Witness data for an argument
 pub struct ArgumentWitness<T> {
     /// Witness for current row
     pub curr: [T; COLUMNS],

--- a/mvpoly/src/utils.rs
+++ b/mvpoly/src/utils.rs
@@ -170,7 +170,7 @@ pub fn get_mapping_with_primes<const N: usize>() -> Vec<usize> {
 }
 
 /// Compute all the possible two factors decomposition of a number n.
-/// It uses an cache where previous values have been computed.
+/// It uses a cache where previous values have been computed.
 /// For instance, if n = 6, the function will return [(1, 6), (2, 3), (3, 2), (6, 1)].
 /// The cache might be used to store the results of previous computations.
 /// The cache is a hashmap where the key is the number and the value is the


### PR DESCRIPTION
This pull request fixes spelling issues in the `argument.rs` and `utils.rs` files. 

- Fixed "a argument" → "an argument" in `argument.rs`.
- Corrected "an cache" → "a cache" in `utils.rs`.
