### PR TITLE
Arrabbiata: move challenge semantic into its own module

### DIFF
--- a/arrabbiata/src/challenge.rs
+++ b/arrabbiata/src/challenge.rs
@@ -1,0 +1,114 @@
+use ark_ff::{Field, Zero};
+use core::{
+    fmt::{Display, Formatter, Result},
+    ops::Index,
+};
+use kimchi::circuits::expr::AlphaChallengeTerm;
+use serde::{Deserialize, Serialize};
+use strum::EnumCount;
+use strum_macros::EnumCount as EnumCountMacro;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, EnumCountMacro)]
+pub enum ChallengeTerm {
+    /// Used to aggregate the constraints describing the relation. It is used to
+    /// enforce all constraints are satisfied at the same time.
+    /// Often noted `α`.
+    ConstraintRandomiser,
+    /// Both challenges used in the permutation argument
+    Beta,
+    Gamma,
+    /// Used to homogenize the constraints and allow the protocol to fold two
+    /// instances of the same relation into a new one.
+    /// Often noted `u` in the paper mentioning "folding protocols".
+    ConstraintHomogeniser,
+    /// Used by the accumulation protocol (folding) to perform a random linear
+    /// transformation of the witnesses and the public values.
+    /// Often noted `r` in the paper mentioning "folding protocols".
+    RelationRandomiser,
+}
+
+impl Display for ChallengeTerm {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match self {
+            ChallengeTerm::ConstraintRandomiser => write!(f, "alpha"),
+            ChallengeTerm::Beta => write!(f, "beta"),
+            ChallengeTerm::Gamma => write!(f, "gamma"),
+            ChallengeTerm::ConstraintHomogeniser => write!(f, "u"),
+            ChallengeTerm::RelationRandomiser => write!(f, "r"),
+        }
+    }
+}
+
+pub struct Challenges<F> {
+    /// Used to aggregate the constraints describing the relation. It is used to
+    /// enforce all constraints are satisfied at the same time.
+    /// Often noted `α`.
+    pub constraint_randomiser: F,
+
+    /// Both challenges used in the permutation argument.
+    pub beta: F,
+    pub gamma: F,
+
+    /// Used to homogenize the constraints and allow the protocol to fold two
+    /// instances of the same relation into a new one.
+    /// Often noted `u` in the paper mentioning "folding protocols".
+    pub constraint_homogeniser: F,
+
+    /// Used by the accumulation protocol (folding) to perform a random linear
+    /// transformation of the witnesses and the public values.
+    /// Often noted `r` in the paper mentioning "folding protocols".
+    pub relation_randomiser: F,
+}
+
+impl<F> Index<usize> for Challenges<F> {
+    type Output = F;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        if index == 0 {
+            &self.constraint_randomiser
+        } else if index == 1 {
+            &self.beta
+        } else if index == 2 {
+            &self.gamma
+        } else if index == 3 {
+            &self.constraint_homogeniser
+        } else if index == 4 {
+            &self.relation_randomiser
+        } else {
+            panic!(
+                "Index out of bounds, only {} are defined",
+                ChallengeTerm::COUNT
+            )
+        }
+    }
+}
+
+impl<F: Zero> Default for Challenges<F> {
+    fn default() -> Self {
+        Self {
+            constraint_randomiser: F::zero(),
+            beta: F::zero(),
+            gamma: F::zero(),
+            constraint_homogeniser: F::zero(),
+            relation_randomiser: F::zero(),
+        }
+    }
+}
+
+impl<F: Field> Index<ChallengeTerm> for Challenges<F> {
+    type Output = F;
+
+    fn index(&self, term: ChallengeTerm) -> &Self::Output {
+        match term {
+            ChallengeTerm::ConstraintRandomiser => &self.constraint_randomiser,
+            ChallengeTerm::Beta => &self.beta,
+            ChallengeTerm::Gamma => &self.gamma,
+            ChallengeTerm::ConstraintHomogeniser => &self.constraint_homogeniser,
+            ChallengeTerm::RelationRandomiser => &self.relation_randomiser,
+        }
+    }
+}
+
+impl<'a> AlphaChallengeTerm<'a> for ChallengeTerm {
+    const ALPHA: Self = Self::ConstraintRandomiser;
+}

--- a/arrabbiata/src/columns.rs
+++ b/arrabbiata/src/columns.rs
@@ -1,12 +1,6 @@
-use ark_ff::{Field, Zero};
-use kimchi::circuits::expr::{AlphaChallengeTerm, CacheId, ConstantExpr, Expr, FormattedOutput};
-use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashMap,
-    fmt::{Display, Formatter, Result},
-    ops::Index,
-};
-use strum::EnumCount;
+use crate::challenge::ChallengeTerm;
+use kimchi::circuits::expr::{CacheId, ConstantExpr, Expr, FormattedOutput};
+use std::collections::HashMap;
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 
 use crate::NUMBER_OF_COLUMNS;
@@ -58,110 +52,6 @@ impl From<Column> for usize {
             Column::Selector(_) => unimplemented!("Selectors are not supported. This method is supposed to be called only to compute the cross-term and an optimisation is in progress to avoid the inclusion of the selectors in the multi-variate polynomial."),
         }
     }
