### PR TITLE
Deps: bump up arkworks to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,9 +147,9 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "ark-algebra-test-templates"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400bd3a79c741b1832f1416d4373ae077ef82ca14a8b4cee1248a2f11c8b9172"
+checksum = "fd4c6293624cb11978fe9940af61faa16e85431fa9993ed2e11ea422099a564c"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -161,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "ark-bn254"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -172,17 +178,21 @@ dependencies = [
 
 [[package]]
 name = "ark-ec"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
+ "ahash",
  "ark-ff",
  "ark-poly",
  "ark-serialize",
  "ark-std",
- "derivative",
- "hashbrown 0.13.2",
- "itertools 0.10.5",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.3",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
  "num-traits",
  "rayon",
  "zeroize",
@@ -190,90 +200,94 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
  "ark-std",
- "derivative",
+ "arrayvec",
  "digest",
- "itertools 0.10.5",
+ "educe",
+ "itertools 0.13.0",
  "num-bigint",
  "num-traits",
  "paste",
  "rayon",
- "rustc_version",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "ark-ff-macros"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
  "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "ark-poly"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
+ "ahash",
  "ark-ff",
  "ark-serialize",
  "ark-std",
- "derivative",
- "hashbrown 0.13.2",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.3",
  "rayon",
 ]
 
 [[package]]
 name = "ark-serialize"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
+ "arrayvec",
  "digest",
  "num-bigint",
+ "rayon",
 ]
 
 [[package]]
 name = "ark-serialize-derive"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "ark-std"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
  "rand",
