### PR TITLE
Saffron CI Speedups and Cleanups

### DIFF
--- a/.github/workflows/saffron.yml
+++ b/.github/workflows/saffron.yml
@@ -31,16 +31,28 @@ jobs:
       - name: Apply the Rust smart cacheing
         uses: Swatinem/rust-cache@v2
 
+      - name: Cache SRS data
+        id: cache-srs
+        uses: actions/cache@v3
+        with:
+          path: ./srs
+          # The SRS generation never changes, so we don't need a content-based key
+          key: srs-cache-key
+
+      - name: Generate and Cache SRS
+        if: steps.cache-srs.outputs.cache-hit != 'true'
+        run: cargo test -p kimchi heavy_test_srs_serialization --release
+
       - name: Build the saffron cli binary
         run: |
           cargo build --release --bin saffron
 
       - name: Run the saffron e2e encoding tests on small lorem file
         run: |
-          ./saffron/test-encoding.sh saffron/fixtures/lorem.txt
+          ./saffron/test-encoding.sh saffron/fixtures/lorem.txt ./srs/test_vesta.srs
 
       # Randomly generate an input file between roughly 50MB and 200MB
       - name: Run the saffron e2e encoding on large random file
         run: |
           (base64 /dev/urandom | head -c $(shuf -i 50000000-200000000 -n 1) | tr -dc "A-Za-z0-9 " | fold -w100 > bigfile.txt) 2>/dev/null
-          RUST_LOG=debug ./saffron/test-encoding.sh bigfile.txt
+          RUST_LOG=debug ./saffron/test-encoding.sh bigfile.txt ./srs/test_vesta.srs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,6 +912,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2651,6 +2661,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "clap 4.4.18",
+ "ctor",
  "hex",
  "kimchi",
  "mina-curves",

