### PR TITLE
[saffron] Property based test for query

### DIFF
--- a/saffron/Cargo.toml
+++ b/saffron/Cargo.toml
@@ -38,9 +38,8 @@ time = { version = "0.3", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [ "ansi", "env-filter", "fmt", "time" ] }
 
-ark-std.workspace = true
-
 [dev-dependencies]
+ark-std.workspace = true
 ctor = "0.2"
 proptest.workspace = true
 once_cell.workspace = true


### PR DESCRIPTION
- move the `blob_test_utils` module to `utils.rs` and use as standard way for all data generation. Renamed the generator from `BlobData` to `UserData` to reflect that it has nothing to do with blobs apriori

- reworked @marcbeunardeau88 's test to generate and test multiple queries for every user data generation round