### PR TITLE
Fix plonk-wasm compilation warnings [easy]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,3 +116,6 @@ utils = { path = "./utils", version = "0.1.0" }
 lto = true
 panic = 'abort'
 # codegen-units = 1
+
+[profile.release.package.plonk_wasm]
+debug = true

--- a/plonk-wasm/Cargo.toml
+++ b/plonk-wasm/Cargo.toml
@@ -58,9 +58,6 @@ poly-commitment = { workspace = true }
 [dev-dependencies]
 wasm-bindgen-test.workspace = true
 
-[profile.release]
-debug = true
-
 [features]
 nodejs = []
 

--- a/plonk-wasm/Cargo.toml
+++ b/plonk-wasm/Cargo.toml
@@ -65,15 +65,3 @@ nodejs = []
 wasm-opt = false
 #wasm-opt = ["-O4", "--detect-features", "--enable-mutable-globals" ]
 #wasm-opt = ["-O4", "--enable-mutable-globals"]
-
-[build]
-rustflags = [
-  "-C",
-  "target-feature=+atomics,+bulk-memory",
-]
-
-[target.wasm32-unknown-unknown]
-rustflags = [
-  "-C",
-  "target-feature=+atomics,+bulk-memory",
-]

--- a/plonk-wasm/config.toml
+++ b/plonk-wasm/config.toml
@@ -1,0 +1,11 @@
+[build]
+rustflags = [
+  "-C",
+  "target-feature=+atomics,+bulk-memory",
+]
+
+[target.wasm32-unknown-unknown]
+rustflags = [
+  "-C",
+  "target-feature=+atomics,+bulk-memory",
+]


### PR DESCRIPTION
First commit fixes this warning:

```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /home/volhovm/code/proof-systems/plonk-wasm/Cargo.toml
workspace: /home/volhovm/code/proof-systems/Cargo.toml
```

Second commit fixes this warning (these options are ignored unless they're in `.cargo/config.toml`: https://doc.rust-lang.org/cargo/reference/config.html):

```
warning: /home/volhovm/code/proof-systems/plonk-wasm/Cargo.toml: unused manifest key: build
warning: /home/volhovm/code/proof-systems/plonk-wasm/Cargo.toml: unused manifest key: target.wasm32-unknown-unknown.rustflags
```