### PR TITLE
Arrabbiata: move sponge init state into setup

### DIFF
--- a/arrabbiata/src/main.rs
+++ b/arrabbiata/src/main.rs
@@ -7,7 +7,6 @@
 use arrabbiata::{
     challenge::ChallengeTerm,
     cli,
-    curve::PlonkSpongeConstants,
     interpreter::{self, InterpreterEnv},
     setup::IndexedRelation,
     witness, MIN_SRS_LOG2_SIZE, VERIFIER_CIRCUIT_SIZE,
@@ -15,7 +14,6 @@ use arrabbiata::{
 use clap::Parser;
 use log::{debug, info};
 use mina_curves::pasta::{Fp, Fq, Pallas, Vesta};
-use mina_poseidon::constants::SpongeConstants;
 use num_bigint::BigInt;
 use std::time::Instant;
 
@@ -35,21 +33,12 @@ pub fn execute(args: cli::ExecuteArgs) {
 
     info!("Instantiating environment to execute square-root {n_iteration} times with SRS of size 2^{srs_log2_size}");
 
+    // FIXME: correctly setup
     let indexed_relation = IndexedRelation::new(srs_log2_size);
 
     let domain_size = 1 << srs_log2_size;
 
-    // FIXME: setup correctly the initial sponge state
-    let sponge_e1: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH] =
-        std::array::from_fn(|_i| BigInt::from(42u64));
-
-    // FIXME: make a setup phase to build the selectors
-    let mut env = witness::Env::<Fp, Fq, Vesta, Pallas>::new(
-        BigInt::from(1u64),
-        sponge_e1.clone(),
-        sponge_e1.clone(),
-        indexed_relation,
-    );
+    let mut env = witness::Env::<Fp, Fq, Vesta, Pallas>::new(BigInt::from(1u64), indexed_relation);
 
     let n_iteration_per_fold = domain_size - VERIFIER_CIRCUIT_SIZE;
 

--- a/arrabbiata/src/setup.rs
+++ b/arrabbiata/src/setup.rs
@@ -28,7 +28,7 @@ use kimchi::circuits::domains::EvaluationDomains;
 use log::{debug, info};
 use mina_poseidon::constants::SpongeConstants;
 use mvpoly::{monomials::Sparse, MVPoly};
-use num_bigint::BigUint;
+use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
 use o1_utils::FieldHelpers;
 use poly_commitment::{ipa::SRS, SRS as _};
@@ -86,6 +86,14 @@ pub struct IndexedRelation<
     /// the same job over both curves.
     pub constraints_fp: HashMap<Gadget, Vec<Sparse<Fp, { MV_POLYNOMIAL_ARITY }, { MAX_DEGREE }>>>,
     pub constraints_fq: HashMap<Gadget, Vec<Sparse<Fq, { MV_POLYNOMIAL_ARITY }, { MAX_DEGREE }>>>,
+
+    /// Initial state of the sponge, containing circuit specific
+    /// information.
+    // FIXME: setup correctly with the initial transcript.
+    // The sponge must be initialized correctly with all the information
+    // related to the actual relation being accumulated/proved.
+    // Note that it must include the information of both circuits!
+    pub initial_sponge: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH],
 }
 
 impl<
@@ -179,6 +187,10 @@ where
                 .collect()
         };
 
+        // FIXME: setup correctly the initial sponge state
+        let sponge_e1: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH] =
+            std::array::from_fn(|_i| BigInt::from(42u64));
+
         Self {
             domain_fp,
             domain_fq,
@@ -186,6 +198,7 @@ where
             srs_e2,
             constraints_fp,
             constraints_fq,
+            initial_sponge: sponge_e1,
         }
     }
 

--- a/arrabbiata/src/witness.rs
+++ b/arrabbiata/src/witness.rs
@@ -784,12 +784,7 @@ where
     <<E1 as CommitmentCurve>::Params as CurveConfig>::BaseField: PrimeField,
     <<E2 as CommitmentCurve>::Params as CurveConfig>::BaseField: PrimeField,
 {
-    pub fn new(
-        z0: BigInt,
-        sponge_e1: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH],
-        sponge_e2: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH],
-        indexed_relation: setup::IndexedRelation<Fp, Fq, E1, E2>,
-    ) -> Self {
+    pub fn new(z0: BigInt, indexed_relation: setup::IndexedRelation<Fp, Fq, E1, E2>) -> Self {
         let srs_size = indexed_relation.get_srs_size();
         let (blinder_e1, blinder_e2) = indexed_relation.get_srs_blinders();
 
@@ -845,10 +840,16 @@ where
         let previous_challenges_e1: Challenges<BigInt> = Challenges::default();
         let previous_challenges_e2: Challenges<BigInt> = Challenges::default();
 
+        // FIXME: use setup
         let prover_sponge_state: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH] =
             std::array::from_fn(|_| BigInt::from(0_u64));
         let verifier_sponge_state: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH] =
             std::array::from_fn(|_| BigInt::from(0_u64));
