### PR TITLE
Fixed typos

### DIFF
--- a/book/src/fundamentals/zkbook_groups.md
+++ b/book/src/fundamentals/zkbook_groups.md
@@ -212,7 +212,7 @@ $$
 
 so the triple $(X, Y, Z)$ corresponds to the affine point $(X/Z^2, Y/Z^3)$. These are the fastest for computing group addition on a normal computer.
 
-#### Take aways
+#### Take always, away
 
 - Use affine coordinates when the cost of division doesn't matter and saving space is important. Specific contexts to keep in mind:
 

--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1937,7 +1937,7 @@ sequenceDiagram
     Prover->>Verifier: aggregated evaluation proof (involves more interaction)
 ```
 
-The Fiat-Shamir transform simulates the verifier messages via a hash function that hashes the transcript of the protocol so far before outputing verifier messages.
+The Fiat-Shamir transform simulates the verifier messages via a hash function that hashes the transcript of the protocol so far before outputting verifier messages.
 You can find these operations under the [proof creation](#proof-creation) and [proof verification](#proof-verification) algorithms as absorption and squeezing of values with the sponge.
 
 ### Proof Structure

--- a/kimchi/snarky-deriver/README.md
+++ b/kimchi/snarky-deriver/README.md
@@ -1,4 +1,4 @@
-# Snarky deriver
+# Snarky derive, driver
 
 This crate contains procedural macros used by snarky.
 In Rust, procedural macros must be defined in a separate crate, this is why this code is split from kimchi.


### PR DESCRIPTION
### Changes

1. **File:** `/kimchi/snarky-deriver/README.md`
    - Fixed `deriver` to `derive, driver` (Line 1)
1. **File:** `/book/src/fundamentals/zkbook_groups.md`
    - Fixed `aways` to `always, away` (Line 215)
1. **File:** `/book/src/specs/kimchi.md`
    - Fixed `outputing` to `outputting` (Line 1940)

### Purpose

- Enhanced the clarity and professionalism of the documentation.
- Fixed minor grammatical issues for better understanding.