### PR TITLE
[saffron] standardize e2e generated file names

### DIFF
--- a/saffron/e2e-test.sh
+++ b/saffron/e2e-test.sh
@@ -13,7 +13,7 @@ if [ $# -eq 2 ]; then
 fi
 COMMITMENT_FILE="${INPUT_FILE%.*}_commitment.bin"
 ENCODED_FILE="${INPUT_FILE%.*}.bin"
-DECODED_FILE="${INPUT_FILE%.*}-decoded${INPUT_FILE##*.}"
+DECODED_FILE="${INPUT_FILE%.*}_decoded.${INPUT_FILE##*.}"
 
 # Ensure input file exists
 if [ ! -f "$INPUT_FILE" ]; then


### PR DESCRIPTION
as requested by @dannywillems [here](https://github.com/o1-labs/proof-systems/pull/3005#pullrequestreview-2604185238)

- use underscore as separator 
- fix `.txt` extension for `*_decoded` file
- [justify](https://github.com/o1-labs/proof-systems/pull/3005/files#r1948180600) usage of `tee`

You can test by removing the `rm` cleanup statement at the end of the test and check the git status, e.g.

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	saffron/fixtures/lorem.bin
	saffron/fixtures/lorem_commitment.bin
	saffron/fixtures/lorem_decoded.txt

```