### PR TITLE
plonk-wasm: Fix the warning until we can update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,8 +222,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-macros"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+source = "git+https://github.com/richardpringle/algebra?branch=fix-warning#3f06040925f313f3dcaaebafa69e94a664eb200c"
 dependencies = [
  "num-bigint",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,9 @@ signer = { path = "./signer", version = "0.1.0" }
 turshi = { path = "./turshi", version = "0.1.0" }
 utils = { path = "./utils", version = "0.1.0" }
 
+[patch.crates-io]
+ark-ff-macros = { git = "https://github.com/richardpringle/algebra", branch = "fix-warning", package = "ark-ff-macros" }
+
 [profile.release]
 lto = true
 panic = 'abort'


### PR DESCRIPTION
`ark-ff` contains breaking changes so it might take a while to update.
On the current version of Rust, we get a bunch of annoying scoping
warnings that are easily fixed. I've got an open PR to
`arkworks-rs/algebra` (the workspace repo) to backport there changes
from `0.5.x` onto a 0.4.x branch. Hopefully they accept the PR and do a
new patch release. If not, we can update the dependency.

The `arkworks` team doesn't currrently have a branch to support patches, but maybe they'll consider it
