### PR TITLE
[saffron] cleanup query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,6 +2675,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sha3",
+ "thiserror",
  "time",
  "tracing",
  "tracing-subscriber",

--- a/saffron/Cargo.toml
+++ b/saffron/Cargo.toml
@@ -34,6 +34,7 @@ rmp-serde.workspace = true
 serde.workspace = true
 serde_with.workspace = true
 sha3.workspace = true
+thiserror.workspace = true
 time = { version = "0.3", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [ "ansi", "env-filter", "fmt", "time" ] }

--- a/saffron/src/utils.rs
+++ b/saffron/src/utils.rs
@@ -297,6 +297,25 @@ mod tests {
           }
         }
 
+    fn padded_field_length(xs: &[u8]) -> usize {
+        let m = Fp::MODULUS_BIT_SIZE as usize / 8;
+        let n = xs.len();
+        let num_field_elems = (n + m - 1) / m;
+        let num_polys = (num_field_elems + DOMAIN.size() - 1) / DOMAIN.size();
+        DOMAIN.size() * num_polys
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(20))]
+        #[test]
+        fn test_padded_byte_length(UserData(xs) in UserData::arbitrary()
+    )
+          { let chunked = encode_for_domain(&*DOMAIN, &xs);
+            let n = chunked.into_iter().flatten().count();
+            prop_assert_eq!(n, padded_field_length(&xs));
+          }
+        }
+
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(20))]
         #[test]

--- a/saffron/src/utils.rs
+++ b/saffron/src/utils.rs
@@ -59,7 +59,7 @@ pub struct QueryBytes {
 #[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Debug)]
 /// We store the data in a vector of vector of field element
 /// The inner vector represent polynomials
-pub struct FieldElt {
+struct FieldElt {
     /// the index of the polynomial the data point is attached too
     poly_index: usize,
     /// the index of the root of unity the data point is attached too
@@ -146,14 +146,6 @@ impl QueryBytes {
                 n_polys,
             }
         };
-        if start.poly_index >= n_polys {
-            return Err(QueryError::QueryOutOfBounds {
-                poly_index: start.poly_index,
-                eval_index: start.eval_index,
-                n_polys,
-                domain_size,
-            });
-        };
         let byte_end = self.start + self.len;
         let end = {
             let end_field_nb = byte_end / n;
@@ -164,7 +156,8 @@ impl QueryBytes {
                 n_polys,
             }
         };
-        if end.poly_index >= n_polys {
+
+        if start.poly_index >= n_polys || end.poly_index >= n_polys {
             return Err(QueryError::QueryOutOfBounds {
                 poly_index: end.poly_index,
                 eval_index: end.eval_index,
@@ -196,6 +189,10 @@ pub mod test_utils {
     impl UserData {
         pub fn len(&self) -> usize {
             self.0.len()
+        }
+
+        pub fn is_empty(&self) -> bool {
+            self.0.is_empty()
         }
     }
 


### PR DESCRIPTION
## Summary
@marcbeunardeau88 did the initial index arithmetic to make the query interface, this PR just cleans up that work. I added additional tests to cover edge cases and attempted to make it more idiomatic (in an opinionated fashion).

The commits are atomic, individual diffs should be clear

## Changes
- add an error type for malformed queries and force construction of well formed queries through smart constructor `into_query_field`. Added tests. https://github.com/o1-labs/proof-systems/commit/416ed93c800bb52046061435ba8ef5c83d6cc0e5
- remove hard coded use of values like `31` (https://github.com/o1-labs/proof-systems/commit/482964f0e30ba6c01c7e102aa9f80c6d768c8c0b, https://github.com/o1-labs/proof-systems/commit/ffa98c747a37ca628ff358fe6dc5408ca261fc80) and `2 ^ 16` (https://github.com/o1-labs/proof-systems/commit/416ed93c800bb52046061435ba8ef5c83d6cc0e5)
- Use the iterator to fulfill the query https://github.com/o1-labs/proof-systems/commit/3935f75c7de9d3b69dc5fbf589b2307b77c53bd6
- Added test to check that the nil query doesn't throw an error https://github.com/o1-labs/proof-systems/commit/af1b31b83c47ad259fe278b54c2cd82f1a4e530e