### PR TITLE
Add custom feature to enable jemalloc dependencies

### DIFF
--- a/kimchi/Cargo.toml
+++ b/kimchi/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/lib.rs"
 bench = false       # needed for criterion (https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options)
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tikv-jemalloc-ctl = { workspace = true }
-tikv-jemallocator = { workspace = true }
+tikv-jemalloc-ctl = { workspace = true, optional = true }
+tikv-jemallocator = { workspace = true, optional = true }
 
 [dependencies]
 ark-bn254 = { workspace = true, optional = true }
@@ -96,3 +96,4 @@ ocaml_types = [
 bn254 = ["ark-bn254"]
 wasm_types = ["wasm-bindgen"]
 check_feature_flags = []
+diagnostics = ["tikv-jemalloc-ctl", "tikv-jemallocator"]

--- a/kimchi/src/tests/framework.rs
+++ b/kimchi/src/tests/framework.rs
@@ -34,7 +34,7 @@ use rand_core::{CryptoRng, RngCore};
 use std::time::Instant;
 
 // Returns the number of bytes allocated by the heap at a given point in time
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "diagnostics"))]
 fn heap_allocated() -> usize {
     use tikv_jemalloc_ctl::{epoch, stats};
 
@@ -42,7 +42,7 @@ fn heap_allocated() -> usize {
     stats::allocated::read().unwrap()
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(any(target_arch = "wasm32", not(feature = "diagnostics")))]
 fn heap_allocated() -> usize {
     0
 }

--- a/kimchi/src/tests/lazy_mode.rs
+++ b/kimchi/src/tests/lazy_mode.rs
@@ -14,7 +14,7 @@ use mina_poseidon::{
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use rand::Rng;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "diagnostics"))]
 use tikv_jemallocator::Jemalloc;
 
 type SpongeParams = PlonkSpongeConstantsKimchi;
@@ -25,7 +25,7 @@ type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;
 
 #[test]
 fn test_lazy_mode_benchmark() {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "diagnostics"))]
     #[global_allocator]
     static GLOBAL: Jemalloc = Jemalloc;
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 license = "Apache-2.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tikv-jemalloc-ctl = { workspace = true }
-tikv-jemallocator = { workspace = true }
+tikv-jemalloc-ctl = { workspace = true, optional = true }
+tikv-jemallocator = { workspace = true, optional = true }
 
 [dependencies]
 ark-ec.workspace = true
@@ -36,3 +36,6 @@ thiserror.workspace = true
 ark-ec.workspace = true
 mina-curves.workspace = true
 secp256k1.workspace = true
+
+[features]
+diagnostics = ["tikv-jemalloc-ctl", "tikv-jemallocator"]

--- a/utils/src/lazy_cache.rs
+++ b/utils/src/lazy_cache.rs
@@ -173,7 +173,7 @@ mod test {
         thread,
     };
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "diagnostics"))]
     fn print_heap_usage(label: &str) {
         use tikv_jemalloc_ctl::{epoch, stats};
 
@@ -264,7 +264,7 @@ mod test {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "diagnostics"))]
     #[test]
     fn test_lazy_cache_allocation() {
         use tikv_jemallocator::Jemalloc;


### PR DESCRIPTION
This PR adds a custom feature in `kimchi` and `o1-utils` called `diagnostics` that should be passed whenever we want to include the dependencies `tikv-jemalloc-ctl` and `tikv-jemallocator`. That means, tests using `jemalloc` to measure memory allocation will only perform the memory measurements if both run with `--features diagnostics` and the target architecture is not `wasm32` (this last condition was added in https://github.com/o1-labs/proof-systems/pull/3079 to pass CI). 

The reason I am doing this is that tikv packages seem to have issues with the custom build target `riscv32im-succinct-zkvm-elf` used in SP1. By adding an optional cargo feature we can still run those tests for internal benchmarking while preserving compatibility with external teams without needing them to change their current build commands. Otherwise they need to work on a fork of `proof-systems` that comments out the parts of the code using `jemalloc`-related functions.

Closes https://github.com/o1-labs/proof-systems/issues/3255