### PR TITLE
fix nightly ci

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -60,7 +60,6 @@ jobs:
       - name: Run all tests with the code coverage
         run: |
           eval $(opam env)
-          make clean
           make nextest-all-with-coverage
           make test-doc-with-coverage
           make generate-test-coverage-report

--- a/plonk-wasm/src/lib.rs
+++ b/plonk-wasm/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(get_mut_unchecked)]
 //! The Marlin_plonk_stubs crate exports some functionalities
 //! and structures from the following the Rust crates to OCaml:
 //!


### PR DESCRIPTION
the nightly job was running `make clean` before running the tests, which deleted all the generated mips bin files. This PR fixes this problem.