### PR TITLE
Arrabbiata: implement and document a ZkApp trait

### DIFF
--- a/arrabbiata/src/lib.rs
+++ b/arrabbiata/src/lib.rs
@@ -70,3 +70,5 @@ pub const NUMBER_OF_GADGETS: usize =
 ///
 /// It is going to be used to convert into the representation used in [mvpoly].
 pub const MV_POLYNOMIAL_ARITY: usize = NUMBER_OF_COLUMNS * 2;
+
+pub mod zkapp_registry;

--- a/arrabbiata/src/lib.rs
+++ b/arrabbiata/src/lib.rs
@@ -17,6 +17,7 @@ pub mod poseidon_3_60_0_5_5_fp;
 pub mod poseidon_3_60_0_5_5_fq;
 pub mod setup;
 pub mod witness;
+pub mod zkapp_registry;
 
 /// The maximum degree of the polynomial that can be represented by the
 /// polynomial-time function the library supports.
@@ -70,5 +71,3 @@ pub const NUMBER_OF_GADGETS: usize =
 ///
 /// It is going to be used to convert into the representation used in [mvpoly].
 pub const MV_POLYNOMIAL_ARITY: usize = NUMBER_OF_COLUMNS * 2;
-
-pub mod zkapp_registry;

--- a/arrabbiata/src/lib.rs
+++ b/arrabbiata/src/lib.rs
@@ -23,28 +23,30 @@ pub mod zkapp_registry;
 /// polynomial-time function the library supports.
 pub const MAX_DEGREE: usize = 5;
 
-/// The minimum SRS size required to use Nova, in base 2.
-pub const MIN_SRS_LOG2_SIZE: usize = 8;
-
-/// The maximum number of columns that can be used in the circuit.
-pub const NUMBER_OF_COLUMNS: usize = 15;
-
-/// The number of rows the verifier circuit requires.
-// FIXME:
-// We will increase the verifier circuit size step by step, while we are finishing
-// the implementation.
-// 1. We start by absorbing all the accumulators of each column. Adding one at
-// the end for now as the Poseidon circuit writes on the next row. This would be
-// changing in the near future as we're polishing the circuit.
-// Absorbing + executing the permutation takes
-// (PlonkSpongeConstants::PERM_ROUNDS_FULL / 5 + 1) rows.
-pub const VERIFIER_CIRCUIT_SIZE: usize =
-    (PlonkSpongeConstants::PERM_ROUNDS_FULL / 5 + 1) * NUMBER_OF_COLUMNS + 1;
-
 /// The maximum number of bits the fields can be.
 /// It is critical as we have some assumptions for the gadgets describing the
 /// verifier circuit.
 pub const MAXIMUM_FIELD_SIZE_IN_BITS: u64 = 255;
+
+/// The minimum SRS size required to use Nova, in base 2.
+pub const MIN_SRS_LOG2_SIZE: usize = 8;
+
+/// The arity of the multivariate polynomials describing the constraints.
+/// We consider, erroneously, that a public input can be considered as a
+/// column and fit an entire polynomial. This is subject to change, as most
+/// values considered as public inputs at the moment are fixed for the
+/// relation. We also suppose that the private inputs on the next row can be
+/// used, hence the multiplication by two.
+///
+/// It is going to be used to convert into the representation used in [mvpoly].
+pub const MV_POLYNOMIAL_ARITY: usize = NUMBER_OF_COLUMNS * 2;
+
+/// The maximum number of columns that can be used in the circuit.
+pub const NUMBER_OF_COLUMNS: usize = 15;
+
+/// The number of gadgets supported by the program
+pub const NUMBER_OF_GADGETS: usize =
+    column::Gadget::COUNT + (PlonkSpongeConstants::PERM_ROUNDS_FULL / 5);
 
 /// Define the number of values we must absorb when computating the hash to the
 /// public IO.
@@ -58,16 +60,14 @@ pub const MAXIMUM_FIELD_SIZE_IN_BITS: u64 = 255;
 /// verifier circuit.
 pub const NUMBER_OF_VALUES_TO_ABSORB_PUBLIC_IO: usize = NUMBER_OF_COLUMNS * 2;
 
