### PR TITLE
Corrected typos

### DIFF
--- a/book/specifications/kimchi/template.md
+++ b/book/specifications/kimchi/template.md
@@ -446,7 +446,7 @@ sequenceDiagram
     Prover->>Verifier: aggregated evaluation proof (involves more interaction)
 ```
 
-The Fiat-Shamir transform simulates the verifier messages via a hash function that hashes the transcript of the protocol so far before outputing verifier messages.
+The Fiat-Shamir transform simulates the verifier messages via a hash function that hashes the transcript of the protocol so far before outputting verifier messages.
 You can find these operations under the [proof creation](#proof-creation) and [proof verification](#proof-verification) algorithms as absorption and squeezing of values with the sponge.
 
 ### Proof Structure

--- a/book/src/specs/kimchi.md
+++ b/book/src/specs/kimchi.md
@@ -1203,7 +1203,7 @@ One could lay this out as a double-width gate for chained foreign additions and 
 We reuse the foreign field addition gate for the final bound check since this is an addition with a
 specific parameter structure. Checking that the correct right input, overflow, and overflow are used shall
 be done by copy constraining these values with a public input value. One could have a specific gate
-for just this check requiring less constrains, but the cost of adding one more selector gate outweights
+for just this check requiring less constrains, but the cost of adding one more selector gate outweighs
 the savings of one row and a few constraints of difference.
 
 ##### Integration
@@ -2119,7 +2119,7 @@ The following sections specify how a prover creates a proof, and how a verifier 
 
 To create a proof, the prover expects:
 
-* A prover index, containing a representation of the circuit (and optionaly pre-computed values to be used in the proof creation).
+* A prover index, containing a representation of the circuit (and optionally pre-computed values to be used in the proof creation).
 * The (filled) registers table, representing parts of the execution trace of the circuit.
 
 ```admonish


### PR DESCRIPTION
### Changes

1. **File:** `/book/specifications/kimchi/template.md`
    - Fixed `outputing` to `outputting` (Line 449)
1. **File:** `/book/src/specs/kimchi.md`
    - Fixed `outweights` to `outweighs` (Line 1206)
    - Fixed `optionaly` to `optionally` (Line 2122)

### Purpose

- EImproved the documentation's clarity and professional tone.
- Corrected small grammatical errors to enhance comprehension.