### PR TITLE
Fix bench mina circuit CI job: don't require target/ to be present

### DIFF
--- a/.github/workflows/benches-mina-prover.yml
+++ b/.github/workflows/benches-mina-prover.yml
@@ -42,11 +42,7 @@ jobs:
           set -x
           pwd
           sleep 1
-          ls target/
-          sleep 1
           ls .
-          sleep 1
-          ls criterion-ps-mina-master-baseline/
           sleep 1
           tree criterion-ps-mina-master-baseline/
           sleep 1


### PR DESCRIPTION
The CI error in some PRs (e.g. here https://github.com/o1-labs/proof-systems/actions/runs/14995579037/job/42128868995) was present because the script assumed `target/` directory present in the repo. Which is absent until you build it for the first time. Before it was present I guess due to build caching. 

This PR removes the requirement.