-/// The number of gadgets supported by the program
-pub const NUMBER_OF_GADGETS: usize =
-    column::Gadget::COUNT + (PlonkSpongeConstants::PERM_ROUNDS_FULL / 5);
-
-/// The arity of the multivariate polynomials describing the constraints.
-/// We consider, erroneously, that a public input can be considered as a
-/// column and fit an entire polynomial. This is subject to change, as most
-/// values considered as public inputs at the moment are fixed for the
-/// relation. We also suppose that the private inputs on the next row can be
-/// used, hence the multiplication by two.
-///
-/// It is going to be used to convert into the representation used in [mvpoly].
-pub const MV_POLYNOMIAL_ARITY: usize = NUMBER_OF_COLUMNS * 2;
+/// The number of rows the verifier circuit requires.
+// FIXME:
+// We will increase the verifier circuit size step by step, while we are finishing
+// the implementation.
+// 1. We start by absorbing all the accumulators of each column. Adding one at
+// the end for now as the Poseidon circuit writes on the next row. This would be
+// changing in the near future as we're polishing the circuit.
+// Absorbing + executing the permutation takes
+// (PlonkSpongeConstants::PERM_ROUNDS_FULL / 5 + 1) rows.
+pub const VERIFIER_CIRCUIT_SIZE: usize =
+    (PlonkSpongeConstants::PERM_ROUNDS_FULL / 5 + 1) * NUMBER_OF_COLUMNS + 1;

--- a/arrabbiata/src/zkapp_registry/mod.rs
+++ b/arrabbiata/src/zkapp_registry/mod.rs
@@ -1,0 +1,114 @@
+use ark_ff::PrimeField;
+
+use crate::{curve::ArrabbiataCurve, interpreter::InterpreterEnv};
+
+/// A ZkApp is a program that can be executed and proven using a
+/// (zero-knowledge) succinct non-interactive argument of knowledge or in short
+/// a zkSNARK. In particular, the interface is designed to be used with the
+/// Arrabbiata accumulation scheme and its corresponding decider.
+///
+/// A ZkApp is defined over a list of instructions (of type `Instruction`),
+/// where each instruction is a step of the computation. The computation is
+/// defined by the control-flow of the ZkApp, which is defined by the methods
+/// [Self::fetch_next_instruction] and [Self::fetch_instruction].
+/// An instruction is considered to be filling only one row of the execution
+/// trace.
+///
+/// A list of instructions sharing the same constraints is called a gadget (of
+/// type `Gadget`). Each instruction must be convertible to a gadget, therefore
+/// the type restriction to `From<Instruction>`. It will be used in particular
+/// by the method [setup] to build the list of selectors.
+///
+/// An instruction can also transport some data, which can be used to guide the
+/// control-flow and to provide additional information to the interpreter while
+/// executing [Self::run].
+/// For instance, a gadget could be `EllipticCurveScaling`, which could be
+/// formed by a set of instructions `EllipticCurveScaling(bit)` where `bit`
+/// defines the bit of the scalar that is being processed.
+///
+/// A ZkApp structure is responsible to provide a dummy witness, used to
+/// generate a first non-folded instance. The dummy witness is a satisfying
+/// execution trace for dummy inputs.
+pub trait ZkApp<C: ArrabbiataCurve, Instruction: Copy, Gadget: From<Instruction>>
+where
+    C::BaseField: PrimeField,
+{
+    /// Provide a dummy witness, used to generate a first non-folded instance.
+    fn dummy_witness(&self, srs_size: usize) -> Vec<Vec<C::ScalarField>>;
+
+    /// Fetch the first instruction to execute.
+    fn fetch_instruction(&self) -> Instruction;
+
+    /// Describe the control-flow of the ZkApp.
+    /// This function should return the next instruction to execute after
+    /// `current_instr`.
+    ///
+    /// If the current instruction is the last one, it should return `None`.
+    ///
+    /// The method is going to be called by the [execute] function and [setup]
+    /// function.
+    fn fetch_next_instruction(&self, current_instr: Instruction) -> Option<Instruction>;
+
+    /// Execute the instruction `instr` over the interpreter environment `E`.
+    ///
+    /// The interpreter environment is responsible to keep track of the
+    /// execution trace, and to provide the necessary values to the ZkApp.
+    ///
+    /// The method is going to be called by the [execute] function, which is
+    /// responsible to build the whole execution trace, instruction by
+    /// instruction. The stoppingcondition is when the
+    /// [Self::fetch_next_instruction] returns `None`.
+    fn run<E: InterpreterEnv>(&self, env: &mut E, instr: Instruction);
+}
+
+/// Execute the ZkApp `zkapp` over the interpreter environment `env`.
+/// This is a generic function that can be used to execute any ZkApp.
+pub fn execute<
+    E: InterpreterEnv,
+    C: ArrabbiataCurve,
+    Instruction: Copy,
+    Gadget: From<Instruction>,
+    Z: ZkApp<C, Instruction, Gadget>,
+>(
+    zkapp: &Z,
+    env: &mut E,
+) where
+    C::BaseField: PrimeField,
+{
+    let mut instr: Option<Instruction> = Some(zkapp.fetch_instruction());
+    while let Some(i) = instr {
+        zkapp.run(env, i);
+        env.reset();
+        instr = zkapp.fetch_next_instruction(i);
+    }
+}
+
+/// Create a setup for the ZkApp.
+///
+/// The setup will define the shape of the execution trace.
+/// It is mostly consisting of the list of selectors that are used to select the
+/// columns that are used in the computation, and how constrained they are.
+///
+/// For now, the concept of gadget and selectors are mixed together. We
+/// should separate them in the future to allow more flexibility.
+pub fn setup<
+    C: ArrabbiataCurve,
+    Instruction: Copy,
+    Gadget: From<Instruction>,
+    Z: ZkApp<C, Instruction, Gadget>,
+>(
+    zkapp: &Z,
+) -> Vec<Gadget>
+where
+    C::BaseField: PrimeField,
+{
+    let mut circuit: Vec<Gadget> = vec![];
+    let mut instr: Option<Instruction> = Some(zkapp.fetch_instruction());
+    while let Some(i) = instr {
+        circuit.push(Gadget::from(i));
+        instr = zkapp.fetch_next_instruction(i);
+    }
+    circuit
+}
+
+pub mod verifier;

