### PR TITLE
plonk-wasm: remove --no-check-features flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ O1VM_MIPS_BIN_FILES = $(patsubst ${O1VM_MIPS_SOURCE_DIR}/%.asm,${O1VM_MIPS_BIN_D
 # In addition to that, the version in the CI (see file
 # .github/workflows/wasm.yml) should be changed accordingly.
 NIGHTLY_RUST_VERSION = "nightly-2024-06-13"
-WASM_RUSTFLAGS = "-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--no-check-features -C link-arg=--max-memory=4294967296"
+WASM_RUSTFLAGS = "-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--max-memory=4294967296"
 PLONK_WASM_NODEJS_OUTDIR ?= target/nodejs
 PLONK_WASM_WEB_OUTDIR ?= target/web
 

--- a/plonk-wasm/Cargo.toml
+++ b/plonk-wasm/Cargo.toml
@@ -73,14 +73,10 @@ wasm-opt = false
 rustflags = [
   "-C",
   "target-feature=+atomics,+bulk-memory",
-  "-C",
-  "link-arg=--no-check-features",
 ]
 
 [target.wasm32-unknown-unknown]
 rustflags = [
   "-C",
   "target-feature=+atomics,+bulk-memory",
-  "-C",
-  "link-arg=--no-check-features",
 ]


### PR DESCRIPTION
To be used with https://github.com/MinaProtocol/mina/pull/16843.

The option `-C --link-arg=FLAGS` is passed to the compiler `rustc`. In particular, the value `FLAGS` is going to be passed to the linker.

The option `--check-features`, trackable in [the
llm-project/lld](https://github.com/llvm/llvm-project/blob/main/lld/wasm/Options.td#L265) has the following purpose:
```
defm check_features: BB<"check-features",
    "Check feature compatibility of linked objects (default)",
    "Ignore feature compatibility of linked objects">;
```

In particular, `wasm-ld`, the linker driver for WebAssembly and used in our case, is based [on this codebase](https://lld.llvm.org/WebAssembly.html), and share the flag.

The cancelling flag is `--no-check-features`, currently used in Mina when building the WebAssembly target, passed to `wasm-ld` behind. Based on the description, the feature flag `--check-features` is the default one, and is used to check compatibility between the different objects the compiler toolchain is building. I guess, for instance, it checks if it has been built with the same flags (like `+atomics`, etc).

I do not understand why this flag has been introduced, and when. It does not seem we want to avoid checking the feature compatibility. I do not find any reference in the [wasm-bindgen
documentation](https://rustwasm.github.io/wasm-bindgen/?search=%22check-features%22).

It might be the case that the original author added the flag when they encountered an issue like [this
one](https://github.com/emscripten-core/emscripten/issues/10370#issue-560798692). However, when removing the flag, the issue does not appear.

An additional reason I would like to introduce this change is that on the test machine arm64, the following error
appears (3780d0f17ebe5c6397a8a9ece7cdb3199d6892cb):
```
$ RUST_TARGET_FEATURE_OPTIMISATIONS=n dune build src/lib/crypto/kimchi_bindings/
   = note: cc: error: unrecognized command-line option '--no-check-features'; did you mean '--no-check-data-deps'?
   [...]
   Rrror: Installing wasm-bindgen with cargo
Caused by: Installing wasm-bindgen with cargo
Caused by: failed to execute `cargo install`: exited with exit status: 101
  full command: "cargo" "install" "--force" "wasm-bindgen-cli" "--root" "/home/app/.cache/.wasm-pack/.wasm-bindgen-cargo-install-0.2.87" "--version" "0.2.87"
```

After switching to the branch:
```
git fetch
git checkout dw/remove-no-check-features-flag-wasm
RUST_TARGET_FEATURE_OPTIMISATIONS=n dune build src/lib/crypto/kimchi_bindings/
```
the error disappears.