### PR TITLE
CI: use Rust 1.79 everywhere and drop older versions

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   OCAML_VERSION: "4.14.0"
-  RUST_TOOLCHAIN_VERSION: "1.71"
+  RUST_TOOLCHAIN_VERSION: "1.79"
 
 jobs:
   bench:

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_toolchain_version: ["1.74"]
+        rust_toolchain_version: ["1.79"]
         # FIXME: currently not available for 5.0.0.
         # It might be related to boxroot dependency, and we would need to bump
         # up the ocaml-rs dependency

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_toolchain_version: ["1.72"]
+        rust_toolchain_version: ["1.79"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        rust_toolchain_version: ["1.72", "1.73", "1.74", "1.75", "1.76", "1.77", "1.78", "1.79"]
+        rust_toolchain_version: ["1.79"]
         # FIXME: currently not available for 5.0.0.
         # It might be related to boxroot dependency, and we would need to bump
         # up the ocaml-rs dependency

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -8,7 +8,7 @@ env:
   OCAML_VERSION: "4.14.0"
   # This version has been chosen randomly. It seems that with 2023-11-16, it is
   # broken. The compiler crashes. Feel free to pick any newer working version.
-  RUST_TOOLCHAIN_VERSION: "1.72"
+  RUST_TOOLCHAIN_VERSION: "1.79"
 
 jobs:
   release:

--- a/.github/workflows/o1vm-ci.yml
+++ b/.github/workflows/o1vm-ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     strategy:
       matrix:
-        rust_toolchain_version: ["1.74"]
+        rust_toolchain_version: ["1.79"]
         # FIXME: currently not available for 5.0.0.
         # It might be related to boxroot dependency, and we would need to bump
         # up the ocaml-rs dependency

--- a/.github/workflows/saffron.yml
+++ b/.github/workflows/saffron.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_toolchain_version: ["1.74"]
+        rust_toolchain_version: ["1.79"]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Related to https://github.com/MinaProtocol/mina/pull/16652/ is merged.