### PR TITLE
Arrabbiata: use GAT instead of type parameters in ZkApp trait

### DIFF
--- a/arrabbiata/src/zkapp_registry/minroot.rs
+++ b/arrabbiata/src/zkapp_registry/minroot.rs
@@ -38,11 +38,15 @@ where
     pub n: usize,
 }
 
-impl<C> ZkApp<C, Instruction, Gadget> for MinRoot<C>
+impl<C> ZkApp<C> for MinRoot<C>
 where
     C: ArrabbiataCurve,
     C::BaseField: PrimeField,
 {
+    type Instruction = Instruction;
+
+    type Gadget = Gadget;
+
     fn dummy_witness(&self, _srs_size: usize) -> Vec<Vec<C::ScalarField>> {
         unimplemented!()
     }
@@ -51,7 +55,10 @@ where
         Instruction::ComputeFifthRoot(0)
     }
 
-    fn fetch_next_instruction(&self, current_instr: Instruction) -> Option<Instruction> {
+    fn fetch_next_instruction(
+        &self,
+        current_instr: Self::Instruction,
+    ) -> Option<Self::Instruction> {
         match current_instr {
             Instruction::ComputeFifthRoot(i) => {
                 if i < self.n {
@@ -63,7 +70,7 @@ where
         }
     }
 
-    fn run<E: InterpreterEnv>(&self, env: &mut E, instr: Instruction) {
+    fn run<E: InterpreterEnv>(&self, env: &mut E, instr: Self::Instruction) {
         match instr {
             Instruction::ComputeFifthRoot(_i) => {
                 let x = {

--- a/arrabbiata/src/zkapp_registry/verifier.rs
+++ b/arrabbiata/src/zkapp_registry/verifier.rs
@@ -107,22 +107,29 @@ impl<C> Default for Verifier<C> {
     }
 }
 
-impl<C> ZkApp<C, Instruction, Gadget> for Verifier<C>
+impl<C> ZkApp<C> for Verifier<C>
 where
     C: ArrabbiataCurve,
     C::BaseField: PrimeField,
 {
+    type Instruction = Instruction;
+
+    type Gadget = Gadget;
+
     fn dummy_witness(&self, _srs_size: usize) -> Vec<Vec<C::ScalarField>> {
         unimplemented!("Dummy witness for the verifier is not implemented yet")
     }
 
     /// Fetch the first instruction to execute.
-    fn fetch_instruction(&self) -> Instruction {
+    fn fetch_instruction(&self) -> Self::Instruction {
         Instruction::PoseidonSpongeAbsorb(0)
     }
 
     /// Describe the control-flow for the verifier circuit.
-    fn fetch_next_instruction(&self, current_instruction: Instruction) -> Option<Instruction> {
+    fn fetch_next_instruction(
+        &self,
+        current_instruction: Self::Instruction,
+    ) -> Option<Self::Instruction> {
         match current_instruction {
             Instruction::PoseidonFullRound(idx, starting_round) => {
                 assert_eq!(starting_round % 5, 0);
@@ -177,7 +184,7 @@ where
         }
     }
 
-    fn run<E: InterpreterEnv>(&self, env: &mut E, instr: Instruction) {
+    fn run<E: InterpreterEnv>(&self, env: &mut E, instr: Self::Instruction) {
         match instr {
             Instruction::EllipticCurveScaling(i_comm, processing_bit) => {
                 assert!(processing_bit < MAXIMUM_FIELD_SIZE_IN_BITS, "Invalid bit index. The fields are maximum on {MAXIMUM_FIELD_SIZE_IN_BITS} bits, therefore we cannot process the bit {processing_bit}");


### PR DESCRIPTION
Do not review.

As suggested by @richardpringle in https://github.com/o1-labs/proof-systems/pull/3097#pullrequestreview-2708680045.
