### PR TITLE
Add a benchmark comparing IPA commitment w/ and w/o Lagrange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,6 +2818,7 @@ dependencies = [
  "itertools 0.12.1",
  "mina-curves",
  "mina-poseidon",
+ "num-bigint",
  "o1-utils",
  "ocaml",
  "ocaml-gen",

--- a/poly-commitment/Cargo.toml
+++ b/poly-commitment/Cargo.toml
@@ -18,6 +18,7 @@ ark-serialize.workspace = true
 blake2.workspace = true
 hex.workspace = true
 itertools.workspace = true
+num-bigint.workspace = true
 once_cell.workspace = true
 rand.workspace = true
 rand_core.workspace = true

--- a/poly-commitment/benches/ipa.rs
+++ b/poly-commitment/benches/ipa.rs
@@ -1,14 +1,20 @@
 //! Run this bench using `cargo criterion -p poly-commitment --bench ipa`
 
-use ark_ff::UniformRand;
-use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, Radix2EvaluationDomain};
+use ark_ff::{UniformRand, Zero};
+use ark_poly::{
+    univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, Evaluations,
+    Radix2EvaluationDomain,
+};
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use groupmap::GroupMap;
 use mina_curves::pasta::{Fp, Vesta, VestaParameters};
 use mina_poseidon::{constants::PlonkSpongeConstantsKimchi, sponge::DefaultFqSponge, FqSponge};
+use num_bigint::BigUint;
+use o1_utils::{BigUintFieldHelpers, FieldHelpers};
 use poly_commitment::{
     commitment::CommitmentCurve, ipa::SRS, utils::DensePolynomialOrEvaluations, PolyComm, SRS as _,
 };
+use rand::Rng;
 
 fn benchmark_ipa_commit_vesta(c: &mut Criterion) {
     let mut group = c.benchmark_group("IPA Commit");
@@ -33,6 +39,89 @@ fn benchmark_ipa_commit_vesta(c: &mut Criterion) {
                             DensePolynomial::<Fp>::from_coefficients_vec(poly_coefficients)
                         },
                         |poly| black_box(srs.commit_non_hiding(&poly, chunks_n)),
+                        BatchSize::LargeInput,
+                    )
+                },
+            );
+        }
+    }
+}
+
+// This benchmark demonstrates that
+// `commit_evaluations_non_hiding` is generally faster than
+// `commit_non_hiding` when committing evaluations; and especially so
+// when the evaluations vector is sparse or contains small elements.
+fn benchmark_ipa_commit_evals_vesta(c: &mut Criterion) {
+    let mut group = c.benchmark_group("IPA Commit Evaluations");
+    let mut rng = o1_utils::tests::make_test_rng(None);
+
+    group.measurement_time(core::time::Duration::from_secs(10));
+
+    let srs_size_log = 15;
+
+    let n = 1 << srs_size_log;
+    let srs = SRS::<Vesta>::create(n);
+    let domain = Radix2EvaluationDomain::new(n).unwrap();
+    srs.get_lagrange_basis_from_domain_size(n);
+
+    for sparsity in [0.05, 0.2, 0.5, 0.99].into_iter() {
+        for bitlen in [16, 32, 64, 128, 256].into_iter() {
+            // When bitlen > |Fp|, Fp::rand() % bitlenmod will return
+            // just field value without performing modulo reduction.
+            let bitlenmod: BigUint = Fp::from(1).to_biguint() << bitlen;
+            group.bench_function(
+                format!(
+                    "com w/o Lagrange (|SRS| 2^{{{}}}, sparsity {}%, bitlen {})",
+                    srs_size_log,
+                    (sparsity * 100.0) as usize,
+                    bitlen
+                ),
+                |b| {
+                    b.iter_batched(
+                        || {
+                            let evaluations: Vec<Fp> = (0..n)
+                                .map(|_| {
+                                    if rng.gen::<f64>() < sparsity {
+                                        (Fp::rand(&mut rng).to_biguint() % bitlenmod.clone())
+                                            .to_field()
+                                            .unwrap()
+                                    } else {
+                                        Fp::zero()
+                                    }
+                                })
+                                .collect();
+                            Evaluations::from_vec_and_domain(evaluations, domain)
+                        },
+                        |evals| black_box(srs.commit_non_hiding(&evals.interpolate(), 1)),
+                        BatchSize::LargeInput,
+                    )
+                },
+            );
+
+            group.bench_function(
+                format!(
+                    "com Lagrange (|SRS| 2^{{{}}}, sparsity {}%, bitlen {})",
+                    srs_size_log,
+                    (sparsity * 100.0) as usize,
+                    bitlen
+                ),
+                |b| {
+                    b.iter_batched(
+                        || {
+                            let evaluations: Vec<Fp> = (0..n)
+                                .map(|_| {
+                                    if rng.gen::<f64>() < sparsity {
+                                        (Fp::rand(&mut rng).to_biguint() % bitlenmod.clone())
+                                            .to_field()
+                                            .unwrap()
+                                    } else {
+                                        Fp::zero()
+                                    }
+                                })
+                                .collect();
+                            Evaluations::from_vec_and_domain(evaluations, domain)
+                        },
+                        |evals| black_box(srs.commit_evaluations_non_hiding(domain, &evals)),
                         BatchSize::LargeInput,
                     )
                 },
@@ -88,6 +177,7 @@ fn benchmark_ipa_open_vesta(c: &mut Criterion) {
 criterion_group!(
     benches,
     benchmark_ipa_commit_vesta,
+    benchmark_ipa_commit_evals_vesta,
     benchmark_ipa_open_vesta
 );
 criterion_main!(benches);


### PR DESCRIPTION
Adds the subj benchmark. I wanted to see where exactly the tradeoff is located in terms of using `commit_non_hiding(evals.interpolate())` vs `commit_evaluations(&evals)`.

Results below.