### PR TITLE
plonk-wasm: appease Clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ env:
   CARGO_TERM_COLOR: always
   # 30 MB of stack for Keccak tests
   RUST_MIN_STACK: 31457280
-  CARGO_EXTRA_ARGS: "--workspace --exclude plonk_wasm --exclude saffron"
 
 jobs:
   run_mdbook:

--- a/plonk-wasm/src/arkworks/pasta_fp.rs
+++ b/plonk-wasm/src/arkworks/pasta_fp.rs
@@ -224,7 +224,7 @@ pub fn caml_pasta_fp_domain_generator(log2_size: i32) -> WasmPastaFp {
 #[wasm_bindgen]
 pub fn caml_pasta_fp_to_bytes(x: WasmPastaFp) -> Vec<u8> {
     let len = core::mem::size_of::<Fp>();
-    let mut str: Vec<u8> = Vec::with_capacity(len);
+    let mut str: Vec<u8> = vec![0; len];
     str.resize(len, 0);
     let str_as_fp: *mut Fp = str.as_mut_ptr().cast::<Fp>();
     unsafe {

--- a/plonk-wasm/src/arkworks/pasta_fq.rs
+++ b/plonk-wasm/src/arkworks/pasta_fq.rs
@@ -224,7 +224,7 @@ pub fn caml_pasta_fq_domain_generator(log2_size: i32) -> WasmPastaFq {
 #[wasm_bindgen]
 pub fn caml_pasta_fq_to_bytes(x: WasmPastaFq) -> Vec<u8> {
     let len = core::mem::size_of::<Fq>();
-    let mut str: Vec<u8> = Vec::with_capacity(len);
+    let mut str: Vec<u8> = vec![0; len];
     str.resize(len, 0);
     let str_as_fq: *mut Fq = str.as_mut_ptr().cast::<Fq>();
     unsafe {

--- a/plonk-wasm/src/lib.rs
+++ b/plonk-wasm/src/lib.rs
@@ -43,13 +43,27 @@ pub fn create_zero_u32_ptr() -> *mut u32 {
     Box::into_raw(std::boxed::Box::new(0))
 }
 
+/// Free a pointer. This method is exported in the WebAssembly module to be used
+/// on the JavaScript side, see `web-backend.js`.
+///
+/// # Safety
+///
+/// See
+/// `<https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref>`
 #[wasm_bindgen]
-pub fn free_u32_ptr(ptr: *mut u32) {
+pub unsafe fn free_u32_ptr(ptr: *mut u32) {
     let _drop_me = unsafe { std::boxed::Box::from_raw(ptr) };
 }
 
+/// Set the value of a pointer. This method is exported in the WebAssembly
+/// module to be used on the JavaScript side, see `web-backend.js`.
+///
+/// # Safety
+///
+/// See
+/// `<https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref>`
 #[wasm_bindgen]
-pub fn set_u32_ptr(ptr: *mut u32, arg: u32) {
+pub unsafe fn set_u32_ptr(ptr: *mut u32, arg: u32) {
     // The rust docs explicitly forbid using this for cross-thread syncronization. Oh well, we
     // don't have anything better. As long as it works in practice, we haven't upset the undefined
     // behavior dragons.
@@ -58,9 +72,16 @@ pub fn set_u32_ptr(ptr: *mut u32, arg: u32) {
     }
 }
 
+/// This method is exported in the WebAssembly to be used on the JavaScript
+/// side, see `web-backend.js`.
+///
+/// # Safety
+///
+/// See
+/// `<https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref>`
 #[allow(unreachable_code)]
 #[wasm_bindgen]
-pub fn wait_until_non_zero(ptr: *const u32) -> u32 {
+pub unsafe fn wait_until_non_zero(ptr: *const u32) -> u32 {
     // The rust docs explicitly forbid using this for cross-thread syncronization. Oh well, we
     // don't have anything better. As long as it works in practice, we haven't upset the undefined
     // behavior dragons.

--- a/plonk-wasm/src/oracles.rs
+++ b/plonk-wasm/src/oracles.rs
@@ -115,28 +115,23 @@ macro_rules! impl_oracles {
                 }
             }
 
-            impl Into<RandomOracles<$F>> for WasmRandomOracles
+            impl From<WasmRandomOracles> for RandomOracles<$F>
             {
-                fn into(self) -> RandomOracles<$F> {
-                    let joint_combiner =
-                        match (self.joint_combiner_chal, self.joint_combiner) {
-                            (Some(joint_combiner_chal), Some(joint_combiner)) => {
-                                Some((ScalarChallenge(joint_combiner_chal.into()), joint_combiner.into()))
-                            },
-                            _ => None
-                        };
-                    RandomOracles {
-                        joint_combiner,
-                        beta: self.beta.into(),
-                        gamma: self.gamma.into(),
-                        alpha_chal: ScalarChallenge(self.alpha_chal.into()),
-                        alpha: self.alpha.into(),
-                        zeta: self.zeta.into(),
-                        v: self.v.into(),
-                        u: self.u.into(),
-                        zeta_chal: ScalarChallenge(self.zeta_chal.into()),
-                        v_chal: ScalarChallenge(self.v_chal.into()),
-                        u_chal: ScalarChallenge(self.u_chal.into()),
+                fn from(ro: WasmRandomOracles) -> Self {
+                    Self {
+                        joint_combiner: ro.joint_combiner_chal.and_then(|x| {
+                            ro.joint_combiner.map(|y| (ScalarChallenge(x.into()), y.into()))
+                        }),
+                        beta: ro.beta.into(),
+                        gamma: ro.gamma.into(),
+                        alpha_chal: ScalarChallenge(ro.alpha_chal.into()),
+                        alpha: ro.alpha.into(),
+                        zeta: ro.zeta.into(),
+                        v: ro.v.into(),
+                        u: ro.u.into(),
+                        zeta_chal: ScalarChallenge(ro.zeta_chal.into()),
+                        v_chal: ScalarChallenge(ro.v_chal.into()),
+                        u_chal: ScalarChallenge(ro.u_chal.into()),
                     }
                 }
             }

--- a/plonk-wasm/src/pasta_fp_plonk_index.rs
+++ b/plonk-wasm/src/pasta_fp_plonk_index.rs
@@ -1,4 +1,5 @@
 use ark_poly::EvaluationDomain;
+use base64::{engine::general_purpose, Engine};
 use kimchi::circuits::lookup::runtime_tables::RuntimeTableCfg;
 
 use crate::{
@@ -270,7 +271,7 @@ pub fn caml_pasta_fp_plonk_index_write(
 #[wasm_bindgen]
 pub fn caml_pasta_fp_plonk_index_serialize(index: &WasmPastaFpPlonkIndex) -> String {
     let serialized = rmp_serde::to_vec(&index.0).unwrap();
-    base64::encode(serialized)
+    general_purpose::STANDARD.encode(serialized)
 }
 
 // helpers

--- a/plonk-wasm/src/pasta_fq_plonk_index.rs
+++ b/plonk-wasm/src/pasta_fq_plonk_index.rs
@@ -1,4 +1,5 @@
 use ark_poly::EvaluationDomain;
+use base64::{engine::general_purpose, Engine};
 use kimchi::circuits::lookup::runtime_tables::RuntimeTableCfg;
 
 use crate::{
@@ -269,5 +270,5 @@ pub fn caml_pasta_fq_plonk_index_write(
 #[wasm_bindgen]
 pub fn caml_pasta_fq_plonk_index_serialize(index: &WasmPastaFqPlonkIndex) -> String {
     let serialized = rmp_serde::to_vec(&index.0).unwrap();
-    base64::encode(serialized)
+    general_purpose::STANDARD.encode(serialized)
 }

--- a/plonk-wasm/src/plonk_proof.rs
+++ b/plonk-wasm/src/plonk_proof.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use ark_ec::AffineRepr;
 use ark_ff::One;
+use base64::{engine::general_purpose, Engine};
 use core::{array, convert::TryInto};
 use groupmap::GroupMap;
 use kimchi::{
@@ -618,7 +619,7 @@ macro_rules! impl_proof {
                 pub fn serialize(&self) -> String {
                     let (proof, _public_input) = self.into();
                     let serialized = rmp_serde::to_vec(&proof).unwrap();
-                    base64::encode(serialized)
+                    general_purpose::STANDARD.encode(serialized)
                 }
             }
 

--- a/plonk-wasm/src/plonk_verifier_index.rs
+++ b/plonk-wasm/src/plonk_verifier_index.rs
@@ -587,6 +587,7 @@ macro_rules! impl_verification_key {
             #[wasm_bindgen]
             impl [<Wasm $field_name:camel PlonkVerifierIndex>] {
                 #[wasm_bindgen(constructor)]
+                #[allow(clippy::too_many_arguments)]
                 pub fn new(
                     domain: &WasmDomain,
                     max_poly_size: i32,
@@ -642,7 +643,7 @@ macro_rules! impl_verification_key {
                 }
             }
 
-            pub fn to_wasm<'a>(
+            pub fn to_wasm(
                 srs: &Arc<SRS<$G>>,
                 vi: DlogVerifierIndex<$G, OpeningProof<$G>>,
             ) -> WasmPlonkVerifierIndex {

--- a/plonk-wasm/src/srs.rs
+++ b/plonk-wasm/src/srs.rs
@@ -145,7 +145,8 @@ macro_rules! impl_srs {
             pub fn [<$name:snake _lagrange_commitments_whole_domain_read_from_ptr>](
                 ptr: *mut WasmVector<$WasmPolyComm>,
             ) -> WasmVector<$WasmPolyComm> {
-                // read the commitment at the pointers address, hack for the web worker implementation (see o1js web worker impl for details)
+                // read the commitment at the pointers address, hack for the web
+                // worker implementation (see o1js web worker impl for details)
                 let b = unsafe { Box::from_raw(ptr) };
                 b.as_ref().clone()
             }

--- a/plonk-wasm/src/srs.rs
+++ b/plonk-wasm/src/srs.rs
@@ -141,8 +141,14 @@ macro_rules! impl_srs {
                 Box::into_raw(boxed_comm)
             }
 
+            /// Reads the lagrange commitments from a raw pointer.
+            ///
+            /// # Safety
+            ///
+            /// This function is unsafe because it might dereference a
+            /// raw pointer.
             #[wasm_bindgen]
-            pub fn [<$name:snake _lagrange_commitments_whole_domain_read_from_ptr>](
+            pub unsafe fn [<$name:snake _lagrange_commitments_whole_domain_read_from_ptr>](
                 ptr: *mut WasmVector<$WasmPolyComm>,
             ) -> WasmVector<$WasmPolyComm> {
                 // read the commitment at the pointers address, hack for the web


### PR DESCRIPTION
Built on top of https://github.com/o1-labs/proof-systems/pull/3144

This patch fixes the Makefile target `lint` when the crate `plonk_wasm` is included.
From this patch, `make lint` will always be run on all the crates defined in the workspace.

The patch does not aim to modify any semantics of plonk-wasm.
The reviewer can reproduce the set of commits by applying the recommendation of the output of `make lint` on each file. 