@@ -282,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "ark-test-curves"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c22c2469f93dfcace9a98baabb7af1bc0c40de82c07cffbc0deba4acf41a90"
+checksum = "5cc137bb3271671a597ae79157030f88affe9fa7975207c3b781a01cb9ed0372"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -333,6 +347,12 @@ dependencies = [
  "strum",
  "strum_macros",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "askama"
@@ -1129,6 +1149,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1183,26 @@ name = "entities"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "env_filter"
@@ -1439,6 +1491,9 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1800,6 +1855,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -3218,15 +3282,6 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,14 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-ark-algebra-test-templates = "0.4.2"
-ark-bn254 = { version = "0.4.0" }
-ark-ec = { version = "0.4.2", features = ["parallel"] }
-ark-ff = { version = "0.4.2", features = ["parallel", "asm"] }
-ark-poly = { version = "0.4.2", features = ["parallel"] }
-ark-serialize = "0.4.2"
-ark-std = { version = "0.4.0", features = ["parallel"] }
-ark-test-curves = { version = "0.4.2", features = ["parallel", "asm"] }
+ark-algebra-test-templates = "0.5"
+ark-bn254 = { version = "0.5" }
+ark-ec = { version = "0.5", features = ["parallel"] }
+ark-ff = { version = "0.5", features = ["parallel", "asm"] }
+ark-poly = { version = "0.5", features = ["parallel"] }
+ark-serialize = "0.5"
+ark-std = { version = "0.5", features = ["parallel"] }
+ark-test-curves = { version = "0.5", features = ["parallel", "asm"] }
 base64 = "0.21.5"
 bcs = "0.1.3"
 bitvec = "1.0.0"

--- a/arrabbiata/tests/witness.rs
+++ b/arrabbiata/tests/witness.rs
@@ -1,4 +1,4 @@
-use ark_ec::{AffineRepr, Group};
+use ark_ec::{AffineRepr, PrimeGroup};
 use ark_ff::{PrimeField, UniformRand};
 use arrabbiata::{
     curve::PlonkSpongeConstants,

--- a/folding/src/checker.rs
+++ b/folding/src/checker.rs
@@ -6,7 +6,7 @@ use crate::{
     instance_witness::Instance,
     ExpExtension, FoldingConfig, Radix2EvaluationDomain, RelaxedInstance, RelaxedWitness,
 };
-use ark_ec::AffineRepr;
+use ark_ec::{AdditiveGroup, AffineRepr};
 use ark_ff::{Field, Zero};
 use ark_poly::Evaluations;
 use core::ops::Index;

--- a/folding/src/error_term.rs
+++ b/folding/src/error_term.rs
@@ -10,6 +10,7 @@ use crate::{
     quadraticization::ExtendedWitnessGenerator,
     FoldingConfig, FoldingEnv, Instance, RelaxedInstance, RelaxedWitness, ScalarField,
 };
+use ark_ec::AdditiveGroup;
 use ark_ff::{Field, One, Zero};
 use ark_poly::{Evaluations, Radix2EvaluationDomain};
 use kimchi::circuits::expr::Variable;
@@ -47,8 +48,8 @@ pub(crate) fn eval_sided<'a, C: FoldingConfig>(
         Atom(col) => env.col(col, side),
         Double(e) => {
             let col = eval_sided(e, env, side);
-            col.map(Field::double, |f| {
-                Field::double_in_place(f);
+            col.map(AdditiveGroup::double, |f| {
+                AdditiveGroup::double_in_place(f);
             })
         }
         Square(e) => {
@@ -111,15 +112,15 @@ pub(crate) fn eval_exp_error<'a, C: FoldingConfig>(
         Atom(col) => env.col(col, side),
         Double(e) => {
             let col = eval_exp_error(e, env, side);
-            col.map(Field::double, |f| {
-                Field::double_in_place(f);
+            col.map(AdditiveGroup::double, |f| {
+                AdditiveGroup::double_in_place(f);
             })
         }
         Square(e) => match exp.folding_degree() {
             Degree::Two => {
                 let cross = eval_exp_error(e, env, side) * eval_exp_error(e, env, side.other());
-                cross.map(Field::double, |f| {
-                    Field::double_in_place(f);
+                cross.map(AdditiveGroup::double, |f| {
+                    AdditiveGroup::double_in_place(f);
                 })
             }
             _ => {

--- a/ivc/src/expr_eval.rs
+++ b/ivc/src/expr_eval.rs
@@ -1,6 +1,6 @@
 use crate::plonkish_lang::{CombinableEvals, PlonkishChallenge, PlonkishWitnessGeneric};
 use ark_ec::AffineRepr;
-use ark_ff::Field;
+use ark_ff::{AdditiveGroup, Field};
 use ark_poly::{Evaluations, Radix2EvaluationDomain as R2D};
 use core::ops::Index;
 use folding::{
@@ -115,8 +115,8 @@ impl<
             Atom(column) => self.process_extended_folding_column(column),
             Double(e) => {
                 let col = self.eval_naive_fexpr(e);
-                col.map(Field::double, |f| {
-                    Field::double_in_place(f);
+                col.map(AdditiveGroup::double, |f| {
+                    AdditiveGroup::double_in_place(f);
                 })
             }
             Square(e) => {
@@ -173,8 +173,8 @@ impl<
             }
             Double(e) => {
                 let col = self.eval_naive_fcompat(e);
-                col.map(Field::double, |f| {
-                    Field::double_in_place(f);
+                col.map(AdditiveGroup::double, |f| {
+                    AdditiveGroup::double_in_place(f);
                 })
             }
             Square(e) => {

--- a/ivc/src/prover.rs
+++ b/ivc/src/prover.rs
@@ -318,9 +318,7 @@ where
                 println!("Interpolated expression is zero");
             }
 
-            let (quotient, remainder) = interpolated
-                .divide_by_vanishing_poly(domain.d1)
-                .unwrap_or_else(|| panic!("ERROR: Cannot divide by vanishing polynomial"));
+            let (quotient, remainder) = interpolated.divide_by_vanishing_poly(domain.d1);
             if !remainder.is_zero() {
                 panic!("ERROR: Remainder is not zero for joint folding expression",);
             }

--- a/ivc/tests/simple.rs
+++ b/ivc/tests/simple.rs
@@ -832,9 +832,7 @@ pub fn heavy_test_simple_add() {
                     Evaluations::from_vec_and_domain(evaluations_d8.clone(), domain.d8)
                         .interpolate();
                 if !interpolated.is_zero() {
-                    let (_, remainder) = interpolated
-                        .divide_by_vanishing_poly(domain.d1)
-                        .unwrap_or_else(|| panic!("Cannot divide by vanishing polynomial"));
+                    let (_, remainder) = interpolated.divide_by_vanishing_poly(domain.d1);
                     if !remainder.is_zero() {
                         panic!("Remainder is not zero for expression #{expr_i}: {}", expr,);
                     }
@@ -916,9 +914,7 @@ pub fn heavy_test_simple_add() {
             let interpolated =
                 Evaluations::from_vec_and_domain(evaluations_big, evaluation_domain).interpolate();
             if !interpolated.is_zero() {
-                let (_, remainder) = interpolated
-                    .divide_by_vanishing_poly(domain.d1)
-                    .unwrap_or_else(|| panic!("ERROR: Cannot divide by vanishing polynomial"));
+                let (_, remainder) = interpolated.divide_by_vanishing_poly(domain.d1);
                 if !remainder.is_zero() {
                     panic!(
                         "ERROR: Remainder is not zero for joint expression: {}",

--- a/kimchi-stubs/src/projective.rs
+++ b/kimchi-stubs/src/projective.rs
@@ -1,4 +1,4 @@
-use ark_ec::{AffineRepr, CurveGroup, Group};
+use ark_ec::{AdditiveGroup, AffineRepr, CurveGroup, PrimeGroup};
 use ark_ff::UniformRand;
 use paste::paste;
 use rand::rngs::StdRng;

--- a/kimchi/src/circuits/polynomials/generic.rs
+++ b/kimchi/src/circuits/polynomials/generic.rs
@@ -362,10 +362,8 @@ pub mod testing {
             // would be better just to check the equation on all the rows.
 
             // verify that it is divisible by Z_H
-            match res.divide_by_vanishing_poly(self.cs.domain.d1) {
-                Some((_quotient, rest)) => rest.is_zero(),
-                None => false,
-            }
+            let (_quotient, rest) = res.divide_by_vanishing_poly(self.cs.domain.d1);
+            rest.is_zero()
         }
     }
 

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -66,8 +66,7 @@ macro_rules! check_constraint {
         if cfg!(debug_assertions) {
             let (_, res) = $evaluation
                 .interpolate_by_ref()
-                .divide_by_vanishing_poly($index.cs.domain.d1)
-                .unwrap();
+                .divide_by_vanishing_poly($index.cs.domain.d1);
             if !res.is_zero() {
                 panic!("couldn't divide by vanishing polynomial: {}", $label);
             }
@@ -873,9 +872,7 @@ where
             f += &public_poly;
 
             // divide contributions with vanishing polynomial
-            let (mut quotient, res) = f
-                .divide_by_vanishing_poly(index.cs.domain.d1)
-                .ok_or(ProverError::Prover("division by vanishing polynomial"))?;
+            let (mut quotient, res) = f.divide_by_vanishing_poly(index.cs.domain.d1);
             if !res.is_zero() {
                 return Err(ProverError::Prover(
                     "rest of division by vanishing polynomial",

--- a/kimchi/src/tests/ec.rs
+++ b/kimchi/src/tests/ec.rs
@@ -3,7 +3,7 @@ use crate::circuits::{
     gate::{CircuitGate, GateType},
     wires::*,
 };
-use ark_ec::{AffineRepr, CurveGroup};
+use ark_ec::{AdditiveGroup, AffineRepr, CurveGroup};
 use ark_ff::{Field, One, UniformRand, Zero};
 use core::{array, ops::Mul};
 use mina_curves::pasta::{Fp as F, Pallas as Other, Vesta, VestaParameters};

--- a/kimchi/src/tests/endomul.rs
+++ b/kimchi/src/tests/endomul.rs
@@ -6,8 +6,8 @@ use crate::{
     },
     tests::framework::TestFramework,
 };
-use ark_ec::{AffineRepr, CurveGroup};
-use ark_ff::{BigInteger, BitIteratorLE, Field, One, PrimeField, UniformRand, Zero};
+use ark_ec::{AdditiveGroup, AffineRepr, CurveGroup};
+use ark_ff::{BigInteger, BitIteratorLE, One, PrimeField, UniformRand, Zero};
 use core::{array, ops::Mul};
 use mina_curves::pasta::{Fp as F, Pallas as Other, Vesta, VestaParameters};
 use mina_poseidon::{

--- a/kimchi/src/tests/varbasemul.rs
+++ b/kimchi/src/tests/varbasemul.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     tests::framework::TestFramework,
 };
-use ark_ec::{AffineRepr, CurveGroup};
+use ark_ec::{AdditiveGroup, AffineRepr, CurveGroup};
 use ark_ff::{BigInteger, BitIteratorLE, Field, One, PrimeField, UniformRand, Zero};
 use mina_curves::pasta::{Fp as F, Pallas as Other, Vesta, VestaParameters};
 use mina_poseidon::{

--- a/msm/src/prover.rs
+++ b/msm/src/prover.rs
@@ -265,14 +265,11 @@ where
         let mut last_constraint_failed = None;
         // Only for debugging purposes
         for expr in constraints.iter() {
-            let fail_q_division =
-                ProverError::ConstraintNotSatisfied(format!("Unsatisfied expression: {:}", expr));
             // Check this expression are witness satisfied
             let (_, res) = expr
                 .evaluations(&column_env)
                 .interpolate_by_ref()
-                .divide_by_vanishing_poly(domain.d1)
-                .ok_or(fail_q_division.clone())?;
+                .divide_by_vanishing_poly(domain.d1);
             if !res.is_zero() {
                 eprintln!("Unsatisfied expression: {}", expr);
                 //return Err(fail_q_division);
@@ -313,9 +310,7 @@ where
         };
         // We compute the polynomial t(X) by dividing the constraints polynomial
         // by the vanishing polynomial, i.e. Z_H(X).
-        let (quotient, res) = expr_evaluation_interpolated
-            .divide_by_vanishing_poly(domain.d1)
-            .unwrap_or_else(fail_final_q_division);
+        let (quotient, res) = expr_evaluation_interpolated.divide_by_vanishing_poly(domain.d1);
         // As the constraints must be verified on H, the rest of the division
         // must be equal to 0 as the constraints polynomial and Z_H(X) are both
         // equal on H.

--- a/mvpoly/tests/monomials.rs
+++ b/mvpoly/tests/monomials.rs
@@ -1,4 +1,4 @@
-use ark_ff::{Field, One, UniformRand, Zero};
+use ark_ff::{AdditiveGroup, Field, One, UniformRand, Zero};
 use core::cmp::Ordering;
 use kimchi::circuits::{
     berkeley_columns::BerkeleyChallengeTerm,

--- a/o1vm/src/pickles/lookup_prover.rs
+++ b/o1vm/src/pickles/lookup_prover.rs
@@ -140,9 +140,7 @@ where
         Radix2EvaluationDomain<G::ScalarField>,
     > = constraint.evaluations(&eval_env);
     let t_numerator_poly = t_numerator_evaluation.interpolate();
-    let (t, rem) = t_numerator_poly
-        .divide_by_vanishing_poly(domain.d1)
-        .unwrap();
+    let (t, rem) = t_numerator_poly.divide_by_vanishing_poly(domain.d1);
     assert!(!rem.is_zero());
     let t_commitment = srs.commit_non_hiding(
         &t, 8, //TODO: check the degree,

--- a/o1vm/src/pickles/prover.rs
+++ b/o1vm/src/pickles/prover.rs
@@ -288,14 +288,11 @@ where
         // And we interpolate using the evaluations
         let expr_evaluation_interpolated = expr_evaluation.interpolate();
 
-        let fail_final_q_division = || panic!("Fail division by vanishing poly");
         let fail_remainder_not_zero =
             || panic!("The constraints are not satisfied since the remainder is not zero");
         // We compute the polynomial t(X) by dividing the constraints polynomial
         // by the vanishing polynomial, i.e. Z_H(X).
-        let (quotient, rem) = expr_evaluation_interpolated
-            .divide_by_vanishing_poly(domain.d1)
-            .unwrap_or_else(fail_final_q_division);
+        let (quotient, rem) = expr_evaluation_interpolated.divide_by_vanishing_poly(domain.d1);
         // As the constraints must be verified on H, the rest of the division
         // must be equal to 0 as the constraints polynomial and Z_H(X) are both
         // equal on H.

--- a/plonk-wasm/src/projective.rs
+++ b/plonk-wasm/src/projective.rs
@@ -1,4 +1,4 @@
-use ark_ec::{AffineRepr, CurveGroup, Group};
+use ark_ec::{AdditiveGroup, AffineRepr, CurveGroup, PrimeGroup};
 use ark_ff::UniformRand;
 use paste::paste;
 use rand::rngs::StdRng;

--- a/poly-commitment/benches/msm.rs
+++ b/poly-commitment/benches/msm.rs
@@ -90,7 +90,7 @@ fn benchmark_msm_vesta(c: &mut Criterion) {
 /// For even bigger MSMs (larger than 2^16), splitting in more chunks
 /// (e.g. 4) might be the best solution.
 fn benchmark_msm_parallel_vesta(c: &mut Criterion) {
-    use ark_ec::{AffineRepr, CurveGroup, Group, VariableBaseMSM};
+    use ark_ec::{AffineRepr, CurveGroup, PrimeGroup, VariableBaseMSM};
     use rayon::prelude::*;
 
     let max_threads_global = rayon::max_num_threads();

--- a/poly-commitment/src/combine.rs
+++ b/poly-commitment/src/combine.rs
@@ -16,8 +16,8 @@
 //! such a scratch array within each algorithm.
 
 use ark_ec::{
-    models::short_weierstrass::Affine as SWJAffine, short_weierstrass::SWCurveConfig, AffineRepr,
-    CurveGroup, Group,
+    models::short_weierstrass::Affine as SWJAffine, short_weierstrass::SWCurveConfig,
+    AdditiveGroup, AffineRepr, CurveGroup,
 };
 use ark_ff::{BitIteratorBE, Field, One, PrimeField, Zero};
 use itertools::Itertools;

--- a/poly-commitment/src/ipa.rs
+++ b/poly-commitment/src/ipa.rs
@@ -106,7 +106,7 @@ where
         base_fields.push(t)
     }
 
-    let t = G::BaseField::from_base_prime_field_elems(&base_fields).unwrap();
+    let t = G::BaseField::from_base_prime_field_elems(base_fields).unwrap();
 
     let (x, y) = map.to_group(t);
     G::of_coordinates(x, y).mul_by_cofactor()

--- a/poseidon/src/sponge.rs
+++ b/poseidon/src/sponge.rs
@@ -111,7 +111,7 @@ pub struct DefaultFrSponge<Fr: Field, SC: SpongeConstants> {
 fn pack<B: BigInteger>(limbs_lsb: &[u64]) -> B {
     let mut res: B = 0u64.into();
     for &x in limbs_lsb.iter().rev() {
-        res.muln(64);
+        res <<= 64;
         res.add_with_carry(&x.into());
     }
     res

--- a/saffron/src/folding.rs
+++ b/saffron/src/folding.rs
@@ -318,9 +318,7 @@ where
         let fail_final_q_division = || panic!("Division by vanishing poly must not fail");
         // We compute the polynomial t(X) by dividing the constraints polynomial
         // by the vanishing polynomial, i.e. Z_H(X).
-        let (quotient, res) = numerator_eval_interpolated
-            .divide_by_vanishing_poly(domain.d1)
-            .unwrap_or_else(fail_final_q_division);
+        let (quotient, res) = numerator_eval_interpolated.divide_by_vanishing_poly(domain.d1);
         // As the constraints must be verified on H, the rest of the division
         // must be equal to 0 as the constraints polynomial and Z_H(X) are both
         // equal on H.

--- a/saffron/src/read_proof.rs
+++ b/saffron/src/read_proof.rs
@@ -102,9 +102,7 @@ where
         };
         // We compute the polynomial t(X) by dividing the constraints polynomial
         // by the vanishing polynomial, i.e. Z_H(X).
-        let (quotient, res) = numerator_eval_interpolated
-            .divide_by_vanishing_poly(domain.d1)
-            .unwrap_or_else(fail_final_q_division);
+        let (quotient, res) = numerator_eval_interpolated.divide_by_vanishing_poly(domain.d1);
         // As the constraints must be verified on H, the rest of the division
         // must be equal to 0 as the constraints polynomial and Z_H(X) are both
         // equal on H.


### PR DESCRIPTION
See changelog: https://github.com/arkworks-rs/algebra/blob/master/CHANGELOG.md

See https://github.com/arkworks-rs/algebra/pull/850.

This is a path forward supporting more recent Rust version, and also bumping ocaml-rs.