### PR TITLE
Fix clippy & suppress plonk-wasm deprecated clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
   CARGO_TERM_COLOR: always
   # 30 MB of stack for Keccak tests
   RUST_MIN_STACK: 31457280
-  CARGO_EXTRA_ARGS: "--workspace --exclude plonk_wasm --exclude saffron"
+  CARGO_EXTRA_ARGS: "--workspace --exclude plonk_wasm"
 
 jobs:
   run_mdbook:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
   CARGO_TERM_COLOR: always
   # 30 MB of stack for Keccak tests
   RUST_MIN_STACK: 31457280
-  CARGO_EXTRA_ARGS: "--workspace --exclude plonk_wasm"
+  CARGO_EXTRA_ARGS: "--workspace"
 
 jobs:
   run_mdbook:

--- a/plonk-wasm/src/pasta_fp_plonk_index.rs
+++ b/plonk-wasm/src/pasta_fp_plonk_index.rs
@@ -267,9 +267,11 @@ pub fn caml_pasta_fp_plonk_index_write(
         .map_err(|e| JsValue::from_str(&format!("caml_pasta_fp_plonk_index_read: {e}")))
 }
 
+#[allow(deprecated)]
 #[wasm_bindgen]
 pub fn caml_pasta_fp_plonk_index_serialize(index: &WasmPastaFpPlonkIndex) -> String {
     let serialized = rmp_serde::to_vec(&index.0).unwrap();
+    // Deprecated used on purpose: updating this leads to a bug in o1js
     base64::encode(serialized)
 }
 

--- a/plonk-wasm/src/pasta_fq_plonk_index.rs
+++ b/plonk-wasm/src/pasta_fq_plonk_index.rs
@@ -266,8 +266,10 @@ pub fn caml_pasta_fq_plonk_index_write(
         .map_err(|e| JsValue::from_str(&format!("caml_pasta_fq_plonk_index_read: {e}")))
 }
 
+#[allow(deprecated)]
 #[wasm_bindgen]
 pub fn caml_pasta_fq_plonk_index_serialize(index: &WasmPastaFqPlonkIndex) -> String {
     let serialized = rmp_serde::to_vec(&index.0).unwrap();
+    // Deprecated used on purpose: updating this leads to a bug in o1js
     base64::encode(serialized)
 }

--- a/plonk-wasm/src/plonk_proof.rs
+++ b/plonk-wasm/src/plonk_proof.rs
@@ -615,9 +615,11 @@ macro_rules! impl_proof {
                 }
 
                 #[wasm_bindgen]
+                #[allow(deprecated)]
                 pub fn serialize(&self) -> String {
                     let (proof, _public_input) = self.into();
                     let serialized = rmp_serde::to_vec(&proof).unwrap();
+                    // Deprecated used on purpose: updating this leads to a bug in o1js
                     base64::encode(serialized)
                 }
             }

--- a/saffron/src/read_proof.rs
+++ b/saffron/src/read_proof.rs
@@ -307,21 +307,17 @@ mod tests {
 
         let data: Vec<ScalarField> = {
             let mut data = vec![];
-            (0..SRS_SIZE)
-                .into_iter()
-                .for_each(|_| data.push(Fp::rand(&mut rng)));
+            (0..SRS_SIZE).for_each(|_| data.push(Fp::rand(&mut rng)));
             data
         };
 
         let data_poly: DensePolynomial<ScalarField> =
-            Evaluations::from_vec_and_domain(data.clone(), (*DOMAIN).d1).interpolate();
+            Evaluations::from_vec_and_domain(data.clone(), DOMAIN.d1).interpolate();
         let data_comm: Curve = SRS.commit_non_hiding(&data_poly, 1).chunks[0];
 
         let query: Vec<ScalarField> = {
             let mut query = vec![];
-            (0..SRS_SIZE)
-                .into_iter()
-                .for_each(|_| query.push(Fp::from(rand::thread_rng().gen::<f64>() < 0.1)));
+            (0..SRS_SIZE).for_each(|_| query.push(Fp::from(rand::thread_rng().gen::<f64>() < 0.1)));
             query
         };
 


### PR DESCRIPTION
This fixes some clippy warnings:
- Fixes saffron related warnings. Also un-excludes saffron from CI so that these checks are done before merging.
- Suppresses plonk-wasm deprication warnings (https://github.com/o1-labs/proof-systems/pull/3163). Un-excludes plonk-wasm from CI, same reasoning.