### PR TITLE
Arrabbiata: define Challenges structure

### DIFF
--- a/arrabbiata/src/columns.rs
+++ b/arrabbiata/src/columns.rs
@@ -60,31 +60,43 @@ impl From<Column> for usize {
 }
 
 pub struct Challenges<F: Field> {
-    /// Challenge used to aggregate the constraints
+    /// Used to aggregate the constraints describing the relation. It is used to
+    /// enforce all constraints are satisfied at the same time.
     pub alpha: F,
 
-    /// Both challenges used in the permutation argument
+    /// Both challenges used in the permutation argument.
     pub beta: F,
     pub gamma: F,
 
-    /// Challenge to homogenize the constraints
-    pub homogenous_challenge: F,
+    /// Used to homogenize the constraints and allow the protocol to fold two
+    /// instances of the same relation into a new one.
+    /// Often noted `u` in the paper mentioning "folding protocols".
+    pub homogeniser: F,
 
-    /// Random coin used to aggregate witnesses while folding
+    /// Used by the accumulation protocol.
+    /// (folding) to perform a random linear transformation of the witnesses and
+    /// the public values.
+    /// Often noted `r` in the paper mentioning "folding protocols".
     pub r: F,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ChallengeTerm {
-    /// Challenge used to aggregate the constraints
+    /// Used to aggregate the constraints describing the relation. It is used to
+    /// enforce all constraints are satisfied at the same time.
     Alpha,
     /// Both challenges used in the permutation argument
     Beta,
     Gamma,
-    /// Challenge to homogenize the constraints
-    HomogenousChallenge,
-    /// Random coin used to aggregate witnesses while folding
-    R,
+    /// Used to homogenize the constraints and allow the protocol to fold two
+    /// instances of the same relation into a new one.
+    /// Often noted `u` in the paper mentioning "folding protocols".
+    Homogeniser,
+    /// Used by the accumulation protocol
+    /// (folding) to perform a random linear transformation of the witnesses and
+    /// the public values.
+    /// Often noted `r` in the paper mentioning "folding protocols".
+    Randomiser,
 }
 
 impl Display for ChallengeTerm {
@@ -93,8 +105,8 @@ impl Display for ChallengeTerm {
             ChallengeTerm::Alpha => write!(f, "alpha"),
             ChallengeTerm::Beta => write!(f, "beta"),
             ChallengeTerm::Gamma => write!(f, "gamma"),
-            ChallengeTerm::HomogenousChallenge => write!(f, "u"),
-            ChallengeTerm::R => write!(f, "r"),
+            ChallengeTerm::Homogeniser => write!(f, "u"),
+            ChallengeTerm::Randomiser => write!(f, "r"),
         }
     }
 }
@@ -106,8 +118,8 @@ impl<F: Field> Index<ChallengeTerm> for Challenges<F> {
             ChallengeTerm::Alpha => &self.alpha,
             ChallengeTerm::Beta => &self.beta,
             ChallengeTerm::Gamma => &self.gamma,
-            ChallengeTerm::HomogenousChallenge => &self.homogenous_challenge,
-            ChallengeTerm::R => &self.r,
+            ChallengeTerm::Homogeniser => &self.homogeniser,
+            ChallengeTerm::Randomiser => &self.r,
         }
     }
 }

--- a/arrabbiata/src/columns.rs
+++ b/arrabbiata/src/columns.rs
@@ -1,4 +1,4 @@
-use ark_ff::Field;
+use ark_ff::{Field, Zero};
 use kimchi::circuits::expr::{AlphaChallengeTerm, CacheId, ConstantExpr, Expr, FormattedOutput};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -100,6 +100,18 @@ impl<F> Index<usize> for Challenges<F> {
                 "Index out of bounds, only {} are defined",
                 ChallengeTerm::COUNT
             )
+        }
+    }
+}
+
+impl<F: Zero> Default for Challenges<F> {
+    fn default() -> Self {
+        Self {
+            alpha: F::zero(),
+            beta: F::zero(),
+            gamma: F::zero(),
+            homogeniser: F::zero(),
+            r: F::zero(),
         }
     }
 }

--- a/arrabbiata/src/columns.rs
+++ b/arrabbiata/src/columns.rs
@@ -6,6 +6,7 @@ use std::{
     fmt::{Display, Formatter, Result},
     ops::Index,
 };
+use strum::EnumCount;
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 
 use crate::NUMBER_OF_COLUMNS;
