### PR TITLE
Revert "Cargo: remove config.toml defining alias"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"


### PR DESCRIPTION
I don't think the alias actually causes any problems and is convenient for local development. We just can't use the alias in the makefile

