### PR TITLE
[saffron] Add as_indices method to QueryField

### DIFF
--- a/saffron/src/utils.rs
+++ b/saffron/src/utils.rs
@@ -99,6 +99,18 @@ impl<F: PrimeField> QueryField<F> {
 
         answer[(self.leftover_start)..(answer.len() - self.leftover_end)].to_vec()
     }
+
+    /// Returns the indices of the field elements that are used to answer the query
+    pub fn as_indices(self, n_chunks: usize) -> Vec<Vec<usize>> {
+        let mut result: Vec<Vec<usize>> = Vec::with_capacity(n_chunks);
+        self.start
+            .into_iter()
+            .take_while(|x| x <= &self.end)
+            .for_each(|x| {
+                result[x.poly_index].push(x.eval_index);
+            });
+        result
+    }
 }
 
 impl Iterator for FieldElt {


### PR DESCRIPTION
This method will allow us to convert a `QueryField` value into a format useful for the prove method.

For context, before this PR you can construct a query as a value of type `QueryBytes` which is just an offset and a length. From there you can conver to `QueryField`, but since the fields are private you can't convert this to what we normally call a "query", which is like a `0/1` vector of length = domain size