### PR TITLE
Add Oracle tests for MIPS

### DIFF
--- a/o1vm/src/cannon.rs
+++ b/o1vm/src/cannon.rs
@@ -316,6 +316,7 @@ pub const HINT_CLIENT_WRITE_FD: i32 = 4;
 pub const PREIMAGE_CLIENT_READ_FD: i32 = 5;
 pub const PREIMAGE_CLIENT_WRITE_FD: i32 = 6;
 
+#[derive(Clone)]
 pub struct Preimage(Vec<u8>);
 
 impl Preimage {

--- a/o1vm/src/interpreters/mips/column.rs
+++ b/o1vm/src/interpreters/mips/column.rs
@@ -8,7 +8,7 @@ use strum::EnumCount;
 
 use super::{ITypeInstruction, JTypeInstruction, RTypeInstruction};
 
-pub(crate) const SCRATCH_SIZE_WITHOUT_KECCAK: usize = 45;
+pub(crate) const SCRATCH_SIZE_WITHOUT_KECCAK: usize = 93;
 /// The number of hashes performed so far in the block
 pub(crate) const MIPS_HASH_COUNTER_OFF: usize = SCRATCH_SIZE_WITHOUT_KECCAK;
 /// The number of bytes of the preimage that have been read so far in this hash

--- a/o1vm/src/interpreters/mips/registers.rs
+++ b/o1vm/src/interpreters/mips/registers.rs
@@ -6,11 +6,12 @@ pub const REGISTER_LO: usize = 33;
 pub const REGISTER_CURRENT_IP: usize = 34;
 pub const REGISTER_NEXT_IP: usize = 35;
 pub const REGISTER_HEAP_POINTER: usize = 36;
-pub const REGISTER_PREIMAGE_KEY_START: usize = 37;
-pub const REGISTER_PREIMAGE_KEY_END: usize = REGISTER_PREIMAGE_KEY_START + 8 /* 37 + 8 = 45 */;
-pub const REGISTER_PREIMAGE_OFFSET: usize = 45;
+pub const REGISTER_PREIMAGE_KEY_WRITE_OFFSET: usize = 37;
+pub const REGISTER_PREIMAGE_KEY_START: usize = 38;
+pub const REGISTER_PREIMAGE_KEY_END: usize = REGISTER_PREIMAGE_KEY_START + 32 /* 38 + 32 = 70 */;
+pub const REGISTER_PREIMAGE_OFFSET: usize = 70;
 
-pub const NUM_REGISTERS: usize = 46;
+pub const NUM_REGISTERS: usize = 71;
 
 /// This represents the internal state of the virtual machine.
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
@@ -21,7 +22,8 @@ pub struct Registers<T> {
     pub current_instruction_pointer: T,
     pub next_instruction_pointer: T,
     pub heap_pointer: T,
-    pub preimage_key: [T; 8],
+    pub preimage_key_write_offset: T,
+    pub preimage_key: [T; 32],
     pub preimage_offset: T,
 }
 
@@ -35,6 +37,7 @@ impl<T> Registers<T> {
                 &self.current_instruction_pointer,
                 &self.next_instruction_pointer,
                 &self.heap_pointer,
+                &self.preimage_key_write_offset,
             ])
             .chain(self.preimage_key.iter())
             .chain([&self.preimage_offset])