--- a/arrabbiata/src/zkapp_registry/mod.rs
+++ b/arrabbiata/src/zkapp_registry/mod.rs
@@ -2,6 +2,8 @@ use crate::{column::E, curve::ArrabbiataCurve, interpreter::InterpreterEnv};
 use ark_ff::PrimeField;
 use std::{collections::HashMap, hash::Hash};
 
+pub mod verifier;
+
 /// A ZkApp is a program that can be executed and proven using a
 /// (zero-knowledge) succinct non-interactive argument of knowledge or in short
 /// a zkSNARK. In particular, the interface is designed to be used with the
@@ -138,5 +140,3 @@ where
     }
     constraints
 }
-
-pub mod verifier;

--- a/arrabbiata/src/zkapp_registry/verifier.rs
+++ b/arrabbiata/src/zkapp_registry/verifier.rs
@@ -95,11 +95,16 @@ impl From<Instruction> for Gadget {
     }
 }
 
-pub struct Verifier<C: ArrabbiataCurve>
-where
-    C::BaseField: PrimeField,
-{
-    pub _field: std::marker::PhantomData<C>,
+pub struct Verifier<C> {
+    _field: std::marker::PhantomData<C>,
+}
+
+impl<C> Default for Verifier<C> {
+    fn default() -> Self {
+        Self {
+            _field: std::marker::PhantomData,
+        }
+    }
 }
 
 impl<C: ArrabbiataCurve> ZkApp<C, Instruction, Gadget> for Verifier<C>

--- a/arrabbiata/src/zkapp_registry/verifier.rs
+++ b/arrabbiata/src/zkapp_registry/verifier.rs
@@ -107,8 +107,9 @@ impl<C> Default for Verifier<C> {
     }
 }
 
-impl<C: ArrabbiataCurve> ZkApp<C, Instruction, Gadget> for Verifier<C>
+impl<C> ZkApp<C, Instruction, Gadget> for Verifier<C>
 where
