### PR TITLE
Deps: Removing serde_json exact version pin, replaced with semver caret.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ rmp-serde = "=1.2.0"
 secp256k1 = "0.28.2"
 serde = { version = "=1.0.219", features = ["derive", "rc"] }
 serde-wasm-bindgen = "=0.6.5"
-serde_json = "=1.0.109"
+serde_json = "^1.0.109"
 serde_with = "3.12"
 sha2 = "0.10.0"
 sha3 = "0.10.8"


### PR DESCRIPTION
Motivation:

Proof-systems needs to co-exist with other rust libraries. Pinning the version of serde_json (a very common library) to a specific (older) version is very restrictive. Requesting it be unpinned and replaced with caret.