### PR TITLE
Typos fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Generally, proof-systems intends to be synchronized with the mina repository (se
 - `compatible`:
   - Compatible with `rampup` in `mina`.
   - Mina's `compatible`, similarly to mina's `master`, does not have `proof-systems`.
-- `berkley`: future hardfork release, will be going out to berkeley.
+- `berkeley`: future hardfork release, will be going out to berkeley.
   - This is where hotfixes go.
 - `develop`: matches mina's `develop`, soft fork-compatibility.
   - Also used by `mina/o1js-main` and `o1js/main`.

--- a/book/specifications/kimchi/template.md
+++ b/book/specifications/kimchi/template.md
@@ -461,7 +461,7 @@ The following sections specify how a prover creates a proof, and how a verifier 
 
 To create a proof, the prover expects:
 
-* A prover index, containing a representation of the circuit (and optionaly pre-computed values to be used in the proof creation).
+* A prover index, containing a representation of the circuit (and optionally pre-computed values to be used in the proof creation).
 * The (filled) registers table, representing parts of the execution trace of the circuit.
 
 ```admonish

--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1696,7 +1696,7 @@ To create the index, follow these steps:
    with the table ID of the table.
 	* Copy the entries from the table to new rows in the corresponding columns of the concatenated table.
 	* Fill in any unused columns with 0 (to match the dummy value)
-6. Pad the end of the concatened table with the dummy value.
+6. Pad the end of the concatenated table with the dummy value.
 7. Pad the end of the table id vector with 0s.
 8. pre-compute polynomial and evaluation form for the look up tables
 9. pre-compute polynomial and evaluation form for the table IDs,
@@ -2156,7 +2156,7 @@ The prover then follows the following steps to create the proof:
    Note: unlike the original PLONK protocol,
    the prover also provides evaluations of the public polynomial to help the verifier circuit.
    This is why we need to absorb the commitment to the public polynomial at this point.
-1. Commit to the witness columns by creating `COLUMNS` hidding commitments.
+1. Commit to the witness columns by creating `COLUMNS` hiding, hidden commitments.
 
    Note: since the witness is in evaluation form,
    we can use the `commit_evaluation` optimization.
@@ -2193,7 +2193,7 @@ The prover then follows the following steps to create the proof:
 	* Commit to the aggregation polynomial.
 	* Absorb the commitment to the aggregation polynomial with the Fq-Sponge.
 1. Compute the permutation aggregation polynomial $z$.
-1. Commit (hidding) to the permutation aggregation polynomial $z$.
+1. Commit (hiding, hidden) to the permutation aggregation polynomial $z$.
 1. Absorb the permutation aggregation polynomial $z$ with the Fq-Sponge.
 1. Sample $\alpha'$ with the Fq-Sponge.
 1. Derive $\alpha$ from $\alpha'$ using the endomorphism (TODO: details)


### PR DESCRIPTION
### Changes

1. **File:** `/CONTRIBUTING.md`
    - Fixed `berkley` to `berkeley` (Line 115)
1. **File:** `/book/specifications/kimchi/template.md`
    - Fixed `optionaly` to `optionally` (Line 464)
1. **File:** `/book/src/specs/kimchi.md`
    - Fixed `concatened` to `concatenated` (Line 1699)
    - Fixed `hidding` to `hiding, hidden` (Line 2159)

### Purpose

- Improved documentation accuracy by fixing typographical errors.
- Ensured better readability and consistency.