### PR TITLE
hasher: use core instead of std

### DIFF
--- a/hasher/src/lib.rs
+++ b/hasher/src/lib.rs
@@ -156,7 +156,7 @@ pub trait Hasher<H: Hashable> {
 fn domain_prefix_to_field<F: PrimeField>(prefix: String) -> F {
     const MAX_DOMAIN_STRING_LEN: usize = 20;
     assert!(prefix.len() <= MAX_DOMAIN_STRING_LEN);
-    let prefix = &prefix[..std::cmp::min(prefix.len(), MAX_DOMAIN_STRING_LEN)];
+    let prefix = &prefix[..core::cmp::min(prefix.len(), MAX_DOMAIN_STRING_LEN)];
     let mut bytes = format!("{prefix:*<MAX_DOMAIN_STRING_LEN$}")
         .as_bytes()
         .to_vec();

--- a/hasher/src/poseidon.rs
+++ b/hasher/src/poseidon.rs
@@ -2,7 +2,7 @@
 //!
 //! An implementation of Mina's hasher based on the poseidon arithmetic sponge
 //!
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::DomainParameter;
 use mina_curves::pasta::Fp;


### PR DESCRIPTION
Relying on [core](https://github.com/rust-lang/rust/tree/master/library/core) instead of [std](https://github.com/rust-lang/rust/tree/master/library/std) decreases the number of dependencies, and make it more portable through different platforms.