+
+        // FIXME: set this up correctly. Temporary as we're moving the initial
+        // transcript state into the setup
+        let sponge_e1 = indexed_relation.initial_sponge.clone();
+        let sponge_e2 = indexed_relation.initial_sponge.clone();
 
         Self {
             // -------

--- a/arrabbiata/tests/witness.rs
+++ b/arrabbiata/tests/witness.rs
@@ -25,18 +25,10 @@ fn test_unit_witness_poseidon_permutation_gadget_one_full_hash() {
     let indexed_relation: IndexedRelation<Fp, Fq, Vesta, Pallas> =
         IndexedRelation::new(srs_log2_size);
 
-    let sponge: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH] = [
-        BigInt::from(42u64),
-        BigInt::from(42u64),
-        BigInt::from(42u64),
-    ];
+    let sponge: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH] =
+        indexed_relation.initial_sponge.clone();
 
-    let mut env = Env::<Fp, Fq, Vesta, Pallas>::new(
-        BigInt::from(1u64),
-        sponge.clone(),
-        sponge.clone(),
-        indexed_relation,
-    );
+    let mut env = Env::<Fp, Fq, Vesta, Pallas>::new(BigInt::from(1u64), indexed_relation);
 
     env.current_instruction = Instruction::PoseidonPermutation(0);
 
@@ -75,18 +67,10 @@ fn test_unit_witness_poseidon_with_absorb_one_full_hash() {
     let indexed_relation: IndexedRelation<Fp, Fq, Vesta, Pallas> =
         IndexedRelation::new(srs_log2_size);
 
-    let sponge: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH] = [
-        BigInt::from(42u64),
-        BigInt::from(42u64),
-        BigInt::from(42u64),
-    ];
+    let sponge: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH] =
+        indexed_relation.initial_sponge.clone();
 
-    let mut env = Env::<Fp, Fq, Vesta, Pallas>::new(
-        BigInt::from(1u64),
-        sponge.clone(),
-        sponge.clone(),
-        indexed_relation,
-    );
+    let mut env = Env::<Fp, Fq, Vesta, Pallas>::new(BigInt::from(1u64), indexed_relation);
 
     env.current_instruction = Instruction::PoseidonSpongeAbsorb;
     interpreter::run_ivc(&mut env, Instruction::PoseidonSpongeAbsorb);
@@ -136,14 +120,7 @@ fn test_unit_witness_elliptic_curve_addition() {
     let srs_log2_size = 6;
     let indexed_relation = IndexedRelation::new(srs_log2_size);
 
-    let sponge_e1: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH] =
-        std::array::from_fn(|_i| BigInt::from(42u64));
-    let mut env = Env::<Fp, Fq, Vesta, Pallas>::new(
-        BigInt::from(1u64),
-        sponge_e1.clone(),
-        sponge_e1.clone(),
-        indexed_relation,
-    );
+    let mut env = Env::<Fp, Fq, Vesta, Pallas>::new(BigInt::from(1u64), indexed_relation);
 
     let instr = Instruction::EllipticCurveAddition(0);
     env.current_instruction = instr;
@@ -212,14 +189,8 @@ fn test_witness_double_elliptic_curve_point() {
     let mut rng = o1_utils::tests::make_test_rng(None);
     let srs_log2_size = 6;
     let indexed_relation = IndexedRelation::new(srs_log2_size);
-    let sponge_e1: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH] =
-        std::array::from_fn(|_i| BigInt::from(42u64));
-    let mut env = Env::<Fp, Fq, Vesta, Pallas>::new(
-        BigInt::from(1u64),
-        sponge_e1.clone(),
-        sponge_e1.clone(),
-        indexed_relation,
-    );
+
+    let mut env = Env::<Fp, Fq, Vesta, Pallas>::new(BigInt::from(1u64), indexed_relation);
 
     env.current_instruction = Instruction::EllipticCurveAddition(0);
 
