### PR TITLE
Run Saffron in it's own workflow, restore OG CI for core lib only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ env:
   CARGO_TERM_COLOR: always
   # 30 MB of stack for Keccak tests
   RUST_MIN_STACK: 31457280
+  CARGO_EXTRA_ARGS: "--workspace --exclude saffron"
 
 jobs:
   run_mdbook:

--- a/.github/workflows/saffron.yml
+++ b/.github/workflows/saffron.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run:
-    name: Run saffron unit and e2e tests
+    name: Run saffron e2e tests
 
     runs-on: ["ubuntu-latest"]
 

--- a/.github/workflows/saffron.yml
+++ b/.github/workflows/saffron.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run the saffron unit tests
         run: |
-          SRS_FILEPATH=./srs/test_vesta.srs RUST_LOG=debug cargo test -p saffron  --release -- --nocapture
+          SRS_FILEPATH=../srs/test_vesta.srs RUST_LOG=debug cargo test -p saffron  --release -- --nocapture
 
       - name: Run the saffron e2e encoding tests on small lorem file
         run: |

--- a/.github/workflows/saffron.yml
+++ b/.github/workflows/saffron.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run:
-    name: Run saffron e2e tests
+    name: Run saffron unit and e2e tests
 
     runs-on: ["ubuntu-latest"]
 
@@ -46,6 +46,10 @@ jobs:
       - name: Build the saffron cli binary
         run: |
           cargo build --release --bin saffron
+
+      - name: Run the saffron unit tests
+        run: |
+          SRS_FILEPATH=./srs/test_vesta.srs RUST_LOG=debug cargo test -p saffron  --release -- --nocapture
 
       - name: Run the saffron e2e encoding tests on small lorem file
         run: |

--- a/Makefile
+++ b/Makefile
@@ -96,24 +96,24 @@ test-all-with-coverage:
 
 
 nextest: ## Test the project with non-heavy tests and using nextest test runner
-		cargo nextest run --all-features --release --profile ci -E "not test(heavy)" $(BIN_EXTRA_ARGS)
+		cargo nextest run --all-features --release $(CARGO_EXTRA_ARGS) --profile ci -E "not test(heavy)" $(BIN_EXTRA_ARGS)
 
 nextest-with-coverage:
-		$(COVERAGE_ENV) BIN_EXTRA_ARGS="$(BIN_EXTRA_ARGS)" $(MAKE) nextest
+		$(COVERAGE_ENV) CARGO_EXTRA_ARGS="$(CARGO_EXTRA_ARGS)" BIN_EXTRA_ARGS="$(BIN_EXTRA_ARGS)" $(MAKE) nextest
 
 
 nextest-heavy: ## Test the project with heavy tests and using nextest test runner
-		cargo nextest run --all-features --release --profile ci -E "test(heavy)" $(BIN_EXTRA_ARGS)
+		cargo nextest run --all-features --release $(CARGO_EXTRA_ARGS) --profile ci -E "test(heavy)" $(BIN_EXTRA_ARGS)
 
 nextest-heavy-with-coverage:
-		$(COVERAGE_ENV) BIN_EXTRA_ARGS="$(BIN_EXTRA_ARGS)" $(MAKE) nextest-heavy
+		$(COVERAGE_ENV) CARGO_EXTRA_ARGS="$(CARGO_EXTRA_ARGS)" BIN_EXTRA_ARGS="$(BIN_EXTRA_ARGS)" $(MAKE) nextest-heavy
 
 
 nextest-all: ## Test the project with all tests and using nextest test runner
-		cargo nextest run --all-features --release --profile ci $(BIN_EXTRA_ARGS)
+		cargo nextest run --all-features --release $(CARGO_EXTRA_ARGS) --profile ci $(BIN_EXTRA_ARGS)
 
 nextest-all-with-coverage:
-		$(COVERAGE_ENV) BIN_EXTRA_ARGS="$(BIN_EXTRA_ARGS)" $(MAKE) nextest-all
+		$(COVERAGE_ENV) CARGO_EXTRA_ARGS="$(CARGO_EXTRA_ARGS)" BIN_EXTRA_ARGS="$(BIN_EXTRA_ARGS)" $(MAKE) nextest-all
 
 
 format: ## Format the code


### PR DESCRIPTION
This _actually_ fixes the problem that #3023 failed to address. 

- Run all saffron unit tests in their own workflow
- Stop running saffron in the general CI workflow

## Post Mortem
The tests themselves weren't even the problem -- there were 2 other major factors:
 - The code coverage job was building everything with instrumentation flags that were causing something like a 100x slowdown :exploding_head: 
 - Since the tests were being run without the SRS cache, they were spending a lot of time computing one (likely once per test module)