### PR TITLE
Arrabbiata: accumulate program state

### DIFF
--- a/arrabbiata/src/main.rs
+++ b/arrabbiata/src/main.rs
@@ -129,6 +129,10 @@ pub fn main() {
 
         // Coin challenge α for combining the constraints
         env.coin_challenge(ChallengeTerm::ConstraintRandomiser);
+        debug!(
+            "Coin challenge α: 0x{chal}",
+            chal = env.challenges[ChallengeTerm::ConstraintRandomiser].to_str_radix(16)
+        );
 
         // ----- Accumulation/folding argument -----
         // FIXME:

--- a/arrabbiata/src/main.rs
+++ b/arrabbiata/src/main.rs
@@ -141,8 +141,15 @@ pub fn main() {
         // FIXME:
         // Absorb the cross-terms
 
-        // FIXME:
-        // Coin challenge r to fold
+        // Coin challenge r to fold the instances of the relation.
+        // FIXME: we must do the step before first! Skipping for now to achieve
+        // the next step, i.e. accumulating on the prover side the different
+        // values below.
+        env.coin_challenge(ChallengeTerm::RelationRandomiser);
+        debug!(
+            "Coin challenge r: 0x{r}",
+            r = env.challenges[ChallengeTerm::RelationRandomiser].to_str_radix(16)
+        );
 
         // FIXME:
         // Compute the accumulated witness

--- a/arrabbiata/src/main.rs
+++ b/arrabbiata/src/main.rs
@@ -150,9 +150,7 @@ pub fn main() {
             "Coin challenge r: 0x{r}",
             r = env.challenges[ChallengeTerm::RelationRandomiser].to_str_radix(16)
         );
-
-        // FIXME:
-        // Compute the accumulated witness
+        env.accumulate_program_state();
 
         // FIXME:
         // Compute the accumulation of the commitments to the witness columns


### PR DESCRIPTION
The reviewer is always encouraged to run:
```
cargo nextest run "test_arrabbiata_binary" --release --nocapture -p arrabbiata
```
that starts the example file. This is also executed in the CI in `tests/cli.rs`.