### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/book/src/pickles/accumulation.md
+++ b/book/src/pickles/accumulation.md
@@ -34,7 +34,7 @@ Pictorially:
 <b>
 Fig 1.
 </b>
-An overview the particular reductions/languages (described below) we require.
+An overview of the particular reductions/languages (described below) we require.
 </figcaption>
 </figure>
 
@@ -62,7 +62,7 @@ used in Pickles:
 <b>
 Fig 2.
 </b>
-An overview the particular reductions/languages (described below) we require.
+An overview of the particular reductions/languages (described below) we require.
 </figcaption>
 </figure>
 
@@ -551,7 +551,7 @@ This concludes the proof.
 #### The "Halo Trick"
 
 The "Halo trick" resides in observing that this is also the case for $\vec{G}^{(k)}$:
-since it is folded the same way as $\vec{\openx}^{(k)}$. It is not hard to convince one-self (using the same type of argument as above) that:
+since it is folded the same way as $\vec{\openx}^{(k)}$. It is not hard to convince oneself (using the same type of argument as above) that:
 
 $$
 G^{(k)} = \langle \vec{h}, \vec{G} \rangle
@@ -559,7 +559,7 @@ $$
 
 Where $\vec{h}$ is the coefficients of $h(X)$ (like $\vec{f}$ is the coefficients of $f(X)$), i.e. $h(X) = \sum_{i = 1}^{\ell} h_i X^{i-1}$
 
-For notational convince (and to emphasise that they are 1 dimensional vectors), define/replace:
+For notational convenience (and to emphasise that they are 1 dimensional vectors), define/replace:
 
 $$
 U = \vec{G}^{(k)} \in \GG, \ \ \ c = \vec{f}^{(k)} \in \FF, \ \ \ h(\openx) = \vec{\openx}^{(k)} \in \FF

--- a/book/src/pickles/zkbook_ips.md
+++ b/book/src/pickles/zkbook_ips.md
@@ -47,7 +47,7 @@ We will give a recursive definition of a few concepts. Making this mathematicall
 
 The data of an **inductive rule for a type $A$** is
 
-- a sequence of inductive sets $A_0, \dots, A_{n-1}$ (note the recursive reference to )
+- a sequence of inductive sets $A_0, \dots, A_{n-1}$ (note the recursive reference to inductive sets)
 
 - a type $W$
 

--- a/o1vm/src/interpreters/mips/witness.rs
+++ b/o1vm/src/interpreters/mips/witness.rs
@@ -37,7 +37,7 @@ use std::{
 };
 
 // TODO: do we want to be more restrictive and refer to the number of accesses
-//       to the SAME register/memory addrss?
+//       to the SAME register/memory address?
 
 /// Maximum number of register accesses per instruction (based on demo)
 pub const MAX_NB_REG_ACC: u64 = 7;
@@ -402,7 +402,7 @@ impl<Fp: PrimeField, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp,
             let pos = self.alloc_scratch();
             unsafe { self.test_zero(x, pos) }
         };
-        // write the non deterministic advice inv_or_zero
+        // write the non-deterministic advice inv_or_zero
         let pos = self.alloc_scratch_inverse();
         if *x == 0 {
             self.write_field_column(pos, Fp::zero());
@@ -745,7 +745,7 @@ impl<Fp: PrimeField, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp,
                     length_byte as u64,
                 );
 
-                // TODO: Proabably, the scratch state of MIPS_LENGTH_BYTES_OFF
+                // TODO: Probably, the scratch state of MIPS_LENGTH_BYTES_OFF
                 // is redundant with lines below
                 unsafe {
                     self.push_memory(&(*addr + i), length_byte as u64);
@@ -772,7 +772,7 @@ impl<Fp: PrimeField, PreImageOracle: PreImageOracleT> InterpreterEnv for Env<Fp,
                 // read in this call
                 preimage_read_len += 1;
 
-                // TODO: Proabably, the scratch state of MIPS_PREIMAGE_BYTES_OFF
+                // TODO: Probably, the scratch state of MIPS_PREIMAGE_BYTES_OFF
                 // is redundant with lines below
                 unsafe {
                     self.push_memory(&(*addr + i), preimage_byte as u64);

--- a/o1vm/src/interpreters/riscv32im/witness.rs
+++ b/o1vm/src/interpreters/riscv32im/witness.rs
@@ -1,5 +1,5 @@
 // TODO: do we want to be more restrictive and refer to the number of accesses
-//       to the SAME register/memory addrss?
+//       to the SAME register/memory address?
 use super::{
     column::Column,
     interpreter::{
@@ -290,7 +290,7 @@ impl<Fp: Field> InterpreterEnv for Env<Fp> {
         let pos = self.alloc_scratch();
         let res = if *x == 0 { 1 } else { 0 };
         self.write_column(pos, res);
-        // write the non deterministic advice inv_or_zero
+        // write the non-deterministic advice inv_or_zero
         let pos = self.alloc_scratch_inverse();
         if *x == 0 {
             self.write_field_column(pos, Fp::zero());

--- a/poly-commitment/src/error.rs
+++ b/poly-commitment/src/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 #[derive(Error, Debug, Clone, Copy)]
 pub enum CommitmentError {
     #[error(
-        "the length of the given blinders ({0}) don't match the length of the commitment ({1})"
+        "the length of the given blinders ({0}) doesn't match the length of the commitment ({1})"
     )]
     BlindersDontMatch(usize, usize),
 }


### PR DESCRIPTION
## Summary
- Fix grammar in error message: "don't match" → "doesn't match"
- Fix spelling of "probably" in comments
- Add hyphenation in "non-deterministic"
- Fix missing words in documentation
- Complete incomplete sentences in markdown docs
- Fix typos in "address"

## Test plan
- No functionality changes, only documentation and comments
- No tests needed as these changes only affect documentation

🤖 Generated with [Claude Code](https://claude.ai/code)