### PR TITLE
Makefile: split target setup and improve architecture and OS support for wasm toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ WASM_RUSTFLAGS = "-C target-feature=+atomics,+bulk-memory,+mutable-globals -C li
 PLONK_WASM_NODEJS_OUTDIR ?= target/nodejs
 PLONK_WASM_WEB_OUTDIR ?= target/web
 
+# This should stay in line with the version used by the argument
+# WASM_PACK_VERSION in
+# MinaProtocol/mina/dockerfiles/stages/1-build-deps
+WASM_PACK_VERSION=0.12.1
+
 # Default target
 all: release
 

--- a/Makefile
+++ b/Makefile
@@ -60,12 +60,20 @@ setup-wasm-pack:
 
 setup-wasm-toolchain:
 		@ARCH=$$(uname -m); \
+		OS=$$(uname -s | tr A-Z a-z); \
+		case $$OS in \
+			linux) OS_PART="unknown-linux-gnu" ;; \
+			darwin) OS_PART="apple-darwin" ;; \
+			*) echo "Unsupported OS: $$OS" && exit 1 ;; \
+		esac; \
 		case $$ARCH in \
-			x86_64) TARGET_ARCH="x86_64-unknown-linux-gnu" ;; \
-			aarch64) TARGET_ARCH="aarch64-unknown-linux-gnu" ;; \
+			x86_64) ARCH_PART="x86_64" ;; \
+			aarch64) ARCH_PART="aarch64" ;; \
 			*) echo "Unsupported architecture: $$ARCH" && exit 1 ;; \
 		esac; \
-		rustup component add rust-src --toolchain ${NIGHTLY_RUST_VERSION}-$$TARGET_ARCH
+		TARGET="$$ARCH_PART-$$OS_PART"; \
+		echo "Installing rust-src for ${NIGHTLY_RUST_VERSION}-$$TARGET"; \
+		rustup component add rust-src --toolchain ${NIGHTLY_RUST_VERSION}-$$TARGET
 
 # https://nexte.st/book/pre-built-binaries.html#using-nextest-in-github-actions
 # FIXME: update to 0.9.68 when we get rid of 1.71 and 1.72.

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ setup-wasm-toolchain:
 		case $$ARCH in \
 			x86_64) ARCH_PART="x86_64" ;; \
 			aarch64) ARCH_PART="aarch64" ;; \
+			arm64) ARCH_PART="aarch64" ;; \
 			*) echo "Unsupported architecture: $$ARCH" && exit 1 ;; \
 		esac; \
 		TARGET="$$ARCH_PART-$$OS_PART"; \

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,9 @@ WASM_PACK_VERSION=0.12.1
 # Default target
 all: release
 
-setup:
+setup: setup-git setup-wasm-pack setup-wasm-toolchain
+
+setup-git:
 		@echo ""
 		@echo "Syncing the Git submodules."
 		@echo ""
@@ -51,13 +53,13 @@ setup:
 		git submodule update --init --recursive
 		@echo ""
 		@echo "Git submodules synced."
-		@echo ""
+
+setup-wasm-pack:
 		@echo "Install wasm-pack"
-		@cargo install wasm-pack
+		@cargo install wasm-pack@${WASM_PACK_VERSION} --force
+
+setup-wasm-toolchain:
 		@rustup component add rust-src --toolchain ${NIGHTLY_RUST_VERSION}-x86_64-unknown-linux-gnu
-		@echo ""
-
-
 
 # https://nexte.st/book/pre-built-binaries.html#using-nextest-in-github-actions
 # FIXME: update to 0.9.68 when we get rid of 1.71 and 1.72.

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,13 @@ setup-wasm-pack:
 		@cargo install wasm-pack@${WASM_PACK_VERSION} --force
 
 setup-wasm-toolchain:
-		@rustup component add rust-src --toolchain ${NIGHTLY_RUST_VERSION}-x86_64-unknown-linux-gnu
+		@ARCH=$$(uname -m); \
+		case $$ARCH in \
+			x86_64) TARGET_ARCH="x86_64-unknown-linux-gnu" ;; \
+			aarch64) TARGET_ARCH="aarch64-unknown-linux-gnu" ;; \
+			*) echo "Unsupported architecture: $$ARCH" && exit 1 ;; \
+		esac; \
+		rustup component add rust-src --toolchain ${NIGHTLY_RUST_VERSION}-$$TARGET_ARCH
 
 # https://nexte.st/book/pre-built-binaries.html#using-nextest-in-github-actions
 # FIXME: update to 0.9.68 when we get rid of 1.71 and 1.72.


### PR DESCRIPTION
See commit messages.

The reviewer is encouraged to run
```
make setup-wasm-toolchain
```
to verify that it works on their OS and architecture, if supported.

It is initially part of https://github.com/o1-labs/proof-systems/pull/3139/, but !3139 is postponed until the build process is fixed. 