@@ -57,6 +60,8 @@ impl<T: Clone> Index<usize> for Registers<T> {
             &self.next_instruction_pointer
         } else if index == REGISTER_HEAP_POINTER {
             &self.heap_pointer
+        } else if index == REGISTER_PREIMAGE_KEY_WRITE_OFFSET {
+            &self.preimage_key_write_offset
         } else if (REGISTER_PREIMAGE_KEY_START..REGISTER_PREIMAGE_KEY_END).contains(&index) {
             &self.preimage_key[index - REGISTER_PREIMAGE_KEY_START]
         } else if index == REGISTER_PREIMAGE_OFFSET {
@@ -81,6 +86,8 @@ impl<T: Clone> IndexMut<usize> for Registers<T> {
             &mut self.next_instruction_pointer
         } else if index == REGISTER_HEAP_POINTER {
             &mut self.heap_pointer
+        } else if index == REGISTER_PREIMAGE_KEY_WRITE_OFFSET {
+            &mut self.preimage_key_write_offset
         } else if (REGISTER_PREIMAGE_KEY_START..REGISTER_PREIMAGE_KEY_END).contains(&index) {
             &mut self.preimage_key[index - REGISTER_PREIMAGE_KEY_START]
         } else if index == REGISTER_PREIMAGE_OFFSET {

--- a/o1vm/src/interpreters/mips/tests.rs
+++ b/o1vm/src/interpreters/mips/tests.rs
@@ -83,19 +83,13 @@ mod rtype {
             0x05, 0x67, 0xbd, 0xa4, 0x08, 0x77, 0xa7, 0xe8, 0x5d, 0xce, 0xb6, 0xff, 0x1f, 0x37,
             0x48, 0x0f, 0xef, 0x3d,
         ];
-        let chunks = preimage_key
-            .chunks(4)
-            .map(|chunk| {
-                ((chunk[0] as u32) << 24)
-                    + ((chunk[1] as u32) << 16)
-                    + ((chunk[2] as u32) << 8)
-                    + (chunk[3] as u32)
-            })
-            .collect::<Vec<_>>();
-        dummy_env.registers.preimage_key = std::array::from_fn(|i| chunks[i]);
+        dummy_env.registers.preimage_key = preimage_key;
 
         // The whole preimage
-        let preimage = dummy_env.preimage_oracle.get_preimage(preimage_key).get();
+        let preimage = dummy_env
+            .preimage_oracle
+            .get_preimage(preimage_key.map(|x| x as u8))
+            .get();
 
         // Total number of bytes that need to be processed (includes length)
         let total_length = 8 + preimage.len() as u32;

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -1169,7 +1169,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
         self.instruction_counter = self.next_instruction_counter();
 
         config.halt_address.iter().for_each(|halt_address: &u32| {
-            if self.get_instruction_pointer() == (*halt_address as u64) {
+            if self.registers.current_instruction_pointer == *halt_address {
                 debug!("Program jumped to halt address: {:#X}", halt_address);
                 self.halt = true;
             }

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -614,13 +614,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp, PreI
     ) -> Self::Variable {
         // The beginning of the syscall
         if self.registers.preimage_offset == 0 {
-            let mut preimage_key = [0u8; 32];
-            for i in 0..8 {
-                let bytes = u32::to_be_bytes(self.registers.preimage_key[i]);
-                for j in 0..4 {
-                    preimage_key[4 * i + j] = bytes[j]
-                }
-            }
+            let preimage_key = self.registers.preimage_key.map(|x| x as u8);
             let preimage = self.preimage_oracle.get_preimage(preimage_key).get();
             self.preimage = Some(preimage.clone());
             self.preimage_key = Some(preimage_key);
@@ -846,12 +840,10 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
             .collect::<Vec<_>>();
 
         let initial_registers = {
-            let preimage_key = {
-                let mut preimage_key = [0u32; 8];
+            let preimage_key: [u32; 32] = {
+                let mut preimage_key = [0u32; 32];
                 for (i, preimage_key_word) in preimage_key.iter_mut().enumerate() {
-                    *preimage_key_word = u32::from_be_bytes(
-                        state.preimage_key[i * 4..(i + 1) * 4].try_into().unwrap(),
-                    )
+                    *preimage_key_word = state.preimage_key[i] as u32;
                 }
                 preimage_key
             };
@@ -862,6 +854,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
                 current_instruction_pointer: initial_instruction_pointer,
                 next_instruction_pointer,
                 heap_pointer: state.heap,
+                preimage_key_write_offset: 0,
                 preimage_key,
                 preimage_offset: state.preimage_offset,
             }

--- a/o1vm/src/pickles/mod.rs
+++ b/o1vm/src/pickles/mod.rs
@@ -31,7 +31,7 @@ pub const DEGREE_QUOTIENT_POLYNOMIAL: u64 = 7;
 
 /// Total number of constraints for all instructions, including the constraints
 /// added for the selectors.
-pub const TOTAL_NUMBER_OF_CONSTRAINTS: usize = 464;
+pub const TOTAL_NUMBER_OF_CONSTRAINTS: usize = 467;
 
 #[cfg(test)]
 mod tests;

--- a/o1vm/tests/test_mips_elf.rs
+++ b/o1vm/tests/test_mips_elf.rs
@@ -11,21 +11,185 @@ use std::{
     path::{Path, PathBuf},
 };
 
+mod test_oracle {
+
+    use log::debug;
+    use o1vm::{
+        cannon::{Hint, Preimage},
+        preimage_oracle::PreImageOracleT,
+    };
+    use sha3::{Digest, Keccak256};
+    use std::collections::HashMap;
+
+    #[allow(dead_code)]
+    #[derive(Debug)]
+    enum KeyType {
+        // LocalKeyType is for input-type pre-images, specific to the local program instance.
+        Local,
+        // Keccak256KeyType is for keccak256 pre-images, for any global shared pre-images.
+        Keccak256,
+        // GlobalGenericKeyType is a reserved key type for generic global data.
+        GlobalGeneric,
+        // Sha256KeyType is for sha256 pre-images, for any global shared pre-images.
+        Sha256,
+        // BlobKeyType is for blob point pre-images.
+        Blob,
+        // PrecompileKeyType is for precompile result pre-images.
+        Precompile,
+    }
+
+    impl KeyType {
+        fn prefix(&self) -> u8 {
+            match self {
+                // The zero key type is illegal to use, ensuring all keys are non-zero.
+                KeyType::Local => 1,
+                KeyType::Keccak256 => 2,
+                KeyType::GlobalGeneric => 3,
+                KeyType::Sha256 => 4,
+                KeyType::Blob => 5,
+                KeyType::Precompile => 6,
+            }
+        }
+
+        fn from_prefix(prefix: u8) -> Self {
+            match prefix {
+                1 => KeyType::Local,
+                2 => KeyType::Keccak256,
+                3 => KeyType::GlobalGeneric,
+                4 => KeyType::Sha256,
+                5 => KeyType::Blob,
+                6 => KeyType::Precompile,
+                _ => panic!("Unknown key type prefix: {}", prefix),
+            }
+        }
+    }
+
+    fn to_preimage_key(kt: KeyType, mut k: [u8; 32]) -> [u8; 32] {
+        k[0] = kt.prefix();
+        k
+    }
+
+    pub struct TestPreImageOracle {
+        preimage: [HashMap<[u8; 32], Preimage>; 6],
+    }
+
+    impl TestPreImageOracle {
+        fn new() -> Self {
+            let preimage = std::array::from_fn(|_| HashMap::new());
+            TestPreImageOracle { preimage }
+        }
+
+        pub fn new_static_oracle(data: Vec<u8>) -> Self {
+            let key = {
+                let mut hasher = Keccak256::new();
+                hasher.update(&data);
+                let k = hasher.finalize();
+                to_preimage_key(KeyType::Keccak256, k.into())
+            };
+            let preimage: HashMap<[u8; 32], Preimage> = {
+                let mut m = HashMap::new();
+                debug!("Inserting preimage for key: {}", hex::encode(key));
+                m.insert(key, Preimage::create(data));
+                m
+            };
+            let mut po = Self::new();
+            po.preimage[KeyType::Keccak256 as usize] = preimage;
+            po
+        }
+
+        pub fn new_precompile_oracle() -> Self {
+            let precompile: [u8; 20] = {
+                let mut a = [0; 20];
+                a[19] = 0xa;
+                a
+            };
+            let input = hex::decode("01e798154708fe7789429634053cbf9f99b619f9f084048927333fce637f549b564c0a11a0f704f4fc3e8acfe0f8245f0ad1347b378fbf96e206da11a5d3630624d25032e67a7e6a4910df5834b8fe70e6bcfeeac0352434196bdf4b2485d5a18f59a8d2a1a625a17f3fea0fe5eb8c896db3764f3185481bc22f91b4aaffcca25f26936857bc3a7c2539ea8ec3a952b7873033e038326e87ed3e1276fd140253fa08e9fc25fb2d9a98527fc22a2c9612fbeafdad446cbc7bcdbdcd780af2c16a").expect("failed to decode hex");
+            let result = {
+                let mut res = vec![0x1];
+                let return_value = hex::decode("000000000000000000000000000000000000000000000000000000000000100073eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001").expect("failed to decode hex");
+                res.extend(return_value);
+                res
+            };
+            let key_data = {
+                let mut d = Vec::with_capacity(precompile.len() + input.len());
+                d.extend_from_slice(&precompile);
+                d.extend_from_slice(&input);
+                d
+            };
+            let key = {
+                let mut hasher = Keccak256::new();
+                hasher.update(&key_data);
+                hasher.finalize().into()
+            };
+            let mut po = Self::new();
+            po.preimage[KeyType::Keccak256 as usize].insert(
+                to_preimage_key(KeyType::Keccak256, key),
+                Preimage::create(key_data),
+            );
+            po.preimage[KeyType::Precompile as usize].insert(
+                to_preimage_key(KeyType::Precompile, key),
+                Preimage::create(result),
+            );
+            po
+        }
+    }
+
+    impl PreImageOracleT for TestPreImageOracle {
+        fn get_preimage(&mut self, key: [u8; 32]) -> Preimage {
+            debug!("Asking oracle for key: {}", hex::encode(key));
+            let key_type = KeyType::from_prefix(key[0]);
+            debug!("Asking oracle for key type {:?}", key_type);
+            let m = &self.preimage[key_type as usize];
+            match m.get(&key) {
+                Some(preimage) => preimage.clone(),
+                None => {
+                    let key_str = hex::encode(key);
+                    panic!("Preimage not found for key {}", key_str)
+                }
+            }
+        }
+
+        fn hint(&mut self, _: Hint) {}
+    }
+}
+
 struct MipsTest {
     bin_file: PathBuf,
+    preimage_oracle: Box<dyn PreImageOracleT>,
 }
 
 // currently excluding any oracle based tests and a select group of tests that are failing
 fn is_test_excluded(bin_file: &Path) -> bool {
     let file_name = bin_file.file_name().unwrap().to_str().unwrap();
     let untested_programs = ["exit_group", "mul"];
-    file_name.starts_with("oracle") || untested_programs.contains(&file_name)
+    untested_programs.contains(&file_name)
 }
 
 impl MipsTest {
+    fn new(bin_file: PathBuf) -> Self {
+        let file_name = bin_file.file_name().unwrap().to_str().unwrap();
+        if file_name.starts_with("oracle_kzg") {
+            MipsTest {
+                bin_file,
+                preimage_oracle: Box::new(test_oracle::TestPreImageOracle::new_precompile_oracle()),
+            }
+        } else if file_name.starts_with("oracle") {
+            let data = "hello world".as_bytes().to_vec();
+            MipsTest {
+                bin_file,
+                preimage_oracle: Box::new(test_oracle::TestPreImageOracle::new_static_oracle(data)),
+            }
+        } else {
+            MipsTest {
+                bin_file,
+                preimage_oracle: Box::new(NullPreImageOracle),
+            }
+        }
+    }
+
     fn parse_state(&self) -> State {
         let curr_dir = std::env::current_dir().unwrap();
-        let path = curr_dir.join(&self.bin_file);
+        let path = curr_dir.join(self.bin_file.clone());
         o1vm::elf_loader::parse_elf(Architecture::Mips, &path).unwrap()
     }
 
@@ -39,7 +203,7 @@ impl MipsTest {
         u32::from_be_bytes(bytes)
     }
 
-    fn run(&self) -> Result<(), String> {
+    fn run(self) -> Result<(), String> {
         println!("Running test: {:?}", self.bin_file);
         let mut state = self.parse_state();
         let halt_address = 0xa7ef00d0_u32;
@@ -55,7 +219,7 @@ impl MipsTest {
         let mut witness = witness::Env::<Fp, Box<dyn PreImageOracleT>>::create(
             cannon::PAGE_SIZE as usize,
             state,
-            Box::new(NullPreImageOracle),
+            self.preimage_oracle,
         );
 
         while !witness.halt {
@@ -93,19 +257,24 @@ mod tests {
     #[test]
     #[cfg_attr(not(feature = "open_mips"), ignore)]
     fn open_mips_tests() {
+        env_logger::init();
         let test_dir = "resources/programs/mips/bin";
         let test_files: Vec<MipsTest> = fs::read_dir(test_dir)
             .unwrap_or_else(|_| panic!("Error reading directory {}", test_dir))
             .filter_map(|entry| entry.ok())
             .map(|entry| entry.path())
             .filter(|f| f.is_file() && f.extension().is_none() && !is_test_excluded(f))
-            .map(|f| MipsTest { bin_file: f })
+            .map(MipsTest::new)
             .collect();
 
         for test in test_files {
-            let test_name = test.bin_file.file_name().unwrap().to_str().unwrap();
+            let test_name = test.bin_file.clone();
             if let Err(err) = test.run() {
-                panic!("Test '{}' failed: {}", test_name, err);
+                panic!(
+                    "Test '{}' failed: {}",
+                    test_name.file_name().unwrap().to_str().unwrap(),
+                    err
+                );
             }
         }
     }


### PR DESCRIPTION
This PR consists of two commits
- [d98442c](https://github.com/o1-labs/proof-systems/pull/2945/commits/d98442c56af3282b252ae1ceecd3f482324ab48e): Add cannon mips tests for oracle reads/writes:
 -- `oracle.asm`
 -- `oracle_kzg.asm`
 -- `oracle_unaligned_read.asm`
 -- `oracle_unaligned_write.asm`
 - [c5095ad](https://github.com/o1-labs/proof-systems/pull/2945/commits/c5095ad5e04e7249bbedf09cd9510600ea415f5d): Make modifications to `SyscallWritePreimage` handler to get tests to pass
 
The test was adapted from the [cannon codebase version](https://github.com/ethereum-optimism/optimism/blob/4a487b8920daa9dc4b496d691d5f283f9bb659b1/cannon/mipsevm/state_test.go). **None of these oracle based tests passed with the current implementation.** The problem was with the `SyscallWritePreimage` syscall handler, which if you look at the test logs for [d98442c](https://github.com/o1-labs/proof-systems/pull/2945/commits/d98442c56af3282b252ae1ceecd3f482324ab48e) you can see the errors of the form:

```
[2025-01-13T16:18:51Z DEBUG o1vm::elf_loader] The executable code starts at address 4194512, has size 304 bytes, and ends at address 4194815.
[2025-01-13T16:18:51Z DEBUG test_mips_elf::test_oracle] Asking oracle for key: 000000000000000000000000000000000000000000000000000000004a29921f
thread 'tests::open_mips_tests' panicked at 'Unknown key type prefix: 0', o1vm/tests/test_mips_elf.rs:62:22
```

If you want to run them locally, you can use the one-liner

```
> RUST_LOG=debug RUST_BACKTRACE=1 cargo test --features open_mips --test test_mips_elf -- --nocapture
```

The problem is that the current write handler isn't writing to the appropriate places in the register. I came up with _a solution_ that fixes the problem with the cost of increasing the scratch space and the number of registers. If we're looking to "pay less" for the correct implementation, we can use this as a starting point.