### PR TITLE
plonk-wasm/lib: add unsafe keyword and add doc accordingly

### DIFF
--- a/plonk-wasm/src/lib.rs
+++ b/plonk-wasm/src/lib.rs
@@ -43,13 +43,27 @@ pub fn create_zero_u32_ptr() -> *mut u32 {
     Box::into_raw(std::boxed::Box::new(0))
 }
 
+/// Free a pointer. This method is exported in the WebAssembly module to be used
+/// on the JavaScript side, see `web-backend.js`.
+///
+/// # Safety
+///
+/// See
+/// `<https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref>`
 #[wasm_bindgen]
-pub fn free_u32_ptr(ptr: *mut u32) {
+pub unsafe fn free_u32_ptr(ptr: *mut u32) {
     let _drop_me = unsafe { std::boxed::Box::from_raw(ptr) };
 }
 
+/// Set the value of a pointer. This method is exported in the WebAssembly
+/// module to be used on the JavaScript side, see `web-backend.js`.
+///
+/// # Safety
+///
+/// See
+/// `<https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref>`
 #[wasm_bindgen]
-pub fn set_u32_ptr(ptr: *mut u32, arg: u32) {
+pub unsafe fn set_u32_ptr(ptr: *mut u32, arg: u32) {
     // The rust docs explicitly forbid using this for cross-thread syncronization. Oh well, we
     // don't have anything better. As long as it works in practice, we haven't upset the undefined
     // behavior dragons.
@@ -58,9 +72,16 @@ pub fn set_u32_ptr(ptr: *mut u32, arg: u32) {
     }
 }
 
+/// This method is exported in the WebAssembly to be used on the JavaScript
+/// side, see `web-backend.js`.
+///
+/// # Safety
+///
+/// See
+/// `<https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref>`
 #[allow(unreachable_code)]
 #[wasm_bindgen]
-pub fn wait_until_non_zero(ptr: *const u32) -> u32 {
+pub unsafe fn wait_until_non_zero(ptr: *const u32) -> u32 {
     // The rust docs explicitly forbid using this for cross-thread syncronization. Oh well, we
     // don't have anything better. As long as it works in practice, we haven't upset the undefined
     // behavior dragons.


### PR DESCRIPTION
This is a no-op, and aims to simply appease Clippy. This commit does not aim to modify the semantics.

- https://github.com/o1-labs/o1js/pull/2140
- https://github.com/o1-labs/o1js-bindings/pull/359
- https://github.com/o1-labs/proof-systems/pull/3161
- https://github.com/MinaProtocol/mina/pull/16891