@@ -80,7 +81,30 @@ pub struct Challenges<F: Field> {
     pub r: F,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+impl<F: Field> Index<usize> for Challenges<F> {
+    type Output = F;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        if index == 0 {
+            &self.alpha
+        } else if index == 1 {
+            &self.beta
+        } else if index == 2 {
+            &self.gamma
+        } else if index == 3 {
+            &self.homogeniser
+        } else if index == 4 {
+            &self.r
+        } else {
+            panic!(
+                "Index out of bounds, only {} are defined",
+                ChallengeTerm::COUNT
+            )
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, EnumCountMacro)]
 pub enum ChallengeTerm {
     /// Used to aggregate the constraints describing the relation. It is used to
     /// enforce all constraints are satisfied at the same time.

--- a/arrabbiata/src/columns.rs
+++ b/arrabbiata/src/columns.rs
@@ -60,7 +60,7 @@ impl From<Column> for usize {
     }
 }
 
-pub struct Challenges<F: Field> {
+pub struct Challenges<F> {
     /// Used to aggregate the constraints describing the relation. It is used to
     /// enforce all constraints are satisfied at the same time.
     pub alpha: F,
@@ -81,7 +81,7 @@ pub struct Challenges<F: Field> {
     pub r: F,
 }
 
-impl<F: Field> Index<usize> for Challenges<F> {
+impl<F> Index<usize> for Challenges<F> {
     type Output = F;
 
     fn index(&self, index: usize) -> &Self::Output {

--- a/arrabbiata/src/columns.rs
+++ b/arrabbiata/src/columns.rs
@@ -63,7 +63,8 @@ impl From<Column> for usize {
 pub struct Challenges<F> {
     /// Used to aggregate the constraints describing the relation. It is used to
     /// enforce all constraints are satisfied at the same time.
-    pub alpha: F,
+    /// Often noted `α`.
+    pub constraint_randomiser: F,
 
     /// Both challenges used in the permutation argument.
     pub beta: F,
@@ -72,13 +73,13 @@ pub struct Challenges<F> {
     /// Used to homogenize the constraints and allow the protocol to fold two
     /// instances of the same relation into a new one.
     /// Often noted `u` in the paper mentioning "folding protocols".
-    pub homogeniser: F,
+    pub constraint_homogeniser: F,
 
     /// Used by the accumulation protocol.
     /// (folding) to perform a random linear transformation of the witnesses and
     /// the public values.
     /// Often noted `r` in the paper mentioning "folding protocols".
-    pub r: F,
+    pub relation_randomiser: F,
 }
 
 impl<F> Index<usize> for Challenges<F> {
@@ -86,15 +87,15 @@ impl<F> Index<usize> for Challenges<F> {
 
     fn index(&self, index: usize) -> &Self::Output {
         if index == 0 {
-            &self.alpha
+            &self.constraint_randomiser
         } else if index == 1 {
             &self.beta
         } else if index == 2 {
             &self.gamma
         } else if index == 3 {
-            &self.homogeniser
+            &self.constraint_homogeniser
         } else if index == 4 {
-            &self.r
+            &self.relation_randomiser
         } else {
             panic!(
                 "Index out of bounds, only {} are defined",
@@ -107,11 +108,11 @@ impl<F> Index<usize> for Challenges<F> {
 impl<F: Zero> Default for Challenges<F> {
     fn default() -> Self {
         Self {
-            alpha: F::zero(),
+            constraint_randomiser: F::zero(),
             beta: F::zero(),
             gamma: F::zero(),
-            homogeniser: F::zero(),
-            r: F::zero(),
+            constraint_homogeniser: F::zero(),
+            relation_randomiser: F::zero(),
         }
     }
 }
@@ -120,29 +121,30 @@ impl<F: Zero> Default for Challenges<F> {
 pub enum ChallengeTerm {
     /// Used to aggregate the constraints describing the relation. It is used to
     /// enforce all constraints are satisfied at the same time.
-    Alpha,
+    /// Often noted `α`.
+    ConstraintRandomiser,
     /// Both challenges used in the permutation argument
     Beta,
     Gamma,
     /// Used to homogenize the constraints and allow the protocol to fold two
     /// instances of the same relation into a new one.
     /// Often noted `u` in the paper mentioning "folding protocols".
-    Homogeniser,
+    ConstraintHomogeniser,
     /// Used by the accumulation protocol
     /// (folding) to perform a random linear transformation of the witnesses and
     /// the public values.
     /// Often noted `r` in the paper mentioning "folding protocols".
-    Randomiser,
+    RelationRandomiser,
 }
 
 impl Display for ChallengeTerm {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
-            ChallengeTerm::Alpha => write!(f, "alpha"),
+            ChallengeTerm::ConstraintRandomiser => write!(f, "alpha"),
             ChallengeTerm::Beta => write!(f, "beta"),
             ChallengeTerm::Gamma => write!(f, "gamma"),
-            ChallengeTerm::Homogeniser => write!(f, "u"),
-            ChallengeTerm::Randomiser => write!(f, "r"),
+            ChallengeTerm::ConstraintHomogeniser => write!(f, "u"),
+            ChallengeTerm::RelationRandomiser => write!(f, "r"),
         }
     }
 }
@@ -151,17 +153,17 @@ impl<F: Field> Index<ChallengeTerm> for Challenges<F> {
 
     fn index(&self, term: ChallengeTerm) -> &Self::Output {
         match term {
-            ChallengeTerm::Alpha => &self.alpha,
+            ChallengeTerm::ConstraintRandomiser => &self.constraint_randomiser,
             ChallengeTerm::Beta => &self.beta,
             ChallengeTerm::Gamma => &self.gamma,
-            ChallengeTerm::Homogeniser => &self.homogeniser,
-            ChallengeTerm::Randomiser => &self.r,
+            ChallengeTerm::ConstraintHomogeniser => &self.constraint_homogeniser,
+            ChallengeTerm::RelationRandomiser => &self.relation_randomiser,
         }
     }
 }
 
 impl<'a> AlphaChallengeTerm<'a> for ChallengeTerm {
-    const ALPHA: Self = Self::Alpha;
+    const ALPHA: Self = Self::ConstraintRandomiser;
 }
 
 pub type E<Fp> = Expr<ConstantExpr<Fp, ChallengeTerm>, Column>;

--- a/arrabbiata/src/columns.rs
+++ b/arrabbiata/src/columns.rs
@@ -75,9 +75,8 @@ pub struct Challenges<F> {
     /// Often noted `u` in the paper mentioning "folding protocols".
     pub constraint_homogeniser: F,
 
-    /// Used by the accumulation protocol.
-    /// (folding) to perform a random linear transformation of the witnesses and
-    /// the public values.
+    /// Used by the accumulation protocol (folding) to perform a random linear
+    /// transformation of the witnesses and the public values.
     /// Often noted `r` in the paper mentioning "folding protocols".
     pub relation_randomiser: F,
 }
@@ -130,9 +129,8 @@ pub enum ChallengeTerm {
     /// instances of the same relation into a new one.
     /// Often noted `u` in the paper mentioning "folding protocols".
     ConstraintHomogeniser,
-    /// Used by the accumulation protocol
-    /// (folding) to perform a random linear transformation of the witnesses and
-    /// the public values.
+    /// Used by the accumulation protocol (folding) to perform a random linear
+    /// transformation of the witnesses and the public values.
     /// Often noted `r` in the paper mentioning "folding protocols".
     RelationRandomiser,
 }

--- a/arrabbiata/src/witness.rs
+++ b/arrabbiata/src/witness.rs
@@ -12,7 +12,7 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::time::Instant;
 
 use crate::{
-    columns::{Column, Gadget},
+    columns::{Challenges, Column, Gadget},
     curve::{ArrabbiataCurve, PlonkSpongeConstants},
     interpreter::{Instruction, InterpreterEnv, Side},
     MAXIMUM_FIELD_SIZE_IN_BITS, NUMBER_OF_COLUMNS, NUMBER_OF_PUBLIC_INPUTS, NUMBER_OF_SELECTORS,
@@ -139,24 +139,24 @@ pub struct Env<
     /// have sent in the SNARK, and we must aggregate them.
     // FIXME: nothing is done yet, and the challenges haven't been decided yet.
     // See top-level documentation of the interpreter for more information.
-    pub challenges: Vec<BigInt>,
+    pub challenges: Challenges<BigInt>,
 
     /// Keep the current executed instruction
     /// List of the accumulated challenges over time, over the curve E1.
-    pub accumulated_challenges_e1: Vec<BigInt>,
+    pub accumulated_challenges_e1: Challenges<BigInt>,
 
     /// List of the accumulated challenges over time, over the curve E2.
-    pub accumulated_challenges_e2: Vec<BigInt>,
+    pub accumulated_challenges_e2: Challenges<BigInt>,
 
     /// Challenges coined over E1 during the last computation.
     /// This field is useful to keep track of the challenges that must be
     /// verified in circuit.
-    pub previous_challenges_e1: Vec<BigInt>,
+    pub previous_challenges_e1: Challenges<BigInt>,
 
     /// Challenges coined over E2 during the last computation.
     /// This field is useful to keep track of the challenges that must be
     /// verified in circuit.
-    pub previous_challenges_e2: Vec<BigInt>,
+    pub previous_challenges_e2: Challenges<BigInt>,
 
     /// This can be used to identify which gadget the interpreter is currently
     /// building.
@@ -940,11 +940,11 @@ where
             .collect();
 
         // FIXME: challenges
-        let challenges: Vec<BigInt> = vec![];
-        let accumulated_challenges_e1: Vec<BigInt> = vec![];
-        let accumulated_challenges_e2: Vec<BigInt> = vec![];
-        let previous_challenges_e1: Vec<BigInt> = vec![];
-        let previous_challenges_e2: Vec<BigInt> = vec![];
+        let challenges: Challenges<BigInt> = Challenges::default();
+        let accumulated_challenges_e1: Challenges<BigInt> = Challenges::default();
+        let accumulated_challenges_e2: Challenges<BigInt> = Challenges::default();
+        let previous_challenges_e1: Challenges<BigInt> = Challenges::default();
+        let previous_challenges_e2: Challenges<BigInt> = Challenges::default();
 
         let prover_sponge_state: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH] =
             std::array::from_fn(|_| BigInt::from(0_u64));


### PR DESCRIPTION
The goal is to be more explicit on the challenges the protocol defines. It will be easier in the code to refer to a particular name instead of an index. Also, we fix the number of challenges, hoping the structure will be linear in memory and we can enjoy the optimsiation of the CPU cache.