--- a/saffron/Cargo.toml
+++ b/saffron/Cargo.toml
@@ -41,5 +41,6 @@ tracing-subscriber = { version = "0.3", features = [ "ansi", "env-filter", "fmt"
 
 [dev-dependencies]
 ark-std.workspace = true
+ctor = "0.2"
 proptest.workspace = true
 once_cell.workspace = true

--- a/saffron/src/blob.rs
+++ b/saffron/src/blob.rs
@@ -22,7 +22,7 @@ pub struct FieldBlob<G: CommitmentCurve> {
     pub data: Vec<DensePolynomial<G::ScalarField>>,
 }
 
-#[instrument(skip_all)]
+#[instrument(skip_all, level = "debug")]
 fn commit_to_blob_data<G: CommitmentCurve>(
     srs: &SRS<G>,
     data: &[DensePolynomial<G::ScalarField>],
@@ -34,7 +34,7 @@ fn commit_to_blob_data<G: CommitmentCurve>(
 }
 
 impl<G: CommitmentCurve> FieldBlob<G> {
-    #[instrument(skip_all)]
+    #[instrument(skip_all, level = "debug")]
     pub fn encode<D: EvaluationDomain<G::ScalarField>>(
         srs: &SRS<G>,
         domain: D,
@@ -51,8 +51,8 @@ impl<G: CommitmentCurve> FieldBlob<G> {
         let commitments = commit_to_blob_data(srs, &data);
 
         debug!(
-            "Encoded {} bytes into {} polynomials",
-            bytes.len(),
+            "Encoded {:.2} MB into {} polynomials",
+            bytes.len() as f32 / 1_000_000.0,
             data.len()
         );
 
@@ -64,7 +64,7 @@ impl<G: CommitmentCurve> FieldBlob<G> {
         }
     }
 
-    #[instrument(skip_all)]
+    #[instrument(skip_all, level = "debug")]
     pub fn decode<D: EvaluationDomain<G::ScalarField>>(domain: D, blob: FieldBlob<G>) -> Vec<u8> {
         // TODO: find an Error type and use Result
         if domain.size() != blob.domain_size {
@@ -93,27 +93,101 @@ impl<G: CommitmentCurve> FieldBlob<G> {
 }
 
 #[cfg(test)]
+mod blob_test_utils {
+    use proptest::prelude::*;
+
+    #[derive(Debug)]
+    pub struct BlobData(pub Vec<u8>);
+
+    #[derive(Clone, Debug)]
+    pub enum DataSize {
+        Small,
+        Medium,
+        Large,
+    }
+
+    // TODO: This is fine for now, but figure out what the realistic expectations are.
+    impl DataSize {
+        fn size_range_bytes(&self) -> (usize, usize) {
+            let c = 1_000_000;
+            match self {
+                Self::Small => (1, 2 * c),
+                Self::Medium => (5 * c, 10 * c),
+                Self::Large => (50 * c, 75 * c),
+            }
+        }
+    }
+
+    impl Arbitrary for DataSize {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            prop_oneof![
+                4 => Just(DataSize::Small),
+                2 => Just(DataSize::Medium),
+                1 => Just(DataSize::Large)
+            ]
+            .boxed()
+        }
+    }
+
+    impl Default for DataSize {
+        fn default() -> Self {
+            Self::Medium
+        }
+    }
+
+    impl Arbitrary for BlobData {
+        type Parameters = DataSize;
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary() -> Self::Strategy {
+            DataSize::arbitrary()
+                .prop_flat_map(|size| {
+                    let (min, max) = size.size_range_bytes();
+                    prop::collection::vec(any::<u8>(), min..max)
+                })
+                .prop_map(BlobData)
+                .boxed()
+        }
+
+        fn arbitrary_with(size: Self::Parameters) -> Self::Strategy {
+            let (min, max) = size.size_range_bytes();
+            prop::collection::vec(any::<u8>(), min..max)
+                .prop_map(BlobData)
+                .boxed()
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
-    use crate::commitment::commit_to_field_elems;
+    use crate::{commitment::commit_to_field_elems, env};
 
     use super::*;
     use ark_poly::Radix2EvaluationDomain;
+    use blob_test_utils::*;
     use mina_curves::pasta::{Fp, Vesta};
     use once_cell::sync::Lazy;
     use proptest::prelude::*;
 
-    const SRS_SIZE: usize = 1 << 16;
-
-    static SRS: Lazy<SRS<Vesta>> = Lazy::new(|| SRS::create(SRS_SIZE));
+    static SRS: Lazy<SRS<Vesta>> = Lazy::new(|| {
+        if let Ok(srs) = std::env::var("SRS_FILEPATH") {
+            env::get_srs_from_cache(srs)
+        } else {
+            SRS::create(1 << 16)
+        }
+    });
 
     static DOMAIN: Lazy<Radix2EvaluationDomain<Fp>> =
-        Lazy::new(|| Radix2EvaluationDomain::new(SRS_SIZE).unwrap());
+        Lazy::new(|| Radix2EvaluationDomain::new(SRS.size()).unwrap());
 
     // check that Vec<u8> -> FieldBlob<Fp> -> Vec<u8> is the identity function
     proptest! {
     #![proptest_config(ProptestConfig::with_cases(20))]
     #[test]
-    fn test_round_trip_blob_encoding( xs in prop::collection::vec(any::<u8>(), 0..=2 * Fp::size_in_bytes() * DOMAIN.size()))
+    fn test_round_trip_blob_encoding(BlobData(xs) in BlobData::arbitrary())
       { let blob = FieldBlob::<Vesta>::encode(&*SRS, *DOMAIN, &xs);
         let bytes = rmp_serde::to_vec(&blob).unwrap();
         let a = rmp_serde::from_slice(&bytes).unwrap();
@@ -128,8 +202,7 @@ mod tests {
     proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
     #[test]
-        fn test_user_and_storage_provider_commitments_equal(xs in prop::collection::vec(any::<u8>(), 0..=2 * Fp::size_in_bytes() * DOMAIN.size())
-        )
+        fn test_user_and_storage_provider_commitments_equal(BlobData(xs) in BlobData::arbitrary())
           { let elems = encode_for_domain(&*DOMAIN, &xs);
             let user_commitments = commit_to_field_elems(&*SRS, *DOMAIN, elems);
             let blob = FieldBlob::<Vesta>::encode(&*SRS, *DOMAIN, &xs);

--- a/saffron/src/blob.rs
+++ b/saffron/src/blob.rs
@@ -106,14 +106,18 @@ mod blob_test_utils {
         Large,
     }
 
-    // TODO: This is fine for now, but figure out what the realistic expectations are.
     impl DataSize {
+        const KB: usize = 1_000;
+        const MB: usize = 1_000_000;
+
         fn size_range_bytes(&self) -> (usize, usize) {
-            let c = 1_000_000;
             match self {
-                Self::Small => (1, 2 * c),
-                Self::Medium => (5 * c, 10 * c),
-                Self::Large => (50 * c, 75 * c),
+                // Small: 1KB - 1MB
+                Self::Small => (Self::KB, Self::MB),
+                // Medium: 1MB - 10MB
+                Self::Medium => (Self::MB, 10 * Self::MB),
+                // Large: 10MB - 100MB
+                Self::Large => (10 * Self::MB, 100 * Self::MB),
             }
         }
     }
@@ -124,8 +128,8 @@ mod blob_test_utils {
 
         fn arbitrary_with(_: ()) -> Self::Strategy {
             prop_oneof![
-                4 => Just(DataSize::Small),
-                2 => Just(DataSize::Medium),
+                6 => Just(DataSize::Small), // 60% chance
+                3 => Just(DataSize::Medium),
                 1 => Just(DataSize::Large)
             ]
             .boxed()
@@ -134,7 +138,7 @@ mod blob_test_utils {
 
     impl Default for DataSize {
         fn default() -> Self {
-            Self::Medium
+            Self::Small
         }
     }
 

--- a/saffron/src/commitment.rs
+++ b/saffron/src/commitment.rs
@@ -10,7 +10,7 @@ use poly_commitment::{
 use rayon::prelude::*;
 use tracing::instrument;
 
-#[instrument(skip_all)]
+#[instrument(skip_all, level = "debug")]
 pub fn commit_to_field_elems<G: CommitmentCurve>(
     srs: &SRS<G>,
     domain: D<G::ScalarField>,
@@ -25,7 +25,7 @@ pub fn commit_to_field_elems<G: CommitmentCurve>(
         .collect()
 }
 
-#[instrument(skip_all)]
+#[instrument(skip_all, level = "debug")]
 pub fn fold_commitments<
     G: AffineRepr,
     EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,

--- a/saffron/src/env.rs
+++ b/saffron/src/env.rs
@@ -1,0 +1,58 @@
+use std::{fs::File, path::Path};
+
+use kimchi::precomputed_srs::TestSRS;
+use poly_commitment::{commitment::CommitmentCurve, ipa::SRS};
+use time::macros::format_description;
+use tracing::debug;
+use tracing_subscriber::{
+    fmt::{format::FmtSpan, time::UtcTime},
+    EnvFilter,
+};
+
+pub fn get_srs_from_cache<G: CommitmentCurve>(cache: String) -> SRS<G> {
+    debug!("Loading SRS from cache {}", cache);
+    let file_path = Path::new(&cache);
+    let file = File::open(file_path).expect("Error opening SRS cache file");
+    let srs: SRS<G> = {
+        // By convention, proof systems serializes a TestSRS with filename 'test_<CURVE_NAME>.srs'.
+        // The benefit of using this is you don't waste time verifying the SRS.
+        if file_path
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("test_")
+        {
+            let test_srs: TestSRS<G> = rmp_serde::from_read(&file).unwrap();
+            From::from(test_srs)
+        } else {
+            rmp_serde::from_read(&file).unwrap()
+        }
+    };
+    debug!("SRS loaded successfully from cache");
+    srs
+}
+
+pub fn init_console_subscriber() {
+    let timer = UtcTime::new(format_description!(
+        "[year]-[month]-[day]T[hour repr:24]:[minute]:[second].[subsecond digits:3]Z"
+    ));
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_span_events(FmtSpan::CLOSE)
+        .with_timer(timer)
+        .with_target(true)
+        .with_thread_ids(false)
+        .with_line_number(false)
+        .with_file(false)
+        .with_level(true)
+        .with_ansi(true)
+        .with_writer(std::io::stdout)
+        .init();
+}
+
+#[cfg(test)]
+#[ctor::ctor]
+fn init_test_logging() {
+    init_console_subscriber();
+}

--- a/saffron/src/lib.rs
+++ b/saffron/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod blob;
 pub mod cli;
 pub mod commitment;
+pub mod env;
 pub mod utils;

--- a/saffron/src/utils.rs
+++ b/saffron/src/utils.rs
@@ -103,7 +103,7 @@ mod tests {
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(20))]
         #[test]
-        fn test_round_trip_blob_encoding(xs in prop::collection::vec(any::<u8>(), 0..=2 * Fp::size_in_bytes() * DOMAIN.size())
+        fn test_round_trip_encoding_to_field_elems(xs in prop::collection::vec(any::<u8>(), 0..=2 * Fp::size_in_bytes() * DOMAIN.size())
     )
           { let chunked = encode_for_domain(&*DOMAIN, &xs);
             let elems = chunked


### PR DESCRIPTION
## Summary
Collects some improvements to running tests / CI that came up while working on #2968 , felt like it was better to pull them out and apply them in a separate PR

## Changes
- Add SRS caching in CI which reduces the e2e test time from [~3 min](https://github.com/o1-labs/proof-systems/actions/runs/12995728856/job/36243038553?pr=2967) to [20 seconds](https://github.com/o1-labs/proof-systems/actions/runs/12998174831/job/36250749999?pr=2970) :exploding_head:
- Refine the random data generation for the blob unit tests
- add console logging subscriber to tests (still controlled by `RUST_LOG` env var)