### PR TITLE
Move params.sage into its own script directory

### DIFF
--- a/poseidon/scripts/README.md
+++ b/poseidon/scripts/README.md
@@ -1,0 +1,83 @@
+# Utility scripts
+
+## params.sage
+
+A script for generating cryptographic parameters (round constants and MDS
+matrices) for the Poseidon hash function over Pasta fields.
+
+### Overview
+
+This SageMath script generates secure parameters for the Poseidon hash function,
+which is used in zero-knowledge proof systems. It creates:
+
+- Round constants
+- MDS (Maximum Distance Separable) matrices
+
+These parameters can be output in either Rust or OCaml format for use in
+cryptographic implementations.
+
+### Requirements
+
+- [SageMath](https://www.sagemath.org/)
+- Python 3.x
+
+### Usage
+
+```bash
+./params.sage [language] [width] [name] [--rounds ROUNDS]
+```
+
+#### Parameters
+
+- `language`: Output format (`rust` or `ocaml`)
+- `width`: Sponge width (typically 3 or 5)
+- `name`: Parameter set name (use '' for legacy mode)
+- `--rounds`: Number of round constants (default: 100)
+
+#### Examples
+
+Generate legacy 3-wire Poseidon parameters in Rust format:
+```bash
+./params.sage rust 3 ''
+```
+
+Generate named 3-wire Poseidon parameters with 54 rounds:
+```bash
+./params.sage rust 3 3 --rounds 54
+```
+
+Generate parameters for the "kimchi" parameter set:
+```bash
+./params.sage rust 3 kimchi --rounds 55
+```
+
+### Operating Modes
+
+#### Legacy Mode
+
+Activated when `name` is set to '' and width is either 3 or 5. Used for the
+original Poseidon implementations.
+
+#### Named Mode
+
+The current recommended approach where each parameter set has a unique name,
+ensuring completely unique parameters for each hash function definition.
+
+### Parameter Sets
+
+| Name   | Parameters                     |
+|--------|--------------------------------|
+| ''     | Reserved for legacy            |
+| kimchi | rounds=55, width=3, rate=2, alpha=7 |
+
+### Implementation Details
+
+The script uses deterministic randomness based on cryptographic hashing
+(SHA-256) to generate the parameters. The MDS matrices are created using the
+Cauchy matrix construction method to ensure they have the necessary
+cryptographic properties.
+
+### Output
+
+The script outputs parameter declarations ready to be included in Rust or OCaml
+code.

--- a/poseidon/scripts/README.md
+++ b/poseidon/scripts/README.md
@@ -42,7 +42,7 @@ Generate legacy width 3 Poseidon parameters in Rust format:
 ./params.sage rust 3 ''
 ```
 
-Generate named 3-wire Poseidon parameters with 54 rounds:
+Generate width 3 Poseidon parameters with 54 rounds:
 ```bash
 ./params.sage rust 3 3 --rounds 54
 ```

--- a/poseidon/scripts/README.md
+++ b/poseidon/scripts/README.md
@@ -37,7 +37,7 @@ cryptographic implementations.
 
 #### Examples
 
-Generate legacy 3-wire Poseidon parameters in Rust format:
+Generate legacy width 3 Poseidon parameters in Rust format:
 ```bash
 ./params.sage rust 3 ''
 ```

--- a/poseidon/scripts/README.md
+++ b/poseidon/scripts/README.md
@@ -3,7 +3,8 @@
 ## params.sage
 
 A script for generating cryptographic parameters (round constants and MDS
-matrices) for the Poseidon hash function over Pasta fields.
+matrices) for the Poseidon hash function over Pasta fields. The Poseidon
+instance it generates parameters for are only based on full rounds.
 
 ### Overview
 

--- a/poseidon/scripts/README.md
+++ b/poseidon/scripts/README.md
@@ -8,8 +8,8 @@ instance it generates parameters for are only based on full rounds.
 
 ### Overview
 
-This SageMath script generates secure parameters for the Poseidon hash function,
-which is used in zero-knowledge proof systems. It creates:
+This SageMath script generates secure parameters for the Poseidon hash function.
+It creates:
 
 - Round constants
 - MDS (Maximum Distance Separable) matrices

--- a/poseidon/scripts/params.sage
+++ b/poseidon/scripts/params.sage
@@ -1,29 +1,5 @@
 #!/usr/bin/env sage
 
-# This script generates the round constants and MDS matrices for poseidon for the pasta fields.
-#
-# There are two modes of operation: legacy mode and named mode.  Legacy mode is enabled when
-# the name argument is set to '' and the width is either 3 or 5.  These were the parameter sets
-# used for the first 3-wire and 5-wire poseidon instances.  These parameters are generated with:
-#
-#   ./params.sage rust 3 ''
-#   ./params.sage rust 5 ''
-#
-# The language parameter can be either "rust" or "ocaml"
-#
-# Named mode is the currently used mode for parameter generation and requires each parameter
-# set to be given a unique name so that completely unique parameters are created for each
-# definition of a cryptographic hash function.  The latest 3-wire poseidon can be generated with
-#
-#   ./params.sage rust 3 3 --rounds 54
-#
-# Currently used names
-#
-#   Name   | Parameters
-#   -----------------
-#   ''     | Reserved for legacy
-#   kimchi | rounds=55, width=3, rate=2, alpha=7
-
 import hashlib
 import sys
 import argparse


### PR DESCRIPTION
Moving into a nested directory, and add a README (generated by Claude) to explain more in details.
Multiple times people ask what the script was supposed to be doing, and why it was there.
Intermediary, small pull request clarifying this.