### PR TITLE
Saffron: Merge with Demo

### DIFF
--- a/saffron/src/blob.rs
+++ b/saffron/src/blob.rs
@@ -182,7 +182,7 @@ mod tests {
             let xs_len_chunks = xs.len() / (31 * SRS_SIZE);
             xs.truncate(xs_len_chunks * 31 * SRS_SIZE);
 
-            let blob = FieldBlob::from_bytes::<_>(&*SRS, *DOMAIN, &xs);
+            let blob = FieldBlob::from_bytes::<_>(&SRS, *DOMAIN, &xs);
             let bytes = rmp_serde::to_vec(&blob).unwrap();
             let a = rmp_serde::from_slice(&bytes).unwrap();
             // check that ark-serialize is behaving as expected
@@ -198,14 +198,14 @@ mod tests {
     #[test]
     fn test_user_and_storage_provider_commitments_equal(UserData(xs) in UserData::arbitrary())
       { let elems: Vec<_> = encode_for_domain(DOMAIN.size(), &xs).into_iter().flatten().collect();
-        let user_commitments: Vec<_> = commit_to_field_elems(&*SRS, &elems);
-        let blob = FieldBlob::from_bytes::<_>(&*SRS, *DOMAIN, &xs);
+        let user_commitments: Vec<_> = commit_to_field_elems(&SRS, &elems);
+        let blob = FieldBlob::from_bytes::<_>(&SRS, *DOMAIN, &xs);
         prop_assert_eq!(user_commitments, blob.commitments);
       }
     }
 
     fn encode_to_chunk_size(xs: &[u8], chunk_size: usize) -> FieldBlob {
-        let mut blob = FieldBlob::from_bytes::<_>(&*SRS, *DOMAIN, xs);
+        let mut blob = FieldBlob::from_bytes::<_>(&SRS, *DOMAIN, xs);
 
         assert!(blob.data.len() <= chunk_size * crate::SRS_SIZE);
 
@@ -223,20 +223,20 @@ mod tests {
             (UserData::arbitrary_with(DataSize::Medium).prop_flat_map(random_diff))
         ) {
             // start with some random user data
-            let mut xs_blob = FieldBlob::from_bytes::<_>(&*SRS, *DOMAIN, &xs);
+            let mut xs_blob = FieldBlob::from_bytes::<_>(&SRS, *DOMAIN, &xs);
             let diffs = Diff::<ScalarField>::create_from_bytes(&*DOMAIN, &xs, &ys).unwrap();
 
             // check that the user and SP agree on the data
             let user_commitment: Vec<_> = {
                 let elems: Vec<_> = encode_for_domain(DOMAIN.size(), &xs).into_iter().flatten().collect();
-                commit_to_field_elems(&*SRS, &elems)
+                commit_to_field_elems(&SRS, &elems)
 
             };
             prop_assert_eq!(user_commitment.clone(), xs_blob.commitments.clone());
 
             // Update the blob with the diff and check the user can match the commitment
             for diff in diffs.iter() {
-                xs_blob.apply_diff(&*SRS, &*DOMAIN, diff);
+                xs_blob.apply_diff(&SRS, &DOMAIN, diff);
             }
 
             // the updated blob should be the same as if we just start with the new data (with appropriate padding)

--- a/saffron/src/blob.rs
+++ b/saffron/src/blob.rs
@@ -1,158 +1,167 @@
 use crate::{
-    commitment::Commitment,
+    commitment::commit_to_field_elems,
     diff::Diff,
     utils::{decode_into, encode_for_domain},
+    Curve, ProjectiveCurve, ScalarField, SRS_SIZE,
 };
-use ark_ff::PrimeField;
-use ark_poly::{
-    univariate::DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain,
-};
+use ark_ec::{AffineRepr, VariableBaseMSM};
+use ark_ff::{PrimeField, Zero};
+use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use kimchi::curve::KimchiCurve;
-use mina_poseidon::FqSponge;
 use o1_utils::FieldHelpers;
-use poly_commitment::{commitment::CommitmentCurve, ipa::SRS, PolyComm, SRS as _};
+use poly_commitment::{ipa::SRS, SRS as _};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use tracing::{debug, debug_span, instrument};
+use tracing::{debug, instrument};
 
-// A FieldBlob<F> represents the encoding of a Vec<u8> as a list of polynomials over F,
-// where F is a prime field. The polyonomials are represented in the monomial basis.
+/// A FieldBlob<F> is what Storage Provider stores per user's
+/// contract: a list of SRS_SIZE * chunk_size field elements, where
+/// chunk_size is how much the client allocated.
+///
+/// It can be seen as the encoding of a Vec<u8>, where each field
+/// element contains 31 bytes.
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(bound = "G::ScalarField : CanonicalDeserialize + CanonicalSerialize")]
-pub struct FieldBlob<G: CommitmentCurve> {
-    pub n_bytes: usize,
-    pub domain_size: usize,
-    pub commitment: Commitment<G>,
+#[serde(bound = "ScalarField : CanonicalDeserialize + CanonicalSerialize")]
+pub struct FieldBlob {
     #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
-    pub chunks: Vec<DensePolynomial<G::ScalarField>>,
+    pub data: Vec<ScalarField>,
+    #[serde_as(as = "Vec<o1_utils::serialization::SerdeAs>")]
+    pub commitments: Vec<Curve>,
 }
 
-#[instrument(skip_all, level = "debug")]
-fn commit_to_blob_data<G: CommitmentCurve>(
-    srs: &SRS<G>,
-    data: &[DensePolynomial<G::ScalarField>],
-) -> Vec<PolyComm<G>> {
-    let num_chunks = 1;
-    data.par_iter()
-        .map(|p| srs.commit_non_hiding(p, num_chunks))
-        .collect()
-}
+impl FieldBlob {
+    pub fn alloc_empty(num_chunks: usize) -> FieldBlob {
+        let data = vec![ScalarField::zero(); num_chunks * SRS_SIZE];
 
-impl<G: KimchiCurve> FieldBlob<G> {
+        let commitments = vec![Curve::zero(); num_chunks];
+
+        FieldBlob { data, commitments }
+    }
+
+    pub fn apply_diff(
+        &mut self,
+        srs: &SRS<Curve>,
+        domain: &Radix2EvaluationDomain<ScalarField>,
+        diff: &Diff<ScalarField>,
+    ) {
+        assert!(diff.addresses.len() == diff.new_values.len());
+
+        let lagrange_basis = srs
+            .get_lagrange_basis(*domain)
+            .iter()
+            .map(|x| x.chunks[0])
+            .collect::<Vec<_>>();
+        let basis = lagrange_basis.as_slice();
+
+        let address_basis: Vec<_> = diff
+            .addresses
+            .par_iter()
+            .map(|idx| basis[*idx as usize])
+            .collect();
+
+        // Old values at `addresses`
+        let old_values: Vec<_> = diff
+            .addresses
+            .iter()
+            .map(|idx| self.data[diff.region as usize * SRS_SIZE + *idx as usize])
+            .collect();
+
+        for (idx, value) in diff.addresses.iter().zip(diff.new_values.iter()) {
+            self.data[SRS_SIZE * diff.region as usize + *idx as usize] = *value;
+        }
+
+        // Lagrange commitment to them.
+        let old_data_commitment =
+            ProjectiveCurve::msm(address_basis.as_slice(), old_values.as_slice()).unwrap();
+
+        // Lagrange commitment to the new values at `addresses`
+        let new_data_commitment =
+            ProjectiveCurve::msm(address_basis.as_slice(), diff.new_values.as_slice()).unwrap();
+
+        let new_commitment = (self.commitments[diff.region as usize] + new_data_commitment
+            - old_data_commitment)
+            .into();
+
+        self.commitments[diff.region as usize] = new_commitment;
+    }
+
+    pub fn from_data(srs: &SRS<Curve>, data: &[ScalarField]) -> FieldBlob {
+        let commitments = commit_to_field_elems(srs, data);
+        FieldBlob {
+            commitments,
+            data: Vec::from(data),
+        }
+    }
+
     #[instrument(skip_all, level = "debug")]
-    pub fn encode<
-        D: EvaluationDomain<G::ScalarField>,
-        EFqSponge: FqSponge<G::BaseField, G, G::ScalarField>,
-    >(
-        srs: &SRS<G>,
+    pub fn from_bytes<D: EvaluationDomain<ScalarField>>(
+        srs: &SRS<Curve>,
         domain: D,
         bytes: &[u8],
-    ) -> FieldBlob<G> {
-        let field_elements = encode_for_domain(&domain, bytes);
-        let domain_size = domain.size();
+    ) -> FieldBlob {
+        let field_elements: Vec<ScalarField> = encode_for_domain(&domain, bytes)
+            .into_iter()
+            .flatten()
+            .collect();
 
-        let chunks: Vec<DensePolynomial<G::ScalarField>> = debug_span!("fft").in_scope(|| {
-            field_elements
-                .par_iter()
-                .map(|chunk| Evaluations::from_vec_and_domain(chunk.to_vec(), domain).interpolate())
-                .collect()
-        });
-        let commitment = {
-            let chunks = commit_to_blob_data(srs, &chunks);
-            let mut sponge = EFqSponge::new(G::other_curve_sponge_params());
-            Commitment::from_chunks(chunks, &mut sponge)
-        };
+        let res = Self::from_data(srs, field_elements.as_slice());
 
         debug!(
             "Encoded {:.2} MB into {} polynomials",
             bytes.len() as f32 / 1_000_000.0,
-            chunks.len()
+            res.commitments.len()
         );
 
-        FieldBlob {
-            n_bytes: bytes.len(),
-            domain_size,
-            commitment,
-            chunks,
-        }
+        res
     }
 
     #[instrument(skip_all, level = "debug")]
-    pub fn decode<D: EvaluationDomain<G::ScalarField>>(domain: D, blob: FieldBlob<G>) -> Vec<u8> {
+    pub fn into_bytes<D: EvaluationDomain<ScalarField>>(domain: D, blob: FieldBlob) -> Vec<u8> {
         // TODO: find an Error type and use Result
-        if domain.size() != blob.domain_size {
+        if domain.size() != SRS_SIZE {
             panic!(
                 "Domain size mismatch, got {}, expected {}",
-                blob.domain_size,
+                SRS_SIZE,
                 domain.size()
             );
         }
-        let n = (G::ScalarField::MODULUS_BIT_SIZE / 8) as usize;
-        let m = G::ScalarField::size_in_bytes();
-        let mut bytes = Vec::with_capacity(blob.n_bytes);
+        // n < m
+        // How many bytes fit into the field
+        let n = (ScalarField::MODULUS_BIT_SIZE / 8) as usize;
+        // How many bytes are necessary to fit a field element
+        let m = ScalarField::size_in_bytes();
+
+        let intended_vec_len = n * blob.commitments.len() * SRS_SIZE;
+        let mut bytes = Vec::with_capacity(intended_vec_len);
         let mut buffer = vec![0u8; m];
 
-        for p in blob.chunks {
-            let evals = p.evaluate_over_domain(domain).evals;
-            for x in evals {
-                decode_into(&mut buffer, x);
-                bytes.extend_from_slice(&buffer[(m - n)..m]);
-            }
+        for x in blob.data {
+            decode_into(&mut buffer, x);
+            bytes.extend_from_slice(&buffer[(m - n)..m]);
         }
 
-        bytes.truncate(blob.n_bytes);
-        bytes
-    }
+        assert!(bytes.len() == intended_vec_len);
 
-    pub fn update<EFqSponge: FqSponge<G::BaseField, G, G::ScalarField>>(
-        &mut self,
-        srs: &SRS<G>,
-        domain: &Radix2EvaluationDomain<G::ScalarField>,
-        diff: Diff<G::ScalarField>,
-    ) {
-        let diff_evaluations = diff.as_evaluations(domain);
-        let commitment = {
-            let commitment_diffs = diff_evaluations
-                .par_iter()
-                .map(|evals| srs.commit_evaluations_non_hiding(*domain, evals))
-                .collect::<Vec<_>>();
-            let mut sponge = EFqSponge::new(G::other_curve_sponge_params());
-            self.commitment.update(commitment_diffs, &mut sponge)
-        };
-        let chunks: Vec<DensePolynomial<G::ScalarField>> = diff_evaluations
-            .into_par_iter()
-            .zip(self.chunks.par_iter())
-            .map(|(evals, p)| {
-                let d_p: DensePolynomial<G::ScalarField> = evals.interpolate();
-                p + &d_p
-            })
-            .collect();
-        self.commitment = commitment;
-        self.chunks = chunks;
-        self.n_bytes = diff.new_byte_len;
+        bytes
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{commitment::commit_to_field_elems, env};
+    use crate::env;
 
     use super::*;
-    use crate::{diff::tests::*, utils::test_utils::*};
+
+    use crate::{diff::tests::*, utils::test_utils::*, Curve, ScalarField};
     use ark_ec::AffineRepr;
     use ark_ff::Zero;
     use ark_poly::Radix2EvaluationDomain;
-    use mina_curves::pasta::{Fp, Vesta, VestaParameters};
-    use mina_poseidon::{constants::PlonkSpongeConstantsKimchi, sponge::DefaultFqSponge};
     use once_cell::sync::Lazy;
     use proptest::prelude::*;
 
-    type VestaFqSponge = DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>;
-
-    static SRS: Lazy<SRS<Vesta>> = Lazy::new(|| {
+    static SRS: Lazy<SRS<Curve>> = Lazy::new(|| {
         if let Ok(srs) = std::env::var("SRS_FILEPATH") {
             env::get_srs_from_cache(srs)
         } else {
@@ -160,50 +169,49 @@ mod tests {
         }
     });
 
-    static DOMAIN: Lazy<Radix2EvaluationDomain<Fp>> =
+    static DOMAIN: Lazy<Radix2EvaluationDomain<ScalarField>> =
         Lazy::new(|| Radix2EvaluationDomain::new(SRS.size()).unwrap());
 
-    // check that Vec<u8> -> FieldBlob<Fp> -> Vec<u8> is the identity function
+    // check that Vec<u8> -> FieldBlob<ScalarField> -> Vec<u8> is the identity function
     proptest! {
     #![proptest_config(ProptestConfig::with_cases(20))]
     #[test]
     fn test_round_trip_blob_encoding(UserData(xs) in UserData::arbitrary())
-      { let blob = FieldBlob::<Vesta>::encode::<_, VestaFqSponge>(&*SRS, *DOMAIN, &xs);
-        let bytes = rmp_serde::to_vec(&blob).unwrap();
-        let a = rmp_serde::from_slice(&bytes).unwrap();
-        // check that ark-serialize is behaving as expected
-        prop_assert_eq!(blob.clone(), a);
-        let ys = FieldBlob::<Vesta>::decode(*DOMAIN, blob);
-        // check that we get the byte blob back again
-        prop_assert_eq!(xs,ys);
-      }
+        {
+            let mut xs = xs.clone();
+            let xs_len_chunks = xs.len() / (31 * SRS_SIZE);
+            xs.truncate(xs_len_chunks * 31 * SRS_SIZE);
+
+            let blob = FieldBlob::from_bytes::<_>(&*SRS, *DOMAIN, &xs);
+            let bytes = rmp_serde::to_vec(&blob).unwrap();
+            let a = rmp_serde::from_slice(&bytes).unwrap();
+            // check that ark-serialize is behaving as expected
+            prop_assert_eq!(blob.clone(), a);
+            let ys = FieldBlob::into_bytes(*DOMAIN, blob);
+            // check that we get the byte blob back again
+            prop_assert_eq!(xs,ys);
+        }
     }
 
     proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
     #[test]
     fn test_user_and_storage_provider_commitments_equal(UserData(xs) in UserData::arbitrary())
-      { let elems = encode_for_domain(&*DOMAIN, &xs);
-        let user_commitments = commit_to_field_elems::<_, VestaFqSponge>(&*SRS, *DOMAIN, elems);
-        let blob = FieldBlob::<Vesta>::encode::<_, VestaFqSponge>(&*SRS, *DOMAIN, &xs);
-        prop_assert_eq!(user_commitments, blob.commitment);
+      { let elems: Vec<_> = encode_for_domain(&*DOMAIN, &xs).into_iter().flatten().collect();
+        let user_commitments: Vec<_> = commit_to_field_elems(&*SRS, &elems);
+        let blob = FieldBlob::from_bytes::<_>(&*SRS, *DOMAIN, &xs);
+        prop_assert_eq!(user_commitments, blob.commitments);
       }
     }
 
-    fn encode_to_chunk_size(xs: &[u8], chunk_size: usize) -> FieldBlob<Vesta> {
-        let mut blob = FieldBlob::<Vesta>::encode::<_, VestaFqSponge>(&*SRS, *DOMAIN, xs);
-        assert!(blob.chunks.len() <= chunk_size);
-        {
-            let pad = DensePolynomial::zero();
-            blob.chunks.resize(chunk_size, pad);
-        }
-        {
-            let pad = PolyComm::new(vec![Vesta::zero()]);
-            let mut commitments = blob.commitment.chunks.clone();
-            commitments.resize(chunk_size, pad);
-            let mut sponge = VestaFqSponge::new(Vesta::other_curve_sponge_params());
-            blob.commitment = Commitment::from_chunks(commitments, &mut sponge);
-        }
+    fn encode_to_chunk_size(xs: &[u8], chunk_size: usize) -> FieldBlob {
+        let mut blob = FieldBlob::from_bytes::<_>(&*SRS, *DOMAIN, xs);
+
+        assert!(blob.data.len() <= chunk_size * crate::SRS_SIZE);
+
+        blob.data.resize(chunk_size * crate::SRS_SIZE, Zero::zero());
+        blob.commitments.resize(chunk_size, Curve::zero());
+
         blob
     }
 
@@ -215,34 +223,26 @@ mod tests {
             (UserData::arbitrary_with(DataSize::Medium).prop_flat_map(random_diff))
         ) {
             // start with some random user data
-            let mut xs_blob = FieldBlob::<Vesta>::encode::<_, VestaFqSponge>(&*SRS, *DOMAIN, &xs);
-            let diff = Diff::<Fp>::create(&*DOMAIN, &xs, &ys).unwrap();
+            let mut xs_blob = FieldBlob::from_bytes::<_>(&*SRS, *DOMAIN, &xs);
+            let diffs = Diff::<ScalarField>::create_from_bytes(&*DOMAIN, &xs, &ys).unwrap();
 
             // check that the user and SP agree on the data
-            let user_commitment = {
-                let elems = encode_for_domain(&*DOMAIN, &xs);
-                commit_to_field_elems::<Vesta, VestaFqSponge>(&*SRS, *DOMAIN, elems)
+            let user_commitment: Vec<_> = {
+                let elems: Vec<_> = encode_for_domain(&*DOMAIN, &xs).into_iter().flatten().collect();
+                commit_to_field_elems(&*SRS, &elems)
 
             };
-            prop_assert_eq!(user_commitment.clone(), xs_blob.commitment.clone());
+            prop_assert_eq!(user_commitment.clone(), xs_blob.commitments.clone());
 
             // Update the blob with the diff and check the user can match the commitment
-            xs_blob.update::<VestaFqSponge>(&*SRS, &*DOMAIN, diff.clone());
-
-            let updated_user_commitment = {
-                let commitment_diffs = diff.as_evaluations(&*DOMAIN)
-                    .par_iter()
-                    .map(|evals| SRS.commit_evaluations_non_hiding(*DOMAIN, evals))
-                    .collect::<Vec<_>>();
-
-                let mut sponge = VestaFqSponge::new(Vesta::other_curve_sponge_params());
-                user_commitment.update(commitment_diffs, &mut sponge)
-            };
-            prop_assert_eq!(updated_user_commitment, xs_blob.commitment.clone());
+            for diff in diffs.iter() {
+                xs_blob.apply_diff(&*SRS, &*DOMAIN, diff);
+            }
 
             // the updated blob should be the same as if we just start with the new data (with appropriate padding)
-            let ys_blob = encode_to_chunk_size(&ys, xs_blob.chunks.len());
-            prop_assert_eq!(xs_blob, ys_blob)
+            let ys_blob = encode_to_chunk_size(&ys, xs_blob.data.len() / SRS_SIZE);
+
+            prop_assert_eq!(xs_blob, ys_blob);
         }
 
     }

--- a/saffron/src/cli.rs
+++ b/saffron/src/cli.rs
@@ -28,7 +28,7 @@ pub struct EncodeFileArgs {
         long,
         short = 'o',
         value_name = "FILE",
-        help = "output file (encoded as field elements)"
+        help = "output file (blob, encoded as field elements)"
     )]
     pub output: String,
 
@@ -41,6 +41,13 @@ pub struct EncodeFileArgs {
         help = "hash of commitments (hex encoded)"
     )]
     pub assert_commitment: Option<HexString>,
+
+    #[arg(
+        long = "challenge-seed",
+        value_name = "CHALLENGE_SEED",
+        help = "challenge seed (hex encoded, used only if assert-commitment is provided)"
+    )]
+    pub challenge_seed: Option<HexString>,
 }
 
 #[derive(Parser)]
@@ -58,6 +65,9 @@ pub struct DecodeFileArgs {
 
     #[arg(long = "srs-filepath", value_name = "SRS_FILEPATH")]
     pub srs_cache: Option<String>,
+
+    #[arg(long = "truncate-to-bytes", value_name = "TRUNCATE_TO_BYTES")]
+    pub truncate_to_bytes: Option<u64>,
 }
 
 #[derive(Parser)]
@@ -70,6 +80,13 @@ pub struct ComputeCommitmentArgs {
 
     #[arg(long = "srs-filepath", value_name = "SRS_FILEPATH")]
     pub srs_cache: Option<String>,
+
+    #[arg(
+        long = "challenge-seed",
+        value_name = "CHALLENGE_SEED",
+        help = "challenge seed (hex encoded)"
+    )]
+    pub challenge_seed: HexString,
 }
 
 #[derive(Parser)]
@@ -78,7 +95,7 @@ pub struct StorageProofArgs {
         long,
         short = 'i',
         value_name = "FILE",
-        help = "input file (encoded as field elements)"
+        help = "input file (blob, encoded as field elements)"
     )]
     pub input: String,
 
@@ -86,11 +103,11 @@ pub struct StorageProofArgs {
     pub srs_cache: Option<String>,
 
     #[arg(
-        long = "challenge",
-        value_name = "CHALLENGE",
-        help = "challenge (hex encoded"
+        long = "challenge-seed",
+        value_name = "CHALLENGE_SEED",
+        help = "challenge seed (hex encoded)"
     )]
-    pub challenge: HexString,
+    pub challenge_seed: HexString,
 }
 
 #[derive(Parser)]
@@ -107,11 +124,11 @@ pub struct VerifyStorageProofArgs {
     pub commitment: HexString,
 
     #[arg(
-        long = "challenge",
-        value_name = "CHALLENGE",
-        help = "challenge (hex encoded"
+        long = "challenge-seed",
+        value_name = "CHALLENGE_SEED",
+        help = "challenge seed (hex encoded)"
     )]
-    pub challenge: HexString,
+    pub challenge_seed: HexString,
 
     #[arg(long, short = 'p', value_name = "PROOF", help = "proof (hex encoded)")]
     pub proof: HexString,

--- a/saffron/src/commitment.rs
+++ b/saffron/src/commitment.rs
@@ -42,7 +42,6 @@ pub fn combine_commitments<G: AffineRepr, EFqSponge: FqSponge<G::BaseField, G, G
 ) -> (G, G::ScalarField) {
     for commitment in commitments.iter() {
         sponge.absorb_g(std::slice::from_ref(commitment))
-        //absorb_commitment(sponge, commitment)
     }
     let alpha = sponge.challenge();
     let powers: Vec<_> = commitments

--- a/saffron/src/commitment.rs
+++ b/saffron/src/commitment.rs
@@ -1,82 +1,57 @@
-use ark_ec::AffineRepr;
+use ark_ec::{AffineRepr, CurveGroup, VariableBaseMSM};
 use ark_ff::One;
-use ark_poly::{Evaluations, Radix2EvaluationDomain as D};
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use kimchi::curve::KimchiCurve;
 use mina_poseidon::FqSponge;
-use poly_commitment::{
-    commitment::{absorb_commitment, CommitmentCurve},
-    ipa::SRS,
-    PolyComm, SRS as _,
-};
+use poly_commitment::{commitment::absorb_commitment, ipa::SRS, PolyComm, SRS as _};
 use rayon::prelude::*;
-use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
-use std::ops::Add;
 use tracing::instrument;
 
-#[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(bound = "G::ScalarField: CanonicalDeserialize + CanonicalSerialize")]
-pub struct Commitment<G: CommitmentCurve> {
-    pub chunks: Vec<PolyComm<G>>,
-    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
-    pub alpha: G::ScalarField,
-    pub folded: PolyComm<G>,
-}
-
-impl<G: KimchiCurve> Commitment<G> {
-    pub fn from_chunks<EFqSponge>(chunks: Vec<PolyComm<G>>, sponge: &mut EFqSponge) -> Self
-    where
-        EFqSponge: FqSponge<G::BaseField, G, G::ScalarField>,
-    {
-        let (folded, alpha) = fold_commitments(sponge, &chunks);
-        Self {
-            chunks,
-            alpha,
-            folded,
-        }
-    }
-
-    pub fn update<EFqSponge>(&self, diff: Vec<PolyComm<G>>, sponge: &mut EFqSponge) -> Self
-    where
-        EFqSponge: FqSponge<G::BaseField, G, G::ScalarField>,
-    {
-        let new_chunks = self.chunks.iter().zip(diff).map(|(g, d)| g.add(&d));
-        Self::from_chunks(new_chunks.collect(), sponge)
-    }
-}
-
 #[instrument(skip_all, level = "debug")]
-pub fn commit_to_field_elems<G: KimchiCurve, EFqSponge>(
-    srs: &SRS<G>,
-    domain: D<G::ScalarField>,
-    field_elems: Vec<Vec<G::ScalarField>>,
-) -> Commitment<G>
+pub fn commit_to_field_elems<G: KimchiCurve>(srs: &SRS<G>, data: &[G::ScalarField]) -> Vec<G>
 where
-    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
+    <G as AffineRepr>::Group: VariableBaseMSM,
 {
-    let commitments = field_elems
-        .par_iter()
-        .map(|chunk| {
-            let evals = Evaluations::from_vec_and_domain(chunk.to_vec(), domain);
-            srs.commit_evaluations_non_hiding(domain, &evals)
+    let basis: Vec<G> = srs
+        .get_lagrange_basis_from_domain_size(crate::SRS_SIZE)
+        .iter()
+        .map(|x| x.chunks[0])
+        .collect();
+
+    let commitments_projective = (0..data.len() / crate::SRS_SIZE)
+        .into_par_iter()
+        .map(|idx| {
+            G::Group::msm(
+                &basis,
+                &data[crate::SRS_SIZE * idx..crate::SRS_SIZE * (idx + 1)],
+            )
+            .unwrap()
+        })
+        .collect::<Vec<_>>();
+
+    let commitments = G::Group::normalize_batch(commitments_projective.as_slice());
+
+    commitments
+}
+
+/// Takes commitments C_i, computes α = hash(C_0 || C_1 || ... || C_n),
+/// returns ∑ α^i C_i.
+#[instrument(skip_all, level = "debug")]
+pub fn combine_commitments<G: AffineRepr, EFqSponge: FqSponge<G::BaseField, G, G::ScalarField>>(
+    sponge: &mut EFqSponge,
+    commitments: &[G],
+) -> (G, G::ScalarField) {
+    let commitments_polycomm: Vec<PolyComm<G>> = commitments
+        .iter()
+        .map(|c| PolyComm {
+            chunks: vec![c.clone()],
         })
         .collect();
-    let mut sponge = EFqSponge::new(G::other_curve_sponge_params());
-    Commitment::from_chunks(commitments, &mut sponge)
-}
 
-#[instrument(skip_all, level = "debug")]
-fn fold_commitments<G: AffineRepr, EFqSponge: FqSponge<G::BaseField, G, G::ScalarField>>(
-    sponge: &mut EFqSponge,
-    commitments: &[PolyComm<G>],
-) -> (PolyComm<G>, G::ScalarField) {
-    for commitment in commitments {
+    for commitment in commitments_polycomm.iter() {
         absorb_commitment(sponge, commitment)
     }
     let alpha = sponge.challenge();
-    let powers: Vec<G::ScalarField> = commitments
+    let powers: Vec<G::ScalarField> = commitments_polycomm
         .iter()
         .scan(G::ScalarField::one(), |acc, _| {
             let res = *acc;
@@ -85,7 +60,8 @@ fn fold_commitments<G: AffineRepr, EFqSponge: FqSponge<G::BaseField, G, G::Scala
         })
         .collect::<Vec<_>>();
     (
-        PolyComm::multi_scalar_mul(&commitments.iter().collect::<Vec<_>>(), &powers),
+        PolyComm::multi_scalar_mul(&commitments_polycomm.iter().collect::<Vec<_>>(), &powers)
+            .chunks[0],
         alpha,
     )
 }

--- a/saffron/src/diff.rs
+++ b/saffron/src/diff.rs
@@ -132,7 +132,7 @@ pub mod tests {
     }
 
     // Adds diff to data
-    fn add_diff_to_data(data: &mut Vec<Vec<Fp>>, diff: &Diff<Fp>) {
+    fn add_diff_to_data(data: &mut [Vec<Fp>], diff: &Diff<Fp>) {
         for (addr, new_value) in diff.addresses.iter().zip(diff.new_values.iter()) {
             data[diff.region as usize][*addr as usize] = *new_value;
         }

--- a/saffron/src/diff.rs
+++ b/saffron/src/diff.rs
@@ -73,8 +73,8 @@ impl<F: PrimeField> Diff<F> {
         old: &[u8],
         new: &[u8],
     ) -> Result<Vec<Diff<F>>, DiffError> {
-        let old_elems: Vec<Vec<F>> = encode_for_domain(domain, old);
-        let mut new_elems: Vec<Vec<F>> = encode_for_domain(domain, new);
+        let old_elems: Vec<Vec<F>> = encode_for_domain(domain.size(), old);
+        let mut new_elems: Vec<Vec<F>> = encode_for_domain(domain.size(), new);
         if old_elems.len() < new_elems.len() {
             return Err(DiffError::CapacityMismatch {
                 max_number_chunks: old_elems.len(),
@@ -149,10 +149,10 @@ pub mod tests {
             prop_assert!(diffs.is_ok());
             let diffs = diffs.unwrap();
 
-            let xs_elems = encode_for_domain(&*DOMAIN, &xs);
+            let xs_elems = encode_for_domain(DOMAIN.size(), &xs);
             let ys_elems = {
                 let pad = vec![Fp::zero(); DOMAIN.size()];
-                let mut elems = encode_for_domain(&*DOMAIN, &ys);
+                let mut elems = encode_for_domain(DOMAIN.size(), &ys);
                 elems.resize(xs_elems.len(), pad);
                 elems
             };

--- a/saffron/src/diff.rs
+++ b/saffron/src/diff.rs
@@ -1,15 +1,20 @@
 use crate::utils::encode_for_domain;
 use ark_ff::PrimeField;
-use ark_poly::{EvaluationDomain, Evaluations, Radix2EvaluationDomain};
+use ark_poly::EvaluationDomain;
 use rayon::prelude::*;
 use thiserror::Error;
 use tracing::instrument;
 
-// sparse representation, keeping only the non-zero differences
+/// Diff request pointing to a single commitment.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Diff<F: PrimeField> {
-    pub chunks: Vec<Vec<(usize, F)>>,
-    pub new_byte_len: usize,
+    /// Which commitment within a group of commitments representing
+    /// the data is the diff for.
+    pub region: u64,
+    /// A list of unique addresses, each ∈ [0, SRS_SIZE]
+    pub addresses: Vec<u64>,
+    /// A list of new values, each corresponding to address in `addresses`
+    pub new_values: Vec<F>,
 }
 
 #[derive(Debug, Error, Clone, PartialEq)]
@@ -23,11 +28,51 @@ pub enum DiffError {
 
 impl<F: PrimeField> Diff<F> {
     #[instrument(skip_all, level = "debug")]
-    pub fn create<D: EvaluationDomain<F>>(
+    pub fn create_from_field_elements(
+        old: &Vec<Vec<F>>,
+        new: &Vec<Vec<F>>,
+    ) -> Result<Vec<Diff<F>>, DiffError> {
+        assert!(
+            old.len() == new.len(),
+            "Input 'old' and 'new' must have the same number of chunks"
+        );
+
+        let diffs: Vec<Diff<_>> = old
+            .par_iter()
+            .zip(new)
+            .enumerate()
+            .filter_map(|(region, (o, n))| {
+                let mut addresses: Vec<u64> = vec![];
+                let mut new_values: Vec<F> = vec![];
+                for (index, (o_elem, n_elem)) in o.iter().zip(n.iter()).enumerate() {
+                    if o_elem != n_elem {
+                        addresses.push(index as u64);
+                        new_values.push(*n_elem);
+                    }
+                }
+
+                if !addresses.is_empty() {
+                    Some(Diff {
+                        region: region as u64,
+                        addresses,
+                        new_values,
+                    })
+                } else {
+                    // do not record a diff with empty changes
+                    None
+                }
+            })
+            .collect();
+
+        Ok(diffs)
+    }
+
+    #[instrument(skip_all, level = "debug")]
+    pub fn create_from_bytes<D: EvaluationDomain<F>>(
         domain: &D,
         old: &[u8],
         new: &[u8],
-    ) -> Result<Diff<F>, DiffError> {
+    ) -> Result<Vec<Diff<F>>, DiffError> {
         let old_elems: Vec<Vec<F>> = encode_for_domain(domain, old);
         let mut new_elems: Vec<Vec<F>> = encode_for_domain(domain, new);
         if old_elems.len() < new_elems.len() {
@@ -40,38 +85,8 @@ impl<F: PrimeField> Diff<F> {
             let padding = vec![F::zero(); domain.size()];
             new_elems.resize(old_elems.len(), padding);
         }
-        Ok(Diff {
-            new_byte_len: new.len(),
-            chunks: new_elems
-                .par_iter()
-                .zip(old_elems)
-                .map(|(n, o)| {
-                    n.iter()
-                        .zip(o)
-                        .enumerate()
-                        .map(|(index, (a, b))| (index, *a - b))
-                        .filter(|(_, x)| !x.is_zero())
-                        .collect()
-                })
-                .collect(),
-        })
-    }
 
-    #[instrument(skip_all, level = "debug")]
-    pub fn as_evaluations(
-        &self,
-        domain: &Radix2EvaluationDomain<F>,
-    ) -> Vec<Evaluations<F, Radix2EvaluationDomain<F>>> {
-        self.chunks
-            .par_iter()
-            .map(|diff| {
-                let mut evals = vec![F::zero(); domain.size()];
-                diff.iter().for_each(|(j, val)| {
-                    evals[*j] = *val;
-                });
-                Evaluations::from_vec_and_domain(evals, *domain)
-            })
-            .collect()
+        Self::create_from_field_elements(&old_elems, &new_elems)
     }
 }
 
@@ -116,16 +131,11 @@ pub mod tests {
             .boxed()
     }
 
-    fn add(mut evals: Vec<Vec<Fp>>, diff: &Diff<Fp>) -> Vec<Vec<Fp>> {
-        evals
-            .par_iter_mut()
-            .zip(diff.chunks.par_iter())
-            .for_each(|(eval_chunk, diff_chunk)| {
-                diff_chunk.iter().for_each(|(j, val)| {
-                    eval_chunk[*j] += val;
-                });
-            });
-        evals.to_vec()
+    // Adds diff to data
+    fn add_diff_to_data(data: &mut Vec<Vec<Fp>>, diff: &Diff<Fp>) {
+        for (addr, new_value) in diff.addresses.iter().zip(diff.new_values.iter()) {
+            data[diff.region as usize][*addr as usize] = *new_value;
+        }
     }
 
     proptest! {
@@ -135,8 +145,10 @@ pub mod tests {
         fn test_allow_legal_diff((UserData(xs), UserData(ys)) in
             (UserData::arbitrary().prop_flat_map(random_diff))
         ) {
-            let diff = Diff::<Fp>::create(&*DOMAIN, &xs, &ys);
-            prop_assert!(diff.is_ok());
+            let diffs = Diff::<Fp>::create_from_bytes(&*DOMAIN, &xs, &ys);
+            prop_assert!(diffs.is_ok());
+            let diffs = diffs.unwrap();
+
             let xs_elems = encode_for_domain(&*DOMAIN, &xs);
             let ys_elems = {
                 let pad = vec![Fp::zero(); DOMAIN.size()];
@@ -144,7 +156,12 @@ pub mod tests {
                 elems.resize(xs_elems.len(), pad);
                 elems
             };
-            let result = add(xs_elems.clone(), &diff.unwrap());
+            assert!(xs_elems.len() == ys_elems.len());
+
+            let mut result = xs_elems.clone();
+            for diff in diffs.into_iter() {
+                add_diff_to_data(&mut result, &diff);
+            }
             prop_assert_eq!(result, ys_elems);
         }
     }
@@ -176,7 +193,7 @@ pub mod tests {
         ) {
             let mut ys = randomize_data(threshold, &data);
             ys.append(&mut extra);
-            let diff = Diff::<Fp>::create(&*DOMAIN, &data, &ys);
+            let diff = Diff::<Fp>::create_from_bytes(&*DOMAIN, &data, &ys);
             prop_assert!(diff.is_err());
         }
     }

--- a/saffron/src/lib.rs
+++ b/saffron/src/lib.rs
@@ -7,7 +7,10 @@ pub mod storage_proof;
 pub mod utils;
 
 use mina_curves::pasta::{Fp, Fq, ProjectiveVesta, Vesta, VestaParameters};
-use mina_poseidon::{constants::PlonkSpongeConstantsKimchi, sponge::DefaultFqSponge};
+use mina_poseidon::{
+    constants::PlonkSpongeConstantsKimchi,
+    sponge::{DefaultFqSponge, DefaultFrSponge},
+};
 
 pub const SRS_SIZE: usize = 1 << 16;
 
@@ -18,3 +21,6 @@ pub type ScalarField = Fp;
 pub type BaseField = Fq;
 
 pub type CurveFqSponge = DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>;
+pub type CurveFrSponge = DefaultFrSponge<ScalarField, PlonkSpongeConstantsKimchi>;
+
+//pub type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;

--- a/saffron/src/lib.rs
+++ b/saffron/src/lib.rs
@@ -3,5 +3,5 @@ pub mod cli;
 pub mod commitment;
 pub mod diff;
 pub mod env;
-pub mod proof;
+pub mod storage_proof;
 pub mod utils;

--- a/saffron/src/lib.rs
+++ b/saffron/src/lib.rs
@@ -5,3 +5,16 @@ pub mod diff;
 pub mod env;
 pub mod storage_proof;
 pub mod utils;
+
+use mina_curves::pasta::{Fp, Fq, ProjectiveVesta, Vesta, VestaParameters};
+use mina_poseidon::{constants::PlonkSpongeConstantsKimchi, sponge::DefaultFqSponge};
+
+pub const SRS_SIZE: usize = 1 << 16;
+
+pub type Curve = Vesta;
+pub type ProjectiveCurve = ProjectiveVesta;
+pub type CurveParameters = VestaParameters;
+pub type ScalarField = Fp;
+pub type BaseField = Fq;
+
+pub type CurveFqSponge = DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>;

--- a/saffron/src/main.rs
+++ b/saffron/src/main.rs
@@ -11,7 +11,7 @@ use saffron::{
     cli::{self, HexString},
     commitment::commit_to_field_elems,
     env,
-    proof::{self, StorageProof},
+    storage_proof::{self, StorageProof},
     utils,
 };
 use std::{
@@ -127,7 +127,7 @@ pub fn storage_proof(args: cli::StorageProofArgs) -> Result<HexString> {
         let group_map = <Vesta as CommitmentCurve>::Map::setup();
         let mut rng = OsRng;
         let evaluation_point = utils::encode(&args.challenge.0);
-        proof::storage_proof::<Vesta, VestaFqSponge>(
+        storage_proof::prove::<Vesta, VestaFqSponge>(
             &srs,
             &group_map,
             blob,
@@ -146,7 +146,7 @@ pub fn verify_storage_proof(args: cli::VerifyStorageProofArgs) -> Result<()> {
     let evaluation_point = utils::encode(&args.challenge.0);
     let proof: StorageProof<Vesta> = rmp_serde::from_slice(&args.proof.0)?;
     let mut rng = OsRng;
-    let res = proof::verify_storage_proof::<Vesta, VestaFqSponge>(
+    let res = storage_proof::verify_fast::<Vesta, VestaFqSponge>(
         &srs,
         &group_map,
         commitment,

--- a/saffron/src/main.rs
+++ b/saffron/src/main.rs
@@ -188,8 +188,13 @@ pub fn verify_storage_proof(args: cli::VerifyStorageProofArgs) -> Result<()> {
 
     let proof: StorageProof = rmp_serde::from_slice(&args.proof.0)?;
     let mut rng = OsRng;
-    let res =
-        storage_proof::verify_fast(&srs, &group_map, combined_data_commitment, &proof, &mut rng);
+    let res = storage_proof::verify_wrt_combined_data_commitment(
+        &srs,
+        &group_map,
+        combined_data_commitment,
+        &proof,
+        &mut rng,
+    );
     assert!(res, "Proof must verify");
     Ok(())
 }

--- a/saffron/src/main.rs
+++ b/saffron/src/main.rs
@@ -137,7 +137,7 @@ pub fn compute_commitment(args: cli::ComputeCommitmentArgs) -> Result<HexString>
         .collect();
 
     let combined_data_commitment_as_polycomm: PolyComm<Curve> = PolyComm {
-        chunks: vec![combined_data_commitment.clone()],
+        chunks: vec![combined_data_commitment],
     };
 
     // this seems completely unnecessary

--- a/saffron/src/storage_proof.rs
+++ b/saffron/src/storage_proof.rs
@@ -213,7 +213,7 @@ mod tests {
     fn test_storage_prove_verify(UserData(data) in UserData::arbitrary()) {
         let mut rng = OsRng;
         let commitments = {
-              let field_elems: Vec<_> = encode_for_domain(&*DOMAIN, &data).into_iter().flatten().collect();
+              let field_elems: Vec<_> = encode_for_domain(DOMAIN.size(), &data).into_iter().flatten().collect();
               commit_to_field_elems(&*SRS, &field_elems)
         };
 

--- a/saffron/src/storage_proof.rs
+++ b/saffron/src/storage_proof.rs
@@ -27,7 +27,7 @@ pub struct StorageProof<G: CommitmentCurve> {
 }
 
 #[instrument(skip_all, level = "debug")]
-pub fn storage_proof<G: KimchiCurve, EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>>(
+pub fn prove<G: KimchiCurve, EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>>(
     srs: &SRS<G>,
     group_map: &G::Map,
     blob: FieldBlob<G>,
@@ -80,10 +80,7 @@ where
 }
 
 #[instrument(skip_all, level = "debug")]
-pub fn verify_storage_proof<
-    G: KimchiCurve,
-    EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>,
->(
+pub fn verify_fast<G: KimchiCurve, EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField>>(
     srs: &SRS<G>,
     group_map: &G::Map,
     commitment: PolyComm<G>,
@@ -159,11 +156,11 @@ mod tests {
         };
         let blob = FieldBlob::<Vesta>::encode::<_, VestaFqSponge>(&*SRS, *DOMAIN, &data);
         let evaluation_point = Fp::rand(&mut rng);
-        let proof = storage_proof::<
+        let proof = prove::<
             Vesta, VestaFqSponge
 
         >(&*SRS, &*GROUP_MAP, blob, evaluation_point, &mut rng);
-        let res = verify_storage_proof::<Vesta, VestaFqSponge>(
+        let res = verify_fast::<Vesta, VestaFqSponge>(
             &*SRS,
             &*GROUP_MAP,
             commitment.folded,

--- a/saffron/src/storage_proof.rs
+++ b/saffron/src/storage_proof.rs
@@ -1,3 +1,15 @@
+//! This module defines the storage proof prover and verifier. Given a
+//! set of commitments C_i and a challenge α the storage proof is just
+//! an opening to the combined commitment ∑α^i C_i. Given that α is
+//! computed by hashing some external challenge secret (e.g. derived
+//! from a hash of a block), and from a hash of the commitments
+//! itself, this in essense proves knowledge of the opening to all the
+//! commitments C_i simultaneously. Given that α is computed by
+//! hashing some external challenge secret (e.g. derived from a hash
+//! of a block), and from a hash of the commitments itself, this in
+//! essense proves knowledge of the opening to all the commitments C_i
+//! simultaneously.
+
 use crate::{blob::FieldBlob, Curve, CurveFqSponge, ProjectiveCurve, ScalarField, SRS_SIZE};
 use ark_ec::{AffineRepr, CurveGroup, VariableBaseMSM};
 use ark_ff::{One, PrimeField, Zero};

--- a/saffron/src/utils.rs
+++ b/saffron/src/utils.rs
@@ -17,6 +17,10 @@ pub fn decode_into<Fp: PrimeField>(buffer: &mut [u8], x: Fp) {
     buffer.copy_from_slice(&bytes);
 }
 
+pub fn decode_into_vec<Fp: PrimeField>(x: Fp) -> Vec<u8> {
+    x.into_bigint().to_bytes_be()
+}
+
 pub fn encode_as_field_elements<F: PrimeField>(bytes: &[u8]) -> Vec<F> {
     let n = (F::MODULUS_BIT_SIZE / 8) as usize;
     bytes

--- a/saffron/src/utils.rs
+++ b/saffron/src/utils.rs
@@ -33,18 +33,14 @@ pub fn encode_as_field_elements<F: PrimeField>(bytes: &[u8]) -> Vec<F> {
         .collect::<Vec<_>>()
 }
 
-pub fn encode_for_domain<F: PrimeField, D: EvaluationDomain<F>>(
-    domain: &D,
-    bytes: &[u8],
-) -> Vec<Vec<F>> {
-    let domain_size = domain.size();
+pub fn encode_for_domain<F: PrimeField>(domain_size: usize, bytes: &[u8]) -> Vec<Vec<F>> {
     let xs = encode_as_field_elements(bytes);
     xs.chunks(domain_size)
         .map(|chunk| {
-            if chunk.len() < domain.size() {
-                let mut padded_chunk = Vec::with_capacity(domain.size());
+            if chunk.len() < domain_size {
+                let mut padded_chunk = Vec::with_capacity(domain_size);
                 padded_chunk.extend_from_slice(chunk);
-                padded_chunk.resize(domain.size(), F::zero());
+                padded_chunk.resize(domain_size, F::zero());
                 padded_chunk
             } else {
                 chunk.to_vec()
@@ -341,7 +337,7 @@ mod tests {
         #[test]
         fn test_round_trip_encoding_to_field_elems(UserData(xs) in UserData::arbitrary()
     )
-          { let chunked = encode_for_domain(&*DOMAIN, &xs);
+          { let chunked = encode_for_domain::<Fp>(DOMAIN.size(), &xs);
             let elems = chunked
               .into_iter()
               .flatten()
@@ -365,7 +361,7 @@ mod tests {
         #[test]
         fn test_padded_byte_length(UserData(xs) in UserData::arbitrary()
     )
-          { let chunked = encode_for_domain(&*DOMAIN, &xs);
+          { let chunked = encode_for_domain::<Fp>(DOMAIN.size(), &xs);
             let n = chunked.into_iter().flatten().count();
             prop_assert_eq!(n, padded_field_length(&xs));
           }
@@ -385,7 +381,7 @@ mod tests {
                     (Just(xs), queries_strategy)
                 })
         ) {
-            let chunked = encode_for_domain(&*DOMAIN, &xs);
+            let chunked = encode_for_domain(DOMAIN.size(), &xs);
             for query in queries {
                 let expected = &xs[query.start..(query.start+query.len)];
                 let field_query: QueryField<Fp> = query.into_query_field(DOMAIN.size(), chunked.len()).unwrap();
@@ -414,7 +410,7 @@ mod tests {
                 })
         ) {
             debug!("check that first query is valid");
-            let chunked = encode_for_domain(&*DOMAIN, &xs);
+            let chunked = encode_for_domain::<Fp>(DOMAIN.size(), &xs);
             let n_polys = chunked.len();
             let query_field = query.into_query_field::<Fp>(DOMAIN.size(), n_polys);
             prop_assert!(query_field.is_ok());
@@ -442,7 +438,7 @@ mod tests {
                     (Just(xs), query_strategy)
                 })
         ) {
-            let chunked = encode_for_domain(&*DOMAIN, &xs);
+            let chunked = encode_for_domain(DOMAIN.size(), &xs);
             let n_polys = chunked.len();
             let field_query: QueryField<Fp> = query.into_query_field(DOMAIN.size(), n_polys).unwrap();
             let got_answer = field_query.apply(&chunked);


### PR DESCRIPTION
This PR attempts to bring the current version of the saffron closer to the demo. It makes a lot of changes that are not easily decoupblable from each other, I'll try to summarise them later.
* Remove group generics from half of the file, use `Curve = Vesta, ScalarField = Fp` etc defined in `saffron::lib` now.
    * Justification: we will use only one curve for these, so using generics adds a lot of visual noise. Especially with MSMs since we have to write `<G as AffineCurve>::ScalarField` everywhere.
* Rewrite `diff` module: now the diff contains not the delta but the final value. Might be a good idea to rename to `WriteReq`.
    * Justification: In 99% cases wire types will contain write requests with new values, not the deltas. The deltas are computed by storage provider. 
* Rewrite storage proof. Use evaluation point as squeezed after hashing commitments.
* Extract challenge for computing the `randomized_data_commitment`. We can use Merkle tree root later.