### PR TITLE
Deps: remove some pinned versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ criterion = { version = "0.5", features = [
 ] }
 elf = "0.7.2"
 env_logger = "0.11.1"
-getrandom = { version = "=0.2.15", features = ["js"] }
+getrandom = { version = "0.2.15", features = ["js"] }
 hex = { version = "0.4", features = ["serde"] }
 iai = "0.1"
 itertools = "0.12.1"
@@ -65,18 +65,18 @@ ocaml = { version = "0.22.2" }
 ocaml-gen = { version = "1.0.0" }
 once_cell = "=1.21.3"
 os_pipe = { version = "1.1.4", features = ["io_safety"] }
-paste = "=1.0.15"
+paste = "1.0.15"
 proptest = "1.0.0"
 proptest-derive = "0.4.0"
-rand = { version = "=0.8.5", features = ["std_rng"] }
+rand = { version = "0.8.5", features = ["std_rng"] }
 rand_chacha = { version = "0.3.0" }
 rand_core = { version = "0.6.3" }
 rayon = "=1.10.0"
 regex = "1.10.2"
-rmp-serde = "=1.2.0"
+rmp-serde = "1.2.0"
 secp256k1 = "0.28.2"
-serde = { version = "=1.0.219", features = ["derive", "rc"] }
-serde-wasm-bindgen = "=0.6.5"
+serde = { version = "1.0.219", features = ["derive", "rc"] }
+serde-wasm-bindgen = "0.6.5"
 serde_json = "^1.0.109"
 serde_with = "3.12"
 sha2 = "0.10.0"


### PR DESCRIPTION
It was introduced while investigating a bug when moving kimchi-stubs and plonk-wasm. It ended up being base64