### PR TITLE
Fix saffron blob.rs cargo doc warnings (microPR)

### DIFF
--- a/saffron/src/blob.rs
+++ b/saffron/src/blob.rs
@@ -15,11 +15,11 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use tracing::{debug, instrument};
 
-/// A FieldBlob<F> is what Storage Provider stores per user's
-/// contract: a list of SRS_SIZE * num_chunks field elements, where
+/// A `FieldBlob<F>` is what Storage Provider stores per user's
+/// contract: a list of `SRS_SIZE * num_chunks` field elements, where
 /// num_chunks is how much the client allocated.
 ///
-/// It can be seen as the encoding of a Vec<u8>, where each field
+/// It can be seen as the encoding of a `Vec<u8>`, where each field
 /// element contains 31 bytes.
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
Fixes cargo docs complaining, which led to the github pages docs CI failure: https://github.com/o1-labs/proof-systems/actions/runs/14340847614/job/40199432360