### PR TITLE
Deps: remove unused proc-macros2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ ocaml = { version = "0.22.2" }
 ocaml-gen = { version = "0.1.5" }
 once_cell = "1.10.0"
 os_pipe = { version = "1.1.4", features = ["io_safety"] }
-proc-macro2 = "1.0.43"
 proptest = "1.0.0"
 proptest-derive = "0.4.0"
 quote = "1.0.21"


### PR DESCRIPTION
Note that it will also be removed in MIna. Also, it was a dependency that was causing some issues when upgrading Rust because of the strict version requirements we were imposing on the Mina side, for no apparent reasons, as unused.