-}
-
-pub struct Challenges<F> {
-    /// Used to aggregate the constraints describing the relation. It is used to
-    /// enforce all constraints are satisfied at the same time.
-    /// Often noted `α`.
-    pub constraint_randomiser: F,
-
-    /// Both challenges used in the permutation argument.
-    pub beta: F,
-    pub gamma: F,
-
-    /// Used to homogenize the constraints and allow the protocol to fold two
-    /// instances of the same relation into a new one.
-    /// Often noted `u` in the paper mentioning "folding protocols".
-    pub constraint_homogeniser: F,
-
-    /// Used by the accumulation protocol (folding) to perform a random linear
-    /// transformation of the witnesses and the public values.
-    /// Often noted `r` in the paper mentioning "folding protocols".
-    pub relation_randomiser: F,
-}
-
-impl<F> Index<usize> for Challenges<F> {
-    type Output = F;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        if index == 0 {
-            &self.constraint_randomiser
-        } else if index == 1 {
-            &self.beta
-        } else if index == 2 {
-            &self.gamma
-        } else if index == 3 {
-            &self.constraint_homogeniser
-        } else if index == 4 {
-            &self.relation_randomiser
-        } else {
-            panic!(
-                "Index out of bounds, only {} are defined",
-                ChallengeTerm::COUNT
-            )
-        }
-    }
-}
-
-impl<F: Zero> Default for Challenges<F> {
-    fn default() -> Self {
-        Self {
-            constraint_randomiser: F::zero(),
-            beta: F::zero(),
-            gamma: F::zero(),
-            constraint_homogeniser: F::zero(),
-            relation_randomiser: F::zero(),
-        }
-    }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, EnumCountMacro)]
-pub enum ChallengeTerm {
-    /// Used to aggregate the constraints describing the relation. It is used to
-    /// enforce all constraints are satisfied at the same time.
-    /// Often noted `α`.
-    ConstraintRandomiser,
-    /// Both challenges used in the permutation argument
-    Beta,
-    Gamma,
-    /// Used to homogenize the constraints and allow the protocol to fold two
-    /// instances of the same relation into a new one.
-    /// Often noted `u` in the paper mentioning "folding protocols".
-    ConstraintHomogeniser,
-    /// Used by the accumulation protocol (folding) to perform a random linear
-    /// transformation of the witnesses and the public values.
-    /// Often noted `r` in the paper mentioning "folding protocols".
-    RelationRandomiser,
-}
-
-impl Display for ChallengeTerm {
-    fn fmt(&self, f: &mut Formatter) -> Result {
-        match self {
-            ChallengeTerm::ConstraintRandomiser => write!(f, "alpha"),
-            ChallengeTerm::Beta => write!(f, "beta"),
-            ChallengeTerm::Gamma => write!(f, "gamma"),
-            ChallengeTerm::ConstraintHomogeniser => write!(f, "u"),
-            ChallengeTerm::RelationRandomiser => write!(f, "r"),
-        }
-    }
-}
-impl<F: Field> Index<ChallengeTerm> for Challenges<F> {
-    type Output = F;
-
-    fn index(&self, term: ChallengeTerm) -> &Self::Output {
-        match term {
-            ChallengeTerm::ConstraintRandomiser => &self.constraint_randomiser,
-            ChallengeTerm::Beta => &self.beta,
-            ChallengeTerm::Gamma => &self.gamma,
-            ChallengeTerm::ConstraintHomogeniser => &self.constraint_homogeniser,
-            ChallengeTerm::RelationRandomiser => &self.relation_randomiser,
-        }
-    }
-}
-
-impl<'a> AlphaChallengeTerm<'a> for ChallengeTerm {
-    const ALPHA: Self = Self::ConstraintRandomiser;
 }
 
 pub type E<Fp> = Expr<ConstantExpr<Fp, ChallengeTerm>, Column>;

--- a/arrabbiata/src/lib.rs
+++ b/arrabbiata/src/lib.rs
@@ -2,6 +2,7 @@ use curve::PlonkSpongeConstants;
 use mina_poseidon::constants::SpongeConstants;
 use strum::EnumCount as _;
 
+pub mod challenge;
 pub mod column_env;
 pub mod columns;
 pub mod constraints;

--- a/arrabbiata/src/witness.rs
+++ b/arrabbiata/src/witness.rs
@@ -12,7 +12,8 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::time::Instant;
 
 use crate::{
-    columns::{Challenges, Column, Gadget},
+    challenge::Challenges,
+    columns::{Column, Gadget},
     curve::{ArrabbiataCurve, PlonkSpongeConstants},
     interpreter::{Instruction, InterpreterEnv, Side},
     MAXIMUM_FIELD_SIZE_IN_BITS, NUMBER_OF_COLUMNS, NUMBER_OF_PUBLIC_INPUTS, NUMBER_OF_SELECTORS,


### PR DESCRIPTION
Simple move, only as the code is larger than initially, and should not be related to the column module.