@@ -249,16 +220,14 @@ where
     RNG: RngCore + CryptoRng,
 {
     let srs_log2_size = 10;
-    let indexed_relation = IndexedRelation::new(srs_log2_size);
 
-    let sponge_e1: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH] =
-        std::array::from_fn(|_i| r.clone());
-    let mut env = Env::<Fp, Fq, Vesta, Pallas>::new(
-        BigInt::from(1u64),
-        sponge_e1.clone(),
-        sponge_e1.clone(),
-        indexed_relation,
-    );
+    // FIXME: For test purposes, to get a deterministic result, changing the
+    // initial sponge state. The challenge in the circuit will be the first
+    // element of the state.
+    let mut indexed_relation = IndexedRelation::new(srs_log2_size);
+    indexed_relation.initial_sponge = std::array::from_fn(|_i| r.clone());
+
+    let mut env = Env::<Fp, Fq, Vesta, Pallas>::new(BigInt::from(1u64), indexed_relation);
 
     let i_comm = 0;
     let p1: Pallas = {
@@ -318,7 +287,7 @@ fn test_regression_witness_structure_sizeof() {
     // thining about the memory efficiency of the codebase.
     assert_eq!(
         std::mem::size_of::<Env<Fp, Fq, Vesta, Pallas>>(),
-        4920,
+        5016,
         "The witness environment structure probably changed"
     );
 }

--- a/arrabbiata/tests/witness_utils.rs
+++ b/arrabbiata/tests/witness_utils.rs
@@ -3,11 +3,8 @@
 //! A user is expected to use the gadget methods.
 //! The API of the utilities is more subject to changes.
 
-use arrabbiata::{
-    curve::PlonkSpongeConstants, interpreter::InterpreterEnv, setup::IndexedRelation, witness::Env,
-};
+use arrabbiata::{interpreter::InterpreterEnv, setup::IndexedRelation, witness::Env};
 use mina_curves::pasta::{Fp, Fq, Pallas, Vesta};
-use mina_poseidon::constants::SpongeConstants;
 use num_bigint::BigInt;
 use o1_utils::FieldHelpers;
 
@@ -18,14 +15,7 @@ fn test_constrain_boolean_witness_negative_value() {
     let indexed_relation = IndexedRelation::new(srs_log2_size);
     let mut env = {
         let z0 = BigInt::from(1u64);
-        let sponge_e1: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH] =
-            std::array::from_fn(|_i| BigInt::from(0u64));
-        Env::<Fp, Fq, Vesta, Pallas>::new(
-            z0,
-            sponge_e1.clone(),
-            sponge_e1.clone(),
-            indexed_relation,
-        )
+        Env::<Fp, Fq, Vesta, Pallas>::new(z0, indexed_relation)
     };
 
     env.constrain_boolean(BigInt::from(-42));
@@ -37,14 +27,7 @@ fn test_constrain_boolean_witness_positive_and_negative_modulus() {
     let indexed_relation = IndexedRelation::new(srs_log2_size);
     let mut env = {
         let z0 = BigInt::from(1u64);
-        let sponge_e1: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH] =
-            std::array::from_fn(|_i| BigInt::from(0u64));
-        Env::<Fp, Fq, Vesta, Pallas>::new(
-            z0,
-            sponge_e1.clone(),
-            sponge_e1.clone(),
-            indexed_relation,
-        )
+        Env::<Fp, Fq, Vesta, Pallas>::new(z0, indexed_relation)
     };
 
     let modulus: BigInt = Fp::modulus_biguint().into();
@@ -58,14 +41,7 @@ fn test_constrain_boolean_witness_positive_and_negative_modulus() {
 fn test_write_column_return_the_result_reduced_in_field() {
     let srs_log2_size = 6;
     let indexed_relation = IndexedRelation::new(srs_log2_size);
-    let sponge_e1: [BigInt; PlonkSpongeConstants::SPONGE_WIDTH] =
-        std::array::from_fn(|_i| BigInt::from(42u64));
-    let mut env = Env::<Fp, Fq, Vesta, Pallas>::new(
-        BigInt::from(1u64),
-        sponge_e1.clone(),
-        sponge_e1.clone(),
-        indexed_relation,
-    );
+    let mut env = Env::<Fp, Fq, Vesta, Pallas>::new(BigInt::from(1u64), indexed_relation);
     let modulus: BigInt = Fp::modulus_biguint().into();
     let pos_x = env.allocate();
     let res = env.write_column(pos_x, modulus.clone() + BigInt::from(1u64));


### PR DESCRIPTION
This PR simply aims to move the transcript initialization into the setup, for further changes. This PR does not change any semantic. It is purely on the API.