### PR TITLE
Snarky/doc: remove link to crates kimchi as it does not exist

### DIFF
--- a/kimchi/snarky-deriver/src/lib.rs
+++ b/kimchi/snarky-deriver/src/lib.rs
@@ -1,8 +1,7 @@
-//! **This crate is not meant to be imported directly by users**.
-//! You should import [kimchi](https://crates.io/crates/kimchi) instead.
-//!
 //! snarky-deriver adds a number of derives to make snarky easier to use.
-//! Refer to the [snarky](https://o1-labs.github.io/proof-systems/rustdoc/kimchi/snarky/index.html) documentation.
+//! Refer to the
+//! [snarky](https://o1-labs.github.io/proof-systems/rustdoc/kimchi/snarky/index.html)
+//! documentation.
 
 extern crate proc_macro;
 use std::collections::HashSet;


### PR DESCRIPTION
See related bot PR https://github.com/o1-labs/proof-systems/pull/3088