### PR TITLE
[Saffron] Add update function

### DIFF
--- a/saffron/e2e-test.sh
+++ b/saffron/e2e-test.sh
@@ -13,6 +13,31 @@ if [ $# -eq 2 ]; then
 fi
 ENCODED_FILE="${INPUT_FILE%.*}.bin"
 DECODED_FILE="${INPUT_FILE%.*}-decoded${INPUT_FILE##*.}"
+PERTURBED_FILE="${INPUT_FILE%.*}_perturbed"
+ENCODED_DIFF_FILE="${ENCODED_FILE%.*}_diff.bin"
+
+compare_files() {
+   local file1="$1"
+   local file2="$2"
+   
+   echo "Comparing files..."
+   if cmp -s "$file1" "$file2"; then
+       echo "✓ Success: Files are identical"
+   else
+       echo "✗ Error: Files differ"
+       echo "Keeping files for inspection"
+       diff "$file1" "$file2"
+       exit 1
+   fi
+}
+
+perturb_bytes() {
+   local input_file=$1
+   local output_file=$2
+   local threshold=${3:-0.1}  # Default 10% chance
+   
+   perl -pe "rand() < $threshold and \$_ = chr(rand(256))" "$input_file" > "$output_file"
+}
 
 # Ensure input file exists
 if [ ! -f "$INPUT_FILE" ]; then
@@ -22,8 +47,6 @@ fi
 
 # Compute commitment and capture last line
 COMMITMENT=$(cargo run --release --bin saffron compute-commitment -i "$INPUT_FILE" $SRS_ARG | tee /dev/stderr | tail -n 1)
-
-
 
 # Run encode with captured commitment
 echo "Encoding $INPUT_FILE to $ENCODED_FILE"
@@ -61,16 +84,28 @@ if ! cargo run --release --bin saffron decode -i "$ENCODED_FILE" -o "$DECODED_FI
     exit 1
 fi
 
-# Compare files
-echo "Comparing original and decoded files..."
-if cmp -s "$INPUT_FILE" "$DECODED_FILE"; then
-    echo "✓ Success: Files are identical"
-    echo "Cleaning up temporary files..."
-    rm -f "$ENCODED_FILE" "$DECODED_FILE"
-    exit 0
-else
-    echo "✗ Error: Files differ"
-    echo "Keeping temporary files for inspection"
-    diff "$INPUT_FILE" "$DECODED_FILE"
+# Compare file to original
+compare_files "$INPUT_FILE" "$DECODED_FILE"
+
+# Usage example in your script:
+perturb_bytes "$INPUT_FILE" "$PERTURBED_FILE" 0.1
+
+echo "Calculating diff for upated $INPUT_FILE (stored updated data in $PERTURBED_FILE)"
+cargo run --release --bin saffron calculate-diff --old "$INPUT_FILE" --new "$PERTURBED_FILE" -o "$ENCODED_DIFF_FILE" $SRS_ARG
+
+echo "Updating file with Storage Provider"
+cargo run --release --bin saffron update -i "$ENCODED_FILE" --diff-file "$ENCODED_DIFF_FILE" --assert-commitment "$COMMITMENT" $SRS_ARG
+
+# Run decode
+echo "Decoding $ENCODED_FILE to $DECODED_FILE"
+if ! cargo run --release --bin saffron decode -i "$ENCODED_FILE" -o "$DECODED_FILE" $SRS_ARG; then
+    echo "Decoding failed"
     exit 1
 fi
+
+# Compare update file to perturbed file
+compare_files "$PERTURBED_FILE" "$DECODED_FILE"
+
+echo "Cleaning up temporary files..."
+rm -f "$ENCODED_FILE" "$DECODED_FILE" "$PERTURBED_FILE" "$ENCODED_DIFF_FILE"
+exit 0

--- a/saffron/e2e-test.sh
+++ b/saffron/e2e-test.sh
@@ -13,10 +13,10 @@ if [ $# -eq 2 ]; then
 fi
 
 ENCODED_FILE="${INPUT_FILE%.*}.bin"
-DECODED_FILE="${INPUT_FILE%.*}-decoded${INPUT_FILE##*.}"
-PERTURBED_FILE="${INPUT_FILE%.*}_perturbed${INPUT_FILE##*.}"
+DECODED_FILE="${INPUT_FILE%.*}_decoded.${INPUT_FILE##*.}"
+PERTURBED_FILE="${INPUT_FILE%.*}_perturbed.${INPUT_FILE##*.}"
 ENCODED_DIFF_FILE="${ENCODED_FILE%.*}_diff.bin"
-DECODED_PERTURBED_FILE="${PERTURBED_FILE}-decoded${INPUT_FILE##*.}"
+DECODED_PERTURBED_FILE="${PERTURBED_FILE%.*}_decoded.${PERTURBED_FILE##*.}"
 
 compare_files() {
    local file1="$1"

--- a/saffron/src/blob.rs
+++ b/saffron/src/blob.rs
@@ -224,14 +224,15 @@ mod tests {
     proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
     #[test]
-        fn test_update(UserData(xs) in UserData::arbitrary()
-        )
+        fn test_update((threshold, UserData(xs)) in (0.0..1.0f64).prop_flat_map(|t| {
+           UserData::arbitrary().prop_map(move |d| (t, d))
+        }))
         {
             // start with some random user data
             let mut xs_blob = FieldBlob::<Vesta>::encode::<_, DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>>(&*SRS, *DOMAIN, &xs);
 
             // randomly update this data and then update the blob
-            let ys = random_perturbation(0.25, &xs);
+            let ys = random_perturbation(threshold, &xs);
             let d = make_diff(&*DOMAIN, &xs, &ys);
             xs_blob.update::<DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>>(&*SRS, &*DOMAIN, d);
 

--- a/saffron/src/blob.rs
+++ b/saffron/src/blob.rs
@@ -1,8 +1,6 @@
-use std::collections::HashMap;
-
 use crate::{
     commitment::fold_commitments,
-    utils::{decode_into, encode_for_domain},
+    utils::{decode_into, encode_for_domain, Diff},
 };
 use ark_ec::AffineRepr;
 use ark_ff::{PrimeField, Zero};
@@ -122,16 +120,17 @@ impl<G: KimchiCurve> FieldBlob<G> {
         &mut self,
         srs: &SRS<G>,
         domain: &Radix2EvaluationDomain<G::ScalarField>,
-        diffs: Vec<HashMap<usize, G::ScalarField>>,
+        diff: Diff<G::ScalarField>,
     ) {
-        let updates: Vec<(usize, PolyComm<G>, DensePolynomial<G::ScalarField>)> = diffs
+        let updates: Vec<(usize, PolyComm<G>, DensePolynomial<G::ScalarField>)> = diff
+            .evaluation_diffs
             .into_par_iter()
             .enumerate()
-            .map(|(index, diff)| {
+            .map(|(index, d)| {
                 let d_p = {
                     let evals = (0..domain.size())
                         .map(|i| {
-                            diff.get(&i)
+                            d.get(&i)
                                 .copied()
                                 .unwrap_or(<G as AffineRepr>::ScalarField::zero())
                         })

--- a/saffron/src/cli.rs
+++ b/saffron/src/cli.rs
@@ -65,6 +65,9 @@ pub struct ComputeCommitmentArgs {
     #[arg(long, short = 'i', value_name = "FILE", help = "input file")]
     pub input: String,
 
+    #[arg(long, short = 'o', value_name = "FILE", help = "output file")]
+    pub output: String,
+
     #[arg(long = "srs-filepath", value_name = "SRS_FILEPATH")]
     pub srs_cache: Option<String>,
 }
@@ -122,8 +125,22 @@ pub struct CalculateDiffArgs {
     #[arg(long, value_name = "FILE", help = "old data file")]
     pub old: String,
 
+    #[arg(
+        long = "old-commitment-file",
+        value_name = "FILE",
+        help = "commitment file for old data"
+    )]
+    pub old_commitment: String,
+
     #[arg(long, value_name = "FILE", help = "new data file")]
     pub new: String,
+
+    #[arg(
+        long = "new-commitment-file",
+        value_name = "FILE",
+        help = "file to write new commitment"
+    )]
+    pub new_commitment_file: String,
 
     #[arg(long, short = 'o', value_name = "FILE", help = "output file")]
     pub output: String,

--- a/saffron/src/cli.rs
+++ b/saffron/src/cli.rs
@@ -124,6 +124,32 @@ pub struct CalculateDiffArgs {
 
     #[arg(long, value_name = "FILE", help = "new data file")]
     pub new: String,
+
+    #[arg(long, short = 'o', value_name = "FILE", help = "output file")]
+    pub output: String,
+}
+
+#[derive(Parser)]
+pub struct UpdateArgs {
+    #[arg(long = "srs-filepath", value_name = "SRS_FILEPATH")]
+    pub srs_cache: Option<String>,
+
+    #[arg(long, short = 'i', value_name = "FILE", help = "input file")]
+    pub input: String,
+
+    #[arg(
+        long = "diff-file",
+        value_name = "FILE",
+        help = "hex encoded Diff struct"
+    )]
+    pub diff_file: String,
+
+    #[arg(
+        long = "assert-commitment",
+        value_name = "COMMITMENT",
+        help = "hash of commitments (hex encoded)"
+    )]
+    pub assert_commitment: Option<HexString>,
 }
 
 #[derive(Parser)]
@@ -145,4 +171,6 @@ pub enum Commands {
     VerifyStorageProof(VerifyStorageProofArgs),
     #[command(name = "calculate-diff")]
     CalculateDiff(CalculateDiffArgs),
+    #[command(name = "update")]
+    Update(UpdateArgs),
 }

--- a/saffron/src/cli.rs
+++ b/saffron/src/cli.rs
@@ -115,6 +115,18 @@ pub struct VerifyStorageProofArgs {
 }
 
 #[derive(Parser)]
+pub struct CalculateDiffArgs {
+    #[arg(long = "srs-filepath", value_name = "SRS_FILEPATH")]
+    pub srs_cache: Option<String>,
+
+    #[arg(long, value_name = "FILE", help = "old data file")]
+    pub old: String,
+
+    #[arg(long, value_name = "FILE", help = "new data file")]
+    pub new: String,
+}
+
+#[derive(Parser)]
 #[command(
     name = "saffron",
     version = "0.1",
@@ -131,4 +143,6 @@ pub enum Commands {
     StorageProof(StorageProofArgs),
     #[command(name = "verify-storage-proof")]
     VerifyStorageProof(VerifyStorageProofArgs),
+    #[command(name = "calculate-diff")]
+    CalculateDiff(CalculateDiffArgs),
 }

--- a/saffron/src/commitment.rs
+++ b/saffron/src/commitment.rs
@@ -1,6 +1,7 @@
 use ark_ec::AffineRepr;
 use ark_ff::One;
 use ark_poly::{Evaluations, Radix2EvaluationDomain as D};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use kimchi::curve::KimchiCurve;
 use mina_poseidon::FqSponge;
 use poly_commitment::{
@@ -9,28 +10,87 @@ use poly_commitment::{
     PolyComm, SRS as _,
 };
 use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use tracing::instrument;
 
+use crate::utils::Diff;
+
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(bound = "G::ScalarField: CanonicalDeserialize + CanonicalSerialize")]
+pub struct Commitment<G: CommitmentCurve> {
+    pub commitments: Vec<PolyComm<G>>,
+    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
+    pub alpha: G::ScalarField,
+    pub folded_commitment: PolyComm<G>,
+}
+
+impl<G: KimchiCurve> Commitment<G> {
+    pub fn from_commitments<EFqSponge>(
+        commitments: Vec<PolyComm<G>>,
+        sponge: &mut EFqSponge,
+    ) -> Self
+    where
+        EFqSponge: FqSponge<G::BaseField, G, G::ScalarField>,
+    {
+        let (folded_commitment, alpha) = fold_commitments(sponge, &commitments);
+        Self {
+            commitments,
+            alpha,
+            folded_commitment,
+        }
+    }
+
+    pub fn update<EFqSponge>(
+        &mut self,
+        srs: &SRS<G>,
+        domain: D<G::ScalarField>,
+        diff: &Diff<G::ScalarField>,
+    ) where
+        EFqSponge: FqSponge<G::BaseField, G, G::ScalarField>,
+    {
+        let ds: Vec<PolyComm<G>> = diff
+            .evaluation_diffs
+            .iter()
+            .map(|diff| {
+                let evals = Evaluations::from_vec_and_domain(diff.to_vec(), domain);
+                srs.commit_evaluations_non_hiding(domain, &evals)
+            })
+            .collect();
+        let commitments: Vec<PolyComm<G>> = self
+            .commitments
+            .iter()
+            .zip(ds.iter())
+            .map(|(c, d)| c + d)
+            .collect();
+        let mut sponge = EFqSponge::new(G::other_curve_sponge_params());
+        *self = Commitment::from_commitments(commitments, &mut sponge);
+    }
+}
+
 #[instrument(skip_all, level = "debug")]
-pub fn commit_to_field_elems<G: CommitmentCurve>(
+pub fn commit_to_field_elems<G: KimchiCurve, EFqSponge>(
     srs: &SRS<G>,
     domain: D<G::ScalarField>,
     field_elems: Vec<Vec<G::ScalarField>>,
-) -> Vec<PolyComm<G>> {
-    field_elems
+) -> Commitment<G>
+where
+    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
+{
+    let commitments = field_elems
         .par_iter()
         .map(|chunk| {
             let evals = Evaluations::from_vec_and_domain(chunk.to_vec(), domain);
             srs.commit_evaluations_non_hiding(domain, &evals)
         })
-        .collect()
+        .collect();
+    let mut sponge = EFqSponge::new(G::other_curve_sponge_params());
+    Commitment::from_commitments(commitments, &mut sponge)
 }
 
 #[instrument(skip_all, level = "debug")]
-pub fn fold_commitments<
-    G: AffineRepr,
-    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
->(
+fn fold_commitments<G: AffineRepr, EFqSponge: FqSponge<G::BaseField, G, G::ScalarField>>(
     sponge: &mut EFqSponge,
     commitments: &[PolyComm<G>],
 ) -> (PolyComm<G>, G::ScalarField) {
@@ -50,20 +110,4 @@ pub fn fold_commitments<
         PolyComm::multi_scalar_mul(&commitments.iter().collect::<Vec<_>>(), &powers),
         alpha,
     )
-}
-
-pub fn user_commitment<
-    G: KimchiCurve,
-    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
->(
-    srs: &SRS<G>,
-    domain: D<G::ScalarField>,
-    field_elems: Vec<Vec<G::ScalarField>>,
-) -> PolyComm<G> {
-    let commitments = commit_to_field_elems(srs, domain, field_elems);
-    let (commitment, _) = {
-        let mut sponge = EFqSponge::new(G::other_curve_sponge_params());
-        fold_commitments(&mut sponge, &commitments)
-    };
-    commitment
 }

--- a/saffron/src/proof.rs
+++ b/saffron/src/proof.rs
@@ -44,7 +44,7 @@ where
             .fold(init, |(acc_poly, curr_power), curr_poly| {
                 (
                     acc_poly + curr_poly.scale(curr_power),
-                    curr_power * blob.alpha,
+                    curr_power * blob.commitment.alpha,
                 )
             })
             .0
@@ -119,7 +119,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        commitment::{commit_to_field_elems, fold_commitments},
+        commitment::commit_to_field_elems,
         env,
         utils::{encode_for_domain, test_utils::UserData},
     };
@@ -153,13 +153,9 @@ mod tests {
     #[test]
     fn test_storage_prove_verify(UserData(data) in UserData::arbitrary()) {
         let mut rng = OsRng;
-        let (commitment,_) = {
+        let commitment = {
             let field_elems = encode_for_domain(&*DOMAIN, &data);
-            let user_commitments = commit_to_field_elems(&*SRS, *DOMAIN, field_elems);
-            let mut fq_sponge = VestaFqSponge::new(
-                mina_poseidon::pasta::fq_kimchi::static_params(),
-            );
-            fold_commitments(&mut fq_sponge, &user_commitments)
+            commit_to_field_elems::<Vesta, VestaFqSponge>(&*SRS, *DOMAIN, field_elems)
         };
         let blob = FieldBlob::<Vesta>::encode::<_, VestaFqSponge>(&*SRS, *DOMAIN, &data);
         let evaluation_point = Fp::rand(&mut rng);
@@ -170,7 +166,7 @@ mod tests {
         let res = verify_storage_proof::<Vesta, VestaFqSponge>(
             &*SRS,
             &*GROUP_MAP,
-            commitment,
+            commitment.folded_commitment,
             evaluation_point,
             &proof,
             &mut rng,


### PR DESCRIPTION
## Summary
The user needs to be able to update data with the storage provider. This is done by posting "diff" objects, not by simply posting the raw updated data. This PR implements this feature.

## Changes
- add `Diff` type and utils function for computing a `Diff` over binary data. 
- add update method on `FieldBlob` type. Add tests for random updates on random data.
- add two cli commands:
  1. `calculate-diff`: used by the user to calculate the `Diff` object using the `old` and `new` files as input https://github.com/o1-labs/proof-systems/commit/6eeb13eabe277b0bc978c8ede2e0dda16b6fcd75
  2. `update`: Ask the storage provider to update some given data using the `Diff` object calculated by `(1)` https://github.com/o1-labs/proof-systems/commit/61bb85ffdb1d50d0c559114a6fc34b644aa1c876
- update e2e test script to perform a diff operation and check that the data was updated correctly. https://github.com/o1-labs/proof-systems/commit/2ba1a3f3c3f8ab9ddc6ecd5f8febe6e9b6a66c21