### PR TITLE
Stop generating new scratch state for halt addresses

### DIFF
--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -1169,7 +1169,7 @@ impl<Fp: Field, PreImageOracle: PreImageOracleT> Env<Fp, PreImageOracle> {
         self.instruction_counter = self.next_instruction_counter();
 
         config.halt_address.iter().for_each(|halt_address: &u32| {
-            if self.get_instruction_pointer() == (*halt_address as u64) {
+            if self.registers.current_instruction_pointer == *halt_address {
                 debug!("Program jumped to halt address: {:#X}", halt_address);
                 self.halt = true;
             }


### PR DESCRIPTION
This PR fixes the bug introduced in https://github.com/o1-labs/proof-systems/pull/2926, which is then 'fixed' incorrectly [here](https://github.com/o1-labs/proof-systems/pull/2945/files#diff-28425787191170e725968d01849f8039700326796697f8c9f5180c3ecfe8f1bfL11).