### PR TITLE
Deps: enforcing strict deps on arkworks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-ark-algebra-test-templates = "0.4.2"
-ark-bn254 = { version = "0.4.0" }
-ark-ec = { version = "0.4.2", features = ["parallel"] }
-ark-ff = { version = "0.4.2", features = ["parallel", "asm"] }
-ark-poly = { version = "0.4.2", features = ["parallel"] }
-ark-serialize = "0.4.2"
-ark-std = { version = "0.4.0", features = ["parallel"] }
-ark-test-curves = { version = "0.4.2", features = ["parallel", "asm"] }
+ark-algebra-test-templates = "=0.4.2"
+ark-bn254 = { version = "=0.4.0" }
+ark-ec = { version = "=0.4.2", features = ["parallel"] }
+ark-ff = { version = "=0.4.2", features = ["parallel", "asm"] }
+ark-poly = { version = "=0.4.2", features = ["parallel"] }
+ark-serialize = "=0.4.2"
+ark-std = { version = "=0.4.0", features = ["parallel"] }
+ark-test-curves = { version = "=0.4.2", features = ["parallel", "asm"] }
 base64 = "0.21.5"
 bcs = "0.1.3"
 bitvec = "1.0.0"


### PR DESCRIPTION
As arkworks do not follow semver, it is worth having strict condition on the version we want. Also, this has to be replicated on the Mina side to be sure we have the same version.