### PR TITLE
Add multiplicity tracking for lookups

### DIFF
--- a/o1vm/src/interpreters/mips/tests_helpers.rs
+++ b/o1vm/src/interpreters/mips/tests_helpers.rs
@@ -3,7 +3,7 @@ use crate::{
     interpreters::mips::{
         interpreter::{debugging::InstructionParts, InterpreterEnv},
         registers::Registers,
-        witness::{Env as WEnv, SyscallEnv},
+        witness::{Env as WEnv, LookupMultiplicities, SyscallEnv},
     },
     preimage_oracle::PreImageOracleT,
 };
@@ -92,6 +92,7 @@ where
         scratch_state_idx_inverse: 0,
         scratch_state: [Fp::from(0); SCRATCH_SIZE],
         scratch_state_inverse: [Fp::from(0); SCRATCH_SIZE_INVERSE],
+        lookup_multiplicities: LookupMultiplicities::new(),
         selector: crate::interpreters::mips::column::N_MIPS_SEL_COLS,
         halt: false,
         // Keccak related

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -75,6 +75,20 @@ pub struct LookupMultiplicities {
     pub reset_lookup: Vec<u64>,
 }
 
+impl LookupMultiplicities {
+    pub fn new() -> Self {
+        LookupMultiplicities {
+            pad_lookup: vec![0; LookupTableIDs::PadLookup.length()],
+            round_constants_lookup: vec![0; LookupTableIDs::RoundConstantsLookup.length()],
+            at_most_4_lookup: vec![0; LookupTableIDs::AtMost4Lookup.length()],
+            byte_lookup: vec![0; LookupTableIDs::ByteLookup.length()],
+            range_check_16_lookup: vec![0; LookupTableIDs::RangeCheck16Lookup.length()],
+            sparse_lookup: vec![0; LookupTableIDs::SparseLookup.length()],
+            reset_lookup: vec![0; LookupTableIDs::ResetLookup.length()],
+        }
+    }
+}
+
 /// This structure represents the environment the virtual machine state will use
 /// to transition. This environment will be used by the interpreter. The virtual
 /// machine has access to its internal state and some external memory. In
@@ -924,15 +938,7 @@ impl<Fp: PrimeField, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
             preimage_key: None,
             keccak_env: None,
             hash_counter: 0,
-            lookup_multiplicities: LookupMultiplicities {
-                pad_lookup: vec![0; LookupTableIDs::PadLookup.length()],
-                round_constants_lookup: vec![0; LookupTableIDs::RoundConstantsLookup.length()],
-                at_most_4_lookup: vec![0; LookupTableIDs::AtMost4Lookup.length()],
-                byte_lookup: vec![0; LookupTableIDs::ByteLookup.length()],
-                range_check_16_lookup: vec![0; LookupTableIDs::RangeCheck16Lookup.length()],
-                sparse_lookup: vec![0; LookupTableIDs::SparseLookup.length()],
-                reset_lookup: vec![0; LookupTableIDs::ResetLookup.length()],
-            },
+            lookup_multiplicities: LookupMultiplicities::new(),
         }
     }
 

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -89,6 +89,12 @@ impl LookupMultiplicities {
     }
 }
 
+impl Default for LookupMultiplicities {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// This structure represents the environment the virtual machine state will use
 /// to transition. This environment will be used by the interpreter. The virtual
 /// machine has access to its internal state and some external memory. In

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -20,7 +20,7 @@ use crate::{
             registers::Registers,
         },
     },
-    lookups::Lookup,
+    lookups::{Lookup, LookupTableIDs},
     preimage_oracle::PreImageOracleT,
     utils::memory_size,
 };
@@ -142,9 +142,21 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
         }
     }
 