+    C: ArrabbiataCurve,
     C::BaseField: PrimeField,
 {
     fn dummy_witness(&self, _srs_size: usize) -> Vec<Vec<C::ScalarField>> {

--- a/arrabbiata/src/zkapp_registry/verifier.rs
+++ b/arrabbiata/src/zkapp_registry/verifier.rs
@@ -18,6 +18,7 @@ use crate::{
     MAXIMUM_FIELD_SIZE_IN_BITS, NUMBER_OF_COLUMNS,
 };
 use ark_ff::PrimeField;
+use core::hash::Hash;
 use log::debug;
 use mina_poseidon::constants::SpongeConstants;
 use num_bigint::BigInt;
@@ -51,6 +52,7 @@ pub enum Instruction {
     NoOp,
 }
 
+#[derive(Eq, Hash, PartialEq)]
 pub enum Gadget {
     /// The following gadgets implement the Poseidon hash instance described in
     /// the top-level documentation. In the current setup, with

--- a/arrabbiata/src/zkapp_registry/verifier.rs
+++ b/arrabbiata/src/zkapp_registry/verifier.rs
@@ -1,0 +1,486 @@
+//! This module contains a generic verifier for Arrabbiata.
+//!
+//! The verifier is implemented as a ZkApp, and is responsible to build the
+//! verification of a previous execution trace.
+//!
+//! Considering the verifier as a ZkApp allows to reuse the same interface.
+//! Also, it eases the development of other verifiers, as the interface is
+//! generic and can be reused.
+//!
+//! The verifier circuit has the following structure:
+//! - absorb the accumulators of each accumulator, and run the Poseidon hash
+//!   after each absorbtion.
+//! - [...] TBD
+use crate::{
+    curve::{ArrabbiataCurve, PlonkSpongeConstants},
+    interpreter::{InterpreterEnv, Side},
+    zkapp_registry::ZkApp,
+    MAXIMUM_FIELD_SIZE_IN_BITS, NUMBER_OF_COLUMNS,
+};
+use ark_ff::PrimeField;
+use log::debug;
+use mina_poseidon::constants::SpongeConstants;
+use num_bigint::BigInt;
+
+#[derive(Copy, Clone)]
+pub enum Instruction {
+    /// This gadget implements the Poseidon hash instance described in the
+    /// top-level documentation of the interpreter [crate::interpreter]. In the
+    /// current setup, with [NUMBER_OF_COLUMNS] columns, we can compute 5 full
+    /// rounds per row.
+    ///
+    /// The first parameter is an index, which can be used by the environment to
+    /// have more information on the values that have been absorbed previously.
+    /// It can also be used by the control-flow method to know when to stop.
+    ///
+    /// We split the Poseidon gadget in 13 sub-gadgets, one for each set of 5
+    /// full rounds and one for the absorbtion. The second parameter is the
+    /// starting round of the permutation. It is expected to be a multiple of
+    /// five. The absorption is defined by the instruction PoseidonSpongeAbsorb.
+    PoseidonFullRound(usize, usize),
+    /// Absorb [PlonkSpongeConstants::SPONGE_WIDTH - 1] elements into the
+    /// sponge. The elements are absorbed into the last
+    /// [PlonkSpongeConstants::SPONGE_WIDTH - 1] elements of the sponge state.
+    ///
+    /// The parameter can be used to know which value to absorb.
+    PoseidonSpongeAbsorb(usize),
+
+    EllipticCurveScaling(usize, u64),
+    EllipticCurveAddition(usize),
+    /// The NoOp will simply do nothing
+    NoOp,
+}
+
+pub enum Gadget {
+    /// The following gadgets implement the Poseidon hash instance described in
+    /// the top-level documentation. In the current setup, with
+    /// [crate::NUMBER_OF_COLUMNS] columns, we can compute 5 full
+    /// rounds per row.
+    ///
+    /// We split the Poseidon gadget in 13 sub-gadgets, one for each set of 5
+    /// full rounds and one for the absorbtion. The parameter is the starting
+    /// round of Poseidon. It is expected to be a multiple of five.
+    PoseidonFullRound(usize),
+    /// Absorb [PlonkSpongeConstants::SPONGE_WIDTH - 1] elements into the
+    /// sponge. The elements are absorbed into the last
+    /// [PlonkSpongeConstants::SPONGE_WIDTH - 1] elements of the permutation
+    /// state.
+    ///
+    /// The values to be absorbed depend on the state of the environment while
+    /// executing this instruction.
+    PoseidonSpongeAbsorb,
+
+    EllipticCurveScaling,
+    EllipticCurveAddition,
+
+    /// A dummy gadget, doing nothing. Use for padding.
+    NoOp,
+}
+
+/// Convert an instruction into the corresponding gadget.
+impl From<Instruction> for Gadget {
+    fn from(val: Instruction) -> Gadget {
+        match val {
+            Instruction::NoOp => Gadget::NoOp,
+            Instruction::PoseidonFullRound(_idx, starting_round) => {
+                assert_eq!(starting_round % 5, 0);
+                Gadget::PoseidonFullRound(starting_round)
+            }
+            Instruction::PoseidonSpongeAbsorb(_) => Gadget::PoseidonSpongeAbsorb,
+            Instruction::EllipticCurveScaling(_i_comm, _s) => Gadget::EllipticCurveScaling,
+            Instruction::EllipticCurveAddition(_i) => Gadget::EllipticCurveAddition,
+        }
+    }
+}
+
+pub struct Verifier<C: ArrabbiataCurve>
+where
+    C::BaseField: PrimeField,
+{
+    pub _field: std::marker::PhantomData<C>,
+}
+
+impl<C: ArrabbiataCurve> ZkApp<C, Instruction, Gadget> for Verifier<C>
+where
+    C::BaseField: PrimeField,
+{
+    fn dummy_witness(&self, _srs_size: usize) -> Vec<Vec<C::ScalarField>> {
+        unimplemented!("Dummy witness for the verifier is not implemented yet")
+    }
+
+    /// Fetch the first instruction to execute.
+    fn fetch_instruction(&self) -> Instruction {
+        Instruction::PoseidonSpongeAbsorb(0)
+    }
+
+    /// Describe the control-flow for the verifier circuit.
+    fn fetch_next_instruction(&self, current_instruction: Instruction) -> Option<Instruction> {
+        match current_instruction {
+            Instruction::PoseidonFullRound(idx, starting_round) => {
+                assert_eq!(starting_round % 5, 0);
+                // Executing five full rounds of Poseidon until we reach the last
+                // set of five rounds.
+                if starting_round < PlonkSpongeConstants::PERM_ROUNDS_FULL - 5 {
+                    Some(Instruction::PoseidonFullRound(idx, starting_round + 5))
+                } else {
+                    // When we reach the last set of five rounds, either we
+                    // continue absorbing or we stop, for now.
+                    if idx < NUMBER_OF_COLUMNS - 1 {
+                        Some(Instruction::PoseidonSpongeAbsorb(idx + 1))
+                    } else {
+                        Some(Instruction::NoOp)
+                    }
+                }
+            }
+            Instruction::PoseidonSpongeAbsorb(idx) => {
+                assert!(
+                    idx < NUMBER_OF_COLUMNS,
+                    "By construction, this case should not happen"
+                );
+                // After absorbing we automatically run the permutation.
+                Some(Instruction::PoseidonFullRound(idx, 0))
+            }
+            Instruction::EllipticCurveScaling(i_comm, bit) => {
+                // TODO: we still need to substract (or not?) the blinder.
+                // Maybe we can avoid this by aggregating them.
+                // TODO: we also need to aggregate the cross-terms.
+                // Therefore i_comm must also take into the account the number
+                // of cross-terms.
+                assert!(i_comm < NUMBER_OF_COLUMNS, "Maximum number of columns reached ({NUMBER_OF_COLUMNS}), increase the number of columns");
+                assert!(bit < MAXIMUM_FIELD_SIZE_IN_BITS, "Maximum number of bits reached ({MAXIMUM_FIELD_SIZE_IN_BITS}), increase the number of bits");
+                if bit < 255 - 1 {
+                    Some(Instruction::EllipticCurveScaling(i_comm, bit + 1))
+                } else if i_comm < NUMBER_OF_COLUMNS - 1 {
+                    Some(Instruction::EllipticCurveScaling(i_comm + 1, 0))
+                } else {
+                    // We have computed all the bits for all the columns
+                    Some(Instruction::NoOp)
+                }
+            }
+            Instruction::EllipticCurveAddition(i_comm) => {
+                if i_comm < NUMBER_OF_COLUMNS - 1 {
+                    Some(Instruction::EllipticCurveAddition(i_comm + 1))
+                } else {
+                    Some(Instruction::NoOp)
+                }
+            }
+            // Whenever we reach a NoOp, we stop the execution.
+            Instruction::NoOp => None,
+        }
+    }
+
+    fn run<E: InterpreterEnv>(&self, env: &mut E, instr: Instruction) {
+        match instr {
+            Instruction::EllipticCurveScaling(i_comm, processing_bit) => {
+                assert!(processing_bit < MAXIMUM_FIELD_SIZE_IN_BITS, "Invalid bit index. The fields are maximum on {MAXIMUM_FIELD_SIZE_IN_BITS} bits, therefore we cannot process the bit {processing_bit}");
+                assert!(i_comm < NUMBER_OF_COLUMNS, "Invalid index. We do only support the scaling of the commitments to the columns, for now. We must additionally support the scaling of cross-terms and error terms");
+                debug!("Processing scaling of commitment {i_comm}, bit {processing_bit}");
+                // When processing the first bit, we must load the scalar, and it
+                // comes from previous computation.
+                // The two first columns are supposed to be used for the output.
+                // It will be used to write the result of the scalar multiplication
+                // in the next row.
+                let res_col_x = env.allocate();
+                let res_col_y = env.allocate();
+                let tmp_col_x = env.allocate();
+                let tmp_col_y = env.allocate();
+                let scalar_col = env.allocate();
+                let next_row_res_col_x = env.allocate_next_row();
+                let next_row_res_col_y = env.allocate_next_row();
+                let next_row_tmp_col_x = env.allocate_next_row();
+                let next_row_tmp_col_y = env.allocate_next_row();
+                let next_row_scalar_col = env.allocate_next_row();
+
+                // For the bit, we do have two cases. If we are processing the first
+                // bit, we must load the bit from a previous computed value. In the
+                // case of folding, it will be the output of the Poseidon hash.
+                // Therefore we do need the permutation argument.
+                // If it is not the first bit, we suppose the previous value has
+                // been written in the previous step in the current row.
+                let scalar = if processing_bit == 0 {
+                    env.coin_folding_combiner(scalar_col)
+                } else {
+                    env.read_position(scalar_col)
+                };
+                // FIXME: we do add the blinder. We must substract it at the end.
+                // Perform the following algorithm (double-and-add):
+                // res = O <-- blinder
+                // tmp = P
+                // for i in 0..256:
+                //   if r[i] == 1:
+                //     res = res + tmp
+                //   tmp = tmp + tmp
+                //
+                // - `processing_bit` is the i-th bit of the scalar, i.e. i in the loop
+                // described above.
+                // - `i_comm` is used to fetch the commitment.
+                //
+                // If it is the first bit, we must load the commitment using the
+                // permutation argument.
+                // FIXME: the initial value of the result should be a non-zero
+                // point. However, it must be a public value otherwise the prover
+                // might lie on the initial value.
+                // We do have 15 public inputs on each row, we could use some of them.
+                let (res_x, res_y) = if processing_bit == 0 {
+                    // Load the commitment
+                    unsafe { env.load_temporary_accumulators(res_col_x, res_col_y, Side::Right) }
+                } else {
+                    // Otherwise, the previous step has written the previous result
+                    // in its "next row", i.e. this row.
+                    let res_x = { env.read_position(res_col_x) };
+                    let res_y = { env.read_position(res_col_y) };
+                    (res_x, res_y)
+                };
+                // Same for the accumulated temporary value
+                let (tmp_x, tmp_y) = if processing_bit == 0 {
+                    unsafe { env.load_temporary_accumulators(tmp_col_x, tmp_col_y, Side::Left) }
+                } else {
+                    (env.read_position(tmp_col_x), env.read_position(tmp_col_y))
+                };
+                // Conditional addition:
+                // if bit == 1, then res = tmp + res
+                // else res = res
+                // First we compute tmp + res
+                // FIXME: we do suppose that res != tmp -> no doubling and no check
+                // if they are the same
+                // IMPROVEME: reuse elliptic curve addition
+                let (res_plus_tmp_x, res_plus_tmp_y) = {
+                    let lambda = {
+                        let pos = env.allocate();
+                        env.compute_lambda(
+                            pos,
+                            env.zero(),
+                            tmp_x.clone(),
+                            tmp_y.clone(),
+                            res_x.clone(),
+                            res_y.clone(),
+                        )
+                    };
+                    // x3 = λ^2 - x1 - x2
+                    let x3 = {
+                        let pos = env.allocate();
+                        let lambda_square = lambda.clone() * lambda.clone();
+                        let res = lambda_square.clone() - tmp_x.clone() - res_x.clone();
+                        env.write_column(pos, res)
+                    };
+                    // y3 = λ (x1 - x3) - y1
+                    let y3 = {
+                        let pos = env.allocate();
+                        let x1_minus_x3 = tmp_x.clone() - x3.clone();
+                        let res = lambda.clone() * x1_minus_x3.clone() - tmp_y.clone();
+                        env.write_column(pos, res)
+                    };
+                    (x3, y3)
+                };
+                // tmp = tmp + tmp
+                // Compute the double of the temporary value
+                // The slope is saved in a column created in the call to
+                // `double_ec_point`
+                // We ignore the result as it will be used at the next step only.
+                let (_double_tmp_x, _double_tmp_y) = {
+                    env.double_ec_point(
+                        next_row_tmp_col_x,
+                        next_row_tmp_col_y,
+                        tmp_x.clone(),
+                        tmp_y.clone(),
+                    )
+                };
+                let bit = {
+                    let pos = env.allocate();
+                    unsafe { env.bitmask_be(&scalar, 1, 0, pos) }
+                };
+                // Checking it is a boolean -> degree 2
+                env.constrain_boolean(bit.clone());
+                let next_scalar = {
+                    unsafe {
+                        env.bitmask_be(
+                            &scalar,
+                            MAXIMUM_FIELD_SIZE_IN_BITS.try_into().unwrap(),
+                            1,
+                            next_row_scalar_col,
+                        )
+                    }
+                };
+                // Degree 1
+                env.assert_equal(
+                    scalar.clone(),
+                    bit.clone() + env.constant(BigInt::from(2)) * next_scalar.clone(),
+                );
+                let _x3 = {
+                    let res = bit.clone() * res_plus_tmp_x.clone()
+                        + (env.one() - bit.clone()) * res_x.clone();
+                    env.write_column(next_row_res_col_x, res)
+                };
+                let _y3 = {
+                    let res = bit.clone() * res_plus_tmp_y.clone()
+                        + (env.one() - bit.clone()) * res_y.clone();
+                    env.write_column(next_row_res_col_y, res)
+                };
+            }
+            Instruction::EllipticCurveAddition(i_comm) => {
+                assert!(i_comm < NUMBER_OF_COLUMNS, "Invalid index. We do only support the addition of the commitments to the columns, for now. We must additionally support the scaling of cross-terms and error terms");
+                let (x1, y1) = {
+                    let x1 = env.allocate();
+                    let y1 = env.allocate();
+                    unsafe { env.load_temporary_accumulators(x1, y1, Side::Left) }
+                };
+                let (x2, y2) = {
+                    let x2 = env.allocate();
+                    let y2 = env.allocate();
+                    unsafe { env.load_temporary_accumulators(x2, y2, Side::Right) }
+                };
+                let is_same_point = {
+                    let pos = env.allocate();
+                    unsafe {
+                        env.is_same_ec_point(pos, x1.clone(), y1.clone(), x2.clone(), y2.clone())
+                    }
+                };
+                let lambda = {
+                    let pos = env.allocate();
+                    env.compute_lambda(
+                        pos,
+                        is_same_point,
+                        x1.clone(),
+                        y1.clone(),
+                        x2.clone(),
+                        y2.clone(),
+                    )
+                };
+                // x3 = λ^2 - x1 - x2
+                let x3 = {
+                    let pos = env.allocate();
+                    let lambda_square = lambda.clone() * lambda.clone();
+                    let res = lambda_square.clone() - x1.clone() - x2.clone();
+                    env.write_column(pos, res)
+                };
+                // y3 = λ (x1 - x3) - y1
+                {
+                    let pos = env.allocate();
+                    let x1_minus_x3 = x1.clone() - x3.clone();
+                    let res = lambda.clone() * x1_minus_x3.clone() - y1.clone();
+                    env.write_column(pos, res)
+                };
+            }
+            Instruction::PoseidonFullRound(_idx, starting_round) => {
+                assert!(
+                    starting_round < PlonkSpongeConstants::PERM_ROUNDS_FULL,
+                    "Invalid round index. Only values below {} are allowed.",
+                    PlonkSpongeConstants::PERM_ROUNDS_FULL
+                );
+                assert!(
+                    starting_round % 5 == 0,
+                    "Invalid round index. Only values that are multiple of 5 are allowed."
+                );
+                debug!(
+                    "Executing instruction Poseidon starting from round {starting_round} to {}",
+                    starting_round + 5
+                );
+
+                let round_input_positions: Vec<E::Position> = (0
+                    ..PlonkSpongeConstants::SPONGE_WIDTH)
+                    .map(|_i| env.allocate())
+                    .collect();
+
+                let round_output_positions: Vec<E::Position> = (0
+                    ..PlonkSpongeConstants::SPONGE_WIDTH)
+                    .map(|_i| env.allocate_next_row())
+                    .collect();
+
+                let state: Vec<E::Variable> = if starting_round == 0 {
+                    round_input_positions
+                        .iter()
+                        .enumerate()
+                        .map(|(i, pos)| env.load_poseidon_state(*pos, i))
+                        .collect()
+                } else {
+                    round_input_positions
+                        .iter()
+                        .map(|pos| env.read_position(*pos))
+                        .collect()
+                };
+
+                // 5 is the number of rounds we treat per row
+                (0..5).fold(state, |state, idx_round| {
+                    let state: Vec<E::Variable> =
+                        state.iter().map(|x| env.compute_x5(x.clone())).collect();
+
+                    let round = starting_round + idx_round;
+
+                    let rcs: Vec<E::Variable> = (0..PlonkSpongeConstants::SPONGE_WIDTH)
+                        .map(|i| env.get_poseidon_round_constant(round, i))
+                        .collect();
+
+                    let state: Vec<E::Variable> = rcs
+                        .iter()
+                        .enumerate()
+                        .map(|(i, rc)| {
+                            let acc: E::Variable =
+                                state.iter().enumerate().fold(env.zero(), |acc, (j, x)| {
+                                    acc + env.get_poseidon_mds_matrix(i, j) * x.clone()
+                                });
+                            // The last iteration is written on the next row.
+                            if idx_round == 4 {
+                                env.write_column(round_output_positions[i], acc + rc.clone())
+                            } else {
+                                // Otherwise, we simply allocate a new position
+                                // in the circuit.
+                                let pos = env.allocate();
+                                env.write_column(pos, acc + rc.clone())
+                            }
+                        })
+                        .collect();
+
+                    // If we are at the last round, we save the state in the
+                    // environment.
+                    // FIXME/IMPROVEME: we might want to execute more Poseidon
+                    // full hash in sequentially, and then save one row. For
+                    // now, we will save the state at the end of the last round
+                    // and reload it at the beginning of the next Poseidon full
+                    // hash.
+                    if round == PlonkSpongeConstants::PERM_ROUNDS_FULL - 1 {
+                        state.iter().enumerate().for_each(|(i, x)| {
+                            unsafe { env.save_poseidon_state(x.clone(), i) };
+                        });
+                    };
+
+                    state
+                });
+            }
+            Instruction::PoseidonSpongeAbsorb(_idx) => {
+                let round_input_positions: Vec<E::Position> = (0
+                    ..PlonkSpongeConstants::SPONGE_WIDTH - 1)
+                    .map(|_i| env.allocate())
+                    .collect();
+
+                let state: Vec<E::Variable> = round_input_positions
+                    .iter()
+                    .enumerate()
+                    .map(|(i, pos)| env.load_poseidon_state(*pos, i + 1))
+                    .collect();
+
+                let values_to_absorb: Vec<E::Variable> = (0..PlonkSpongeConstants::SPONGE_WIDTH
+                    - 1)
+                    .map(|_i| unsafe {
+                        let pos = env.allocate();
+                        env.fetch_value_to_absorb(pos)
+                    })
+                    .collect();
+
+                let output: Vec<E::Variable> = state
+                    .iter()
+                    .zip(values_to_absorb.iter())
+                    .map(|(s, v)| {
+                        let pos = env.allocate();
+                        env.write_column(pos, s.clone() + v.clone())
+                    })
+                    .collect();
+
+                output
+                    .iter()
+                    .enumerate()
+                    .for_each(|(i, o)| unsafe { env.save_poseidon_state(o.clone(), i + 1) })
+            }
+            Instruction::NoOp => {}
+        }
+    }
+}

--- a/arrabbiata/tests/test_zkapp_verifier.rs
+++ b/arrabbiata/tests/test_zkapp_verifier.rs
@@ -1,12 +1,9 @@
 use arrabbiata::zkapp_registry::verifier::{Gadget, Verifier};
-use core::marker::PhantomData;
 use mina_curves::pasta::Vesta;
 
 #[test]
 fn test_zkapp_verifier_setup_size() {
-    let zkapp: Verifier<Vesta> = Verifier::<Vesta> {
-        _field: PhantomData,
-    };
+    let zkapp: Verifier<Vesta> = Verifier::<Vesta>::default();
     let setup_size = arrabbiata::zkapp_registry::setup(&zkapp);
 
     // This is the current value of VERIFIER_CIRCUIT_SIZE in lib.rs
@@ -15,9 +12,7 @@ fn test_zkapp_verifier_setup_size() {
 
 #[test]
 fn test_zkapp_verifier_get_constraints_per_gadget() {
-    let zkapp: Verifier<Vesta> = Verifier::<Vesta> {
-        _field: PhantomData,
-    };
+    let zkapp: Verifier<Vesta> = Verifier::<Vesta>::default();
     let constraints = arrabbiata::zkapp_registry::get_constraints_per_gadget(&zkapp);
 
     // Checking the number of gadgets

--- a/arrabbiata/tests/test_zkapp_verifier.rs
+++ b/arrabbiata/tests/test_zkapp_verifier.rs
@@ -1,0 +1,52 @@
+use arrabbiata::zkapp_registry::verifier::{Gadget, Verifier};
+use core::marker::PhantomData;
+use mina_curves::pasta::Vesta;
+
+#[test]
+fn test_zkapp_verifier_setup_size() {
+    let zkapp: Verifier<Vesta> = Verifier::<Vesta> {
+        _field: PhantomData,
+    };
+    let setup_size = arrabbiata::zkapp_registry::setup(&zkapp);
+
+    // This is the current value of VERIFIER_CIRCUIT_SIZE in lib.rs
+    assert_eq!(setup_size.len(), 196);
+}
+
+#[test]
+fn test_zkapp_verifier_get_constraints_per_gadget() {
+    let zkapp: Verifier<Vesta> = Verifier::<Vesta> {
+        _field: PhantomData,
+    };
+    let constraints = arrabbiata::zkapp_registry::get_constraints_per_gadget(&zkapp);
+
+    // Checking the number of gadgets
+    // 12 for PoseidonFullRound
+    // 1 for PoseidonAbsorb
+    // 1 for NoOp
+    assert_eq!(constraints.len(), 12 + 1 + 1);
+
+    {
+        let csts = constraints[&Gadget::PoseidonSpongeAbsorb].clone();
+        assert_eq!(csts.len(), 2);
+        // Each constraint has a degree of 1
+        csts.iter().for_each(|c| {
+            assert_eq!(c.degree(1, 0), 1);
+        });
+    }
+    {
+        (0..12).for_each(|i| {
+            let csts = constraints[&Gadget::PoseidonFullRound(i * 5)].clone();
+            assert_eq!(csts.len(), 15);
+            // Each constraint has a degree of 5
+            csts.iter().for_each(|c| {
+                assert_eq!(c.degree(1, 0), 5);
+            });
+        });
+    }
+
+    {
+        let csts = constraints[&Gadget::NoOp].clone();
+        assert_eq!(csts.len(), 0);
+    }
+}


### PR DESCRIPTION
This PR introduces the concept of "ZkApp" - the name might require to be changed later - and encodes the Arrabbiata verifier currently available in "run_ivc" as a ZkApp. It contains changes initially defined in the draft PR https://github.com/o1-labs/proof-systems/pull/3061.

In a future PR, an application, MinRoot, will be added. From there, a rework on the interface of `IndexedRelation` will be performed to provide a real world use case of Arrabbiata, end-to-end.
It will gather the PR https://github.com/o1-labs/proof-systems/pull/3061 and https://github.com/o1-labs/proof-systems/pull/3067, in addition to a better management of the sponge. The permutation argument, initially sketched in https://github.com/o1-labs/proof-systems/pull/2593, will also be introduced.

Note that the interface does not include all the requirements to include, for instance, a zkVM.
In particular, a zkVM must have access to an external "memory", where the `fetch_next_instruction` gets its own data.
The o1vm is therefore not directly compatible with this interface.
However, I do believe it will be clearer how to integrate it when lookups will be introduced in the witness environment.