### PR TITLE
Arrabbiata: implement gadget PoseidonSpongeAbsorb

### DIFF
--- a/arrabbiata/src/column.rs
+++ b/arrabbiata/src/column.rs
@@ -29,7 +29,18 @@ pub enum Gadget {
     /// We split the Poseidon gadget in 13 sub-gadgets, one for each set of 5
     /// permutations and one for the absorbtion. The parameteris the starting
     /// round of Poseidon. It is expected to be a multiple of five.
+    ///
+    /// Note that, for now, the gadget can only be used by the verifier circuit.
     PoseidonPermutation(usize),
+    /// Absorb [PlonkSpongeConstants::SPONGE_WIDTH - 1] elements into the
+    /// sponge. The elements are absorbed into the last
+    /// [PlonkSpongeConstants::SPONGE_WIDTH - 1] elements of the permutation
+    /// state.
+    ///
+    /// The values to be absorbed depend on the state of the environment while
+    /// executing this instruction.
+    ///
+    /// Note that, for now, the gadget can only be used by the verifier circuit.
     PoseidonSpongeAbsorb,
 }
 

--- a/arrabbiata/src/constraint.rs
+++ b/arrabbiata/src/constraint.rs
@@ -213,6 +213,10 @@ where
         self.read_position(pos)
     }
 
+    unsafe fn fetch_value_to_absorb_in_sponge(&mut self, pos: Self::Position) -> Self::Variable {
+        self.read_position(pos)
+    }
+
     unsafe fn load_temporary_accumulators(
         &mut self,
         pos_x: Self::Position,

--- a/arrabbiata/src/interpreter.rs
+++ b/arrabbiata/src/interpreter.rs
@@ -758,6 +758,21 @@ pub trait InterpreterEnv {
         pos: Self::Position,
         curr_round: usize,
     ) -> Self::Variable;
+
+    /// Load the value to absorb at the current step at the position given by
+    /// `pos`.
+    ///
+    /// The values and the absorption order is defined by the
+    /// state of the environment itself.
+    ///
+    /// IMPROVEME: we could have in the environment an heterogeneous typed list,
+    /// and we pop values call after call. However, we try to keep the
+    /// interpreter simple.
+    ///
+    /// # Safety
+    ///
+    /// No constraint is added. It should be used with caution.
+    unsafe fn fetch_value_to_absorb_in_sponge(&mut self, pos: Self::Position) -> Self::Variable;
     // -------------------------
 
     /// Check if the points given by (x1, y1) and (x2, y2) are equals.
@@ -1262,7 +1277,39 @@ pub fn run_ivc<E: InterpreterEnv>(env: &mut E, instr: Instruction) {
             });
         }
         Instruction::PoseidonSpongeAbsorb => {
-            todo!()
+            env.activate_gadget(Gadget::PoseidonSpongeAbsorb);
+
+            let round_input_positions: Vec<E::Position> = (0..PlonkSpongeConstants::SPONGE_WIDTH
+                - 1)
+                .map(|_i| env.allocate())
+                .collect();
+
+            let state: Vec<E::Variable> = round_input_positions
+                .iter()
+                .enumerate()
+                .map(|(i, pos)| env.load_poseidon_state(*pos, i + 1))
+                .collect();
+
+            let values_to_absorb: Vec<E::Variable> = (0..PlonkSpongeConstants::SPONGE_WIDTH - 1)
+                .map(|_i| unsafe {
+                    let pos = env.allocate();
+                    env.fetch_value_to_absorb_in_sponge(pos)
+                })
+                .collect();
+
+            let output: Vec<E::Variable> = state
+                .iter()
+                .zip(values_to_absorb.iter())
+                .map(|(s, v)| {
+                    let pos = env.allocate();
+                    env.write_column(pos, s.clone() + v.clone())
+                })
+                .collect();
+
+            output
+                .iter()
+                .enumerate()
+                .for_each(|(i, o)| unsafe { env.save_poseidon_state(o.clone(), i + 1) })
         }
         Instruction::NoOp => {}
     }

