### PR TITLE
Reverting some commits...

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ env:
   CARGO_TERM_COLOR: always
   # 30 MB of stack for Keccak tests
   RUST_MIN_STACK: 31457280
+  CARGO_EXTRA_ARGS: "--workspace --exclude plonk_wasm --exclude saffron"
 
 jobs:
   run_mdbook:

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ O1VM_MIPS_BIN_FILES = $(patsubst ${O1VM_MIPS_SOURCE_DIR}/%.asm,${O1VM_MIPS_BIN_D
 # In addition to that, the version in the CI (see file
 # .github/workflows/wasm.yml) should be changed accordingly.
 NIGHTLY_RUST_VERSION = "nightly-2024-06-13"
-WASM_RUSTFLAGS = "-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--max-memory=4294967296"
+WASM_RUSTFLAGS = "-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--no-check-features -C link-arg=--max-memory=4294967296"
 PLONK_WASM_NODEJS_OUTDIR ?= target/nodejs
 PLONK_WASM_WEB_OUTDIR ?= target/web
 

--- a/plonk-wasm/Cargo.toml
+++ b/plonk-wasm/Cargo.toml
@@ -73,10 +73,14 @@ wasm-opt = false
 rustflags = [
   "-C",
   "target-feature=+atomics,+bulk-memory",
+  "-C",
+  "link-arg=--no-check-features",
 ]
 
 [target.wasm32-unknown-unknown]
 rustflags = [
   "-C",
   "target-feature=+atomics,+bulk-memory",
+  "-C",
+  "link-arg=--no-check-features",
 ]

--- a/plonk-wasm/src/arkworks/pasta_fp.rs
+++ b/plonk-wasm/src/arkworks/pasta_fp.rs
@@ -224,7 +224,7 @@ pub fn caml_pasta_fp_domain_generator(log2_size: i32) -> WasmPastaFp {
 #[wasm_bindgen]
 pub fn caml_pasta_fp_to_bytes(x: WasmPastaFp) -> Vec<u8> {
     let len = core::mem::size_of::<Fp>();
-    let mut str: Vec<u8> = vec![0; len];
+    let mut str: Vec<u8> = Vec::with_capacity(len);
     str.resize(len, 0);
     let str_as_fp: *mut Fp = str.as_mut_ptr().cast::<Fp>();
     unsafe {

--- a/plonk-wasm/src/arkworks/pasta_fq.rs
+++ b/plonk-wasm/src/arkworks/pasta_fq.rs
@@ -224,7 +224,7 @@ pub fn caml_pasta_fq_domain_generator(log2_size: i32) -> WasmPastaFq {
 #[wasm_bindgen]
 pub fn caml_pasta_fq_to_bytes(x: WasmPastaFq) -> Vec<u8> {
     let len = core::mem::size_of::<Fq>();
-    let mut str: Vec<u8> = vec![0; len];
+    let mut str: Vec<u8> = Vec::with_capacity(len);
     str.resize(len, 0);
     let str_as_fq: *mut Fq = str.as_mut_ptr().cast::<Fq>();
     unsafe {

--- a/plonk-wasm/src/lib.rs
+++ b/plonk-wasm/src/lib.rs
@@ -43,27 +43,13 @@ pub fn create_zero_u32_ptr() -> *mut u32 {
     Box::into_raw(std::boxed::Box::new(0))
 }
 
-/// Free a pointer. This method is exported in the WebAssembly module to be used
-/// on the JavaScript side, see `web-backend.js`.
-///
-/// # Safety
-///
-/// See
-/// `<https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref>`
 #[wasm_bindgen]
-pub unsafe fn free_u32_ptr(ptr: *mut u32) {
+pub fn free_u32_ptr(ptr: *mut u32) {
     let _drop_me = unsafe { std::boxed::Box::from_raw(ptr) };
 }
 
-/// Set the value of a pointer. This method is exported in the WebAssembly
-/// module to be used on the JavaScript side, see `web-backend.js`.
-///
-/// # Safety
-///
-/// See
-/// `<https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref>`
 #[wasm_bindgen]
-pub unsafe fn set_u32_ptr(ptr: *mut u32, arg: u32) {
+pub fn set_u32_ptr(ptr: *mut u32, arg: u32) {
     // The rust docs explicitly forbid using this for cross-thread syncronization. Oh well, we
     // don't have anything better. As long as it works in practice, we haven't upset the undefined
     // behavior dragons.
@@ -72,16 +58,9 @@ pub unsafe fn set_u32_ptr(ptr: *mut u32, arg: u32) {
     }
 }
 
-/// This method is exported in the WebAssembly to be used on the JavaScript
-/// side, see `web-backend.js`.
-///
-/// # Safety
-///
-/// See
-/// `<https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref>`
 #[allow(unreachable_code)]
 #[wasm_bindgen]
-pub unsafe fn wait_until_non_zero(ptr: *const u32) -> u32 {
+pub fn wait_until_non_zero(ptr: *const u32) -> u32 {
     // The rust docs explicitly forbid using this for cross-thread syncronization. Oh well, we
     // don't have anything better. As long as it works in practice, we haven't upset the undefined
     // behavior dragons.

--- a/plonk-wasm/src/oracles.rs
+++ b/plonk-wasm/src/oracles.rs
@@ -115,28 +115,23 @@ macro_rules! impl_oracles {
                 }
             }
 
-            impl Into<RandomOracles<$F>> for WasmRandomOracles
+            impl From<WasmRandomOracles> for RandomOracles<$F>
             {
-                fn into(self) -> RandomOracles<$F> {
-                    let joint_combiner =
-                        match (self.joint_combiner_chal, self.joint_combiner) {
-                            (Some(joint_combiner_chal), Some(joint_combiner)) => {
-                                Some((ScalarChallenge(joint_combiner_chal.into()), joint_combiner.into()))
-                            },
-                            _ => None
-                        };
-                    RandomOracles {
-                        joint_combiner,
-                        beta: self.beta.into(),
-                        gamma: self.gamma.into(),
-                        alpha_chal: ScalarChallenge(self.alpha_chal.into()),
-                        alpha: self.alpha.into(),
-                        zeta: self.zeta.into(),
-                        v: self.v.into(),
-                        u: self.u.into(),
-                        zeta_chal: ScalarChallenge(self.zeta_chal.into()),
-                        v_chal: ScalarChallenge(self.v_chal.into()),
-                        u_chal: ScalarChallenge(self.u_chal.into()),
+                fn from(ro: WasmRandomOracles) -> Self {
+                    Self {
+                        joint_combiner: ro.joint_combiner_chal.and_then(|x| {
+                            ro.joint_combiner.map(|y| (ScalarChallenge(x.into()), y.into()))
+                        }),
+                        beta: ro.beta.into(),
+                        gamma: ro.gamma.into(),
+                        alpha_chal: ScalarChallenge(ro.alpha_chal.into()),
+                        alpha: ro.alpha.into(),
+                        zeta: ro.zeta.into(),
+                        v: ro.v.into(),
+                        u: ro.u.into(),
+                        zeta_chal: ScalarChallenge(ro.zeta_chal.into()),
+                        v_chal: ScalarChallenge(ro.v_chal.into()),
+                        u_chal: ScalarChallenge(ro.u_chal.into()),
                     }
                 }
             }

--- a/plonk-wasm/src/oracles.rs
+++ b/plonk-wasm/src/oracles.rs
@@ -115,23 +115,28 @@ macro_rules! impl_oracles {
                 }
             }
 
-            impl From<WasmRandomOracles> for RandomOracles<$F>
+            impl Into<RandomOracles<$F>> for WasmRandomOracles
             {
-                fn from(ro: WasmRandomOracles) -> Self {
-                    Self {
-                        joint_combiner: ro.joint_combiner_chal.and_then(|x| {
-                            ro.joint_combiner.map(|y| (ScalarChallenge(x.into()), y.into()))
-                        }),
-                        beta: ro.beta.into(),
-                        gamma: ro.gamma.into(),
-                        alpha_chal: ScalarChallenge(ro.alpha_chal.into()),
-                        alpha: ro.alpha.into(),
-                        zeta: ro.zeta.into(),
-                        v: ro.v.into(),
-                        u: ro.u.into(),
-                        zeta_chal: ScalarChallenge(ro.zeta_chal.into()),
-                        v_chal: ScalarChallenge(ro.v_chal.into()),
-                        u_chal: ScalarChallenge(ro.u_chal.into()),
+                fn into(self) -> RandomOracles<$F> {
+                    let joint_combiner =
+                        match (self.joint_combiner_chal, self.joint_combiner) {
+                            (Some(joint_combiner_chal), Some(joint_combiner)) => {
+                                Some((ScalarChallenge(joint_combiner_chal.into()), joint_combiner.into()))
+                            },
+                            _ => None
+                        };
+                    RandomOracles {
+                        joint_combiner,
+                        beta: self.beta.into(),
+                        gamma: self.gamma.into(),
+                        alpha_chal: ScalarChallenge(self.alpha_chal.into()),
+                        alpha: self.alpha.into(),
+                        zeta: self.zeta.into(),
+                        v: self.v.into(),
+                        u: self.u.into(),
+                        zeta_chal: ScalarChallenge(self.zeta_chal.into()),
+                        v_chal: ScalarChallenge(self.v_chal.into()),
+                        u_chal: ScalarChallenge(self.u_chal.into()),
                     }
                 }
             }

--- a/plonk-wasm/src/pasta_fp_plonk_index.rs
+++ b/plonk-wasm/src/pasta_fp_plonk_index.rs
@@ -1,5 +1,4 @@
 use ark_poly::EvaluationDomain;
-use base64::{engine::general_purpose, Engine};
 use kimchi::circuits::lookup::runtime_tables::RuntimeTableCfg;
 
 use crate::{
@@ -271,7 +270,7 @@ pub fn caml_pasta_fp_plonk_index_write(
 #[wasm_bindgen]
 pub fn caml_pasta_fp_plonk_index_serialize(index: &WasmPastaFpPlonkIndex) -> String {
     let serialized = rmp_serde::to_vec(&index.0).unwrap();
-    general_purpose::STANDARD.encode(serialized)
+    base64::encode(serialized)
 }
 
 // helpers

--- a/plonk-wasm/src/pasta_fp_plonk_index.rs
+++ b/plonk-wasm/src/pasta_fp_plonk_index.rs
@@ -1,4 +1,5 @@
 use ark_poly::EvaluationDomain;
+use base64::{engine::general_purpose, Engine};
 use kimchi::circuits::lookup::runtime_tables::RuntimeTableCfg;
 
 use crate::{
@@ -270,7 +271,7 @@ pub fn caml_pasta_fp_plonk_index_write(
 #[wasm_bindgen]
 pub fn caml_pasta_fp_plonk_index_serialize(index: &WasmPastaFpPlonkIndex) -> String {
     let serialized = rmp_serde::to_vec(&index.0).unwrap();
-    base64::encode(serialized)
+    general_purpose::STANDARD.encode(serialized)
 }
 
 // helpers

--- a/plonk-wasm/src/pasta_fq_plonk_index.rs
+++ b/plonk-wasm/src/pasta_fq_plonk_index.rs
@@ -1,4 +1,5 @@
 use ark_poly::EvaluationDomain;
+use base64::{engine::general_purpose, Engine};
 use kimchi::circuits::lookup::runtime_tables::RuntimeTableCfg;
 
 use crate::{
@@ -269,5 +270,5 @@ pub fn caml_pasta_fq_plonk_index_write(
 #[wasm_bindgen]
 pub fn caml_pasta_fq_plonk_index_serialize(index: &WasmPastaFqPlonkIndex) -> String {
     let serialized = rmp_serde::to_vec(&index.0).unwrap();
-    base64::encode(serialized)
+    general_purpose::STANDARD.encode(serialized)
 }

--- a/plonk-wasm/src/pasta_fq_plonk_index.rs
+++ b/plonk-wasm/src/pasta_fq_plonk_index.rs
@@ -1,5 +1,4 @@
 use ark_poly::EvaluationDomain;
-use base64::{engine::general_purpose, Engine};
 use kimchi::circuits::lookup::runtime_tables::RuntimeTableCfg;
 
 use crate::{
@@ -270,5 +269,5 @@ pub fn caml_pasta_fq_plonk_index_write(
 #[wasm_bindgen]
 pub fn caml_pasta_fq_plonk_index_serialize(index: &WasmPastaFqPlonkIndex) -> String {
     let serialized = rmp_serde::to_vec(&index.0).unwrap();
-    general_purpose::STANDARD.encode(serialized)
+    base64::encode(serialized)
 }

--- a/plonk-wasm/src/plonk_proof.rs
+++ b/plonk-wasm/src/plonk_proof.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use ark_ec::AffineRepr;
 use ark_ff::One;
-use base64::{engine::general_purpose, Engine};
 use core::{array, convert::TryInto};
 use groupmap::GroupMap;
 use kimchi::{
@@ -619,7 +618,7 @@ macro_rules! impl_proof {
                 pub fn serialize(&self) -> String {
                     let (proof, _public_input) = self.into();
                     let serialized = rmp_serde::to_vec(&proof).unwrap();
-                    general_purpose::STANDARD.encode(serialized)
+                    base64::encode(serialized)
                 }
             }
 

--- a/plonk-wasm/src/plonk_proof.rs
+++ b/plonk-wasm/src/plonk_proof.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use ark_ec::AffineRepr;
 use ark_ff::One;
+use base64::{engine::general_purpose, Engine};
 use core::{array, convert::TryInto};
 use groupmap::GroupMap;
 use kimchi::{
@@ -618,7 +619,7 @@ macro_rules! impl_proof {
                 pub fn serialize(&self) -> String {
                     let (proof, _public_input) = self.into();
                     let serialized = rmp_serde::to_vec(&proof).unwrap();
-                    base64::encode(serialized)
+                    general_purpose::STANDARD.encode(serialized)
                 }
             }
 

--- a/plonk-wasm/src/plonk_verifier_index.rs
+++ b/plonk-wasm/src/plonk_verifier_index.rs
@@ -587,7 +587,6 @@ macro_rules! impl_verification_key {
             #[wasm_bindgen]
             impl [<Wasm $field_name:camel PlonkVerifierIndex>] {
                 #[wasm_bindgen(constructor)]
-                #[allow(clippy::too_many_arguments)]
                 pub fn new(
                     domain: &WasmDomain,
                     max_poly_size: i32,
@@ -643,7 +642,7 @@ macro_rules! impl_verification_key {
                 }
             }
 
-            pub fn to_wasm(
+            pub fn to_wasm<'a>(
                 srs: &Arc<SRS<$G>>,
                 vi: DlogVerifierIndex<$G, OpeningProof<$G>>,
             ) -> WasmPlonkVerifierIndex {

--- a/plonk-wasm/src/srs.rs
+++ b/plonk-wasm/src/srs.rs
@@ -141,14 +141,8 @@ macro_rules! impl_srs {
                 Box::into_raw(boxed_comm)
             }
 
-            /// Reads the lagrange commitments from a raw pointer.
-            ///
-            /// # Safety
-            ///
-            /// This function is unsafe because it might dereference a
-            /// raw pointer.
             #[wasm_bindgen]
-            pub unsafe fn [<$name:snake _lagrange_commitments_whole_domain_read_from_ptr>](
+            pub fn [<$name:snake _lagrange_commitments_whole_domain_read_from_ptr>](
                 ptr: *mut WasmVector<$WasmPolyComm>,
             ) -> WasmVector<$WasmPolyComm> {
                 // read the commitment at the pointers address, hack for the web


### PR DESCRIPTION
Counterpart in Mina: https://github.com/MinaProtocol/mina/pull/16887
Counterpart in o1js: https://github.com/o1-labs/o1js/pull/2128

Reverting some commits introduced in https://github.com/o1-labs/proof-systems/pull/3149. The PR!3149 seems to contain gentle changes, as it is mostly to appease Clippy.

However, if someone tries to run o1js on top of [3f63052](https://github.com/o1-labs/proof-systems/commit/3f6305282527b6f93b2c067d97fcdb29539eb7de), different errors will happen.

1. One is described in [this comment](https://github.com/o1-labs/proof-systems/pull/3157#issuecomment-2786154239), which seems to be related to https://github.com/o1-labs/proof-systems/commit/0154940d434ec481fbaa030528ebeb97d6e295ab.
This PR reverts this commit, after that revert the revert (confirming that there is an actual issue with the change), and again revert the set. I'm keeping this in the history in case we want to debug later.
 
2. Another one is having tests hanging indefinitely, without logs.

I initially reverted (a bit arbitraly, but still on the idea that the code semantics might be changed by wasm-bindgen) the following commits:
- https://github.com/o1-labs/proof-systems/commit/00ab94743810b6447800987f1ed541d0aaa16901, see [a0f7ecf](https://github.com/o1-labs/proof-systems/pull/3157/commits/a0f7ecf22fa2cc39b3d51be5ec6bf103c64be770)
- https://github.com/o1-labs/proof-systems/commit/01f043a68b84abdfdb4551be4aeeccdf46648287, see [ef33f82](https://github.com/o1-labs/proof-systems/pull/3157/commits/ef33f828b240a8f90b8558eade111878e76599f2)
- https://github.com/o1-labs/proof-systems/commit/76f44f332cde9e85ad294447e34320c24017d80f, see [be0ab46](https://github.com/o1-labs/proof-systems/pull/3157/commits/be0ab46d7ed5782f4f8a38e9dd4e703a0ae0a334)
- https://github.com/o1-labs/proof-systems/commit/c103083215cf20fa0b49da543f5f70a63567c915, see [1ac15e6](https://github.com/o1-labs/proof-systems/pull/3157/commits/1ac15e6d669d50b168570126d788bd80e0a5358d)
- https://github.com/o1-labs/proof-systems/commit/0154940d434ec481fbaa030528ebeb97d6e295ab, see [c4e5d6f](https://github.com/o1-labs/proof-systems/pull/3157/commits/c4e5d6f0210d3c8942021edc53a6329ebb005d0e)
- https://github.com/o1-labs/proof-systems/commit/8837834141f1f286abfa150cdda13bf60ef18e82, see [e58a737](https://github.com/o1-labs/proof-systems/pull/3157/commits/e58a737c27d7b77547a203007db37b1911e99917)
- https://github.com/o1-labs/proof-systems/commit/af6f5f3656520da801f1fbd9354445d7209060a6, see [7e8ecf6](https://github.com/o1-labs/proof-systems/pull/3157/commits/7e8ecf64a581808fe1c9b1e2f3c70bc2d48600fe)

In addition to that https://github.com/o1-labs/proof-systems/commit/1c8e9b69c0334788c7ed8ea4480acf2ebbd4f86d, see [78c75a8](https://github.com/o1-labs/proof-systems/pull/3157/commits/78c75a817a4915a8a7faa309cbcc96d7767ec9ac) is reverted as it impacts this CI.

I ended up re-introducing https://github.com/o1-labs/proof-systems/commit/00ab94743810b6447800987f1ed541d0aaa16901, see [98e9d70](https://github.com/o1-labs/proof-systems/pull/3157/commits/98e9d70f075200193e814388cbbc067401c9ffa2) as it really looks inoffensive to me.

I would prefer to start from this set of reverts, and step by step reintroducing them.
Follow-up PR will come.

The reviewer is encouraged to monitor the state of the CI of o1js [here](https://github.com/o1-labs/o1js/pull/2128), and review the Mina + proof-systems commit used, to convince them that this gives back a clean master branch we can start to build on top of again.

The reviewer can convince themselves there are some issues by looking at logs of the CI of this [o1js commit](https://github.com/o1-labs/o1js/pull/2128/commits/9b4b57fa8b1c3ffdae29c8a4b4ff7367ad9f3d67) for instance. The four commits on top of it are after these changes.