-    fn add_lookup(&mut self, _lookup: Lookup<Self::Variable>) {
+    fn add_lookup(&mut self, lookup: Lookup<Self::Variable>) {
         // No-op, constraints only
-        // TODO: keep track of multiplicities of fixed tables here as in Keccak?
+        match lookup.table_id {
+            LookupTableIDs::PadLookup => (),
+            LookupTableIDs::RoundConstantsLookup => (),
+            LookupTableIDs::AtMost4Lookup => (),
+            LookupTableIDs::ByteLookup => (),
+            LookupTableIDs::RangeCheck16Lookup => (),
+            LookupTableIDs::SparseLookup => (),
+            LookupTableIDs::ResetLookup => (),
+            LookupTableIDs::MemoryLookup => (),
+            LookupTableIDs::RegisterLookup => (),
+            LookupTableIDs::SyscallLookup => (),
+            LookupTableIDs::KeccakStepLookup => (),
+        }
     }
 
     fn instruction_counter(&self) -> Self::Variable {

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -24,7 +24,7 @@ use crate::{
     preimage_oracle::PreImageOracleT,
     utils::memory_size,
 };
-use ark_ff::Field;
+use ark_ff::{Field, PrimeField};
 use core::panic;
 use kimchi::o1_utils::Two;
 use kimchi_msm::LogupTableID;
@@ -107,7 +107,7 @@ fn fresh_scratch_state<Fp: Field, const N: usize>() -> [Fp; N] {
     array::from_fn(|_| Fp::zero())
 }
 
-impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreImageOracle> {
+impl<Fp: PrimeField, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreImageOracle> {
     type Position = Column;
 
     fn alloc_scratch(&mut self) -> Self::Position {
@@ -843,7 +843,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
     }
 }
 
-impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
+impl<Fp: PrimeField, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
     pub fn create(page_size: usize, state: State, preimage_oracle: PreImageOracle) -> Self {
         let initial_instruction_pointer = state.pc;
         let next_instruction_pointer = state.next_pc;

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -152,6 +152,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
             LookupTableIDs::RangeCheck16Lookup => (),
             LookupTableIDs::SparseLookup => (),
             LookupTableIDs::ResetLookup => (),
+            // RAM ones, no multiplicities
             LookupTableIDs::MemoryLookup => (),
             LookupTableIDs::RegisterLookup => (),
             LookupTableIDs::SyscallLookup => (),

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -27,6 +27,7 @@ use crate::{
 use ark_ff::Field;
 use core::panic;
 use kimchi::o1_utils::Two;
+use kimchi_msm::LogupTableID;
 use log::{debug, info};
 use std::{
     array,
@@ -99,6 +100,7 @@ pub struct Env<Fp, PreImageOracle: PreImageOracleT> {
     pub preimage_key: Option<[u8; 32]>,
     pub keccak_env: Option<KeccakEnv<Fp>>,
     pub hash_counter: u64,
+    pub lookup_multiplicities: LookupMultiplicities,
 }
 
 fn fresh_scratch_state<Fp: Field, const N: usize>() -> [Fp; N] {
@@ -913,6 +915,14 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
             preimage_key: None,
             keccak_env: None,
             hash_counter: 0,
+            lookup_multiplicities: LookupMultiplicities {
+                pad_lookup: vec![0; LookupTableIDs::PadLookup.length()],
+                round_constants_lookup: vec![0; LookupTableIDs::RoundConstantsLookup.length()],
+                at_most_4_lookup: vec![0; LookupTableIDs::AtMost4Lookup.length()],
+                byte_lookup: vec![0; LookupTableIDs::ByteLookup.length()],
+                sparse_lookup: vec![0; LookupTableIDs::SparseLookup.length()],
+                reset_lookup: vec![0; LookupTableIDs::ResetLookup.length()],
+            },
         }
     }
 

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -64,6 +64,15 @@ impl SyscallEnv {
     }
 }
 
+pub struct LookupMultiplicities {
+    pub pad_lookup: Vec<u64>,
+    pub round_constants_lookup: Vec<u64>,
+    pub at_most_4_lookup: Vec<u64>,
+    pub byte_lookup: Vec<u64>,
+    pub sparse_lookup: Vec<u64>,
+    pub reset_lookup: Vec<u64>,
+}
+
 /// This structure represents the environment the virtual machine state will use
 /// to transition. This environment will be used by the interpreter. The virtual
 /// machine has access to its internal state and some external memory. In

--- a/o1vm/src/lookups.rs
+++ b/o1vm/src/lookups.rs
@@ -107,7 +107,7 @@ impl LookupTableID for LookupTableIDs {
     }
 
     fn ix_by_value<F: PrimeField>(&self, _value: &[F]) -> Option<usize> {
-        todo!()
+        None
     }
 
     fn all_variants() -> Vec<Self> {

--- a/o1vm/src/lookups.rs
+++ b/o1vm/src/lookups.rs
@@ -106,8 +106,36 @@ impl LookupTableID for LookupTableIDs {
         panic!("No runtime tables specified");
     }
 
-    fn ix_by_value<F: PrimeField>(&self, _value: &[F]) -> Option<usize> {
-        None
+    fn ix_by_value<F: PrimeField>(&self, value: &[F]) -> Option<usize> {
+        // Shamelessly copied from below, where it is likely also incorrect.
+        let idx = value[0]
+            .to_bytes()
+            .iter()
+            .rev()
+            .fold(0u64, |acc, &x| acc * 256 + x as u64) as usize;
+        match self {
+            // Fixed tables
+            Self::RoundConstantsLookup
+            | Self::AtMost4Lookup
+            | Self::ByteLookup
+            | Self::RangeCheck16Lookup
+            | Self::ResetLookup => Some(idx),
+            Self::PadLookup => Some(idx - 1),
+            Self::SparseLookup => {
+                // Big yikes. This is copied from below.
+                let res = u64::from_str_radix(&format!("{:x}", idx), 2);
+                if let Ok(ok) = res {
+                    Some(ok as usize)
+                } else {
+                    panic!("Help");
+                }
+            }
+            // Non-fixed tables
+            Self::MemoryLookup
+            | Self::RegisterLookup
+            | Self::SyscallLookup
+            | Self::KeccakStepLookup => None,
+        }
     }
 
     fn all_variants() -> Vec<Self> {

--- a/o1vm/tests/test_mips_elf.rs
+++ b/o1vm/tests/test_mips_elf.rs
@@ -1,4 +1,4 @@
-use ark_ff::Field;
+use ark_ff::PrimeField;
 use mina_curves::pasta::Fp;
 use o1vm::{
     cannon::{self, State, VmConfiguration},
@@ -29,7 +29,10 @@ impl MipsTest {
         o1vm::elf_loader::parse_elf(Architecture::Mips, &path).unwrap()
     }
 
-    fn read_word<Fp: Field, T: PreImageOracleT>(env: &mut witness::Env<Fp, T>, addr: u32) -> u32 {
+    fn read_word<Fp: PrimeField, T: PreImageOracleT>(
+        env: &mut witness::Env<Fp, T>,
+        addr: u32,
+    ) -> u32 {
         let bytes: [u8; 4] = [
             env.get_memory_direct(addr),
             env.get_memory_direct(addr + 1),


### PR DESCRIPTION
This PR builds upon https://github.com/o1-labs/proof-systems/pull/2950. This PR adds tracking for fixed-table multiplicities in the witness generation. We can use these to inject them at the end of execution, for use in the lookup protocol. This way, we can use the delayed lookup argument for everything.

The indexing code is bad; this is mostly derived from existing code.