### PR TITLE
Arrabbiata: specialise E1::BaseField into a PrimeField

### DIFF
--- a/arrabbiata/src/witness.rs
+++ b/arrabbiata/src/witness.rs
@@ -49,7 +49,10 @@ pub struct Env<
     Fq: PrimeField,
     E1: ArrabbiataCurve<ScalarField = Fp, BaseField = Fq>,
     E2: ArrabbiataCurve<ScalarField = Fq, BaseField = Fp>,
-> {
+> where
+    E1::BaseField: PrimeField,
+    E2::BaseField: PrimeField,
+{
     // ----------------
     // Setup related (domains + SRS)
     /// Domain for Fp


### PR DESCRIPTION
In addition to that, a helper to get the curve parameters is requested into the implementation of the trait ArrabbiataCurve. This is to avoid adding additional type constraints when accessing the parameters is required.