--- a/arrabbiata/src/interpreter.rs
+++ b/arrabbiata/src/interpreter.rs
@@ -603,9 +603,19 @@ pub enum Instruction {
     /// using "public inputs".
     ///
     /// We split the Poseidon gadget in 13 sub-gadgets, one for each set of 5
-    /// permutations and one for the absorbtion. The parameteris the starting
-    /// round of Poseidon. It is expected to be a multiple of five.
+    /// permutations and one for the absorbtion. The parameter is the starting
+    /// round of the permutation. It is expected to be a multiple of five.
+    ///
+    /// Note that, for now, the gadget can only be used by the verifier circuit.
     PoseidonPermutation(usize),
+    /// Absorb [PlonkSpongeConstants::SPONGE_WIDTH - 1] elements into the
+    /// sponge. The elements are absorbed into the last
+    /// [PlonkSpongeConstants::SPONGE_WIDTH - 1] elements of the sponge state.
+    ///
+    /// The values to be absorbed depend on the state of the environment while
+    /// executing this instruction.
+    ///
+    /// Note that, for now, the gadget can only be used by the verifier circuit.
     PoseidonSpongeAbsorb,
     EllipticCurveScaling(usize, u64),
     EllipticCurveAddition(usize),

--- a/arrabbiata/src/witness.rs
+++ b/arrabbiata/src/witness.rs
@@ -557,6 +557,50 @@ where
         }
     }
 
+    unsafe fn fetch_value_to_absorb_in_sponge(&mut self, pos: Self::Position) -> Self::Variable {
+        let (col, curr_or_next) = pos;
+        // Purely arbitrary for now
+        let Column::X(_idx) = col else {
+            panic!("Only private inputs can be accepted to load the values to be absorbed")
+        };
+        assert_eq!(
+            curr_or_next,
+            CurrOrNext::Curr,
+            "Only the current row can be used to load the values to be absorbed"
+        );
+        // FIXME: for now, we only absorb the commitments to the columns
+        let idx = self.idx_values_to_absorb;
+        let res = if idx < 2 * NUMBER_OF_COLUMNS {
+            let idx_col = idx / 2;
+            debug!("Absorbing the accumulator for the column index {idx_col}. After this, there will still be {} elements to absorb", NUMBER_OF_VALUES_TO_ABSORB_PUBLIC_IO - idx - 1);
+            if self.current_iteration % 2 == 0 {
+                let (pt_x, pt_y) = self.accumulated_committed_state_e2[idx_col]
+                    .get_first_chunk()
+                    .to_coordinates()
+                    .unwrap();
+                if idx % 2 == 0 {
+                    self.write_column(pos, pt_x.to_biguint().into())
+                } else {
+                    self.write_column(pos, pt_y.to_biguint().into())
+                }
+            } else {
+                let (pt_x, pt_y) = self.accumulated_committed_state_e1[idx_col]
+                    .get_first_chunk()
+                    .to_coordinates()
+                    .unwrap();
+                if idx % 2 == 0 {
+                    self.write_column(pos, pt_x.to_biguint().into())
+                } else {
+                    self.write_column(pos, pt_y.to_biguint().into())
+                }
+            }
+        } else {
+            unimplemented!("We only absorb the accumulators for now. Of course, this is not sound.")
+        };
+        self.idx_values_to_absorb += 1;
+        res
+    }
+
     unsafe fn load_temporary_accumulators(
         &mut self,
         pos_x: Self::Position,

--- a/arrabbiata/tests/constraint.rs
+++ b/arrabbiata/tests/constraint.rs
@@ -157,6 +157,21 @@ fn test_gadget_poseidon_permutation() {
 }
 
 #[test]
+fn test_gadget_poseidon_sponge_absorb() {
+    let instr = Instruction::PoseidonSpongeAbsorb;
+    // Only two addition constraints
+    helper_compute_constraints_gadget(instr, 2);
+
+    let mut exp_degrees = HashMap::new();
+    exp_degrees.insert(1, 2);
+    helper_check_expected_degree_constraints(instr, exp_degrees);
+
+    helper_gadget_number_of_columns_used(instr, 6, 0);
+
+    helper_check_gadget_activated(instr, Gadget::PoseidonSpongeAbsorb);
+}
+
+#[test]
 fn test_get_mvpoly_equivalent() {
     // Check that each constraint can be converted to a MVPoly. The type of the
     // MVPoly is crucial as it determines the maximum degree of the constraint


### PR DESCRIPTION
This gadget, with `PoseidonPermutation(usize)`, aims to replace the gadget `Poseidon`, as suggested in #3050.
In a future PR, the gadget `Poseidon` is going to be removed, and the implementation of the methods `fetch_values_to_absorb` and `round_constants` are going to be replaced by the newly added methods.

The gadget is essentially two additions + use of the permutation argument to fetch the values. These two constraints could be provided generically for the whole circuit, but we leave this for future works.

An important note is that the gadget supposes that the permutation argument is implemented, through the use of `load_poseidon_state`, `save_poseidon_state` and `fetch_value_to_absorb_in_sponge`. This will come later.