### PR TITLE
CI/gh-page: reverting used Rust toolchailchain to 1.72

### DIFF
--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -8,7 +8,7 @@ env:
   OCAML_VERSION: "4.14.0"
   # This version has been chosen randomly. It seems that with 2023-11-16, it is
   # broken. The compiler crashes. Feel free to pick any newer working version.
-  RUST_TOOLCHAIN_VERSION: "1.79"
+  RUST_TOOLCHAIN_VERSION: "1.72"
 
 jobs:
   release:


### PR DESCRIPTION
Updating to nightly will be done when 'time' will have been updated.

Reverting the version bump up introduced in this PR: https://github.com/o1-labs/proof-systems/pull/3068
'time' is updated in https://github.com/o1-labs/proof-systems/pull/3089, but the PR is on hold for now as we must first bump up Mina with the latest proof-systems, c.f. https://github.com/MinaProtocol/mina/pull/16782