### PR TITLE
Cleanup & factorize `pows`-related code

### DIFF
--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -24,7 +24,7 @@ use core::{
     ops::{Add, AddAssign, Index, Mul, MulAssign, Neg, Sub},
 };
 use itertools::Itertools;
-use o1_utils::{foreign_field::ForeignFieldHelpers, FieldHelpers};
+use o1_utils::{field_helpers::pows, foreign_field::ForeignFieldHelpers, FieldHelpers};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -1013,20 +1013,6 @@ enum EvalResult<'a, F: FftField> {
     },
 }
 
-/// Compute the powers of `x`, `x^0, ..., x^{n - 1}`
-pub fn pows<F: Field>(x: F, n: usize) -> Vec<F> {
-    if n == 0 {
-        return vec![F::one()];
-    } else if n == 1 {
-        return vec![F::one(), x];
-    }
-    let mut v = vec![F::one(), x];
-    for i in 2..n {
-        v.push(v[i - 1] * x);
-    }
-    v
-}
-
 /// Compute the evaluations of the unnormalized lagrange polynomial on
 /// H_8 or H_4. Taking H_8 as an example, we show how to compute this
 /// polynomial on the expanded domain.
@@ -1099,8 +1085,8 @@ fn unnormalized_lagrange_evals<
     // |res_domain| = k * |H|
 
     // omega_k^0, ..., omega_k^k
-    let omega_k_n_pows = pows(res_domain.group_gen.pow([n]), k);
-    let omega_k_pows = pows(res_domain.group_gen, k);
+    let omega_k_n_pows = pows(k, res_domain.group_gen.pow([n]));
+    let omega_k_pows = pows(k, res_domain.group_gen);
 
     let mut evals: Vec<F> = {
         let mut v = vec![F::one(); k * (n as usize)];

--- a/saffron/og-flow/main.rs
+++ b/saffron/og-flow/main.rs
@@ -5,6 +5,7 @@ use mina_curves::pasta::{Fp, Vesta, VestaParameters};
 use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi, sponge::DefaultFqSponge, FqSponge as _,
 };
+use o1_utils::field_helpers::pows;
 use poly_commitment::{
     commitment::{absorb_commitment, BatchEvaluationProof, CommitmentCurve, Evaluation},
     ipa::SRS,
@@ -143,14 +144,7 @@ pub fn main() -> ExitCode {
         println!("- Storage protocol iteration {i}");
         println!("  - Computing randomizers for data chunks");
         let now = std::time::Instant::now();
-        let powers = committed_chunks
-            .iter()
-            .scan(Fp::one(), |acc, _| {
-                let res = *acc;
-                *acc *= challenge;
-                Some(res)
-            })
-            .collect::<Vec<_>>();
+        let powers = pows(committed_chunks.len(), challenge);
         let duration = now.elapsed();
         println!(
             "    - Took {:?}s / {:?}ms / {:?}us / {:?}ns",

--- a/saffron/src/utils.rs
+++ b/saffron/src/utils.rs
@@ -1,8 +1,8 @@
-use std::marker::PhantomData;
-
+use ark_ec::{AffineRepr, CurveGroup, VariableBaseMSM};
 use ark_ff::{BigInteger, PrimeField};
 use ark_poly::EvaluationDomain;
-use o1_utils::FieldHelpers;
+use o1_utils::{field_helpers::pows, FieldHelpers};
+use std::marker::PhantomData;
 use thiserror::Error;
 use tracing::instrument;
 
@@ -273,6 +273,17 @@ pub fn min_encoding_chunks<F: PrimeField, D: EvaluationDomain<F>>(domain: &D, xs
 pub fn chunk_size_in_bytes<F: PrimeField, D: EvaluationDomain<F>>(domain: &D) -> usize {
     let m = F::MODULUS_BIT_SIZE as usize / 8;
     domain.size() * m
+}
+
+/// For commitments [C_i] and randomness r, returns ∑ r^i C_i.
+pub fn aggregate_commitments<G: AffineRepr>(randomness: G::ScalarField, commitments: &[G]) -> G {
+    // powers_of_randomness = [1, r, r², r³, …]
+    let powers_of_randomness = pows(commitments.len(), randomness);
+    let aggregated_commitment =
+    // Using unwrap() is safe here, as err is returned when commitments and powers have different lengths,
+    // and powers are built with commitment.len().
+        G::Group::msm(commitments, powers_of_randomness.as_slice()).unwrap().into_affine();
+    aggregated_commitment
 }
 
 #[cfg(test)]

--- a/utils/src/field_helpers.rs
+++ b/utils/src/field_helpers.rs
@@ -211,7 +211,7 @@ pub fn i32_to_field<F: From<u64> + Neg<Output = F>>(i: i32) -> F {
 /// field element `x` (from `1` to `x^(d-1)`).
 pub fn pows<F: Field>(d: usize, x: F) -> Vec<F> {
     let mut acc = F::one();
-    let mut res = vec![];
+    let mut res = Vec::with_capacity(d);
     for _ in 1..=d {
         res.push(acc);
         acc *= x;


### PR DESCRIPTION
This PR unifies scalar’s powers generation through the repository, only using `utils::field_helpers::pows` and removing other implementations.

It also unify the commitments aggregation in Saffron by adding a new function in saffron/utils.