### PR TITLE
Parameterise `ColumnIndexer`

### DIFF
--- a/ivc/src/ivc/columns.rs
+++ b/ivc/src/ivc/columns.rs
@@ -378,7 +378,7 @@ pub enum IVCColumn {
     Block6UOutput,
 }
 
-impl ColumnIndexer for IVCColumn {
+impl ColumnIndexer<usize> for IVCColumn {
     /// Number of columns used by the IVC circuit
     /// It contains at least the columns used for Poseidon.
     /// It does not include the additional columns that might be required

--- a/ivc/src/ivc/helpers.rs
+++ b/ivc/src/ivc/helpers.rs
@@ -10,7 +10,11 @@ use kimchi_msm::{
 use super::{LIMB_BITSIZE_XLARGE, N_LIMBS_XLARGE};
 
 /// Helper. Combines small limbs into big limbs.
-pub fn combine_large_to_xlarge<F: PrimeField, CIx: ColumnIndexer, Env: ColAccessCap<F, CIx>>(
+pub fn combine_large_to_xlarge<
+    F: PrimeField,
+    CIx: ColumnIndexer<usize>,
+    Env: ColAccessCap<F, CIx>,
+>(
     x: [Env::Variable; N_LIMBS_LARGE],
 ) -> [Env::Variable; N_LIMBS_XLARGE] {
     combine_limbs_m_to_n::<
@@ -25,7 +29,11 @@ pub fn combine_large_to_xlarge<F: PrimeField, CIx: ColumnIndexer, Env: ColAccess
 }
 
 /// Helper. Combines 17x15bit limbs into 1 native field element.
-pub fn combine_small_to_full<F: PrimeField, CIx: ColumnIndexer, Env: ColAccessCap<F, CIx>>(
+pub fn combine_small_to_full<
+    F: PrimeField,
+    CIx: ColumnIndexer<usize>,
+    Env: ColAccessCap<F, CIx>,
+>(
     x: [Env::Variable; N_LIMBS_SMALL],
 ) -> Env::Variable {
     let [res] =

--- a/ivc/src/ivc/mod.rs
+++ b/ivc/src/ivc/mod.rs
@@ -74,8 +74,8 @@ mod tests {
     type IVCWitnessBuilderEnvRaw<LT> = WitnessBuilderEnv<
         Fp,
         IVCColumn,
-        { <IVCColumn as ColumnIndexer>::N_COL - N_BLOCKS },
-        { <IVCColumn as ColumnIndexer>::N_COL - N_BLOCKS },
+        { <IVCColumn as ColumnIndexer<usize>>::N_COL - N_BLOCKS },
+        { <IVCColumn as ColumnIndexer<usize>>::N_COL - N_BLOCKS },
         0,
         N_FSEL_IVC,
         LT,

--- a/ivc/src/poseidon_55_0_7_3_2/columns.rs
+++ b/ivc/src/poseidon_55_0_7_3_2/columns.rs
@@ -29,7 +29,7 @@ pub enum PoseidonColumn<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> {
     RoundConstant(usize, usize),
 }
 
-impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> ColumnIndexer
+impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> ColumnIndexer<usize>
     for PoseidonColumn<STATE_SIZE, NB_FULL_ROUND>
 {
     // - STATE_SIZE input columns

--- a/ivc/src/poseidon_55_0_7_3_2/mod.rs
+++ b/ivc/src/poseidon_55_0_7_3_2/mod.rs
@@ -43,8 +43,8 @@ mod tests {
     type PoseidonWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         TestPoseidonColumn,
-        { <TestPoseidonColumn as ColumnIndexer>::N_COL },
-        { <TestPoseidonColumn as ColumnIndexer>::N_COL },
+        { <TestPoseidonColumn as ColumnIndexer<usize>>::N_COL },
+        { <TestPoseidonColumn as ColumnIndexer<usize>>::N_COL },
         N_DSEL,
         N_FSEL,
         DummyLookupTable,

--- a/ivc/src/poseidon_55_0_7_3_7/columns.rs
+++ b/ivc/src/poseidon_55_0_7_3_7/columns.rs
@@ -20,7 +20,7 @@ pub enum PoseidonColumn<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> {
     RoundConstant(usize, usize),
 }
 
-impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> ColumnIndexer
+impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize> ColumnIndexer<usize>
     for PoseidonColumn<STATE_SIZE, NB_FULL_ROUND>
 {
     const N_COL: usize = STATE_SIZE + NB_FULL_ROUND * STATE_SIZE;

--- a/ivc/src/poseidon_55_0_7_3_7/mod.rs
+++ b/ivc/src/poseidon_55_0_7_3_7/mod.rs
@@ -41,8 +41,8 @@ mod tests {
     type PoseidonWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         TestPoseidonColumn,
-        { <TestPoseidonColumn as ColumnIndexer>::N_COL },
-        { <TestPoseidonColumn as ColumnIndexer>::N_COL },
+        { <TestPoseidonColumn as ColumnIndexer<usize>>::N_COL },
+        { <TestPoseidonColumn as ColumnIndexer<usize>>::N_COL },
         N_DSEL,
         N_FSEL,
         DummyLookupTable,

--- a/ivc/src/poseidon_8_56_5_3_2/columns.rs
+++ b/ivc/src/poseidon_8_56_5_3_2/columns.rs
@@ -30,7 +30,7 @@ pub enum PoseidonColumn<
 }
 
 impl<const STATE_SIZE: usize, const NB_FULL_ROUND: usize, const NB_PARTIAL_ROUND: usize>
-    ColumnIndexer for PoseidonColumn<STATE_SIZE, NB_FULL_ROUND, NB_PARTIAL_ROUND>
+    ColumnIndexer<usize> for PoseidonColumn<STATE_SIZE, NB_FULL_ROUND, NB_PARTIAL_ROUND>
 {
     // - STATE_SIZE input columns
     // - for each partial round:

--- a/ivc/src/poseidon_8_56_5_3_2/mod.rs
+++ b/ivc/src/poseidon_8_56_5_3_2/mod.rs
@@ -32,8 +32,8 @@ mod tests {
     type PoseidonWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         Column,
-        { <Column as ColumnIndexer>::N_COL },
-        { <Column as ColumnIndexer>::N_COL },
+        { <Column as ColumnIndexer<usize>>::N_COL },
+        { <Column as ColumnIndexer<usize>>::N_COL },
         N_DSEL,
         N_FSEL,
         DummyLookupTable,

--- a/ivc/tests/simple.rs
+++ b/ivc/tests/simple.rs
@@ -67,7 +67,7 @@ pub enum AdditionColumn {
     C,
 }
 
-impl ColumnIndexer for AdditionColumn {
+impl ColumnIndexer<usize> for AdditionColumn {
     const N_COL: usize = 3;
 
     fn to_column(self) -> Column<usize> {
@@ -119,7 +119,7 @@ pub fn heavy_test_simple_add() {
     const N_FSEL_TOTAL: usize = N_FSEL_IVC;
 
     // Total number of witness columns in IVC. The blocks are public selectors.
-    const N_WIT_IVC: usize = <IVCColumn as ColumnIndexer>::N_COL - N_FSEL_IVC;
+    const N_WIT_IVC: usize = <IVCColumn as ColumnIndexer<usize>>::N_COL - N_FSEL_IVC;
 
     // Number of witness columns in the circuit.
     // It consists of the columns of the inner circuit and the columns for the

--- a/msm/src/circuit_design/capabilities.rs
+++ b/msm/src/circuit_design/capabilities.rs
@@ -10,7 +10,7 @@ use ark_ff::PrimeField;
 
 /// Environment capability for accessing and reading columns. This is necessary for
 /// building constraints.
-pub trait ColAccessCap<F: PrimeField, CIx: ColumnIndexer> {
+pub trait ColAccessCap<F: PrimeField, CIx: ColumnIndexer<usize>> {
     // NB: 'static here means that `Variable` does not contain any
     // references with a lifetime less than 'static. Which is true in
     // our case. Necessary for `set_assert_mapper`
@@ -39,7 +39,7 @@ pub trait ColAccessCap<F: PrimeField, CIx: ColumnIndexer> {
 
 /// Environment capability similar to `ColAccessCap` but for /also
 /// writing/ columns. Used on the witness side.
-pub trait ColWriteCap<F: PrimeField, CIx: ColumnIndexer>
+pub trait ColWriteCap<F: PrimeField, CIx: ColumnIndexer<usize>>
 where
     Self: ColAccessCap<F, CIx>,
 {
@@ -47,7 +47,7 @@ where
 }
 
 /// Capability for invoking table lookups.
-pub trait LookupCap<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID>
+pub trait LookupCap<F: PrimeField, CIx: ColumnIndexer<usize>, LT: LookupTableID>
 where
     Self: ColAccessCap<F, CIx>,
 {
@@ -62,7 +62,7 @@ where
 /// Holds a "current" row that can be moved forward with `next_row`.
 /// The `ColWriteCap` and `ColAccessCap` reason in terms of current
 /// row. The two other methods can be used to read/write previous.
-pub trait MultiRowReadCap<F: PrimeField, CIx: ColumnIndexer>
+pub trait MultiRowReadCap<F: PrimeField, CIx: ColumnIndexer<usize>>
 where
     Self: ColWriteCap<F, CIx>,
 {
@@ -84,7 +84,7 @@ where
 // F-typed inputs to a function.
 /// A direct field access capability modelling an abstract witness
 /// builder. Not for constraint building.
-pub trait DirectWitnessCap<F: PrimeField, CIx: ColumnIndexer>
+pub trait DirectWitnessCap<F: PrimeField, CIx: ColumnIndexer<usize>>
 where
     Self: MultiRowReadCap<F, CIx>,
 {
@@ -106,7 +106,7 @@ where
 /// partially) in the constraint builder case. For example, "hcopy",
 /// despite its name, does not do any "write", so hcopy !=>
 /// write_column.
-pub trait HybridCopyCap<F: PrimeField, CIx: ColumnIndexer>
+pub trait HybridCopyCap<F: PrimeField, CIx: ColumnIndexer<usize>>
 where
     Self: ColAccessCap<F, CIx>,
 {
@@ -120,7 +120,7 @@ where
 ////////////////////////////////////////////////////////////////////////////
 
 /// Write an array of values simultaneously.
-pub fn read_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer, ColMap>(
+pub fn read_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer<usize>, ColMap>(
     env: &mut Env,
     column_map: ColMap,
 ) -> [Env::Variable; ARR_N]
@@ -133,7 +133,7 @@ where
 }
 
 /// Write a field element directly as a constant.
-pub fn write_column_const<F, Env, CIx: ColumnIndexer>(env: &mut Env, col: CIx, var: &F)
+pub fn write_column_const<F, Env, CIx: ColumnIndexer<usize>>(env: &mut Env, col: CIx, var: &F)
 where
     F: PrimeField,
     Env: ColWriteCap<F, CIx>,
@@ -142,7 +142,7 @@ where
 }
 
 /// Write an array of values simultaneously.
-pub fn write_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer, ColMap>(
+pub fn write_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer<usize>, ColMap>(
     env: &mut Env,
     input: [Env::Variable; ARR_N],
     column_map: ColMap,
@@ -157,7 +157,7 @@ pub fn write_column_array<F, Env, const ARR_N: usize, CIx: ColumnIndexer, ColMap
 }
 
 /// Write an array of /field/ values simultaneously.
-pub fn write_column_array_const<F, Env, const ARR_N: usize, CIx: ColumnIndexer, ColMap>(
+pub fn write_column_array_const<F, Env, const ARR_N: usize, CIx: ColumnIndexer<usize>, ColMap>(
     env: &mut Env,
     input: &[F; ARR_N],
     column_map: ColMap,

--- a/msm/src/circuit_design/composition.rs
+++ b/msm/src/circuit_design/composition.rs
@@ -151,27 +151,35 @@ where
 /// impossible to instantiate `SubEnv` with two /completely/ different
 /// lenses and then write proper trait implementations. Rust complains
 /// about conflicting trait implementations.
-struct SubEnv<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L> {
+struct SubEnv<'a, F: PrimeField, CIx1: ColumnIndexer<usize>, Env1: ColAccessCap<F, CIx1>, L> {
     env: &'a mut Env1,
     lens: L,
     phantom: PhantomData<(F, CIx1)>,
 }
 
 /// Sub environment with a lens that is mapping columns.
-pub struct SubEnvColumn<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>(
-    SubEnv<'a, F, CIx1, Env1, L>,
-);
+pub struct SubEnvColumn<
+    'a,
+    F: PrimeField,
+    CIx1: ColumnIndexer<usize>,
+    Env1: ColAccessCap<F, CIx1>,
+    L,
+>(SubEnv<'a, F, CIx1, Env1, L>);
 
 /// Sub environment with a lens that is mapping lookup tables.
-pub struct SubEnvLookup<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>(
-    SubEnv<'a, F, CIx1, Env1, L>,
-);
+pub struct SubEnvLookup<
+    'a,
+    F: PrimeField,
+    CIx1: ColumnIndexer<usize>,
+    Env1: ColAccessCap<F, CIx1>,
+    L,
+>(SubEnv<'a, F, CIx1, Env1, L>);
 
 ////////////////////////////////////////////////////////////////////////////
 // Trait implementations
 ////////////////////////////////////////////////////////////////////////////
 
-impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>
+impl<'a, F: PrimeField, CIx1: ColumnIndexer<usize>, Env1: ColAccessCap<F, CIx1>, L>
     SubEnv<'a, F, CIx1, Env1, L>
 {
     pub fn new(env: &'a mut Env1, lens: L) -> Self {
@@ -183,7 +191,7 @@ impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>
     }
 }
 
-impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>
+impl<'a, F: PrimeField, CIx1: ColumnIndexer<usize>, Env1: ColAccessCap<F, CIx1>, L>
     SubEnvColumn<'a, F, CIx1, Env1, L>
 {
     pub fn new(env: &'a mut Env1, lens: L) -> Self {
@@ -191,7 +199,7 @@ impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>
     }
 }
 
-impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>
+impl<'a, F: PrimeField, CIx1: ColumnIndexer<usize>, Env1: ColAccessCap<F, CIx1>, L>
     SubEnvLookup<'a, F, CIx1, Env1, L>
 {
     pub fn new(env: &'a mut Env1, lens: L) -> Self {
@@ -202,8 +210,8 @@ impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L>
 impl<
         'a,
         F: PrimeField,
-        CIx1: ColumnIndexer,
-        CIx2: ColumnIndexer,
+        CIx1: ColumnIndexer<usize>,
+        CIx2: ColumnIndexer<usize>,
         Env1: ColAccessCap<F, CIx1>,
         L: MPrism<Source = CIx1, Target = CIx2>,
     > ColAccessCap<F, CIx2> for SubEnv<'a, F, CIx1, Env1, L>
@@ -230,8 +238,8 @@ impl<
 impl<
         'a,
         F: PrimeField,
-        CIx1: ColumnIndexer,
-        CIx2: ColumnIndexer,
+        CIx1: ColumnIndexer<usize>,
+        CIx2: ColumnIndexer<usize>,
         Env1: ColWriteCap<F, CIx1>,
         L: MPrism<Source = CIx1, Target = CIx2>,
     > ColWriteCap<F, CIx2> for SubEnv<'a, F, CIx1, Env1, L>
@@ -244,8 +252,8 @@ impl<
 impl<
         'a,
         F: PrimeField,
-        CIx1: ColumnIndexer,
-        CIx2: ColumnIndexer,
+        CIx1: ColumnIndexer<usize>,
+        CIx2: ColumnIndexer<usize>,
         Env1: HybridCopyCap<F, CIx1>,
         L: MPrism<Source = CIx1, Target = CIx2>,
     > HybridCopyCap<F, CIx2> for SubEnv<'a, F, CIx1, Env1, L>
@@ -258,8 +266,8 @@ impl<
 impl<
         'a,
         F: PrimeField,
-        CIx1: ColumnIndexer,
-        CIx2: ColumnIndexer,
+        CIx1: ColumnIndexer<usize>,
+        CIx2: ColumnIndexer<usize>,
         Env1: ColAccessCap<F, CIx1>,
         L: MPrism<Source = CIx1, Target = CIx2>,
     > ColAccessCap<F, CIx2> for SubEnvColumn<'a, F, CIx1, Env1, L>
@@ -286,8 +294,8 @@ impl<
 impl<
         'a,
         F: PrimeField,
-        CIx1: ColumnIndexer,
-        CIx2: ColumnIndexer,
+        CIx1: ColumnIndexer<usize>,
+        CIx2: ColumnIndexer<usize>,
         Env1: ColWriteCap<F, CIx1>,
         L: MPrism<Source = CIx1, Target = CIx2>,
     > ColWriteCap<F, CIx2> for SubEnvColumn<'a, F, CIx1, Env1, L>
@@ -300,8 +308,8 @@ impl<
 impl<
         'a,
         F: PrimeField,
-        CIx1: ColumnIndexer,
-        CIx2: ColumnIndexer,
+        CIx1: ColumnIndexer<usize>,
+        CIx2: ColumnIndexer<usize>,
         Env1: HybridCopyCap<F, CIx1>,
         L: MPrism<Source = CIx1, Target = CIx2>,
     > HybridCopyCap<F, CIx2> for SubEnvColumn<'a, F, CIx1, Env1, L>
@@ -311,8 +319,8 @@ impl<
     }
 }
 
-impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L> ColAccessCap<F, CIx1>
-    for SubEnvLookup<'a, F, CIx1, Env1, L>
+impl<'a, F: PrimeField, CIx1: ColumnIndexer<usize>, Env1: ColAccessCap<F, CIx1>, L>
+    ColAccessCap<F, CIx1> for SubEnvLookup<'a, F, CIx1, Env1, L>
 {
     type Variable = Env1::Variable;
 
@@ -333,16 +341,16 @@ impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColAccessCap<F, CIx1>, L> Col
     }
 }
 
-impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: ColWriteCap<F, CIx1>, L> ColWriteCap<F, CIx1>
-    for SubEnvLookup<'a, F, CIx1, Env1, L>
+impl<'a, F: PrimeField, CIx1: ColumnIndexer<usize>, Env1: ColWriteCap<F, CIx1>, L>
+    ColWriteCap<F, CIx1> for SubEnvLookup<'a, F, CIx1, Env1, L>
 {
     fn write_column(&mut self, ix: CIx1, value: &Self::Variable) {
         self.0.env.write_column(ix, value);
     }
 }
 
-impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: HybridCopyCap<F, CIx1>, L> HybridCopyCap<F, CIx1>
-    for SubEnvLookup<'a, F, CIx1, Env1, L>
+impl<'a, F: PrimeField, CIx1: ColumnIndexer<usize>, Env1: HybridCopyCap<F, CIx1>, L>
+    HybridCopyCap<F, CIx1> for SubEnvLookup<'a, F, CIx1, Env1, L>
 {
     fn hcopy(&mut self, x: &Self::Variable, ix: CIx1) -> Self::Variable {
         self.0.env.hcopy(x, ix)
@@ -352,7 +360,7 @@ impl<'a, F: PrimeField, CIx1: ColumnIndexer, Env1: HybridCopyCap<F, CIx1>, L> Hy
 impl<
         'a,
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         LT1: LookupTableID,
         LT2: LookupTableID,
         Env1: LookupCap<F, CIx, LT1>,
@@ -373,8 +381,8 @@ impl<
 impl<
         'a,
         F: PrimeField,
-        CIx1: ColumnIndexer,
-        CIx2: ColumnIndexer,
+        CIx1: ColumnIndexer<usize>,
+        CIx2: ColumnIndexer<usize>,
         LT: LookupTableID,
         Env1: LookupCap<F, CIx1, LT>,
         L: MPrism<Source = CIx1, Target = CIx2>,
@@ -389,7 +397,7 @@ impl<
     }
 }
 
-impl<'a, F: PrimeField, CIx: ColumnIndexer, Env1: MultiRowReadCap<F, CIx>, L>
+impl<'a, F: PrimeField, CIx: ColumnIndexer<usize>, Env1: MultiRowReadCap<F, CIx>, L>
     MultiRowReadCap<F, CIx> for SubEnvLookup<'a, F, CIx, Env1, L>
 {
     /// Read value from a (row,column) position.
@@ -408,7 +416,7 @@ impl<'a, F: PrimeField, CIx: ColumnIndexer, Env1: MultiRowReadCap<F, CIx>, L>
     }
 }
 
-impl<'a, F: PrimeField, CIx: ColumnIndexer, Env1: DirectWitnessCap<F, CIx>, L>
+impl<'a, F: PrimeField, CIx: ColumnIndexer<usize>, Env1: DirectWitnessCap<F, CIx>, L>
     DirectWitnessCap<F, CIx> for SubEnvLookup<'a, F, CIx, Env1, L>
 {
     fn variable_to_field(value: Self::Variable) -> F {

--- a/msm/src/circuit_design/constraints.rs
+++ b/msm/src/circuit_design/constraints.rs
@@ -35,7 +35,7 @@ impl<F: PrimeField, LT: LookupTableID> ConstraintBuilderEnv<F, LT> {
     }
 }
 
-impl<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> ColAccessCap<F, CIx>
+impl<F: PrimeField, CIx: ColumnIndexer<usize>, LT: LookupTableID> ColAccessCap<F, CIx>
     for ConstraintBuilderEnv<F, LT>
 {
     type Variable = E<F>;
@@ -61,7 +61,7 @@ impl<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> ColAccessCap<F, CIx>
     }
 }
 
-impl<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> HybridCopyCap<F, CIx>
+impl<F: PrimeField, CIx: ColumnIndexer<usize>, LT: LookupTableID> HybridCopyCap<F, CIx>
     for ConstraintBuilderEnv<F, LT>
 {
     fn hcopy(&mut self, x: &Self::Variable, position: CIx) -> Self::Variable {
@@ -77,7 +77,7 @@ impl<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> HybridCopyCap<F, CIx>
     }
 }
 
-impl<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> LookupCap<F, CIx, LT>
+impl<F: PrimeField, CIx: ColumnIndexer<usize>, LT: LookupTableID> LookupCap<F, CIx, LT>
     for ConstraintBuilderEnv<F, LT>
 {
     fn lookup(&mut self, table_id: LT, value: Vec<<Self as ColAccessCap<F, CIx>>::Variable>) {

--- a/msm/src/circuit_design/witness.rs
+++ b/msm/src/circuit_design/witness.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, iter, marker::PhantomData};
 /// separately is due to a rust limitation.
 pub struct WitnessBuilderEnv<
     F: PrimeField,
-    CIx: ColumnIndexer,
+    CIx: ColumnIndexer<usize>,
     const N_WIT: usize,
     const N_REL: usize,
     const N_DSEL: usize,
@@ -68,7 +68,7 @@ pub struct WitnessBuilderEnv<
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -103,7 +103,7 @@ impl<
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -124,7 +124,7 @@ impl<
 /// for every `T: ColWriteCap`.
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -142,7 +142,7 @@ impl<
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -171,7 +171,7 @@ impl<
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -187,7 +187,7 @@ impl<
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -276,7 +276,7 @@ impl<
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -421,7 +421,7 @@ impl<
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_WIT: usize,
         const N_REL: usize,
         const N_DSEL: usize,

--- a/msm/src/columns.rs
+++ b/msm/src/columns.rs
@@ -73,12 +73,12 @@ impl FormattedOutput for Column<usize> {
 
 /// A datatype expressing a generalized column, but with potentially
 /// more convenient interface than a bare column.
-pub trait ColumnIndexer: core::fmt::Debug + Copy + Eq + Ord {
+pub trait ColumnIndexer<T>: core::fmt::Debug + Copy + Eq + Ord {
     /// Total number of columns in this index.
     const N_COL: usize;
 
     /// Flatten the column "alias" into the integer-like column.
-    fn to_column(self) -> Column<usize>;
+    fn to_column(self) -> Column<T>;
 }
 
 // Implementation to be compatible with folding if we use generic column

--- a/msm/src/fec/columns.rs
+++ b/msm/src/fec/columns.rs
@@ -51,7 +51,7 @@ pub enum FECColumn {
     Inter(FECColumnInter),
 }
 
-impl ColumnIndexer for FECColumnInput {
+impl ColumnIndexer<usize> for FECColumnInput {
     const N_COL: usize = 4 * N_LIMBS_LARGE;
     fn to_column(self) -> Column<usize> {
         match self {
@@ -75,7 +75,7 @@ impl ColumnIndexer for FECColumnInput {
     }
 }
 
-impl ColumnIndexer for FECColumnOutput {
+impl ColumnIndexer<usize> for FECColumnOutput {
     const N_COL: usize = 2 * N_LIMBS_SMALL;
     fn to_column(self) -> Column<usize> {
         match self {
@@ -91,7 +91,7 @@ impl ColumnIndexer for FECColumnOutput {
     }
 }
 
-impl ColumnIndexer for FECColumnInter {
+impl ColumnIndexer<usize> for FECColumnInter {
     const N_COL: usize = 4 * N_LIMBS_LARGE + 10 * N_LIMBS_SMALL + 9;
     fn to_column(self) -> Column<usize> {
         match self {
@@ -146,7 +146,7 @@ impl ColumnIndexer for FECColumnInter {
     }
 }
 
-impl ColumnIndexer for FECColumn {
+impl ColumnIndexer<usize> for FECColumn {
     const N_COL: usize = FEC_N_COLUMNS;
     fn to_column(self) -> Column<usize> {
         match self {

--- a/msm/src/fec/mod.rs
+++ b/msm/src/fec/mod.rs
@@ -27,8 +27,8 @@ mod tests {
     type FECWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         FECColumn,
-        { <FECColumn as ColumnIndexer>::N_COL },
-        { <FECColumn as ColumnIndexer>::N_COL },
+        { <FECColumn as ColumnIndexer<usize>>::N_COL },
+        { <FECColumn as ColumnIndexer<usize>>::N_COL },
         0,
         0,
         LookupTable<Ff1>,

--- a/msm/src/ffa/columns.rs
+++ b/msm/src/ffa/columns.rs
@@ -20,7 +20,7 @@ pub enum FFAColumn {
     Quotient,
 }
 
-impl ColumnIndexer for FFAColumn {
+impl ColumnIndexer<usize> for FFAColumn {
     const N_COL: usize = FFA_N_COLUMNS;
     fn to_column(self) -> Column<usize> {
         let to_column_inner = |offset, i| {

--- a/msm/src/ffa/mod.rs
+++ b/msm/src/ffa/mod.rs
@@ -23,8 +23,8 @@ mod tests {
     type FFAWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         FFAColumn,
-        { <FFAColumn as ColumnIndexer>::N_COL },
-        { <FFAColumn as ColumnIndexer>::N_COL },
+        { <FFAColumn as ColumnIndexer<usize>>::N_COL },
+        { <FFAColumn as ColumnIndexer<usize>>::N_COL },
         0,
         0,
         LookupTable,
@@ -86,8 +86,8 @@ mod tests {
         let proof_inputs = witness_env.get_proof_inputs(domain_size, lookup_tables_data);
 
         crate::test::test_completeness_generic::<
-            { <FFAColumn as ColumnIndexer>::N_COL },
-            { <FFAColumn as ColumnIndexer>::N_COL },
+            { <FFAColumn as ColumnIndexer<usize>>::N_COL },
+            { <FFAColumn as ColumnIndexer<usize>>::N_COL },
             0,
             0,
             LookupTable,

--- a/msm/src/serialization/column.rs
+++ b/msm/src/serialization/column.rs
@@ -40,7 +40,7 @@ pub enum SerializationColumn {
     CoeffResult(usize),
 }
 
-impl ColumnIndexer for SerializationColumn {
+impl ColumnIndexer<usize> for SerializationColumn {
     const N_COL: usize = N_COL_SER;
     fn to_column(self) -> Column<usize> {
         match self {

--- a/msm/src/serialization/interpreter.rs
+++ b/msm/src/serialization/interpreter.rs
@@ -26,7 +26,7 @@ use o1_utils::{field_helpers::FieldHelpers, foreign_field::ForeignElement};
 
 // Such "helpers" defeat the whole purpose of the interpreter.
 // TODO remove
-pub trait HybridSerHelpers<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> {
+pub trait HybridSerHelpers<F: PrimeField, CIx: ColumnIndexer<usize>, LT: LookupTableID> {
     /// Returns the bits between [highest_bit, lowest_bit] of the variable `x`,
     /// and copy the result in the column `position`.
     /// The value `x` is expected to be encoded in big-endian
@@ -41,7 +41,7 @@ pub trait HybridSerHelpers<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID>
         Self: ColAccessCap<F, CIx>;
 }
 
-impl<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> HybridSerHelpers<F, CIx, LT>
+impl<F: PrimeField, CIx: ColumnIndexer<usize>, LT: LookupTableID> HybridSerHelpers<F, CIx, LT>
     for crate::circuit_design::ConstraintBuilderEnv<F, LT>
 {
     fn bitmask_be(
@@ -62,7 +62,7 @@ impl<F: PrimeField, CIx: ColumnIndexer, LT: LookupTableID> HybridSerHelpers<F, C
 
 impl<
         F: PrimeField,
-        CIx: ColumnIndexer,
+        CIx: ColumnIndexer<usize>,
         const N_COL: usize,
         const N_REL: usize,
         const N_DSEL: usize,
@@ -350,7 +350,11 @@ pub fn combine_limbs_m_to_n<
 /// Helper function for limb recombination.
 ///
 /// Combines small limbs into big limbs.
-pub fn combine_small_to_large<F: PrimeField, CIx: ColumnIndexer, Env: ColAccessCap<F, CIx>>(
+pub fn combine_small_to_large<
+    F: PrimeField,
+    CIx: ColumnIndexer<usize>,
+    Env: ColAccessCap<F, CIx>,
+>(
     x: [Env::Variable; N_LIMBS_SMALL],
 ) -> [Env::Variable; N_LIMBS_LARGE] {
     combine_limbs_m_to_n::<
@@ -367,7 +371,7 @@ pub fn combine_small_to_large<F: PrimeField, CIx: ColumnIndexer, Env: ColAccessC
 /// Helper function for limb recombination for carry specifically.
 /// Each big carry limb is stored as 6 (not 5!) small elements. We
 /// accept 36 small limbs, and return 6 large ones.
-pub fn combine_carry<F: PrimeField, CIx: ColumnIndexer, Env: ColAccessCap<F, CIx>>(
+pub fn combine_carry<F: PrimeField, CIx: ColumnIndexer<usize>, Env: ColAccessCap<F, CIx>>(
     x: [Env::Variable; 2 * N_LIMBS_SMALL + 2],
 ) -> [Env::Variable; 2 * N_LIMBS_LARGE - 2] {
     let constant_u128 = |x: u128| Env::constant(From::from(x));
@@ -816,8 +820,8 @@ mod tests {
     type SerializationWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         SerializationColumn,
-        { <SerializationColumn as ColumnIndexer>::N_COL },
-        { <SerializationColumn as ColumnIndexer>::N_COL },
+        { <SerializationColumn as ColumnIndexer<usize>>::N_COL },
+        { <SerializationColumn as ColumnIndexer<usize>>::N_COL },
         0,
         0,
         LookupTable<Ff1>,

--- a/msm/src/serialization/mod.rs
+++ b/msm/src/serialization/mod.rs
@@ -28,8 +28,8 @@ mod tests {
     type SerializationWitnessBuilderEnv = WitnessBuilderEnv<
         Fp,
         SerializationColumn,
-        { <SerializationColumn as ColumnIndexer>::N_COL - N_FSEL_SER },
-        { <SerializationColumn as ColumnIndexer>::N_COL - N_FSEL_SER },
+        { <SerializationColumn as ColumnIndexer<usize>>::N_COL - N_FSEL_SER },
+        { <SerializationColumn as ColumnIndexer<usize>>::N_COL - N_FSEL_SER },
         0,
         N_FSEL_SER,
         LookupTable<Ff1>,

--- a/msm/src/test/test_circuit/columns.rs
+++ b/msm/src/test/test_circuit/columns.rs
@@ -21,7 +21,7 @@ pub enum TestColumn {
     FixedSel3,
 }
 
-impl ColumnIndexer for TestColumn {
+impl ColumnIndexer<usize> for TestColumn {
     const N_COL: usize = N_COL_TEST;
     fn to_column(self) -> Column<usize> {
         let to_column_inner = |offset, i| {

--- a/o1vm/src/interpreters/keccak/column.rs
+++ b/o1vm/src/interpreters/keccak/column.rs
@@ -373,7 +373,7 @@ impl<T: Clone> IndexMut<ColumnAlias> for KeccakWitness<T> {
     }
 }
 
-impl ColumnIndexer for ColumnAlias {
+impl ColumnIndexer<usize> for ColumnAlias {
     const N_COL: usize = N_ZKVM_KECCAK_REL_COLS + N_ZKVM_KECCAK_SEL_COLS;
     fn to_column(self) -> Column<usize> {
         Column::Relation(usize::from(self))
@@ -401,7 +401,7 @@ impl<T: Clone> IndexMut<Steps> for KeccakWitness<T> {
     }
 }
 
-impl ColumnIndexer for Steps {
+impl ColumnIndexer<usize> for Steps {
     const N_COL: usize = N_ZKVM_KECCAK_REL_COLS + N_ZKVM_KECCAK_SEL_COLS;
     fn to_column(self) -> Column<usize> {
         Column::DynamicSelector(usize::from(self) - N_ZKVM_KECCAK_REL_COLS)

--- a/o1vm/src/interpreters/mips/column.rs
+++ b/o1vm/src/interpreters/mips/column.rs
@@ -143,7 +143,7 @@ impl<T: Clone> IndexMut<ColumnAlias> for MIPSWitness<T> {
     }
 }
 
-impl ColumnIndexer for ColumnAlias {
+impl ColumnIndexer<usize> for ColumnAlias {
     const N_COL: usize = N_MIPS_COLS;
 
     fn to_column(self) -> Column<usize> {
@@ -198,7 +198,7 @@ impl<T: Clone> IndexMut<Instruction> for MIPSWitness<T> {
     }
 }
 
-impl ColumnIndexer for Instruction {
+impl ColumnIndexer<usize> for Instruction {
     const N_COL: usize = N_MIPS_REL_COLS + N_MIPS_SEL_COLS;
     fn to_column(self) -> Column<usize> {
         Column::DynamicSelector(usize::from(self) - N_MIPS_REL_COLS)


### PR DESCRIPTION
This PR builds upon https://github.com/o1-labs/proof-systems/pull/2948, adding a type parameter to `ColumnIndexer` corresponding to the parameter for `Column`. This retains the `usize` type everywhere for now.