### PR TITLE
 Broken Link 

### DIFF
--- a/kimchi/snarky-deriver/src/lib.rs
+++ b/kimchi/snarky-deriver/src/lib.rs
@@ -1,5 +1,5 @@
 //! **This crate is not meant to be imported directly by users**.
-//! You should import [kimchi](https://crates.io/crates/kimchi) instead.
+//! You should import [kimchi]() instead.
 //!
 //! snarky-deriver adds a number of derives to make snarky easier to use.
 //! Refer to the [snarky](https://o1-labs.github.io/proof-systems/rustdoc/kimchi/snarky/index.html) documentation.


### PR DESCRIPTION
<img width="1510" alt="Знімок екрана 2025-03-19 о 15 32 18" src="https://github.com/user-attachments/assets/1d3c34b4-a243-4b82-916e-6c9e834b5ae4" />


I found a broken link in the documentation for kimchi. The link to https://crates.io/crates/kimchi is no longer accessible. However, there was no replacement link provided in the update.

Could you please provide the correct link so I can update the reference accordingly?

Thanks!