### PR TITLE
[plonk_wasm] Don't pass around unnecessary vectors

### DIFF
--- a/plonk-wasm/src/arkworks/pasta_fp.rs
+++ b/plonk-wasm/src/arkworks/pasta_fp.rs
@@ -6,16 +6,12 @@ use ark_ff::{
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use core::cmp::Ordering::{Equal, Greater, Less};
-use mina_curves::pasta::{
-    fields::{fft::FpParameters, fp::FpParameters as Fp_params},
-    Fp,
-};
+use mina_curves::pasta::fields::fft::FpParameters;
+use mina_curves::pasta::{fields::fp::FpParameters as Fp_params, Fp};
 use num_bigint::BigUint;
 use rand::rngs::StdRng;
-use wasm_bindgen::{
-    convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi},
-    prelude::*,
-};
+use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi};
+use wasm_bindgen::prelude::*;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
@@ -23,13 +19,15 @@ pub struct WasmPastaFp(pub Fp);
 
 impl crate::wasm_flat_vector::FlatVectorElem for WasmPastaFp {
     const FLATTENED_SIZE: usize = core::mem::size_of::<Fp>();
+
     fn flatten(self) -> Vec<u8> {
         let mut bytes: Vec<u8> = Vec::with_capacity(Self::FLATTENED_SIZE);
         self.0.serialize_compressed(&mut bytes).unwrap();
         bytes
     }
-    fn unflatten(flat: Vec<u8>) -> Self {
-        WasmPastaFp(Fp::deserialize_compressed(flat.as_slice()).unwrap())
+
+    fn unflatten(flat: &[u8]) -> Self {
+        WasmPastaFp(Fp::deserialize_compressed(flat).unwrap())
     }
 }
 

--- a/plonk-wasm/src/arkworks/pasta_fq.rs
+++ b/plonk-wasm/src/arkworks/pasta_fq.rs
@@ -6,16 +6,12 @@ use ark_ff::{
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use core::cmp::Ordering::{Equal, Greater, Less};
-use mina_curves::pasta::{
-    fields::{fft::FpParameters, fq::FqParameters as Fq_params},
-    Fq,
-};
+use mina_curves::pasta::fields::fft::FpParameters;
+use mina_curves::pasta::{fields::fq::FqParameters as Fq_params, Fq};
 use num_bigint::BigUint;
 use rand::rngs::StdRng;
-use wasm_bindgen::{
-    convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi},
-    prelude::*,
-};
+use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi};
+use wasm_bindgen::prelude::*;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
@@ -23,13 +19,15 @@ pub struct WasmPastaFq(pub Fq);
 
 impl crate::wasm_flat_vector::FlatVectorElem for WasmPastaFq {
     const FLATTENED_SIZE: usize = core::mem::size_of::<Fq>();
+
     fn flatten(self) -> Vec<u8> {
         let mut bytes: Vec<u8> = Vec::with_capacity(Self::FLATTENED_SIZE);
         self.0.serialize_compressed(&mut bytes).unwrap();
         bytes
     }
-    fn unflatten(flat: Vec<u8>) -> Self {
-        WasmPastaFq(Fq::deserialize_compressed(flat.as_slice()).unwrap())
+
+    fn unflatten(flat: &[u8]) -> Self {
+        WasmPastaFq(Fq::deserialize_compressed(flat).unwrap())
     }
 }
 

--- a/plonk-wasm/src/wasm_flat_vector.rs
+++ b/plonk-wasm/src/wasm_flat_vector.rs
@@ -22,15 +22,18 @@
 
 use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi};
 
-use core::{convert::From, ops::Deref};
+use core::convert::From;
+use core::ops::Deref;
 
 #[derive(Clone, Debug)]
 pub struct WasmFlatVector<T>(Vec<T>);
 
 pub trait FlatVectorElem {
     const FLATTENED_SIZE: usize;
+
     fn flatten(self) -> Vec<u8>;
-    fn unflatten(flat: Vec<u8>) -> Self;
+
+    fn unflatten(flat: &[u8]) -> Self;
 }
 
 impl<T> Deref for WasmFlatVector<T> {
@@ -107,20 +110,16 @@ impl<T> wasm_bindgen::describe::WasmDescribe for WasmFlatVector<T> {
 
 impl<T: FlatVectorElem> FromWasmAbi for WasmFlatVector<T> {
     type Abi = <Vec<u8> as FromWasmAbi>::Abi;
+
     unsafe fn from_abi(js: Self::Abi) -> Self {
         let data: Vec<u8> = FromWasmAbi::from_abi(js);
-        let mut res: Vec<T> = Vec::with_capacity(data.len() / T::FLATTENED_SIZE);
 
-        let mut buf = Vec::with_capacity(T::FLATTENED_SIZE);
-        for x in data.into_iter() {
-            assert!(buf.len() < T::FLATTENED_SIZE);
-            buf.push(x);
-            if buf.len() >= T::FLATTENED_SIZE {
-                res.push(T::unflatten(buf));
-                buf = Vec::with_capacity(T::FLATTENED_SIZE);
-            }
-        }
-        assert_eq!(buf.len(), 0);
+        let res = data
+            .chunks(T::FLATTENED_SIZE)
+            .inspect(|chunk| assert_eq!(chunk.len(), T::FLATTENED_SIZE))
+            .map(T::unflatten)
+            .collect();
+
         WasmFlatVector(res)
     }
 }
@@ -134,10 +133,7 @@ impl<T: FlatVectorElem> OptionFromWasmAbi for WasmFlatVector<T> {
 impl<T: FlatVectorElem> IntoWasmAbi for WasmFlatVector<T> {
     type Abi = <Vec<u8> as FromWasmAbi>::Abi;
     fn into_abi(self) -> Self::Abi {
-        let mut data: Vec<u8> = Vec::with_capacity(self.0.len() * T::FLATTENED_SIZE);
-        for x in self.0.into_iter() {
-            data.extend(x.flatten().into_iter());
-        }
+        let data: Vec<_> = self.into_iter().flat_map(|x| x.flatten()).collect();
         IntoWasmAbi::into_abi(data)
     }
 }


### PR DESCRIPTION
Applying https://github.com/MinaProtocol/mina/pull/16775 to `proof-systems` since the code moved

Manually allocating can potentially side-step a compiler optimization of re-using previous allocations where possible. Also, it's not a good practive to pass in a `Vec` to a function where all you do with the `Vec` is call `as_slice`. A `Vec` consists of a pointer, a length, and a capacity whereas a slice is only a pointer and a length. Slices should always be prefered when elements aren't being added or removed.


