### PR TITLE
o1vm/lookup: add expressions for lookup constraint

### DIFF
--- a/o1vm/src/pickles/lookup_columns.rs
+++ b/o1vm/src/pickles/lookup_columns.rs
@@ -1,0 +1,18 @@
+use kimchi::circuits::expr::{ConstantExpr, Expr};
+
+pub enum LookupColumns {
+    Wires(usize),
+    Inverses(usize),
+    Acc,
+}
+
+pub enum LookupChallengeTerm {
+    //The challenge to compute 1/(beta + lookupvalue)
+    Beta,
+    // The challenge to combine tuple sum beta^i lookupvalue_i
+    Gamma,
+    // The challenge to combine constraints
+    Alpha,
+}
+
+pub type ELookup<F> = Expr<ConstantExpr<F, LookupChallengeTerm>, LookupColumns>;

--- a/o1vm/src/pickles/mod.rs
+++ b/o1vm/src/pickles/mod.rs
@@ -17,6 +17,8 @@ pub mod proof;
 pub mod prover;
 pub mod verifier;
 
+pub mod lookup_columns;
+
 /// Maximum degree of the constraints.
 /// It does include the additional degree induced by the multiplication of the
 /// selectors.


### PR DESCRIPTION
Lay the ground work to use a specific challenge term and column type for the lookup prover.
Will allow not to reuse the msm columns and berkeley challenge as we usually do