### PR TITLE
PU: Remove Lazy SRS, use test SRS instead

### DIFF
--- a/saffron/benches/folding_bench.rs
+++ b/saffron/benches/folding_bench.rs
@@ -31,8 +31,8 @@ fn bench_folding(c: &mut Criterion) {
     group.bench_function("folding_prover", |b| {
         b.iter_batched(
             || {
-                let relaxed = generate_random_inst_wit_relaxed(&srs, domain, &mut rng);
-                let core = generate_random_inst_wit_core(&srs, domain, &mut rng);
+                let relaxed = generate_random_inst_wit_relaxed(&srs, domain.d1, &mut rng);
+                let core = generate_random_inst_wit_core(&srs, domain.d1, &mut rng);
                 (core, relaxed)
             },
             |((core_instance, core_witness), (relaxed_instance, relaxed_witness))| {
@@ -53,9 +53,9 @@ fn bench_folding(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let (relaxed_instance, relaxed_witness) =
-                    generate_random_inst_wit_relaxed(&srs, domain, &mut rng);
+                    generate_random_inst_wit_relaxed(&srs, domain.d1, &mut rng);
                 let (core_instance, core_witness) =
-                    generate_random_inst_wit_core(&srs, domain, &mut rng);
+                    generate_random_inst_wit_core(&srs, domain.d1, &mut rng);
                 let (_, _, cross_term) = folding_prover(
                     &srs,
                     domain.d1,
@@ -79,7 +79,7 @@ fn bench_folding(c: &mut Criterion) {
 
     group.bench_function("prover_relaxed", |b| {
         b.iter_batched(
-            || generate_random_inst_wit_relaxed(&srs, domain, &mut rng),
+            || generate_random_inst_wit_relaxed(&srs, domain.d1, &mut rng),
             |(relaxed_instance, relaxed_witness)| {
                 black_box(prove_relaxed(
                     &srs,
@@ -95,7 +95,7 @@ fn bench_folding(c: &mut Criterion) {
     });
 
     let (relaxed_instance, relaxed_witness) =
-        generate_random_inst_wit_relaxed(&srs, domain, &mut rng);
+        generate_random_inst_wit_relaxed(&srs, domain.d1, &mut rng);
     let proof = prove_relaxed(
         &srs,
         domain,

--- a/saffron/benches/read_proof_bench.rs
+++ b/saffron/benches/read_proof_bench.rs
@@ -4,34 +4,19 @@ use ark_ff::{One, UniformRand, Zero};
 use ark_poly::{univariate::DensePolynomial, Evaluations};
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use kimchi::{circuits::domains::EvaluationDomains, groupmap::GroupMap};
-use mina_curves::pasta::{Fp, Vesta};
-use once_cell::sync::Lazy;
+use mina_curves::pasta::Fp;
 use poly_commitment::{commitment::CommitmentCurve, ipa::SRS, SRS as _};
 use rand::rngs::OsRng;
 use saffron::{
-    env,
     read_proof::{prove, verify},
-    ScalarField, SRS_SIZE,
+    Curve, ScalarField, SRS_SIZE,
 };
 
-// Set up static resources to avoid re-computation during benchmarks
-static SRS: Lazy<SRS<Vesta>> = Lazy::new(|| {
-    if let Ok(srs) = std::env::var("SRS_FILEPATH") {
-        env::get_srs_from_cache(srs)
-    } else {
-        SRS::create(SRS_SIZE)
-    }
-});
-
-static DOMAIN: Lazy<EvaluationDomains<ScalarField>> =
-    Lazy::new(|| EvaluationDomains::<ScalarField>::create(SRS_SIZE).unwrap());
-
-static GROUP_MAP: Lazy<<Vesta as CommitmentCurve>::Map> =
-    Lazy::new(<Vesta as CommitmentCurve>::Map::setup);
-
 fn generate_test_data(
+    srs: &SRS<Curve>,
+    domain: EvaluationDomains<ScalarField>,
     size: usize,
-) -> (Vec<ScalarField>, Vec<ScalarField>, Vec<ScalarField>, Vesta) {
+) -> (Vec<ScalarField>, Vec<ScalarField>, Vec<ScalarField>, Curve) {
     let mut rng = o1_utils::tests::make_test_rng(None);
 
     // Generate data with specified size
@@ -39,8 +24,8 @@ fn generate_test_data(
 
     // Create data commitment
     let data_poly: DensePolynomial<ScalarField> =
-        Evaluations::from_vec_and_domain(data.clone(), DOMAIN.d1).interpolate();
-    let data_comm: Vesta = SRS.commit_non_hiding(&data_poly, 1).chunks[0];
+        Evaluations::from_vec_and_domain(data.clone(), domain.d1).interpolate();
+    let data_comm: Curve = srs.commit_non_hiding(&data_poly, 1).chunks[0];
 
     // Generate query (about 10% of positions will be queried)
     let query: Vec<ScalarField> = (0..size)
@@ -60,7 +45,11 @@ fn generate_test_data(
 }
 
 fn bench_read_proof_prove(c: &mut Criterion) {
-    let (data, query, answer, data_comm) = generate_test_data(SRS_SIZE);
+    let srs = poly_commitment::precomputed_srs::get_srs_test();
+    let group_map = <Curve as CommitmentCurve>::Map::setup();
+    let domain: EvaluationDomains<ScalarField> = EvaluationDomains::create(srs.size()).unwrap();
+
+    let (data, query, answer, data_comm) = generate_test_data(&srs, domain, SRS_SIZE);
 
     let description = format!("prove size {}", SRS_SIZE);
     c.bench_function(description.as_str(), |b| {
@@ -68,9 +57,9 @@ fn bench_read_proof_prove(c: &mut Criterion) {
             || OsRng,
             |mut rng| {
                 black_box(prove(
-                    &SRS,
-                    *DOMAIN,
-                    &GROUP_MAP,
+                    &srs,
+                    domain,
+                    &group_map,
                     &mut rng,
                     data.as_slice(),
                     query.as_slice(),
@@ -84,14 +73,18 @@ fn bench_read_proof_prove(c: &mut Criterion) {
 }
 
 fn bench_read_proof_verify(c: &mut Criterion) {
-    let (data, query, answer, data_comm) = generate_test_data(SRS_SIZE);
+    let srs = poly_commitment::precomputed_srs::get_srs_test();
+    let group_map = <Curve as CommitmentCurve>::Map::setup();
+    let domain: EvaluationDomains<ScalarField> = EvaluationDomains::create(srs.size()).unwrap();
+
+    let (data, query, answer, data_comm) = generate_test_data(&srs, domain, SRS_SIZE);
 
     // Create proof first
     let mut rng = OsRng;
     let proof = prove(
-        &SRS,
-        *DOMAIN,
-        &GROUP_MAP,
+        &srs,
+        domain,
+        &group_map,
         &mut rng,
         data.as_slice(),
         query.as_slice(),
@@ -105,7 +98,7 @@ fn bench_read_proof_verify(c: &mut Criterion) {
             || OsRng,
             |mut rng| {
                 black_box(verify(
-                    &SRS, *DOMAIN, &GROUP_MAP, &mut rng, &data_comm, &proof,
+                    &srs, domain, &group_map, &mut rng, &data_comm, &proof,
                 ))
             },
             BatchSize::SmallInput,

--- a/saffron/src/blob.rs
+++ b/saffron/src/blob.rs
@@ -135,8 +135,6 @@ impl FieldBlob {
 
 #[cfg(test)]
 mod tests {
-    use crate::env;
-
     use super::*;
 
     use crate::{diff::tests::*, utils::test_utils::*, Curve, ScalarField};
@@ -146,13 +144,7 @@ mod tests {
     use once_cell::sync::Lazy;
     use proptest::prelude::*;
 
-    static SRS: Lazy<SRS<Curve>> = Lazy::new(|| {
-        if let Ok(srs) = std::env::var("SRS_FILEPATH") {
-            env::get_srs_from_cache(srs)
-        } else {
-            SRS::create(1 << 16)
-        }
-    });
+    static SRS: Lazy<SRS<Curve>> = Lazy::new(poly_commitment::precomputed_srs::get_srs_test);
 
     static DOMAIN: Lazy<Radix2EvaluationDomain<ScalarField>> =
         Lazy::new(|| Radix2EvaluationDomain::new(SRS.size()).unwrap());

--- a/saffron/src/storage_proof.rs
+++ b/saffron/src/storage_proof.rs
@@ -178,7 +178,6 @@ mod tests {
     use crate::{
         commitment::{combine_commitments, commit_to_field_elems},
         encoding::encode_for_domain,
-        env,
         utils::test_utils::UserData,
     };
 
@@ -190,13 +189,9 @@ mod tests {
     use poly_commitment::{commitment::CommitmentCurve, ipa::SRS, SRS as _};
     use proptest::prelude::*;
 
-    static SRS: Lazy<SRS<Vesta>> = Lazy::new(|| {
-        if let Ok(srs) = std::env::var("SRS_FILEPATH") {
-            env::get_srs_from_cache(srs)
-        } else {
-            SRS::create(1 << 16)
-        }
-    });
+    // Lazy variables used because proptest does not trivially accept
+    // test precomputes.
+    static SRS: Lazy<SRS<Vesta>> = Lazy::new(poly_commitment::precomputed_srs::get_srs_test);
 
     static DOMAIN: Lazy<Radix2EvaluationDomain<Fp>> =
         Lazy::new(|| Radix2EvaluationDomain::new(SRS.size()).unwrap());


### PR DESCRIPTION
Quite a few tests and benchmarks were using lazy SRS generated on-demand during compile-time. For tests and benchmarks we already had a solution before -- namely, `poly-commitment::precomputed_srs` that reads the pre-generated SRS which already has Lagrange bases pre-generated. This PR uses the latter.

If people like lazy static variables we can use them, but I'd be in favour of using pre-generated SRS embedded into tests, rather than allowing to run tests with an external SRS. I see no value in it and it creates diversity in approaches to test SRSs. I'd like to merge this (to avoid having 2 concurrent approaches), but I'm happy to improve our main approach.