### PR TITLE
Fix typos in codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Generally, proof-systems intends to be synchronized with the mina repository (se
 - `compatible`:
   - Compatible with `rampup` in `mina`.
   - Mina's `compatible`, similarly to mina's `master`, does not have `proof-systems`.
-- `berkley`: future hardfork release, will be going out to berkeley.
+- `berkeley`: future hardfork release, will be going out to berkeley.
   - This is where hotfixes go.
 - `develop`: matches mina's `develop`, soft fork-compatibility.
   - Also used by `mina/o1js-main` and `o1js/main`.

--- a/folding/src/error_term.rs
+++ b/folding/src/error_term.rs
@@ -433,13 +433,13 @@ impl<CF: FoldingConfig> ExtendedEnv<CF> {
 
         // FIXME: use parallelisation
         let blinder = PolyComm::new(vec![relaxed_instance.blinder]);
-        for (expected_i, (i, wit)) in relaxed_witness.extended_witness.extended.iter().enumerate() {
+        for (expected_i, (i, with)) in relaxed_witness.extended_witness.extended.iter().enumerate() {
             // in case any where to be missing for some reason
             assert_eq!(*i, expected_i);
             // Blinding the commitments to support the case the witness is zero.
             // The IVC circuit expects to have non-zero commitments.
             let commit = srs
-                .commit_evaluations_custom(self.domain, wit, &blinder)
+                .commit_evaluations_custom(self.domain, with, &blinder)
                 .unwrap()
                 .commitment;
             relaxed_instance.extended_instance.extended.push(commit)

--- a/folding/src/expressions.rs
+++ b/folding/src/expressions.rs
@@ -97,7 +97,7 @@
 //! ```
 //! and `P_relaxed` is of degree `2`. More
 //! precisely, `P_relaxed` is homogenous. And that is the main idea of folding:
-//! the "relaxation" of a polynomial means we make it homogenous for a certain
+//! the "relaxation" of a polynomial means we make it homogeneous for a certain
 //! degree `d` by introducing the new variable `u`, and introduce the concept of
 //! "error terms" that will englobe the "cross-terms". The prover takes care of
 //! computing the cross-terms and commit to them.
@@ -349,7 +349,7 @@ pub trait FoldingColumnTrait: Copy + Clone {
     PartialEq(bound = "C: FoldingConfig")
 )]
 pub enum ExpExtension<C: FoldingConfig> {
-    /// The variable `u` used to make the polynomial homogenous
+    /// The variable `u` used to make the polynomial homogeneous
     U,
     /// The error term
     Error,

--- a/folding/src/instance_witness.rs
+++ b/folding/src/instance_witness.rs
@@ -374,7 +374,7 @@ impl<G: CommitmentCurve, W: Witness<G>> RelaxedWitness<G, W> {
         // Computing E1 + c^3 E2
         let mut res = Self::combine(a, b, challenge);
 
-        // Now substracting the cross terms
+        // Now subtracting the cross terms
         let [e0, e1] = cross_terms;
 
         for (res, (e0, e1)) in res

--- a/folding/src/standard_config.rs
+++ b/folding/src/standard_config.rs
@@ -242,7 +242,7 @@ mod memoization {
         }
     }
     /// a hashmap like data structure supporting get-or-insert with
-    /// an immutable reference and returning an inmutable reference
+    /// an immutable reference and returning an immutable reference
     /// without guard
     pub struct ColumnMemoizer<C: Hash + Eq, F: Field, const N: usize> {
         first_segment: ColumnMemoizerSegment<F, N>,

--- a/folding/tests/test_decomposable_folding.rs
+++ b/folding/tests/test_decomposable_folding.rs
@@ -35,7 +35,7 @@ pub enum TestColumn {
     C,
 }
 
-// the type for the dynamic selectors, which are esentially witness columns, but
+// the type for the dynamic selectors, which are essentially witness columns, but
 // get special treatment to enable optimizations
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub enum DynamicSelector {
@@ -57,7 +57,7 @@ impl FoldingColumnTrait for TestColumn {
 pub struct TestInstance {
     // 3 from the normal witness + 2 from the dynamic selectors
     commitments: [Curve; 5],
-    // for ilustration only, no constraint in this example uses challenges
+    // for illustration only, no constraint in this example uses challenges
     challenges: [Fp; 3],
     // also challenges, but segregated as folding gives them special treatment
     alphas: Alphas<Fp>,
@@ -96,7 +96,7 @@ impl Instance<Curve> for TestInstance {
 /// Our witness is going to be the polynomials that we will commit too.
 /// Vec<Fp> will be the evaluations of each x_1, x_2 and x_3 over the domain.
 /// This witness includes not only the 3 normal witness columns, but also the
-/// 2 dynamic selector columns that are esentially witness
+/// 2 dynamic selector columns that are essentially witness
 #[derive(Clone)]
 pub struct TestWitness([Evaluations<Fp, Radix2EvaluationDomain<Fp>>; 5]);
 
@@ -139,7 +139,7 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, TestColumn, TestChallenge, Dynami
     ) -> Self {
         // here it is mostly storing the pairs into self, and also computing other things we may need
         // later like the shifted versions, note there are more efficient ways of handling the rotated
-        // witnesses, which are just for example as no contraint uses them anyway
+        // witnesses, which are just for example as no constraint uses them anyway
         let curr_witnesses = [witnesses[0].clone(), witnesses[1].clone()];
         let mut next_witnesses = curr_witnesses.clone();
         for side in next_witnesses.iter_mut() {
@@ -158,14 +158,14 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, TestColumn, TestChallenge, Dynami
     // provide access to columns, here side refers to one of the two pairs you
     // got in new()
     fn col(&self, col: TestColumn, curr_or_next: CurrOrNext, side: Side) -> &[Fp] {
-        let wit = match curr_or_next {
+        let with = match curr_or_next {
             CurrOrNext::Curr => &self.curr_witnesses[side as usize],
             CurrOrNext::Next => &self.next_witnesses[side as usize],
         };
         match col {
-            TestColumn::A => &wit.0[0].evals,
-            TestColumn::B => &wit.0[1].evals,
-            TestColumn::C => &wit.0[2].evals,
+            TestColumn::A => &with.0[0].evals,
+            TestColumn::B => &with.0[1].evals,
+            TestColumn::C => &with.0[2].evals,
         }
     }
 
@@ -183,10 +183,10 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, TestColumn, TestChallenge, Dynami
     // The implementation of this if the same as col(), it is just separated as they
     // have different types to resolve
     fn selector(&self, s: &DynamicSelector, side: Side) -> &[Fp] {
-        let wit = &self.curr_witnesses[side as usize];
+        let with = &self.curr_witnesses[side as usize];
         match s {
-            DynamicSelector::SelecAdd => &wit.0[3].evals,
-            DynamicSelector::SelecSub => &wit.0[4].evals,
+            DynamicSelector::SelecAdd => &with.0[3].evals,
+            DynamicSelector::SelecSub => &with.0[4].evals,
         }
     }
 }
@@ -349,7 +349,7 @@ fn test_decomposable_folding() {
 
     let mut fq_sponge = BaseSponge::new(Curve::other_curve_sponge_params());
 
-    // initiallize the scheme, also getting the final single expression for
+    // initialize the scheme, also getting the final single expression for
     // the entire constraint system
     let (scheme, final_constraint) = DecomposableFoldingScheme::<TestFoldingConfig>::new(
         constraints.clone(),
@@ -448,7 +448,7 @@ fn test_decomposable_folding() {
     //fold mixed
     debug!("fold mixed");
     {
-        // here we use already relaxed pairs, which have a trival x -> x implementation
+        // here we use already relaxed pairs, which have a trivial x -> x implementation
         let folded = scheme.fold_instance_witness_pair(left, right, None, &mut fq_sponge);
         let FoldingOutput {
             folded_instance,

--- a/folding/tests/test_folding_with_quadriticization.rs
+++ b/folding/tests/test_folding_with_quadriticization.rs
@@ -35,7 +35,7 @@ pub enum TestColumn {
     C,
 }
 
-// the type for the dynamic selectors, which are esentially witness columns, but
+// the type for the dynamic selectors, which are essentially witness columns, but
 // get special treatment to enable optimizations
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub enum DynamicSelector {
@@ -57,7 +57,7 @@ impl FoldingColumnTrait for TestColumn {
 pub struct TestInstance {
     // 3 from the normal witness + 2 from the dynamic selectors
     commitments: [Curve; 5],
-    // for ilustration only, no constraint in this example uses challenges
+    // for illustration only, no constraint in this example uses challenges
     challenges: [Fp; 3],
     // also challenges, but segregated as folding gives them special treatment
     alphas: Alphas<Fp>,
@@ -109,7 +109,7 @@ pub struct TestFoldingEnv {
 /// Our witness is going to be the polynomials that we will commit too.
 /// Vec<Fp> will be the evaluations of each x_1, x_2 and x_3 over the domain.
 /// This witness includes not only the 3 normal witness columns, but also the
-/// 2 dynamic selector columns that are esentially witness
+/// 2 dynamic selector columns that are essentially witness
 #[derive(Clone)]
 pub struct TestWitness([Evaluations<Fp, Radix2EvaluationDomain<Fp>>; 5]);
 
@@ -140,7 +140,7 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, TestColumn, TestChallenge, Dynami
         // here it is mostly storing the pairs into self, and also computing
         // other things we may need later like the shifted versions, note there
         // are more efficient ways of handling the rotated witnesses, which are
-        // just for example as no contraint uses them anyway
+        // just for example as no constraint uses them anyway
         let curr_witnesses = [witnesses[0].clone(), witnesses[1].clone()];
         let mut next_witnesses = curr_witnesses.clone();
         for side in next_witnesses.iter_mut() {
@@ -160,14 +160,14 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, TestColumn, TestChallenge, Dynami
     // provide access to columns, here side refers to one of the two pairs you
     // got in new()
     fn col(&self, col: TestColumn, curr_or_next: CurrOrNext, side: Side) -> &[Fp] {
-        let wit = match curr_or_next {
+        let with = match curr_or_next {
             CurrOrNext::Curr => &self.curr_witnesses[side as usize],
             CurrOrNext::Next => &self.next_witnesses[side as usize],
         };
         match col {
-            TestColumn::A => &wit.0[0].evals,
-            TestColumn::B => &wit.0[1].evals,
-            TestColumn::C => &wit.0[2].evals,
+            TestColumn::A => &with.0[0].evals,
+            TestColumn::B => &with.0[1].evals,
+            TestColumn::C => &with.0[2].evals,
         }
     }
 
@@ -185,10 +185,10 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, TestColumn, TestChallenge, Dynami
     // the implementation of this if the same as col(), it is just separated as they
     // have different types to resolve
     fn selector(&self, s: &DynamicSelector, side: Side) -> &[Fp] {
-        let wit = &self.curr_witnesses[side as usize];
+        let with = &self.curr_witnesses[side as usize];
         match s {
-            DynamicSelector::SelecAdd => &wit.0[3].evals,
-            DynamicSelector::SelecMul => &wit.0[4].evals,
+            DynamicSelector::SelecAdd => &with.0[3].evals,
+            DynamicSelector::SelecMul => &with.0[4].evals,
         }
     }
 }
@@ -262,7 +262,7 @@ fn instance_from_witness(
         .collect_vec();
     let commitments: [_; 5] = commitments.try_into().unwrap();
 
-    // here we should absorve the commitments and similar things to later compute challenges
+    // here we should absorb the commitments and similar things to later compute challenges
     // but for this example I just use random values
     let mut rng = thread_rng();
     let mut challenge = || Fp::rand(&mut rng);
@@ -347,7 +347,7 @@ fn test_quadriticization() {
 
     let mut fq_sponge = BaseSponge::new(Curve::other_curve_sponge_params());
 
-    // initiallize the scheme, also getting the final single expression for
+    // initialize the scheme, also getting the final single expression for
     // the entire constraint system
     let (scheme, final_constraint) = DecomposableFoldingScheme::<TestFoldingConfig>::new(
         constraints.clone(),
@@ -473,7 +473,7 @@ fn test_quadriticization() {
     {
         let mut fq_sponge_before_fold = fq_sponge.clone();
 
-        // here we use already relaxed pairs, which have a trival x -> x implementation
+        // here we use already relaxed pairs, which have a trivial x -> x implementation
         let folded = scheme.fold_instance_witness_pair(left, right, None, &mut fq_sponge);
         let FoldingOutput {
             folded_instance,

--- a/folding/tests/test_vanilla_folding.rs
+++ b/folding/tests/test_vanilla_folding.rs
@@ -136,14 +136,14 @@ impl FoldingEnv<Fp, TestInstance, TestWitness, Column, TestChallenge, ()> for Te
     }
 
     fn col(&self, col: Column, curr_or_next: CurrOrNext, side: Side) -> &[Fp] {
-        let wit = match curr_or_next {
+        let with = match curr_or_next {
             CurrOrNext::Curr => &self.curr_witnesses[side as usize],
             CurrOrNext::Next => &self.next_witnesses[side as usize],
         };
         match col {
-            Column::X(0) => &wit.0[0].evals,
-            Column::X(1) => &wit.0[1].evals,
-            Column::X(2) => &wit.0[2].evals,
+            Column::X(0) => &with.0[0].evals,
+            Column::X(1) => &with.0[1].evals,
+            Column::X(2) => &with.0[2].evals,
             Column::Selector(0) => &self.structure.s_add,
             Column::Selector(1) => &self.structure.s_mul,
             // Only 3 columns and 2 selectors

--- a/hasher/src/poseidon.rs
+++ b/hasher/src/poseidon.rs
@@ -19,7 +19,7 @@ use super::{domain_prefix_to_field, Hashable, Hasher};
 /// Poseidon hasher context
 //
 //  The arithmetic sponge parameters are large and costly to initialize,
-//  so we only want to do this once and then re-use the Poseidon context
+//  so we only want to do this once and then reuse the Poseidon context
 //  for many hashes. Also, following approach of the mina code we store
 //  a backup of the initialized sponge state for efficient reuse.
 pub struct Poseidon<SC: SpongeConstants, H: Hashable> {

--- a/mvpoly/src/lib.rs
+++ b/mvpoly/src/lib.rs
@@ -264,7 +264,7 @@ pub trait MVPoly<F: PrimeField, const N: usize, const D: usize>:
     /// scaling factor as a variable.
     ///
     /// This method is particularly useful when you need to compute a
-    /// (possibly random) combinaison of polynomials `P1(X1, ..., Xn), ...,
+    /// (possibly random) combination of polynomials `P1(X1, ..., Xn), ...,
     /// Pm(X1, ..., Xn)`, like when computing a quotient polynomial in the PlonK
     /// PIOP, as the result is the sum of individual "scaled" polynomials:
     /// ```text

--- a/utils/src/array.rs
+++ b/utils/src/array.rs
@@ -136,7 +136,7 @@ mod tests {
     }
 
     #[test]
-    /// Tests whether boxed array tranformations preserve the elements.
+    /// Tests whether boxed array transformations preserve the elements.
     fn test_boxed_stack_completeness() {
         let mut rng = crate::tests::make_test_rng(None);
 


### PR DESCRIPTION
## Summary
- Fixed typos and misspelled words across multiple files
- Changed 'esentially' to 'essentially'
- Changed 'wit' to 'with' in variable names
- Changed 'homogenous' to 'homogeneous'
- Changed 'initiallize' to 'initialize'
- Changed 'contraint' to 'constraint'
- Changed 'berkley' to 'berkeley'
- Changed 'combinaison' to 'combination'
- Changed 'trival' to 'trivial'
- Fixed other miscellaneous typos

This PR builds on top of the typo checking workflow PR, fixing the actual typos in the codebase that were identified.

🤖 Generated with [Claude Code](https://claude.ai/code)