### PR TITLE
[saffron] Add update methods with tests

### DIFF
--- a/saffron/src/commitment.rs
+++ b/saffron/src/commitment.rs
@@ -12,6 +12,7 @@ use poly_commitment::{
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use std::ops::Add;
 use tracing::instrument;
 
 #[serde_as]
@@ -35,6 +36,14 @@ impl<G: KimchiCurve> Commitment<G> {
             alpha,
             folded,
         }
+    }
+
+    pub fn update<EFqSponge>(&self, diff: Vec<PolyComm<G>>, sponge: &mut EFqSponge) -> Self
+    where
+        EFqSponge: FqSponge<G::BaseField, G, G::ScalarField>,
+    {
+        let new_chunks = self.chunks.iter().zip(diff).map(|(g, d)| g.add(&d));
+        Self::from_chunks(new_chunks.collect(), sponge)
     }
 }
 

--- a/saffron/src/diff.rs
+++ b/saffron/src/diff.rs
@@ -8,7 +8,7 @@ use tracing::instrument;
 // sparse representation, keeping only the non-zero differences
 #[derive(Clone, Debug, PartialEq)]
 pub struct Diff<F: PrimeField> {
-    pub evaluation_diffs: Vec<Vec<(usize, F)>>,
+    pub chunks: Vec<Vec<(usize, F)>>,
 }
 
 #[derive(Debug, Error, Clone, PartialEq)]
@@ -40,7 +40,7 @@ impl<F: PrimeField> Diff<F> {
             new_elems.resize(old_elems.len(), padding);
         }
         Ok(Diff {
-            evaluation_diffs: new_elems
+            chunks: new_elems
                 .par_iter()
                 .zip(old_elems)
                 .map(|(n, o)| {
@@ -60,7 +60,7 @@ impl<F: PrimeField> Diff<F> {
         &self,
         domain: &Radix2EvaluationDomain<F>,
     ) -> Vec<Evaluations<F, Radix2EvaluationDomain<F>>> {
-        self.evaluation_diffs
+        self.chunks
             .par_iter()
             .map(|diff| {
                 let mut evals = vec![F::zero(); domain.size()];
@@ -117,7 +117,7 @@ pub mod tests {
     fn add(mut evals: Vec<Vec<Fp>>, diff: &Diff<Fp>) -> Vec<Vec<Fp>> {
         evals
             .par_iter_mut()
-            .zip(diff.evaluation_diffs.par_iter())
+            .zip(diff.chunks.par_iter())
             .for_each(|(eval_chunk, diff_chunk)| {
                 diff_chunk.iter().for_each(|(j, val)| {
                     eval_chunk[*j] += val;

--- a/saffron/src/diff.rs
+++ b/saffron/src/diff.rs
@@ -9,6 +9,7 @@ use tracing::instrument;
 #[derive(Clone, Debug, PartialEq)]
 pub struct Diff<F: PrimeField> {
     pub chunks: Vec<Vec<(usize, F)>>,
+    pub new_byte_len: usize,
 }
 
 #[derive(Debug, Error, Clone, PartialEq)]
@@ -40,6 +41,7 @@ impl<F: PrimeField> Diff<F> {
             new_elems.resize(old_elems.len(), padding);
         }
         Ok(Diff {
+            new_byte_len: new.len(),
             chunks: new_elems
                 .par_iter()
                 .zip(old_elems)
@@ -130,7 +132,7 @@ pub mod tests {
         #![proptest_config(ProptestConfig::with_cases(20))]
         #[test]
 
-        fn test_allow_legal_updates((UserData(xs), UserData(ys)) in
+        fn test_allow_legal_diff((UserData(xs), UserData(ys)) in
             (UserData::arbitrary().prop_flat_map(random_diff))
         ) {
             let diff = Diff::<Fp>::create(&*DOMAIN, &xs, &ys);

--- a/saffron/src/proof.rs
+++ b/saffron/src/proof.rs
@@ -39,7 +39,7 @@ where
 {
     let p = {
         let init = (DensePolynomial::zero(), G::ScalarField::one());
-        blob.data
+        blob.chunks
             .into_iter()
             .fold(init, |(acc_poly, curr_power), curr_poly| {
                 (


### PR DESCRIPTION
- use `chunks` as field name for consistency https://github.com/o1-labs/proof-systems/pull/3009/commits/b83f4e2e7f0215531232994922ed9f15bc9a3068
- add update method for `Commitment` type https://github.com/o1-labs/proof-systems/pull/3009/commits/40851bd8cac1449641b988e7580ba76038f79116
- add update method for `FieldBlob` type with tests https://github.com/o1-labs/proof-systems/pull/3009/commits/dca3c7fb2a212e1c8161b8ee1b2dad3ee56da88a

We discussed moving away from using a CLI to drive the actions e2e test and instead using a client/server implementation with flows written in rust. Instead of implementing the e2e for this flow (which is complicated), I will leave it at the prop tests