### PR TITLE
[saffron] add commitment type shared between user and provider

### DIFF
--- a/saffron/e2e-test.sh
+++ b/saffron/e2e-test.sh
@@ -11,6 +11,7 @@ SRS_ARG=""
 if [ $# -eq 2 ]; then
    SRS_ARG="--srs-filepath $2"
 fi
+COMMITMENT_FILE="${INPUT_FILE%.*}_commitment.bin"
 ENCODED_FILE="${INPUT_FILE%.*}.bin"
 DECODED_FILE="${INPUT_FILE%.*}-decoded${INPUT_FILE##*.}"
 
@@ -21,9 +22,7 @@ if [ ! -f "$INPUT_FILE" ]; then
 fi
 
 # Compute commitment and capture last line
-COMMITMENT=$(cargo run --release --bin saffron compute-commitment -i "$INPUT_FILE" $SRS_ARG | tee /dev/stderr | tail -n 1)
-
-
+COMMITMENT=$(cargo run --release --bin saffron compute-commitment -i "$INPUT_FILE" -o "$COMMITMENT_FILE" $SRS_ARG | tee /dev/stderr | tail -n 1)
 
 # Run encode with captured commitment
 echo "Encoding $INPUT_FILE to $ENCODED_FILE"
@@ -66,7 +65,7 @@ echo "Comparing original and decoded files..."
 if cmp -s "$INPUT_FILE" "$DECODED_FILE"; then
     echo "✓ Success: Files are identical"
     echo "Cleaning up temporary files..."
-    rm -f "$ENCODED_FILE" "$DECODED_FILE"
+    rm -f "$ENCODED_FILE" "$DECODED_FILE" "$COMMITMENT_FILE"
     exit 0
 else
     echo "✗ Error: Files differ"

--- a/saffron/src/blob.rs
+++ b/saffron/src/blob.rs
@@ -124,6 +124,8 @@ mod tests {
     use once_cell::sync::Lazy;
     use proptest::prelude::*;
 
+    type VestaFqSponge = DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>;
+
     static SRS: Lazy<SRS<Vesta>> = Lazy::new(|| {
         if let Ok(srs) = std::env::var("SRS_FILEPATH") {
             env::get_srs_from_cache(srs)
@@ -140,7 +142,7 @@ mod tests {
     #![proptest_config(ProptestConfig::with_cases(20))]
     #[test]
     fn test_round_trip_blob_encoding(UserData(xs) in UserData::arbitrary())
-      { let blob = FieldBlob::<Vesta>::encode::<_, DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>>(&*SRS, *DOMAIN, &xs);
+      { let blob = FieldBlob::<Vesta>::encode::<_, VestaFqSponge>(&*SRS, *DOMAIN, &xs);
         let bytes = rmp_serde::to_vec(&blob).unwrap();
         let a = rmp_serde::from_slice(&bytes).unwrap();
         // check that ark-serialize is behaving as expected
@@ -157,7 +159,7 @@ mod tests {
         fn test_user_and_storage_provider_commitments_equal(UserData(xs) in UserData::arbitrary())
           { let elems = encode_for_domain(&*DOMAIN, &xs);
             let user_commitments = commit_to_field_elems(&*SRS, *DOMAIN, elems);
-            let blob = FieldBlob::<Vesta>::encode::<_, DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>>(&*SRS, *DOMAIN, &xs);
+            let blob = FieldBlob::<Vesta>::encode::<_, VestaFqSponge>(&*SRS, *DOMAIN, &xs);
             prop_assert_eq!(user_commitments, blob.commitments);
           }
         }

--- a/saffron/src/blob.rs
+++ b/saffron/src/blob.rs
@@ -42,7 +42,7 @@ impl<G: KimchiCurve> FieldBlob<G> {
     #[instrument(skip_all, level = "debug")]
     pub fn encode<
         D: EvaluationDomain<G::ScalarField>,
-        EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
+        EFqSponge: FqSponge<G::BaseField, G, G::ScalarField>,
     >(
         srs: &SRS<G>,
         domain: D,
@@ -151,9 +151,9 @@ mod tests {
     #[test]
         fn test_user_and_storage_provider_commitments_equal(UserData(xs) in UserData::arbitrary())
           { let elems = encode_for_domain(&*DOMAIN, &xs);
-            let user_commitments = commit_to_field_elems(&*SRS, *DOMAIN, elems);
+            let user_commitments = commit_to_field_elems::<_, VestaFqSponge>(&*SRS, *DOMAIN, elems);
             let blob = FieldBlob::<Vesta>::encode::<_, VestaFqSponge>(&*SRS, *DOMAIN, &xs);
-            prop_assert_eq!(user_commitments, blob.commitment.chunks);
+            prop_assert_eq!(user_commitments, blob.commitment);
           }
         }
 }

--- a/saffron/src/cli.rs
+++ b/saffron/src/cli.rs
@@ -65,6 +65,9 @@ pub struct ComputeCommitmentArgs {
     #[arg(long, short = 'i', value_name = "FILE", help = "input file")]
     pub input: String,
 
+    #[arg(long, short = 'o', value_name = "FILE", help = "output file")]
+    pub output: String,
+
     #[arg(long = "srs-filepath", value_name = "SRS_FILEPATH")]
     pub srs_cache: Option<String>,
 }

--- a/saffron/src/commitment.rs
+++ b/saffron/src/commitment.rs
@@ -76,10 +76,7 @@ pub fn fold_commitments<G: AffineRepr, EFqSponge: FqSponge<G::BaseField, G, G::S
     )
 }
 
-pub fn user_commitment<
-    G: KimchiCurve,
-    EFqSponge: FqSponge<G::BaseField, G, G::ScalarField>,
->(
+pub fn user_commitment<G: KimchiCurve, EFqSponge: FqSponge<G::BaseField, G, G::ScalarField>>(
     srs: &SRS<G>,
     domain: D<G::ScalarField>,
     field_elems: Vec<Vec<G::ScalarField>>,

--- a/saffron/src/main.rs
+++ b/saffron/src/main.rs
@@ -82,7 +82,7 @@ fn encode_file(args: cli::EncodeFileArgs) -> Result<()> {
         .into_iter()
         .for_each(|asserted_commitment| {
             let c = rmp_serde::from_slice(&asserted_commitment.0).unwrap();
-            if blob.folded_commitment != c {
+            if blob.commitment.folded != c {
                 panic!(
                     "commitment hash mismatch: asserted {}, computed {}",
                     asserted_commitment,

--- a/saffron/src/main.rs
+++ b/saffron/src/main.rs
@@ -22,7 +22,7 @@ use tracing::{debug, debug_span};
 
 pub const DEFAULT_SRS_SIZE: usize = 1 << 16;
 
-type FqSponge = DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>;
+type VestaFqSponge = DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>;
 
 fn get_srs(cache: Option<String>) -> (SRS<Vesta>, Radix2EvaluationDomain<Fp>) {
     let res = match cache {
@@ -77,7 +77,7 @@ fn encode_file(args: cli::EncodeFileArgs) -> Result<()> {
     let mut file = File::open(args.input)?;
     let mut buf = Vec::new();
     file.read_to_end(&mut buf)?;
-    let blob = FieldBlob::<Vesta>::encode::<_, FqSponge>(&srs, domain, &buf);
+    let blob = FieldBlob::<Vesta>::encode::<_, VestaFqSponge>(&srs, domain, &buf);
     args.assert_commitment
         .into_iter()
         .for_each(|asserted_commitment| {
@@ -102,7 +102,7 @@ pub fn compute_commitment(args: cli::ComputeCommitmentArgs) -> Result<HexString>
     let mut buf = Vec::new();
     file.read_to_end(&mut buf)?;
     let field_elems = utils::encode_for_domain(&domain_fp, &buf);
-    let commitment = user_commitment::<_, FqSponge>(&srs, domain_fp, field_elems);
+    let commitment = user_commitment::<_, VestaFqSponge>(&srs, domain_fp, field_elems);
     let res = rmp_serde::to_vec(&commitment)?;
     Ok(HexString(res))
 }
@@ -115,7 +115,13 @@ pub fn storage_proof(args: cli::StorageProofArgs) -> Result<HexString> {
         let group_map = <Vesta as CommitmentCurve>::Map::setup();
         let mut rng = OsRng;
         let evaluation_point = utils::encode(&args.challenge.0);
-        proof::storage_proof::<Vesta, FqSponge>(&srs, &group_map, blob, evaluation_point, &mut rng)
+        proof::storage_proof::<Vesta, VestaFqSponge>(
+            &srs,
+            &group_map,
+            blob,
+            evaluation_point,
+            &mut rng,
+        )
     };
     let res = rmp_serde::to_vec(&proof)?;
     Ok(HexString(res))
@@ -128,7 +134,7 @@ pub fn verify_storage_proof(args: cli::VerifyStorageProofArgs) -> Result<()> {
     let evaluation_point = utils::encode(&args.challenge.0);
     let proof: StorageProof<Vesta> = rmp_serde::from_slice(&args.proof.0)?;
     let mut rng = OsRng;
-    let res = proof::verify_storage_proof::<Vesta, FqSponge>(
+    let res = proof::verify_storage_proof::<Vesta, VestaFqSponge>(
         &srs,
         &group_map,
         commitment,

--- a/saffron/src/main.rs
+++ b/saffron/src/main.rs
@@ -78,18 +78,21 @@ fn encode_file(args: cli::EncodeFileArgs) -> Result<()> {
     let mut buf = Vec::new();
     file.read_to_end(&mut buf)?;
     let blob = FieldBlob::<Vesta>::encode::<_, VestaFqSponge>(&srs, domain, &buf);
-    args.assert_commitment
-        .into_iter()
-        .for_each(|asserted_commitment| {
-            let c = rmp_serde::from_slice(&asserted_commitment.0).unwrap();
-            if blob.commitment.folded != c {
-                panic!(
-                    "commitment hash mismatch: asserted {}, computed {}",
-                    asserted_commitment,
-                    HexString(rmp_serde::encode::to_vec(&c).unwrap())
-                );
-            }
-        });
+    if let Some(asserted) = args.assert_commitment {
+        let asserted_commitment =
+            rmp_serde::from_slice(&asserted.0).expect("failed to decode asserted commitment");
+
+        assert_eq!(
+            blob.commitment.folded,
+            asserted_commitment,
+            "commitment mismatch: asserted {}, computed {}",
+            asserted,
+            HexString(
+                rmp_serde::encode::to_vec(&blob.commitment.folded)
+                    .expect("failed to encode commitment")
+            )
+        );
+    };
     debug!(output_file = args.output, "Writing encoded blob to file",);
     let mut writer = File::create(args.output)?;
     rmp_serde::encode::write(&mut writer, &blob)?;

--- a/saffron/src/main.rs
+++ b/saffron/src/main.rs
@@ -9,7 +9,7 @@ use rand::rngs::OsRng;
 use saffron::{
     blob::FieldBlob,
     cli::{self, HexString},
-    commitment::user_commitment,
+    commitment::commit_to_field_elems,
     env,
     proof::{self, StorageProof},
     utils,
@@ -102,7 +102,7 @@ pub fn compute_commitment(args: cli::ComputeCommitmentArgs) -> Result<HexString>
     let mut buf = Vec::new();
     file.read_to_end(&mut buf)?;
     let field_elems = utils::encode_for_domain(&domain_fp, &buf);
-    let commitment = user_commitment::<_, VestaFqSponge>(&srs, domain_fp, field_elems);
+    let commitment = commit_to_field_elems::<_, VestaFqSponge>(&srs, domain_fp, field_elems);
     let res = rmp_serde::to_vec(&commitment)?;
     Ok(HexString(res))
 }

--- a/saffron/src/proof.rs
+++ b/saffron/src/proof.rs
@@ -132,6 +132,8 @@ mod tests {
     use poly_commitment::{commitment::CommitmentCurve, ipa::SRS, SRS as _};
     use proptest::prelude::*;
 
+    type VestaFqSponge = DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>;
+
     static SRS: Lazy<SRS<Vesta>> = Lazy::new(|| {
         if let Ok(srs) = std::env::var("SRS_FILEPATH") {
             env::get_srs_from_cache(srs)
@@ -154,18 +156,18 @@ mod tests {
         let (commitment,_) = {
             let field_elems = encode_for_domain(&*DOMAIN, &data);
             let user_commitments = commit_to_field_elems(&*SRS, *DOMAIN, field_elems);
-            let mut fq_sponge = DefaultFqSponge::<VestaParameters, PlonkSpongeConstantsKimchi>::new(
+            let mut fq_sponge = VestaFqSponge::new(
                 mina_poseidon::pasta::fq_kimchi::static_params(),
             );
             fold_commitments(&mut fq_sponge, &user_commitments)
         };
-        let blob = FieldBlob::<Vesta>::encode::<_, DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>>(&*SRS, *DOMAIN, &data);
+        let blob = FieldBlob::<Vesta>::encode::<_, VestaFqSponge>(&*SRS, *DOMAIN, &data);
         let evaluation_point = Fp::rand(&mut rng);
         let proof = storage_proof::<
-            Vesta, DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>
+            Vesta, VestaFqSponge
 
         >(&*SRS, &*GROUP_MAP, blob, evaluation_point, &mut rng);
-        let res = verify_storage_proof::<Vesta, DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>>(
+        let res = verify_storage_proof::<Vesta, VestaFqSponge>(
             &*SRS,
             &*GROUP_MAP,
             commitment,

--- a/saffron/src/proof.rs
+++ b/saffron/src/proof.rs
@@ -44,7 +44,7 @@ where
             .fold(init, |(acc_poly, curr_power), curr_poly| {
                 (
                     acc_poly + curr_poly.scale(curr_power),
-                    curr_power * blob.alpha,
+                    curr_power * blob.commitment.alpha,
                 )
             })
             .0


### PR DESCRIPTION
## Summary
The user and storage provider need to communicate about a common commitment type. When working on #3004 I realized that the user will also need to persist these commitments in order to apply updates to them when updating their data. It makes #3004 cleaner if I do this first

## Changes
- Add `Commitment` type ([5b99888](https://github.com/o1-labs/proof-systems/pull/3005/commits/5b99888600060c9734f7f4a988bb1b932f84c8c1)) and use it in the blob ([3940789](https://github.com/o1-labs/proof-systems/pull/3005/commits/394078986cf203f2a308d4a2828df4d81bab4339))
- Add a `-o [output-file]` arg to the `compute-commitment` CLI command to write the `Commitment` value to disk https://github.com/o1-labs/proof-systems/pull/3005/commits/9bb1b56bcaf812f6981fdb5b0fa03eda6e8126ec
- a few trivial cleanups
   - use common type alias for sponge in tests and cli main https://github.com/o1-labs/proof-systems/pull/3005/commits/0ab9cc08c807563e6128f06808cac8ebc29f46b6
   - selective exports from the `commitment` module https://github.com/o1-labs/proof-systems/pull/3005/commits/927ff5bdab36b44c953dcde27535ea614301cae9
   - apply [suggestion](https://github.com/o1-labs/proof-systems/pull/3004#pullrequestreview-2598582602) from #3004 https://github.com/o1-labs/proof-systems/pull/3005/commits/505b3b7dae2484f1a1d41ab2c17010ee7a8e4203