### PR TITLE
Track lookup values in interpreter and proof

### DIFF
--- a/ivc/src/expr_eval.rs
+++ b/ivc/src/expr_eval.rs
@@ -23,10 +23,10 @@ use strum::EnumCount;
 /// Generic structure containing column vectors.
 pub struct GenericVecStructure<G: KimchiCurve>(pub Vec<Vec<G::ScalarField>>);
 
-impl<G: KimchiCurve> Index<GenericColumn> for GenericVecStructure<G> {
+impl<G: KimchiCurve> Index<GenericColumn<usize>> for GenericVecStructure<G> {
     type Output = [G::ScalarField];
 
-    fn index(&self, index: GenericColumn) -> &Self::Output {
+    fn index(&self, index: GenericColumn<usize>) -> &Self::Output {
         match index {
             GenericColumn::FixedSelector(i) => &self.0[i],
             _ => panic!("should not happen"),
@@ -73,7 +73,7 @@ impl<
     }
 
     pub fn process_extended_folding_column<
-        FC: FoldingConfig<Column = GenericColumn, Curve = Curve, Challenge = PlonkishChallenge>,
+        FC: FoldingConfig<Column = GenericColumn<usize>, Curve = Curve, Challenge = PlonkishChallenge>,
     >(
         &self,
         col: &ExtendedFoldingColumn<FC>,
@@ -105,7 +105,7 @@ impl<
     /// Evaluates the expression in the provided side
     pub fn eval_naive_fexpr<
         'a,
-        FC: FoldingConfig<Column = GenericColumn, Curve = Curve, Challenge = PlonkishChallenge>,
+        FC: FoldingConfig<Column = GenericColumn<usize>, Curve = Curve, Challenge = PlonkishChallenge>,
     >(
         &'a self,
         exp: &FoldingExp<FC>,
@@ -136,7 +136,7 @@ impl<
     /// For FoldingCompatibleExp
     pub fn eval_naive_fcompat<
         'a,
-        FC: FoldingConfig<Column = GenericColumn, Curve = Curve, Challenge = PlonkishChallenge>,
+        FC: FoldingConfig<Column = GenericColumn<usize>, Curve = Curve, Challenge = PlonkishChallenge>,
     >(
         &'a self,
         exp: &FoldingCompatibleExpr<FC>,

--- a/ivc/src/ivc/columns.rs
+++ b/ivc/src/ivc/columns.rs
@@ -391,7 +391,7 @@ impl ColumnIndexer for IVCColumn {
     // We also add 1 for the FoldIteration column.
     const N_COL: usize = IVCPoseidonColumn::N_COL + 1 + N_BLOCKS;
 
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         match self {
             // We keep a column that will be used for the folding iteration.
             // Question: do we need it for all the rows or does it appear only

--- a/ivc/src/ivc/columns.rs
+++ b/ivc/src/ivc/columns.rs
@@ -378,7 +378,7 @@ pub enum IVCColumn {
     Block6UOutput,
 }
 
-impl ColumnIndexer for IVCColumn {
+impl ColumnIndexer<usize> for IVCColumn {
     /// Number of columns used by the IVC circuit
     /// It contains at least the columns used for Poseidon.
     /// It does not include the additional columns that might be required

--- a/ivc/src/ivc/helpers.rs
+++ b/ivc/src/ivc/helpers.rs
@@ -10,7 +10,11 @@ use kimchi_msm::{
 use super::{LIMB_BITSIZE_XLARGE, N_LIMBS_XLARGE};
 
 /// Helper. Combines small limbs into big limbs.
-pub fn combine_large_to_xlarge<F: PrimeField, CIx: ColumnIndexer, Env: ColAccessCap<F, CIx>>(
+pub fn combine_large_to_xlarge<
+    F: PrimeField,
+    CIx: ColumnIndexer<usize>,
+    Env: ColAccessCap<F, CIx>,
+>(
     x: [Env::Variable; N_LIMBS_LARGE],
 ) -> [Env::Variable; N_LIMBS_XLARGE] {
     combine_limbs_m_to_n::<
@@ -25,7 +29,11 @@ pub fn combine_large_to_xlarge<F: PrimeField, CIx: ColumnIndexer, Env: ColAccess
 }
 
 /// Helper. Combines 17x15bit limbs into 1 native field element.
-pub fn combine_small_to_full<F: PrimeField, CIx: ColumnIndexer, Env: ColAccessCap<F, CIx>>(
+pub fn combine_small_to_full<
+    F: PrimeField,
+    CIx: ColumnIndexer<usize>,
+    Env: ColAccessCap<F, CIx>,
+>(
     x: [Env::Variable; N_LIMBS_SMALL],
 ) -> Env::Variable {
     let [res] =

--- a/ivc/src/ivc/mod.rs
+++ b/ivc/src/ivc/mod.rs
@@ -74,8 +74,8 @@ mod tests {
     type IVCWitnessBuilderEnvRaw<LT> = WitnessBuilderEnv<
         Fp,
         IVCColumn,
-        { <IVCColumn as ColumnIndexer>::N_COL - N_BLOCKS },
-        { <IVCColumn as ColumnIndexer>::N_COL - N_BLOCKS },
+        { <IVCColumn as ColumnIndexer<usize>>::N_COL - N_BLOCKS },
+        { <IVCColumn as ColumnIndexer<usize>>::N_COL - N_BLOCKS },
         0,
         N_FSEL_IVC,
         LT,

--- a/ivc/src/plonkish_lang.rs
+++ b/ivc/src/plonkish_lang.rs
@@ -75,13 +75,13 @@ impl<
 {
 }
 
-impl<const N_COL: usize, const N_FSEL: usize, F: FftField, Evals: CombinableEvals<F>> Index<Column>
-    for PlonkishWitnessGeneric<N_COL, N_FSEL, F, Evals>
+impl<const N_COL: usize, const N_FSEL: usize, F: FftField, Evals: CombinableEvals<F>>
+    Index<Column<usize>> for PlonkishWitnessGeneric<N_COL, N_FSEL, F, Evals>
 {
     type Output = [F];
 
     /// Map a column alias to the corresponding witness column.
-    fn index(&self, index: Column) -> &Self::Output {
+    fn index(&self, index: Column<usize>) -> &Self::Output {
         match index {
             Column::Relation(i) => self.witness.cols[i].e_as_slice(),
             Column::FixedSelector(i) => self.fixed_selectors[i].e_as_slice(),

--- a/ivc/src/poseidon_55_0_7_3_2/columns.rs
+++ b/ivc/src/poseidon_55_0_7_3_2/columns.rs
@@ -29,7 +29,7 @@ pub enum PoseidonColumn<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> {
     RoundConstant(usize, usize),
 }
 
-impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> ColumnIndexer
+impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> ColumnIndexer<usize>
     for PoseidonColumn<STATE_SIZE, NB_FULL_ROUND>
 {
     // - STATE_SIZE input columns

--- a/ivc/src/poseidon_55_0_7_3_2/columns.rs
+++ b/ivc/src/poseidon_55_0_7_3_2/columns.rs
@@ -42,7 +42,7 @@ impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> ColumnIndexer
     // - STATE_SIZE * NB_FULL_ROUND constants
     const N_COL: usize = STATE_SIZE + 5 * NB_FULL_ROUND * STATE_SIZE;
 
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         match self {
             PoseidonColumn::Input(i) => {
                 assert!(i < STATE_SIZE);

--- a/ivc/src/poseidon_55_0_7_3_2/mod.rs
+++ b/ivc/src/poseidon_55_0_7_3_2/mod.rs
@@ -43,8 +43,8 @@ mod tests {
     type PoseidonWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         TestPoseidonColumn,
-        { <TestPoseidonColumn as ColumnIndexer>::N_COL },
-        { <TestPoseidonColumn as ColumnIndexer>::N_COL },
+        { <TestPoseidonColumn as ColumnIndexer<usize>>::N_COL },
+        { <TestPoseidonColumn as ColumnIndexer<usize>>::N_COL },
         N_DSEL,
         N_FSEL,
         DummyLookupTable,

--- a/ivc/src/poseidon_55_0_7_3_7/columns.rs
+++ b/ivc/src/poseidon_55_0_7_3_7/columns.rs
@@ -25,7 +25,7 @@ impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> ColumnIndexer
 {
     const N_COL: usize = STATE_SIZE + NB_FULL_ROUND * STATE_SIZE;
 
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         match self {
             PoseidonColumn::Input(i) => {
                 assert!(i < STATE_SIZE);

--- a/ivc/src/poseidon_55_0_7_3_7/columns.rs
+++ b/ivc/src/poseidon_55_0_7_3_7/columns.rs
@@ -20,7 +20,7 @@ pub enum PoseidonColumn<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> {
     RoundConstant(usize, usize),
 }
 
-impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> ColumnIndexer
+impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> ColumnIndexer<usize>
     for PoseidonColumn<STATE_SIZE, NB_FULL_ROUND>
 {
     const N_COL: usize = STATE_SIZE + NB_FULL_ROUND * STATE_SIZE;

--- a/ivc/src/poseidon_55_0_7_3_7/mod.rs
+++ b/ivc/src/poseidon_55_0_7_3_7/mod.rs
@@ -41,8 +41,8 @@ mod tests {
     type PoseidonWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         TestPoseidonColumn,
-        { <TestPoseidonColumn as ColumnIndexer>::N_COL },
-        { <TestPoseidonColumn as ColumnIndexer>::N_COL },
+        { <TestPoseidonColumn as ColumnIndexer<usize>>::N_COL },
+        { <TestPoseidonColumn as ColumnIndexer<usize>>::N_COL },
         N_DSEL,
         N_FSEL,
         DummyLookupTable,

--- a/ivc/src/poseidon_8_56_5_3_2/columns.rs
+++ b/ivc/src/poseidon_8_56_5_3_2/columns.rs
@@ -30,7 +30,7 @@ pub enum PoseidonColumn<
 }
 
 impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize, const NB_PARTIAL_ROUND: usize>
-    ColumnIndexer for PoseidonColumn<STATE_SIZE, NB_FULL_ROUND, NB_PARTIAL_ROUND>
+    ColumnIndexer<usize> for PoseidonColumn<STATE_SIZE, NB_FULL_ROUND, NB_PARTIAL_ROUND>
 {
     // - STATE_SIZE input columns
     // - for each partial round:

--- a/ivc/src/poseidon_8_56_5_3_2/columns.rs
+++ b/ivc/src/poseidon_8_56_5_3_2/columns.rs
@@ -54,7 +54,7 @@ impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize, const NB_PARTIAL_ROUND
             + (4 + STATE_SIZE - 1) * NB_PARTIAL_ROUND // partial round
             + STATE_SIZE * (NB_PARTIAL_ROUND + NB_FULL_ROUND); // fixed selectors
 
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         // number of reductions for
         // x -> x^2 -> x^4 -> x^5 -> x^5 * MDS
         let nb_red = 4;

--- a/ivc/src/poseidon_8_56_5_3_2/mod.rs
+++ b/ivc/src/poseidon_8_56_5_3_2/mod.rs
@@ -32,8 +32,8 @@ mod tests {
     type PoseidonWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         Column,
-        { <Column as ColumnIndexer>::N_COL },
-        { <Column as ColumnIndexer>::N_COL },
+        { <Column as ColumnIndexer<usize>>::N_COL },
+        { <Column as ColumnIndexer<usize>>::N_COL },
         N_DSEL,
         N_FSEL,
         DummyLookupTable,

--- a/ivc/src/prover.rs
+++ b/ivc/src/prover.rs
@@ -91,7 +91,7 @@ impl<
         F: Clone,
     > ColumnEvaluations<F> for ProofEvaluations<N_WIT, N_REL, N_DSEL, N_FSEL, F>
 {
-    type Column = kimchi_msm::columns::Column;
+    type Column = kimchi_msm::columns::Column<usize>;
 
     fn evaluate(&self, col: Self::Column) -> Result<PointEvaluations<F>, ExprError<Self::Column>> {
         // TODO: substitute when non-literal generic constants are available
@@ -147,7 +147,7 @@ pub struct Proof<
 pub fn prove<
     EFqSponge: Clone + FqSponge<Fq, G, Fp>,
     EFrSponge: FrSponge<Fp>,
-    FC: FoldingConfig<Column = GenericColumn, Curve = G, Challenge = PlonkishChallenge>,
+    FC: FoldingConfig<Column = GenericColumn<usize>, Curve = G, Challenge = PlonkishChallenge>,
     RNG,
     const N_WIT: usize,
     const N_WIT_QUAD: usize, // witness columns + quad columns

--- a/ivc/src/verifier.rs
+++ b/ivc/src/verifier.rs
@@ -40,7 +40,7 @@ pub type Fq = ark_bn254::Fq;
 pub fn verify<
     EFqSponge: Clone + FqSponge<Fq, G, Fp>,
     EFrSponge: FrSponge<Fp>,
-    FC: FoldingConfig<Column = GenericColumn, Curve = G, Challenge = PlonkishChallenge>,
+    FC: FoldingConfig<Column = GenericColumn<usize>, Curve = G, Challenge = PlonkishChallenge>,
     const N_WIT: usize,
     const N_REL: usize,
     const N_DSEL: usize,

--- a/ivc/tests/folding_ivc.rs
+++ b/ivc/tests/folding_ivc.rs
@@ -71,7 +71,7 @@ fn test_regression_additional_columns_reduction_to_degree_2() {
     impl Witness<Curve> for TestWitness {}
 
     impl FoldingConfig for TestConfig {
-        type Column = Column;
+        type Column = Column<usize>;
 
         type Selector = ();
 
@@ -92,7 +92,7 @@ fn test_regression_additional_columns_reduction_to_degree_2() {
 
     struct Env;
 
-    impl FoldingEnv<Fp, TestInstance, TestWitness, Column, Challenge, ()> for Env {
+    impl FoldingEnv<Fp, TestInstance, TestWitness, Column<usize>, Challenge, ()> for Env {
         type Structure = ();
 
         fn new(
@@ -103,7 +103,7 @@ fn test_regression_additional_columns_reduction_to_degree_2() {
             todo!()
         }
 
-        fn col(&self, _col: Column, _curr_or_next: CurrOrNext, _side: Side) -> &[Fp] {
+        fn col(&self, _col: Column<usize>, _curr_or_next: CurrOrNext, _side: Side) -> &[Fp] {
             todo!()
         }
 

--- a/ivc/tests/simple.rs
+++ b/ivc/tests/simple.rs
@@ -67,10 +67,10 @@ pub enum AdditionColumn {
     C,
 }
 
-impl ColumnIndexer for AdditionColumn {
+impl ColumnIndexer<usize> for AdditionColumn {
     const N_COL: usize = 3;
 
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         match self {
             AdditionColumn::A => Column::Relation(0),
             AdditionColumn::B => Column::Relation(1),
@@ -119,7 +119,7 @@ pub fn heavy_test_simple_add() {
     const N_FSEL_TOTAL: usize = N_FSEL_IVC;
 
     // Total number of witness columns in IVC. The blocks are public selectors.
-    const N_WIT_IVC: usize = <IVCColumn as ColumnIndexer>::N_COL - N_FSEL_IVC;
+    const N_WIT_IVC: usize = <IVCColumn as ColumnIndexer<usize>>::N_COL - N_FSEL_IVC;
 
     // Number of witness columns in the circuit.
     // It consists of the columns of the inner circuit and the columns for the
@@ -189,7 +189,7 @@ pub fn heavy_test_simple_add() {
         const N_ALPHAS: usize,
     > = StandardConfig<
         Curve,
-        Column,
+        Column<usize>,
         PlonkishChallenge,
         PlonkishInstance<Curve, N_COL_TOTAL, N_CHALS, N_ALPHAS>, // TODO check if it's quad or not
         PlonkishWitness<N_COL_TOTAL, N_FSEL, Fp>,

--- a/msm/src/circuit_design/capabilities.rs
+++ b/msm/src/circuit_design/capabilities.rs
@@ -10,7 +10,7 @@ use ark_ff::PrimeField;
 
 /// Environment capability for accessing and reading columns. This is necessary for
 /// building constraints.
-pub trait ColAccessCap<F: PrimeField, CIx: ColumnIndexer> {
+pub trait ColAccessCap<F: PrimeField, CIx: ColumnIndexer<usize>> {
     // NB: 'static here means that `Variable` does not contain any
     // references with a lifetime less than 'static. Which is true in
     // our case. Necessary for `set_assert_mapper`
@@ -39,7 +39,7 @@ pub trait ColAccessCap<F: PrimeField, CIx: ColumnIndexer> {
 
 /// Environment capability similar to `ColAccessCap` but for /also
 /// writing/ columns. Used on the witness side.
-pub trait ColWriteCap<F: PrimeField, CIx: ColumnIndexer>
+pub trait ColWriteCap<F: PrimeField, CIx: ColumnIndexer<usize>>
 where
     Self: ColAccessCap<F, CIx>,
 {
@@ -47,7 +47,7 @@ where
 }
 
 /// Capability for invoking table lookups.
-pub trait LookupCap<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID>
+pub trait LookupCap<F: PrimeField, CIx: ColumnIndexer<usize>, LT: LookupTableID>
 where
     Self: ColAccessCap<F, CIx>,
 {
@@ -62,7 +62,7 @@ where
 /// Holds a "current" row that can be moved forward with `next_row`.
 /// The `ColWriteCap` and `ColAccessCap` reason in terms of current
 /// row. The two other methods can be used to read/write previous.
-pub trait MultiRowReadCap<F: PrimeField, CIx: ColumnIndexer>
+pub trait MultiRowReadCap<F: PrimeField, CIx: ColumnIndexer<usize>>
 where
     Self: ColWriteCap<F, CIx>,
 {
@@ -84,7 +84,7 @@ where
 // F-typed inputs to a function.
 /// A direct field access capability modelling an abstract witness
 /// builder. Not for constraint building.
-pub trait DirectWitnessCap<F: PrimeField, CIx: ColumnIndexer>
+pub trait DirectWitnessCap<F: PrimeField, CIx: ColumnIndexer<usize>>
 where
     Self: MultiRowReadCap<F, CIx>,
 {
@@ -106,7 +106,7 @@ where
 /// partially) in the constraint builder case. For example, "hcopy",
 /// despite its name, does not do any "write", so hcopy !=>
 /// write_column.
-pub trait HybridCopyCap<F: PrimeField, CIx: ColumnIndexer>
+pub trait HybridCopyCap<F: PrimeField, CIx: ColumnIndexer<usize>>
 where
     Self: ColAccessCap<F, CIx>,
 {
@@ -120,7 +120,7 @@ where
 ////////////////////////////////////////////////////////////////////////////
 
 /// Write an array of values simultaneously.
-pub fn read_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer, ColMap>(
+pub fn read_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer<usize>, ColMap>(
     env: &mut Env,
     column_map: ColMap,
 ) -> [Env::Variable; ARR_N]
@@ -133,7 +133,7 @@ where
 }
 
 /// Write a field element directly as a constant.
-pub fn write_column_const<F, Env, CIx: ColumnIndexer>(env: &mut Env, col: CIx, var: &F)
+pub fn write_column_const<F, Env, CIx: ColumnIndexer<usize>>(env: &mut Env, col: CIx, var: &F)
 where
     F: PrimeField,
     Env: ColWriteCap<F, CIx>,
@@ -142,7 +142,7 @@ where
 }
 
 /// Write an array of values simultaneously.
-pub fn write_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer, ColMap>(
+pub fn write_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer<usize>, ColMap>(
     env: &mut Env,
     input: [Env::Variable; ARR_N],
     column_map: ColMap,
@@ -157,7 +157,7 @@ pub fn write_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer, ColMap
 }
 
 /// Write an array of /field/ values simultaneously.
-pub fn write_column_array_const<F, Env, const ARR_N: usize, CIx: ColumnIndexer, ColMap>(
+pub fn write_column_array_const<F, Env, const ARR_N: usize, CIx: ColumnIndexer<usize>, ColMap>(
     env: &mut Env,
     input: &[F; ARR_N],
     column_map: ColMap,

--- a/msm/src/circuit_design/composition.rs
+++ b/msm/src/circuit_design/composition.rs
@@ -151,27 +151,35 @@ where
 /// impossible to instantiate `SubEnv` with two /completely/ different
 /// lenses and then write proper trait implementations. Rust complains
 /// about conflicting trait implementations.
-struct SubEnv<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L> {
+struct SubEnv<'a, F: PrimeField, CIx1: ColumnIndexer<usize>, Env1: ColAccessCap<F, CIx1>, L> {
     env: &'a mut Env1,
     lens: L,
     phantom: PhantomData<(F, CIx1)>,
 }
 
 /// Sub environment with a lens that is mapping columns.
-pub struct SubEnvColumn<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>(
-    SubEnv<'a, F, CIx1, Env1, L>,
-);
+pub struct SubEnvColumn<
+    'a,
+    F: PrimeField,
+    CIx1: ColumnIndexer<usize>,
+    Env1: ColAccessCap<F, CIx1>,
+    L,
+>(SubEnv<'a, F, CIx1, Env1, L>);
 
 /// Sub environment with a lens that is mapping lookup tables.
-pub struct SubEnvLookup<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>(
-    SubEnv<'a, F, CIx1, Env1, L>,
-);
+pub struct SubEnvLookup<
+    'a,
+    F: PrimeField,
+    CIx1: ColumnIndexer<usize>,
+    Env1: ColAccessCap<F, CIx1>,
+    L,
+>(SubEnv<'a, F, CIx1, Env1, L>);
 
 ////////////////////////////////////////////////////////////////////////////
 // Trait implementations
 ////////////////////////////////////////////////////////////////////////////
 
-impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>
+impl<'a, F: PrimeField, CIx1: ColumnIndexer<usize>, Env1: ColAccessCap<F, CIx1>, L>
     SubEnv<'a, F, CIx1, Env1, L>
 {
     pub fn new(env: &'a mut Env1, lens: L) -> Self {
@@ -183,7 +191,7 @@ impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>
     }
 }
 
-impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>
+impl<'a, F: PrimeField, CIx1: ColumnIndexer<usize>, Env1: ColAccessCap<F, CIx1>, L>
     SubEnvColumn<'a, F, CIx1, Env1, L>
 {
     pub fn new(env: &'a mut Env1, lens: L) -> Self {
@@ -191,7 +199,7 @@ impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>
     }
 }
 
-impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>
+impl<'a, F: PrimeField, CIx1: ColumnIndexer<usize>, Env1: ColAccessCap<F, CIx1>, L>
     SubEnvLookup<'a, F, CIx1, Env1, L>
 {
     pub fn new(env: &'a mut Env1, lens: L) -> Self {
@@ -202,8 +210,8 @@ impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>
 impl<
         'a,
         F: PrimeField,
-        CIx1: ColumnIndexer,
-        CIx2: ColumnIndexer,
+        CIx1: ColumnIndexer<usize>,
+        CIx2: ColumnIndexer<usize>,
         Env1: ColAccessCap<F, CIx1>,
         L: MPrism<Source = CIx1, Target = CIx2>,
     > ColAccessCap<F, CIx2> for SubEnv<'a, F, CIx1, Env1, L>
@@ -230,8 +238,8 @@ impl<
 impl<
         'a,
         F: PrimeField,
-        CIx1: ColumnIndexer,
-        CIx2: ColumnIndexer,
+        CIx1: ColumnIndexer<usize>,
+        CIx2: ColumnIndexer<usize>,
         Env1: ColWriteCap<F, CIx1>,
         L: MPrism<Source = CIx1, Target = CIx2>,
     > ColWriteCap<F, CIx2> for SubEnv<'a, F, CIx1, Env1, L>
@@ -244,8 +252,8 @@ impl<
 impl<
         'a,
         F: PrimeField,
-        CIx1: ColumnIndexer,
-        CIx2: ColumnIndexer,
+        CIx1: ColumnIndexer<usize>,
+        CIx2: ColumnIndexer<usize>,
         Env1: HybridCopyCap<F, CIx1>,
         L: MPrism<Source = CIx1, Target = CIx2>,
     > HybridCopyCap<F, CIx2> for SubEnv<'a, F, CIx1, Env1, L>
@@ -258,8 +266,8 @@ impl<
 impl<
         'a,
         F: PrimeField,
-        CIx1: ColumnIndexer,
-        CIx2: ColumnIndexer,
+        CIx1: ColumnIndexer<usize>,
+        CIx2: ColumnIndexer<usize>,
         Env1: ColAccessCap<F, CIx1>,
         L: MPrism<Source = CIx1, Target = CIx2>,
     > ColAccessCap<F, CIx2> for SubEnvColumn<'a, F, CIx1, Env1, L>
@@ -286,8 +294,8 @@ impl<
 impl<
         'a,
         F: PrimeField,
-        CIx1: ColumnIndexer,
-        CIx2: ColumnIndexer,
+        CIx1: ColumnIndexer<usize>,
+        CIx2: ColumnIndexer<usize>,
         Env1: ColWriteCap<F, CIx1>,
         L: MPrism<Source = CIx1, Target = CIx2>,
     > ColWriteCap<F, CIx2> for SubEnvColumn<'a, F, CIx1, Env1, L>
@@ -300,8 +308,8 @@ impl<
 impl<
         'a,
         F: PrimeField,
-        CIx1: ColumnIndexer,
-        CIx2: ColumnIndexer,
+        CIx1: ColumnIndexer<usize>,
+        CIx2: ColumnIndexer<usize>,
         Env1: HybridCopyCap<F, CIx1>,
         L: MPrism<Source = CIx1, Target = CIx2>,
     > HybridCopyCap<F, CIx2> for SubEnvColumn<'a, F, CIx1, Env1, L>
@@ -311,8 +319,8 @@ impl<
     }
 }
 
-impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L> ColAccessCap<F, CIx1>
-    for SubEnvLookup<'a, F, CIx1, Env1, L>
+impl<'a, F: PrimeField, CIx1: ColumnIndexer<usize>, Env1: ColAccessCap<F, CIx1>, L>
+    ColAccessCap<F, CIx1> for SubEnvLookup<'a, F, CIx1, Env1, L>
 {
     type Variable = Env1::Variable;
 
@@ -333,16 +341,16 @@ impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L> Col
     }
 }
 
-impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColWriteCap<F, CIx1>, L> ColWriteCap<F, CIx1>
-    for SubEnvLookup<'a, F, CIx1, Env1, L>
+impl<'a, F: PrimeField, CIx1: ColumnIndexer<usize>, Env1: ColWriteCap<F, CIx1>, L>
+    ColWriteCap<F, CIx1> for SubEnvLookup<'a, F, CIx1, Env1, L>
 {
     fn write_column(&mut self, ix: CIx1, value: &Self::Variable) {
         self.0.env.write_column(ix, value);
     }
 }
 
-impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: HybridCopyCap<F, CIx1>, L> HybridCopyCap<F, CIx1>
-    for SubEnvLookup<'a, F, CIx1, Env1, L>
+impl<'a, F: PrimeField, CIx1: ColumnIndexer<usize>, Env1: HybridCopyCap<F, CIx1>, L>
+    HybridCopyCap<F, CIx1> for SubEnvLookup<'a, F, CIx1, Env1, L>
 {
     fn hcopy(&mut self, x: &Self::Variable, ix: CIx1) -> Self::Variable {
         self.0.env.hcopy(x, ix)
@@ -352,7 +360,7 @@ impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: HybridCopyCap<F, CIx1>, L> Hy
 impl<
         'a,
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         LT1: LookupTableID,
         LT2: LookupTableID,
         Env1: LookupCap<F, CIx, LT1>,
@@ -373,8 +381,8 @@ impl<
 impl<
         'a,
         F: PrimeField,
-        CIx1: ColumnIndexer,
-        CIx2: ColumnIndexer,
+        CIx1: ColumnIndexer<usize>,
+        CIx2: ColumnIndexer<usize>,
         LT: LookupTableID,
         Env1: LookupCap<F, CIx1, LT>,
         L: MPrism<Source = CIx1, Target = CIx2>,
@@ -389,7 +397,7 @@ impl<
     }
 }
 
-impl<'a, F: PrimeField, CIx: ColumnIndexer, Env1: MultiRowReadCap<F, CIx>, L>
+impl<'a, F: PrimeField, CIx: ColumnIndexer<usize>, Env1: MultiRowReadCap<F, CIx>, L>
     MultiRowReadCap<F, CIx> for SubEnvLookup<'a, F, CIx, Env1, L>
 {
     /// Read value from a (row,column) position.
@@ -408,7 +416,7 @@ impl<'a, F: PrimeField, CIx: ColumnIndexer, Env1: MultiRowReadCap<F, CIx>, L>
     }
 }
 
-impl<'a, F: PrimeField, CIx: ColumnIndexer, Env1: DirectWitnessCap<F, CIx>, L>
+impl<'a, F: PrimeField, CIx: ColumnIndexer<usize>, Env1: DirectWitnessCap<F, CIx>, L>
     DirectWitnessCap<F, CIx> for SubEnvLookup<'a, F, CIx, Env1, L>
 {
     fn variable_to_field(value: Self::Variable) -> F {

--- a/msm/src/circuit_design/constraints.rs
+++ b/msm/src/circuit_design/constraints.rs
@@ -35,7 +35,7 @@ impl<F: PrimeField, LT: LookupTableID> ConstraintBuilderEnv<F, LT> {
     }
 }
 
-impl<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> ColAccessCap<F, CIx>
+impl<F: PrimeField, CIx: ColumnIndexer<usize>, LT: LookupTableID> ColAccessCap<F, CIx>
     for ConstraintBuilderEnv<F, LT>
 {
     type Variable = E<F>;
@@ -61,7 +61,7 @@ impl<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> ColAccessCap<F, CIx>
     }
 }
 
-impl<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> HybridCopyCap<F, CIx>
+impl<F: PrimeField, CIx: ColumnIndexer<usize>, LT: LookupTableID> HybridCopyCap<F, CIx>
     for ConstraintBuilderEnv<F, LT>
 {
     fn hcopy(&mut self, x: &Self::Variable, position: CIx) -> Self::Variable {
@@ -77,7 +77,7 @@ impl<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> HybridCopyCap<F, CIx>
     }
 }
 
-impl<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> LookupCap<F, CIx, LT>
+impl<F: PrimeField, CIx: ColumnIndexer<usize>, LT: LookupTableID> LookupCap<F, CIx, LT>
     for ConstraintBuilderEnv<F, LT>
 {
     fn lookup(&mut self, table_id: LT, value: Vec<<Self as ColAccessCap<F, CIx>>::Variable>) {

--- a/msm/src/circuit_design/constraints.rs
+++ b/msm/src/circuit_design/constraints.rs
@@ -15,7 +15,7 @@ use crate::{
 
 pub struct ConstraintBuilderEnv<F: PrimeField, LT: LookupTableID> {
     /// An indexed set of constraints.
-    pub constraints: Vec<Expr<ConstantExpr<F, BerkeleyChallengeTerm>, Column>>,
+    pub constraints: Vec<Expr<ConstantExpr<F, BerkeleyChallengeTerm>, Column<usize>>>,
     /// Aggregated lookups or "reads".
     pub lookup_reads: BTreeMap<LT, Vec<Vec<E<F>>>>,
     /// Aggregated "write" lookups, for runtime tables.

--- a/msm/src/circuit_design/witness.rs
+++ b/msm/src/circuit_design/witness.rs
@@ -284,7 +284,7 @@ impl<
         LT: LookupTableID,
     > WitnessBuilderEnv<F, CIx, N_WIT, N_REL, N_DSEL, N_FSEL, LT>
 {
-    pub fn write_column_raw(&mut self, position: Column, value: F) {
+    pub fn write_column_raw(&mut self, position: Column<usize>, value: F) {
         match position {
             Column::Relation(i) => self.witness.last_mut().unwrap().cols[i] = value,
             Column::FixedSelector(_) => {

--- a/msm/src/circuit_design/witness.rs
+++ b/msm/src/circuit_design/witness.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, iter, marker::PhantomData};
 /// separately is due to a rust limitation.
 pub struct WitnessBuilderEnv<
     F: PrimeField,
-    CIx: ColumnIndexer,
+    CIx: ColumnIndexer<usize>,
     const N_WIT: usize,
     const N_REL: usize,
     const N_DSEL: usize,
@@ -68,7 +68,7 @@ pub struct WitnessBuilderEnv<
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -103,7 +103,7 @@ impl<
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -124,7 +124,7 @@ impl<
 /// for every `T: ColWriteCap`.
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -142,7 +142,7 @@ impl<
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -171,7 +171,7 @@ impl<
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -187,7 +187,7 @@ impl<
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -276,7 +276,7 @@ impl<
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -421,7 +421,7 @@ impl<
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,

--- a/msm/src/column_env.rs
+++ b/msm/src/column_env.rs
@@ -54,7 +54,7 @@ impl<
     > TColumnEnvironment<'a, F, BerkeleyChallengeTerm, BerkeleyChallenges<F>>
     for ColumnEnvironment<'a, N_WIT, N_REL, N_DSEL, N_FSEL, F, ID>
 {
-    type Column = crate::columns::Column;
+    type Column = crate::columns::Column<usize>;
 
     fn get_column(
         &self,

--- a/msm/src/columns.rs
+++ b/msm/src/columns.rs
@@ -5,9 +5,9 @@ use kimchi::circuits::expr::{CacheId, FormattedOutput};
 
 /// Describe a generic indexed variable X_{i}.
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
-pub enum Column {
+pub enum Column<T> {
     /// Columns related to the relation encoded in the circuit
-    Relation(usize),
+    Relation(T),
     /// Columns related to dynamic selectors to indicate gate type
     DynamicSelector(usize),
     /// Constant column that is /always/ fixed for a given circuit.
@@ -25,9 +25,9 @@ pub enum Column {
     LookupFixedTable(u32),
 }
 
-impl Column {
+impl Column<usize> {
     /// Adds offset if the column is `Relation`. Fails otherwise.
-    pub fn add_rel_offset(self, offset: usize) -> Column {
+    pub fn add_rel_offset(self, offset: usize) -> Column<usize> {
         let Column::Relation(i) = self else {
             todo!("add_rel_offset is only implemented for the relation columns")
         };
@@ -35,7 +35,7 @@ impl Column {
     }
 }
 
-impl FormattedOutput for Column {
+impl FormattedOutput for Column<usize> {
     fn latex(&self, _cache: &mut HashMap<CacheId, Self>) -> String {
         match self {
             Column::Relation(i) => format!("x_{{{i}}}"),
@@ -78,12 +78,12 @@ pub trait ColumnIndexer: core::fmt::Debug + Copy + Eq + Ord {
     const N_COL: usize;
 
     /// Flatten the column "alias" into the integer-like column.
-    fn to_column(self) -> Column;
+    fn to_column(self) -> Column<usize>;
 }
 
 // Implementation to be compatible with folding if we use generic column
 // constraints
-impl FoldingColumnTrait for Column {
+impl<T: Copy> FoldingColumnTrait for Column<T> {
     fn is_witness(&self) -> bool {
         match self {
             // Witness

--- a/msm/src/columns.rs
+++ b/msm/src/columns.rs
@@ -73,12 +73,12 @@ impl FormattedOutput for Column<usize> {
 
 /// A datatype expressing a generalized column, but with potentially
 /// more convenient interface than a bare column.
-pub trait ColumnIndexer: core::fmt::Debug + Copy + Eq + Ord {
+pub trait ColumnIndexer<T>: core::fmt::Debug + Copy + Eq + Ord {
     /// Total number of columns in this index.
     const N_COL: usize;
 
     /// Flatten the column "alias" into the integer-like column.
-    fn to_column(self) -> Column<usize>;
+    fn to_column(self) -> Column<T>;
 }
 
 // Implementation to be compatible with folding if we use generic column

--- a/msm/src/expr.rs
+++ b/msm/src/expr.rs
@@ -48,16 +48,16 @@ use crate::columns::Column;
 /// ```
 /// A list of such constraints is used to represent the entire circuit and will
 /// be used to build the quotient polynomial.
-pub type E<F> = Expr<ConstantExpr<F, BerkeleyChallengeTerm>, Column>;
+pub type E<F> = Expr<ConstantExpr<F, BerkeleyChallengeTerm>, Column<usize>>;
 
-pub fn curr_cell<F: Field>(col: Column) -> E<F> {
+pub fn curr_cell<F: Field>(col: Column<usize>) -> E<F> {
     E::Atom(ExprInner::Cell(Variable {
         col,
         row: CurrOrNext::Curr,
     }))
 }
 
-pub fn next_cell<F: Field>(col: Column) -> E<F> {
+pub fn next_cell<F: Field>(col: Column<usize>) -> E<F> {
     E::Atom(ExprInner::Cell(Variable {
         col,
         row: CurrOrNext::Next,

--- a/msm/src/expr.rs
+++ b/msm/src/expr.rs
@@ -23,9 +23,10 @@ use crate::columns::Column;
 /// use kimchi::circuits::expr::{ConstantExprInner, ExprInner, Operations, Variable};
 /// use kimchi::circuits::gate::CurrOrNext;
 /// use kimchi::circuits::berkeley_columns::BerkeleyChallengeTerm;
-/// use kimchi_msm::columns::Column;
+/// use kimchi_msm::columns::{Column as GenericColumn};
 /// use kimchi_msm::expr::E;
 /// pub type Fp = ark_bn254::Fr;
+/// pub type Column = GenericColumn<usize>;
 /// let x1 = E::<Fp>::Atom(
 ///     ExprInner::<Operations<ConstantExprInner<Fp, BerkeleyChallengeTerm>>, Column>::Cell(Variable {
 ///         col: Column::Relation(1),

--- a/msm/src/fec/columns.rs
+++ b/msm/src/fec/columns.rs
@@ -53,7 +53,7 @@ pub enum FECColumn {
 
 impl ColumnIndexer for FECColumnInput {
     const N_COL: usize = 4 * N_LIMBS_LARGE;
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         match self {
             FECColumnInput::XP(i) => {
                 assert!(i < N_LIMBS_LARGE);
@@ -77,7 +77,7 @@ impl ColumnIndexer for FECColumnInput {
 
 impl ColumnIndexer for FECColumnOutput {
     const N_COL: usize = 2 * N_LIMBS_SMALL;
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         match self {
             FECColumnOutput::XR(i) => {
                 assert!(i < N_LIMBS_SMALL);
@@ -93,7 +93,7 @@ impl ColumnIndexer for FECColumnOutput {
 
 impl ColumnIndexer for FECColumnInter {
     const N_COL: usize = 4 * N_LIMBS_LARGE + 10 * N_LIMBS_SMALL + 9;
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         match self {
             FECColumnInter::F(i) => {
                 assert!(i < N_LIMBS_LARGE);
@@ -148,7 +148,7 @@ impl ColumnIndexer for FECColumnInter {
 
 impl ColumnIndexer for FECColumn {
     const N_COL: usize = FEC_N_COLUMNS;
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         match self {
             FECColumn::Input(input) => input.to_column(),
             FECColumn::Inter(inter) => inter.to_column().add_rel_offset(FECColumnInput::N_COL),

--- a/msm/src/fec/columns.rs
+++ b/msm/src/fec/columns.rs
@@ -51,7 +51,7 @@ pub enum FECColumn {
     Inter(FECColumnInter),
 }
 
-impl ColumnIndexer for FECColumnInput {
+impl ColumnIndexer<usize> for FECColumnInput {
     const N_COL: usize = 4 * N_LIMBS_LARGE;
     fn to_column(self) -> Column<usize> {
         match self {
@@ -75,7 +75,7 @@ impl ColumnIndexer for FECColumnInput {
     }
 }
 
-impl ColumnIndexer for FECColumnOutput {
+impl ColumnIndexer<usize> for FECColumnOutput {
     const N_COL: usize = 2 * N_LIMBS_SMALL;
     fn to_column(self) -> Column<usize> {
         match self {
@@ -91,7 +91,7 @@ impl ColumnIndexer for FECColumnOutput {
     }
 }
 
-impl ColumnIndexer for FECColumnInter {
+impl ColumnIndexer<usize> for FECColumnInter {
     const N_COL: usize = 4 * N_LIMBS_LARGE + 10 * N_LIMBS_SMALL + 9;
     fn to_column(self) -> Column<usize> {
         match self {
@@ -146,7 +146,7 @@ impl ColumnIndexer for FECColumnInter {
     }
 }
 
-impl ColumnIndexer for FECColumn {
+impl ColumnIndexer<usize> for FECColumn {
     const N_COL: usize = FEC_N_COLUMNS;
     fn to_column(self) -> Column<usize> {
         match self {

--- a/msm/src/fec/mod.rs
+++ b/msm/src/fec/mod.rs
@@ -27,8 +27,8 @@ mod tests {
     type FECWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         FECColumn,
-        { <FECColumn as ColumnIndexer>::N_COL },
-        { <FECColumn as ColumnIndexer>::N_COL },
+        { <FECColumn as ColumnIndexer<usize>>::N_COL },
+        { <FECColumn as ColumnIndexer<usize>>::N_COL },
         0,
         0,
         LookupTable<Ff1>,

--- a/msm/src/ffa/columns.rs
+++ b/msm/src/ffa/columns.rs
@@ -22,7 +22,7 @@ pub enum FFAColumn {
 
 impl ColumnIndexer for FFAColumn {
     const N_COL: usize = FFA_N_COLUMNS;
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         let to_column_inner = |offset, i| {
             assert!(i < N_LIMBS);
             Column::Relation(N_LIMBS * offset + i)

--- a/msm/src/ffa/columns.rs
+++ b/msm/src/ffa/columns.rs
@@ -20,7 +20,7 @@ pub enum FFAColumn {
     Quotient,
 }
 
-impl ColumnIndexer for FFAColumn {
+impl ColumnIndexer<usize> for FFAColumn {
     const N_COL: usize = FFA_N_COLUMNS;
     fn to_column(self) -> Column<usize> {
         let to_column_inner = |offset, i| {

--- a/msm/src/ffa/mod.rs
+++ b/msm/src/ffa/mod.rs
@@ -23,8 +23,8 @@ mod tests {
     type FFAWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         FFAColumn,
-        { <FFAColumn as ColumnIndexer>::N_COL },
-        { <FFAColumn as ColumnIndexer>::N_COL },
+        { <FFAColumn as ColumnIndexer<usize>>::N_COL },
+        { <FFAColumn as ColumnIndexer<usize>>::N_COL },
         0,
         0,
         LookupTable,
@@ -86,8 +86,8 @@ mod tests {
         let proof_inputs = witness_env.get_proof_inputs(domain_size, lookup_tables_data);
 
         crate::test::test_completeness_generic::<
-            { <FFAColumn as ColumnIndexer>::N_COL },
-            { <FFAColumn as ColumnIndexer>::N_COL },
+            { <FFAColumn as ColumnIndexer<usize>>::N_COL },
+            { <FFAColumn as ColumnIndexer<usize>>::N_COL },
             0,
             0,
             LookupTable,

--- a/msm/src/logup.rs
+++ b/msm/src/logup.rs
@@ -349,7 +349,7 @@ impl<'lt, G, ID: LookupTableID> IntoIterator for &'lt LookupProof<G, ID> {
 /// h(X) * (β + t(X)) * (β + f(X)) = (β + t(X)) + m(X) * (β + f(X))
 /// ```
 pub fn combine_lookups<F: PrimeField, ID: LookupTableID>(
-    column: Column,
+    column: Column<usize>,
     lookups: Vec<Logup<E<F>, ID>>,
 ) -> E<F> {
     let joint_combiner = {
@@ -419,7 +419,7 @@ pub fn constraint_lookups<F: PrimeField, ID: LookupTableID>(
     lookup_writes: &BTreeMap<ID, Vec<Vec<E<F>>>>,
 ) -> Vec<E<F>> {
     let mut constraints: Vec<E<F>> = vec![];
-    let mut lookup_terms_cols: Vec<Column> = vec![];
+    let mut lookup_terms_cols: Vec<Column<usize>> = vec![];
     lookup_reads.iter().for_each(|(table_id, reads)| {
         let mut idx_partial_sum = 0;
         let table_id_u32 = table_id.to_u32();

--- a/msm/src/proof.rs
+++ b/msm/src/proof.rs
@@ -95,7 +95,7 @@ impl<
         ID: LookupTableID,
     > ColumnEvaluations<F> for ProofEvaluations<N_WIT, N_REL, N_DSEL, N_FSEL, F, ID>
 {
-    type Column = crate::columns::Column;
+    type Column = crate::columns::Column<usize>;
 
     fn evaluate(&self, col: Self::Column) -> Result<PointEvaluations<F>, ExprError<Self::Column>> {
         // TODO: substitute when non-literal generic constants are available

--- a/msm/src/serialization/column.rs
+++ b/msm/src/serialization/column.rs
@@ -42,7 +42,7 @@ pub enum SerializationColumn {
 
 impl ColumnIndexer for SerializationColumn {
     const N_COL: usize = N_COL_SER;
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         match self {
             Self::CurrentRow => Column::FixedSelector(0),
             Self::PreviousCoeffRow => Column::FixedSelector(1),

--- a/msm/src/serialization/column.rs
+++ b/msm/src/serialization/column.rs
@@ -40,7 +40,7 @@ pub enum SerializationColumn {
     CoeffResult(usize),
 }
 
-impl ColumnIndexer for SerializationColumn {
+impl ColumnIndexer<usize> for SerializationColumn {
     const N_COL: usize = N_COL_SER;
     fn to_column(self) -> Column<usize> {
         match self {

--- a/msm/src/serialization/interpreter.rs
+++ b/msm/src/serialization/interpreter.rs
@@ -26,7 +26,7 @@ use o1_utils::{field_helpers::FieldHelpers, foreign_field::ForeignElement};
 
 // Such "helpers" defeat the whole purpose of the interpreter.
 // TODO remove
-pub trait HybridSerHelpers<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> {
+pub trait HybridSerHelpers<F: PrimeField, CIx: ColumnIndexer<usize>, LT: LookupTableID> {
     /// Returns the bits between [highest_bit, lowest_bit] of the variable `x`,
     /// and copy the result in the column `position`.
     /// The value `x` is expected to be encoded in big-endian
@@ -41,7 +41,7 @@ pub trait HybridSerHelpers<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID>
         Self: ColAccessCap<F, CIx>;
 }
 
-impl<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> HybridSerHelpers<F, CIx, LT>
+impl<F: PrimeField, CIx: ColumnIndexer<usize>, LT: LookupTableID> HybridSerHelpers<F, CIx, LT>
     for crate::circuit_design::ConstraintBuilderEnv<F, LT>
 {
     fn bitmask_be(
@@ -62,7 +62,7 @@ impl<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> HybridSerHelpers<F, C
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_COL: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -350,7 +350,11 @@ pub fn combine_limbs_m_to_n<
 /// Helper function for limb recombination.
 ///
 /// Combines small limbs into big limbs.
-pub fn combine_small_to_large<F: PrimeField, CIx: ColumnIndexer, Env: ColAccessCap<F, CIx>>(
+pub fn combine_small_to_large<
+    F: PrimeField,
+    CIx: ColumnIndexer<usize>,
+    Env: ColAccessCap<F, CIx>,
+>(
     x: [Env::Variable; N_LIMBS_SMALL],
 ) -> [Env::Variable; N_LIMBS_LARGE] {
     combine_limbs_m_to_n::<
@@ -367,7 +371,7 @@ pub fn combine_small_to_large<F: PrimeField, CIx: ColumnIndexer, Env: ColAccessC
 /// Helper function for limb recombination for carry specifically.
 /// Each big carry limb is stored as 6 (not 5!) small elements. We
 /// accept 36 small limbs, and return 6 large ones.
-pub fn combine_carry<F: PrimeField, CIx: ColumnIndexer, Env: ColAccessCap<F, CIx>>(
+pub fn combine_carry<F: PrimeField, CIx: ColumnIndexer<usize>, Env: ColAccessCap<F, CIx>>(
     x: [Env::Variable; 2 * N_LIMBS_SMALL + 2],
 ) -> [Env::Variable; 2 * N_LIMBS_LARGE - 2] {
     let constant_u128 = |x: u128| Env::constant(From::from(x));
@@ -816,8 +820,8 @@ mod tests {
     type SerializationWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         SerializationColumn,
-        { <SerializationColumn as ColumnIndexer>::N_COL },
-        { <SerializationColumn as ColumnIndexer>::N_COL },
+        { <SerializationColumn as ColumnIndexer<usize>>::N_COL },
+        { <SerializationColumn as ColumnIndexer<usize>>::N_COL },
         0,
         0,
         LookupTable<Ff1>,

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -28,8 +28,8 @@ mod tests {
     type SerializationWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         SerializationColumn,
-        { <SerializationColumn as ColumnIndexer>::N_COL - N_FSEL_SER },
-        { <SerializationColumn as ColumnIndexer>::N_COL - N_FSEL_SER },
+        { <SerializationColumn as ColumnIndexer<usize>>::N_COL - N_FSEL_SER },
+        { <SerializationColumn as ColumnIndexer<usize>>::N_COL - N_FSEL_SER },
         0,
         N_FSEL_SER,
         LookupTable<Ff1>,

--- a/msm/src/test/test_circuit/columns.rs
+++ b/msm/src/test/test_circuit/columns.rs
@@ -23,7 +23,7 @@ pub enum TestColumn {
 
 impl ColumnIndexer for TestColumn {
     const N_COL: usize = N_COL_TEST;
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         let to_column_inner = |offset, i| {
             assert!(i < N_LIMBS);
             Column::Relation(N_LIMBS * offset + i)

--- a/msm/src/test/test_circuit/columns.rs
+++ b/msm/src/test/test_circuit/columns.rs
@@ -21,7 +21,7 @@ pub enum TestColumn {
     FixedSel3,
 }
 
-impl ColumnIndexer for TestColumn {
+impl ColumnIndexer<usize> for TestColumn {
     const N_COL: usize = N_COL_TEST;
     fn to_column(self) -> Column<usize> {
         let to_column_inner = |offset, i| {

--- a/o1vm/src/interpreters/keccak/column.rs
+++ b/o1vm/src/interpreters/keccak/column.rs
@@ -1,7 +1,10 @@
 //! This module defines the custom columns used in the Keccak witness, which
 //! are aliases for the actual Keccak witness columns also defined here.
 use self::{Absorbs::*, Sponges::*, Steps::*};
-use crate::interpreters::keccak::{ZKVM_KECCAK_COLS_CURR, ZKVM_KECCAK_COLS_NEXT};
+use crate::{
+    interpreters::keccak::{ZKVM_KECCAK_COLS_CURR, ZKVM_KECCAK_COLS_NEXT},
+    RelationColumnType,
+};
 use kimchi::circuits::polynomials::keccak::constants::{
     CHI_SHIFTS_B_LEN, CHI_SHIFTS_B_OFF, CHI_SHIFTS_SUM_LEN, CHI_SHIFTS_SUM_OFF, PIRHO_DENSE_E_LEN,
     PIRHO_DENSE_E_OFF, PIRHO_DENSE_ROT_E_LEN, PIRHO_DENSE_ROT_E_OFF, PIRHO_EXPAND_ROT_E_LEN,
@@ -373,10 +376,10 @@ impl<T: Clone> IndexMut<ColumnAlias> for KeccakWitness<T> {
     }
 }
 
-impl ColumnIndexer<usize> for ColumnAlias {
+impl ColumnIndexer<RelationColumnType> for ColumnAlias {
     const N_COL: usize = N_ZKVM_KECCAK_REL_COLS + N_ZKVM_KECCAK_SEL_COLS;
-    fn to_column(self) -> Column<usize> {
-        Column::Relation(usize::from(self))
+    fn to_column(self) -> Column<RelationColumnType> {
+        Column::Relation(RelationColumnType::Scratch(usize::from(self)))
     }
 }
 

--- a/o1vm/src/interpreters/keccak/column.rs
+++ b/o1vm/src/interpreters/keccak/column.rs
@@ -373,7 +373,7 @@ impl<T: Clone> IndexMut<ColumnAlias> for KeccakWitness<T> {
     }
 }
 
-impl ColumnIndexer for ColumnAlias {
+impl ColumnIndexer<usize> for ColumnAlias {
     const N_COL: usize = N_ZKVM_KECCAK_REL_COLS + N_ZKVM_KECCAK_SEL_COLS;
     fn to_column(self) -> Column<usize> {
         Column::Relation(usize::from(self))
@@ -401,7 +401,7 @@ impl<T: Clone> IndexMut<Steps> for KeccakWitness<T> {
     }
 }
 
-impl ColumnIndexer for Steps {
+impl ColumnIndexer<usize> for Steps {
     const N_COL: usize = N_ZKVM_KECCAK_REL_COLS + N_ZKVM_KECCAK_SEL_COLS;
     fn to_column(self) -> Column<usize> {
         Column::DynamicSelector(usize::from(self) - N_ZKVM_KECCAK_REL_COLS)

--- a/o1vm/src/interpreters/keccak/column.rs
+++ b/o1vm/src/interpreters/keccak/column.rs
@@ -375,7 +375,7 @@ impl<T: Clone> IndexMut<ColumnAlias> for KeccakWitness<T> {
 
 impl ColumnIndexer for ColumnAlias {
     const N_COL: usize = N_ZKVM_KECCAK_REL_COLS + N_ZKVM_KECCAK_SEL_COLS;
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         Column::Relation(usize::from(self))
     }
 }
@@ -403,7 +403,7 @@ impl<T: Clone> IndexMut<Steps> for KeccakWitness<T> {
 
 impl ColumnIndexer for Steps {
     const N_COL: usize = N_ZKVM_KECCAK_REL_COLS + N_ZKVM_KECCAK_SEL_COLS;
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         Column::DynamicSelector(usize::from(self) - N_ZKVM_KECCAK_REL_COLS)
     }
 }

--- a/o1vm/src/interpreters/mips/column.rs
+++ b/o1vm/src/interpreters/mips/column.rs
@@ -143,7 +143,7 @@ impl<T: Clone> IndexMut<ColumnAlias> for MIPSWitness<T> {
     }
 }
 
-impl ColumnIndexer for ColumnAlias {
+impl ColumnIndexer<usize> for ColumnAlias {
     const N_COL: usize = N_MIPS_COLS;
 
     fn to_column(self) -> Column<usize> {
@@ -198,7 +198,7 @@ impl<T: Clone> IndexMut<Instruction> for MIPSWitness<T> {
     }
 }
 
-impl ColumnIndexer for Instruction {
+impl ColumnIndexer<usize> for Instruction {
     const N_COL: usize = N_MIPS_REL_COLS + N_MIPS_SEL_COLS;
     fn to_column(self) -> Column<usize> {
         Column::DynamicSelector(usize::from(self) - N_MIPS_REL_COLS)

--- a/o1vm/src/interpreters/mips/column.rs
+++ b/o1vm/src/interpreters/mips/column.rs
@@ -146,7 +146,7 @@ impl<T: Clone> IndexMut<ColumnAlias> for MIPSWitness<T> {
 impl ColumnIndexer for ColumnAlias {
     const N_COL: usize = N_MIPS_COLS;
 
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         match self {
             Self::ScratchState(ss) => {
                 assert!(
@@ -200,7 +200,7 @@ impl<T: Clone> IndexMut<Instruction> for MIPSWitness<T> {
 
 impl ColumnIndexer for Instruction {
     const N_COL: usize = N_MIPS_REL_COLS + N_MIPS_SEL_COLS;
-    fn to_column(self) -> Column {
+    fn to_column(self) -> Column<usize> {
         Column::DynamicSelector(usize::from(self) - N_MIPS_REL_COLS)
     }
 }

--- a/o1vm/src/interpreters/mips/column.rs
+++ b/o1vm/src/interpreters/mips/column.rs
@@ -1,4 +1,7 @@
-use crate::interpreters::mips::Instruction::{self, IType, JType, RType};
+use crate::{
+    interpreters::mips::Instruction::{self, IType, JType, RType},
+    RelationColumnType,
+};
 use kimchi_msm::{
     columns::{Column, ColumnIndexer},
     witness::Witness,
@@ -143,10 +146,10 @@ impl<T: Clone> IndexMut<ColumnAlias> for MIPSWitness<T> {
     }
 }
 
-impl ColumnIndexer<usize> for ColumnAlias {
+impl ColumnIndexer<RelationColumnType> for ColumnAlias {
     const N_COL: usize = N_MIPS_COLS;
 
-    fn to_column(self) -> Column<usize> {
+    fn to_column(self) -> Column<RelationColumnType> {
         match self {
             Self::ScratchState(ss) => {
                 assert!(
@@ -155,7 +158,7 @@ impl ColumnIndexer<usize> for ColumnAlias {
                     SCRATCH_SIZE,
                     ss
                 );
-                Column::Relation(ss)
+                Column::Relation(RelationColumnType::Scratch(ss))
             }
             Self::ScratchStateInverse(ss) => {
                 assert!(
@@ -164,9 +167,9 @@ impl ColumnIndexer<usize> for ColumnAlias {
                     SCRATCH_SIZE_INVERSE,
                     ss
                 );
-                Column::Relation(SCRATCH_SIZE + ss)
+                Column::Relation(RelationColumnType::ScratchInverse(ss))
             }
-            Self::InstructionCounter => Column::Relation(SCRATCH_SIZE + SCRATCH_SIZE_INVERSE),
+            Self::InstructionCounter => Column::Relation(RelationColumnType::InstructionCounter),
             // TODO: what happens with error? It does not have a corresponding alias
             Self::Selector(s) => {
                 assert!(

--- a/o1vm/src/interpreters/mips/tests_helpers.rs
+++ b/o1vm/src/interpreters/mips/tests_helpers.rs
@@ -92,6 +92,8 @@ where
         scratch_state_idx_inverse: 0,
         scratch_state: [Fp::from(0); SCRATCH_SIZE],
         scratch_state_inverse: [Fp::from(0); SCRATCH_SIZE_INVERSE],
+        lookup_state_idx: 0,
+        lookup_state: vec![],
         lookup_multiplicities: LookupMultiplicities::new(),
         selector: crate::interpreters::mips::column::N_MIPS_SEL_COLS,
         halt: false,

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -92,6 +92,8 @@ pub struct Env<Fp, PreImageOracle: PreImageOracleT> {
     pub scratch_state_idx_inverse: usize,
     pub scratch_state: [Fp; SCRATCH_SIZE],
     pub scratch_state_inverse: [Fp; SCRATCH_SIZE_INVERSE],
+    pub lookup_state_idx: usize,
+    pub lookup_state: Vec<u64>,
     pub halt: bool,
     pub syscall_env: SyscallEnv,
     pub selector: usize,
@@ -915,6 +917,8 @@ impl<Fp: PrimeField, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
             scratch_state_idx_inverse: 0,
             scratch_state: fresh_scratch_state(),
             scratch_state_inverse: fresh_scratch_state(),
+            lookup_state_idx: 0,
+            lookup_state: vec![],
             halt: state.exited,
             syscall_env,
             selector,
@@ -945,6 +949,11 @@ impl<Fp: PrimeField, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
     pub fn reset_scratch_state_inverse(&mut self) {
         self.scratch_state_idx_inverse = 0;
         self.scratch_state_inverse = fresh_scratch_state();
+    }
+
+    pub fn reset_lookup_state(&mut self) {
+        self.lookup_state_idx = 0;
+        self.lookup_state = vec![];
     }
 
     pub fn write_column(&mut self, column: Column, value: u64) {
@@ -1190,6 +1199,7 @@ impl<Fp: PrimeField, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
     ) -> Instruction {
         self.reset_scratch_state();
         self.reset_scratch_state_inverse();
+        self.reset_lookup_state();
         let (opcode, _instruction) = self.decode_instruction();
 
         self.pp_info(&config.info_at, metadata, start);

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -199,7 +199,7 @@ impl<Fp: PrimeField, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp,
         add_value(Fp::from(table_id.to_u32()));
         // Add values
         for value in values.iter() {
-            add_value(Fp::from(*value));
+            add_value(*value);
         }
 
         if let Some(idx) = table_id.ix_by_value(values.as_slice()) {

--- a/o1vm/src/lib.rs
+++ b/o1vm/src/lib.rs
@@ -43,4 +43,4 @@ pub use ramlookup::{LookupMode as RAMLookupMode, RAMLookup};
 /// `P(X, Y, Z) = q_x X + q_y Y + q_m X Y + q_o Z + q_c`
 /// To represent this multi-variate polynomial using the expression framework,
 /// we would use 3 different columns.
-pub(crate) type E<F> = Expr<ConstantExpr<F, BerkeleyChallengeTerm>, Column>;
+pub(crate) type E<F> = Expr<ConstantExpr<F, BerkeleyChallengeTerm>, Column<usize>>;

--- a/o1vm/src/lib.rs
+++ b/o1vm/src/lib.rs
@@ -24,6 +24,7 @@ pub mod utils;
 
 pub mod test_preimage_read;
 
+use crate::pickles::column_env::RelationColumnType;
 use kimchi::circuits::{
     berkeley_columns::BerkeleyChallengeTerm,
     expr::{ConstantExpr, Expr},
@@ -43,4 +44,4 @@ pub use ramlookup::{LookupMode as RAMLookupMode, RAMLookup};
 /// `P(X, Y, Z) = q_x X + q_y Y + q_m X Y + q_o Z + q_c`
 /// To represent this multi-variate polynomial using the expression framework,
 /// we would use 3 different columns.
-pub(crate) type E<F> = Expr<ConstantExpr<F, BerkeleyChallengeTerm>, Column<usize>>;
+pub(crate) type E<F> = Expr<ConstantExpr<F, BerkeleyChallengeTerm>, Column<RelationColumnType>>;

--- a/o1vm/src/pickles/column_env.rs
+++ b/o1vm/src/pickles/column_env.rs
@@ -18,6 +18,7 @@ type Evals<F> = Evaluations<F, Radix2EvaluationDomain<F>>;
 pub enum RelationColumnType {
     Scratch(usize),
     ScratchInverse(usize),
+    LookupState(usize),
     InstructionCounter,
     Error,
 }
@@ -66,7 +67,10 @@ impl<G> WitnessColumns<G, [G; N_MIPS_SEL_COLS]> {
         match *col {
             Column::Relation(i) => match i {
                 RelationColumnType::Scratch(i) => Some(&self.scratch[i]),
-                RelationColumnType::ScratchInverse(i) => Some(&self.scratch_inverse[i]),
+                RelationColumnType::ScratchInverse(i) => {
+                    Some(&self.scratch_inverse[i - SCRATCH_SIZE])
+                }
+                RelationColumnType::LookupState(_) => todo!(),
                 RelationColumnType::InstructionCounter => Some(&self.instruction_counter),
                 RelationColumnType::Error => Some(&self.error),
             },

--- a/o1vm/src/pickles/column_env.rs
+++ b/o1vm/src/pickles/column_env.rs
@@ -35,9 +35,10 @@ pub struct ColumnEnvironment<'a, F: FftField> {
     pub domain: EvaluationDomains<F>,
 }
 
-pub fn get_all_columns() -> Vec<Column> {
-    let mut cols =
-        Vec::<Column>::with_capacity(SCRATCH_SIZE + SCRATCH_SIZE_INVERSE + 2 + N_MIPS_SEL_COLS);
+pub fn get_all_columns() -> Vec<Column<usize>> {
+    let mut cols = Vec::<Column<usize>>::with_capacity(
+        SCRATCH_SIZE + SCRATCH_SIZE_INVERSE + 2 + N_MIPS_SEL_COLS,
+    );
     for i in 0..SCRATCH_SIZE + SCRATCH_SIZE_INVERSE + 2 {
         cols.push(Column::Relation(i));
     }
@@ -48,7 +49,7 @@ pub fn get_all_columns() -> Vec<Column> {
 }
 
 impl<G> WitnessColumns<G, [G; N_MIPS_SEL_COLS]> {
-    pub fn get_column(&self, col: &Column) -> Option<&G> {
+    pub fn get_column(&self, col: &Column<usize>) -> Option<&G> {
         match *col {
             Column::Relation(i) => {
                 if i < SCRATCH_SIZE {
@@ -92,7 +93,7 @@ impl<'a, F: FftField> TColumnEnvironment<'a, F, BerkeleyChallengeTerm, BerkeleyC
 {
     // FIXME: do we change to the MIPS column type?
     // We do not want to keep kimchi_msm/generic prover
-    type Column = Column;
+    type Column = Column<usize>;
 
     fn get_column(&self, col: &Self::Column) -> Option<&'a Evals<F>> {
         self.witness.get_column(col)

--- a/o1vm/src/pickles/column_env.rs
+++ b/o1vm/src/pickles/column_env.rs
@@ -70,9 +70,7 @@ impl<G> WitnessColumns<G, [G; N_MIPS_SEL_COLS]> {
         match *col {
             Column::Relation(i) => match i {
                 RelationColumnType::Scratch(i) => Some(&self.scratch[i]),
-                RelationColumnType::ScratchInverse(i) => {
-                    Some(&self.scratch_inverse[i - SCRATCH_SIZE])
-                }
+                RelationColumnType::ScratchInverse(i) => Some(&self.scratch_inverse[i]),
                 RelationColumnType::LookupState(_) => todo!(),
                 RelationColumnType::InstructionCounter => Some(&self.instruction_counter),
                 RelationColumnType::Error => Some(&self.error),

--- a/o1vm/src/pickles/column_env.rs
+++ b/o1vm/src/pickles/column_env.rs
@@ -71,7 +71,7 @@ impl<G> WitnessColumns<G, [G; N_MIPS_SEL_COLS]> {
             Column::Relation(i) => match i {
                 RelationColumnType::Scratch(i) => Some(&self.scratch[i]),
                 RelationColumnType::ScratchInverse(i) => Some(&self.scratch_inverse[i]),
-                RelationColumnType::LookupState(_) => todo!(),
+                RelationColumnType::LookupState(i) => Some(&self.lookup_state[i]),
                 RelationColumnType::InstructionCounter => Some(&self.instruction_counter),
                 RelationColumnType::Error => Some(&self.error),
             },

--- a/o1vm/src/pickles/column_env.rs
+++ b/o1vm/src/pickles/column_env.rs
@@ -14,6 +14,14 @@ use kimchi::circuits::{
 
 type Evals<F> = Evaluations<F, Radix2EvaluationDomain<F>>;
 
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
+pub enum RelationColumnType {
+    Scratch(usize),
+    ScratchInverse(usize),
+    InstructionCounter,
+    Error,
+}
+
 /// The collection of polynomials (all in evaluation form) and constants
 /// required to evaluate an expression as a polynomial.
 ///
@@ -35,13 +43,18 @@ pub struct ColumnEnvironment<'a, F: FftField> {
     pub domain: EvaluationDomains<F>,
 }
 
-pub fn get_all_columns() -> Vec<Column<usize>> {
-    let mut cols = Vec::<Column<usize>>::with_capacity(
+pub fn get_all_columns() -> Vec<Column<RelationColumnType>> {
+    let mut cols = Vec::<Column<RelationColumnType>>::with_capacity(
         SCRATCH_SIZE + SCRATCH_SIZE_INVERSE + 2 + N_MIPS_SEL_COLS,
     );
-    for i in 0..SCRATCH_SIZE + SCRATCH_SIZE_INVERSE + 2 {
-        cols.push(Column::Relation(i));
+    for i in 0..SCRATCH_SIZE {
+        cols.push(Column::Relation(RelationColumnType::Scratch(i)));
     }
+    for i in 0..SCRATCH_SIZE_INVERSE {
+        cols.push(Column::Relation(RelationColumnType::ScratchInverse(i)));
+    }
+    cols.push(Column::Relation(RelationColumnType::InstructionCounter));
+    cols.push(Column::Relation(RelationColumnType::Error));
     for i in 0..N_MIPS_SEL_COLS {
         cols.push(Column::DynamicSelector(i));
     }
@@ -49,25 +62,14 @@ pub fn get_all_columns() -> Vec<Column<usize>> {
 }
 
 impl<G> WitnessColumns<G, [G; N_MIPS_SEL_COLS]> {
-    pub fn get_column(&self, col: &Column<usize>) -> Option<&G> {
+    pub fn get_column(&self, col: &Column<RelationColumnType>) -> Option<&G> {
         match *col {
-            Column::Relation(i) => {
-                if i < SCRATCH_SIZE {
-                    let res = &self.scratch[i];
-                    Some(res)
-                } else if i < SCRATCH_SIZE + SCRATCH_SIZE_INVERSE {
-                    let res = &self.scratch_inverse[i - SCRATCH_SIZE];
-                    Some(res)
-                } else if i == SCRATCH_SIZE + SCRATCH_SIZE_INVERSE {
-                    let res = &self.instruction_counter;
-                    Some(res)
-                } else if i == SCRATCH_SIZE + SCRATCH_SIZE_INVERSE + 1 {
-                    let res = &self.error;
-                    Some(res)
-                } else {
-                    panic!("We should not have that many relation columns. We have {} columns and index {} was given", SCRATCH_SIZE + SCRATCH_SIZE_INVERSE + 2, i);
-                }
-            }
+            Column::Relation(i) => match i {
+                RelationColumnType::Scratch(i) => Some(&self.scratch[i]),
+                RelationColumnType::ScratchInverse(i) => Some(&self.scratch_inverse[i]),
+                RelationColumnType::InstructionCounter => Some(&self.instruction_counter),
+                RelationColumnType::Error => Some(&self.error),
+            },
             Column::DynamicSelector(i) => {
                 assert!(
                     i < N_MIPS_SEL_COLS,
@@ -91,9 +93,7 @@ impl<G> WitnessColumns<G, [G; N_MIPS_SEL_COLS]> {
 impl<'a, F: FftField> TColumnEnvironment<'a, F, BerkeleyChallengeTerm, BerkeleyChallenges<F>>
     for ColumnEnvironment<'a, F>
 {
-    // FIXME: do we change to the MIPS column type?
-    // We do not want to keep kimchi_msm/generic prover
-    type Column = Column<usize>;
+    type Column = Column<RelationColumnType>;
 
     fn get_column(&self, col: &Self::Column) -> Option<&'a Evals<F>> {
         self.witness.get_column(col)

--- a/o1vm/src/pickles/column_env.rs
+++ b/o1vm/src/pickles/column_env.rs
@@ -44,15 +44,18 @@ pub struct ColumnEnvironment<'a, F: FftField> {
     pub domain: EvaluationDomains<F>,
 }
 
-pub fn get_all_columns() -> Vec<Column<RelationColumnType>> {
+pub fn get_all_columns(num_lookup_columns: usize) -> Vec<Column<RelationColumnType>> {
     let mut cols = Vec::<Column<RelationColumnType>>::with_capacity(
-        SCRATCH_SIZE + SCRATCH_SIZE_INVERSE + 2 + N_MIPS_SEL_COLS,
+        SCRATCH_SIZE + SCRATCH_SIZE_INVERSE + num_lookup_columns + 2 + N_MIPS_SEL_COLS,
     );
     for i in 0..SCRATCH_SIZE {
         cols.push(Column::Relation(RelationColumnType::Scratch(i)));
     }
     for i in 0..SCRATCH_SIZE_INVERSE {
         cols.push(Column::Relation(RelationColumnType::ScratchInverse(i)));
+    }
+    for i in 0..num_lookup_columns {
+        cols.push(Column::Relation(RelationColumnType::LookupState(i)));
     }
     cols.push(Column::Relation(RelationColumnType::InstructionCounter));
     cols.push(Column::Relation(RelationColumnType::Error));

--- a/o1vm/src/pickles/main.rs
+++ b/o1vm/src/pickles/main.rs
@@ -109,7 +109,7 @@ pub fn cannon_main(args: cli::cannon::RunArgs) {
                     let mut new_vec =
                         vec![Fp::zero(); curr_proof_inputs.evaluations.instruction_counter.len()];
                     new_vec.push(Fp::from(mips_wit_env.lookup_state[idx]));
-                    curr_proof_inputs.evaluations.lookup_state[idx] = new_vec;
+                    curr_proof_inputs.evaluations.lookup_state.push(new_vec);
                 } else {
                     // Push the value to the column.
                     curr_proof_inputs.evaluations.lookup_state[idx]

--- a/o1vm/src/pickles/main.rs
+++ b/o1vm/src/pickles/main.rs
@@ -97,16 +97,15 @@ pub fn cannon_main(args: cli::cannon::RunArgs) {
         }
         // Lookup state
         {
-            let lookup_state_size = std::cmp::max(
-                curr_proof_inputs.evaluations.lookup_state.len(),
-                mips_wit_env.lookup_state.len(),
-            );
+            let proof_inputs_length = curr_proof_inputs.evaluations.lookup_state.len();
+            let environment_length = mips_wit_env.lookup_state.len();
+            let lookup_state_size = std::cmp::max(proof_inputs_length, environment_length);
             for idx in 0..lookup_state_size {
-                if idx < mips_wit_env.lookup_state.len() {
-                    // We pad with 0s for dummy lookups.
+                if idx >= environment_length {
+                    // We pad with 0s for dummy lookups missing from the environment.
                     curr_proof_inputs.evaluations.lookup_state[idx].push(Fp::zero());
-                } else if idx < curr_proof_inputs.evaluations.lookup_state.len() {
-                    // We create a new column filled with 0s.
+                } else if idx >= proof_inputs_length {
+                    // We create a new column filled with 0s in the proof inputs.
                     let mut new_vec =
                         vec![Fp::zero(); curr_proof_inputs.evaluations.instruction_counter.len()];
                     new_vec.push(Fp::from(mips_wit_env.lookup_state[idx]));

--- a/o1vm/src/pickles/proof.rs
+++ b/o1vm/src/pickles/proof.rs
@@ -6,6 +6,7 @@ use crate::interpreters::mips::column::{N_MIPS_SEL_COLS, SCRATCH_SIZE, SCRATCH_S
 pub struct WitnessColumns<G, S> {
     pub scratch: [G; SCRATCH_SIZE],
     pub scratch_inverse: [G; SCRATCH_SIZE_INVERSE],
+    pub lookup_state: Vec<G>,
     pub instruction_counter: G,
     pub error: G,
     pub selector: S,
@@ -21,6 +22,7 @@ impl<G: KimchiCurve> ProofInputs<G> {
             evaluations: WitnessColumns {
                 scratch: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
                 scratch_inverse: std::array::from_fn(|_| Vec::with_capacity(domain_size)),
+                lookup_state: vec![],
                 instruction_counter: Vec::with_capacity(domain_size),
                 error: Vec::with_capacity(domain_size),
                 selector: Vec::with_capacity(domain_size),

--- a/o1vm/src/pickles/prover.rs
+++ b/o1vm/src/pickles/prover.rs
@@ -128,7 +128,7 @@ where
         WitnessColumns {
             scratch: scratch.try_into().unwrap(),
             scratch_inverse: scratch_inverse.try_into().unwrap(),
-            lookup_state: lookup_state,
+            lookup_state,
             instruction_counter: eval_col(instruction_counter),
             error: eval_col(error.clone()),
             selector: selector.try_into().unwrap(),

--- a/o1vm/src/pickles/prover.rs
+++ b/o1vm/src/pickles/prover.rs
@@ -86,6 +86,7 @@ where
         let WitnessColumns {
             scratch,
             scratch_inverse,
+            lookup_state,
             instruction_counter,
             error,
             selector,
@@ -119,10 +120,15 @@ where
                 eval_col(evals)
             })
             .collect::<Vec<_>>();
+        let lookup_state = lookup_state
+            .into_par_iter()
+            .map(eval_col)
+            .collect::<Vec<_>>();
         let selector = selector.into_par_iter().map(eval_col).collect::<Vec<_>>();
         WitnessColumns {
             scratch: scratch.try_into().unwrap(),
             scratch_inverse: scratch_inverse.try_into().unwrap(),
+            lookup_state: lookup_state,
             instruction_counter: eval_col(instruction_counter),
             error: eval_col(error.clone()),
             selector: selector.try_into().unwrap(),
@@ -134,6 +140,7 @@ where
         let WitnessColumns {
             scratch,
             scratch_inverse,
+            lookup_state,
             instruction_counter,
             error,
             selector,
@@ -151,10 +158,12 @@ where
         // Doing in parallel
         let scratch = scratch.par_iter().map(comm).collect::<Vec<_>>();
         let scratch_inverse = scratch_inverse.par_iter().map(comm).collect::<Vec<_>>();
+        let lookup_state = lookup_state.par_iter().map(comm).collect::<Vec<_>>();
         let selector = selector.par_iter().map(comm).collect::<Vec<_>>();
         WitnessColumns {
             scratch: scratch.try_into().unwrap(),
             scratch_inverse: scratch_inverse.try_into().unwrap(),
+            lookup_state,
             instruction_counter: comm(instruction_counter),
             error: comm(error),
             selector: selector.try_into().unwrap(),
@@ -170,6 +179,7 @@ where
         let WitnessColumns {
             scratch,
             scratch_inverse,
+            lookup_state,
             instruction_counter,
             error,
             selector,
@@ -182,10 +192,15 @@ where
             .into_par_iter()
             .map(eval_d8)
             .collect::<Vec<_>>();
+        let lookup_state = lookup_state
+            .into_par_iter()
+            .map(eval_d8)
+            .collect::<Vec<_>>();
         let selector = selector.into_par_iter().map(eval_d8).collect::<Vec<_>>();
         WitnessColumns {
             scratch: scratch.try_into().unwrap(),
             scratch_inverse: scratch_inverse.try_into().unwrap(),
+            lookup_state,
             instruction_counter: eval_d8(instruction_counter),
             error: eval_d8(error),
             selector: selector.try_into().unwrap(),
@@ -198,6 +213,9 @@ where
         absorb_commitment(&mut fq_sponge, comm)
     }
     for comm in commitments.scratch_inverse.iter() {
+        absorb_commitment(&mut fq_sponge, comm)
+    }
+    for comm in commitments.lookup_state.iter() {
         absorb_commitment(&mut fq_sponge, comm)
     }
     absorb_commitment(&mut fq_sponge, &commitments.instruction_counter);
@@ -314,6 +332,7 @@ where
         let WitnessColumns {
             scratch,
             scratch_inverse,
+            lookup_state,
             instruction_counter,
             error,
             selector,
@@ -321,10 +340,12 @@ where
         let eval = |poly: &DensePolynomial<G::ScalarField>| poly.evaluate(point);
         let scratch = scratch.par_iter().map(eval).collect::<Vec<_>>();
         let scratch_inverse = scratch_inverse.par_iter().map(eval).collect::<Vec<_>>();
+        let lookup_state = lookup_state.par_iter().map(eval).collect::<Vec<_>>();
         let selector = selector.par_iter().map(eval).collect::<Vec<_>>();
         WitnessColumns {
             scratch: scratch.try_into().unwrap(),
             scratch_inverse: scratch_inverse.try_into().unwrap(),
+            lookup_state,
             instruction_counter: eval(instruction_counter),
             error: eval(error),
             selector: selector.try_into().unwrap(),
@@ -375,6 +396,15 @@ where
         fr_sponge.absorb(zeta_eval);
         fr_sponge.absorb(zeta_omega_eval);
     }
+
+    for (zeta_eval, zeta_omega_eval) in zeta_evaluations
+        .lookup_state
+        .iter()
+        .zip(zeta_omega_evaluations.lookup_state.iter())
+    {
+        fr_sponge.absorb(zeta_eval);
+        fr_sponge.absorb(zeta_omega_eval);
+    }
     fr_sponge.absorb(&zeta_evaluations.instruction_counter);
     fr_sponge.absorb(&zeta_omega_evaluations.instruction_counter);
     fr_sponge.absorb(&zeta_evaluations.error);
@@ -401,6 +431,7 @@ where
 
     let mut polynomials: Vec<_> = polys.scratch.into_iter().collect();
     polynomials.extend(polys.scratch_inverse);
+    polynomials.extend(polys.lookup_state);
     polynomials.push(polys.instruction_counter);
     polynomials.push(polys.error);
     polynomials.extend(polys.selector);

--- a/o1vm/src/pickles/verifier.rs
+++ b/o1vm/src/pickles/verifier.rs
@@ -99,6 +99,9 @@ where
     for comm in commitments.scratch_inverse.iter() {
         absorb_commitment(&mut fq_sponge, comm)
     }
+    for comm in commitments.lookup_state.iter() {
+        absorb_commitment(&mut fq_sponge, comm)
+    }
     absorb_commitment(&mut fq_sponge, &commitments.instruction_counter);
     absorb_commitment(&mut fq_sponge, &commitments.error);
     for comm in commitments.selector.iter() {
@@ -144,6 +147,14 @@ where
         .scratch_inverse
         .iter()
         .zip(zeta_omega_evaluations.scratch_inverse.iter())
+    {
+        fr_sponge.absorb(zeta_eval);
+        fr_sponge.absorb(zeta_omega_eval);
+    }
+    for (zeta_eval, zeta_omega_eval) in zeta_evaluations
+        .lookup_state
+        .iter()
+        .zip(zeta_omega_evaluations.lookup_state.iter())
     {
         fr_sponge.absorb(zeta_eval);
         fr_sponge.absorb(zeta_omega_eval);
@@ -204,7 +215,7 @@ where
     let u_chal = fr_sponge.challenge();
     let u = u_chal.to_field(endo_r);
 
-    let mut evaluations: Vec<_> = get_all_columns()
+    let mut evaluations: Vec<_> = get_all_columns(column_eval.commitment.lookup_state.len())
         .into_iter()
         .map(|column| {
             let commitment = column_eval

--- a/o1vm/src/pickles/verifier.rs
+++ b/o1vm/src/pickles/verifier.rs
@@ -40,7 +40,7 @@ struct ColumnEval<'a, G: AffineRepr> {
 }
 
 impl<G: AffineRepr> ColumnEvaluations<G::ScalarField> for ColumnEval<'_, G> {
-    type Column = Column;
+    type Column = Column<usize>;
     fn evaluate(
         &self,
         col: Self::Column,

--- a/o1vm/src/pickles/verifier.rs
+++ b/o1vm/src/pickles/verifier.rs
@@ -24,7 +24,7 @@ use poly_commitment::{
 };
 
 use super::{
-    column_env::get_all_columns,
+    column_env::{get_all_columns, RelationColumnType},
     proof::{Proof, WitnessColumns},
 };
 use crate::{interpreters::mips::column::N_MIPS_SEL_COLS, E};
@@ -40,7 +40,7 @@ struct ColumnEval<'a, G: AffineRepr> {
 }
 
 impl<G: AffineRepr> ColumnEvaluations<G::ScalarField> for ColumnEval<'_, G> {
-    type Column = Column<usize>;
+    type Column = Column<RelationColumnType>;
     fn evaluate(
         &self,
         col: Self::Column,


### PR DESCRIPTION
This PR builds upon https://github.com/o1-labs/proof-systems/pull/2943. This propagates the values involved with lookups as witness columns for the prover.

The majority of changes in this PR are caused by unwinding the old misguided manual mapping of columns to indices. That model still exists in some old, dead code, but we use the now-generic witness kind to remove it where it matters for this PR.