### PR TITLE
CI: dropping versions before Rust 1.82

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   OCAML_VERSION: "4.14.0"
-  RUST_TOOLCHAIN_VERSION: "1.79"
+  RUST_TOOLCHAIN_VERSION: "1.82"
 
 jobs:
   bench:

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_toolchain_version: ["1.79"]
+        rust_toolchain_version: ["1.82"]
         # FIXME: currently not available for 5.0.0.
         # It might be related to boxroot dependency, and we would need to bump
         # up the ocaml-rs dependency

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_toolchain_version: ["1.79"]
+        rust_toolchain_version: ["1.82"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        rust_toolchain_version: ["1.79", "1.80", "1.81", "1.82"]
+        rust_toolchain_version: ["1.82"]
         # FIXME: currently not available for 5.0.0.
         # It might be related to boxroot dependency, and we would need to bump
         # up the ocaml-rs dependency

--- a/.github/workflows/o1vm-ci.yml
+++ b/.github/workflows/o1vm-ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     strategy:
       matrix:
-        rust_toolchain_version: ["1.79"]
+        rust_toolchain_version: ["1.82"]
         # FIXME: currently not available for 5.0.0.
         # It might be related to boxroot dependency, and we would need to bump
         # up the ocaml-rs dependency

--- a/.github/workflows/saffron.yml
+++ b/.github/workflows/saffron.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_toolchain_version: ["1.79"]
+        rust_toolchain_version: ["1.82"]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This should be merged after https://github.com/MinaProtocol/mina/pull/16794 has been merged, with the counterparties in o1js.