### PR TITLE
Saffron: refactor sponge handling

### DIFF
--- a/.github/workflows/saffron.yml
+++ b/.github/workflows/saffron.yml
@@ -46,14 +46,14 @@ jobs:
 
       - name: Run the saffron unit tests
         run: |
-          SRS_FILEPATH=../srs/test_vesta.srs RUST_LOG=debug cargo test -p saffron  --release -- --nocapture
+          SRS_FILEPATH=../srs/test_pallas.srs RUST_LOG=debug cargo test -p saffron  --release -- --nocapture
 
       - name: Run the saffron e2e encoding tests on small lorem file
         run: |
-          ./saffron/e2e-test.sh saffron/fixtures/lorem.txt ./srs/test_vesta.srs
+          ./saffron/e2e-test.sh saffron/fixtures/lorem.txt ./srs/test_pallas.srs
 
       # Randomly generate an input file between roughly 50MB and 200MB
       - name: Run the saffron e2e encoding on large random file
         run: |
           (base64 /dev/urandom | head -c $(shuf -i 50000000-200000000 -n 1) | tr -dc "A-Za-z0-9 " | fold -w100 > bigfile.txt) 2>/dev/null
-          RUST_LOG=debug ./saffron/e2e-test.sh bigfile.txt ./srs/test_vesta.srs
+          RUST_LOG=debug ./saffron/e2e-test.sh bigfile.txt ./srs/test_pallas.srs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ o1vm = { path = "./o1vm", version = "0.1.0" }
 optimism = { path = "./optimism", version = "0.1.0" }
 plonk_wasm = { path = "./plonk-wasm", version = "0.1.0" }
 poly-commitment = { path = "./poly-commitment", version = "0.1.0" }
-saffron = { path = "./poly-commitment", version = "0.1.0" }
+saffron = { path = "./saffron", version = "0.1.0" }
 signer = { path = "./signer", version = "0.1.0" }
 turshi = { path = "./turshi", version = "0.1.0" }
 utils = { path = "./utils", version = "0.1.0" }

--- a/saffron/Cargo.toml
+++ b/saffron/Cargo.toml
@@ -9,9 +9,6 @@ readme = "README.md"
 edition = "2021"
 license = "Apache-2.0"
 
-# [lib]
-# path = "src/lib.rs"
-
 [[bin]]
 name = "saffron"
 path = "src/main.rs"

--- a/saffron/README.md
+++ b/saffron/README.md
@@ -29,7 +29,7 @@ cargo test -p kimchi heavy_test_srs_serialization --release
 You can run this e2e test on any file. For example, to run with the provided lorem file using the SRS cache for testing:
 
 ```bash
-./e2e-test.sh fixtures/lorem.txt ../srs/test_vesta.srs
+./e2e-test.sh fixtures/lorem.txt ../srs/test_pallas.srs
 ```
 
 Note that the log level can be controlled by setting the `RUST_LOG` environment variable.

--- a/saffron/benches/folding_bench.rs
+++ b/saffron/benches/folding_bench.rs
@@ -3,7 +3,6 @@
 
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion, SamplingMode};
 use kimchi::{circuits::domains::EvaluationDomains, groupmap::GroupMap};
-use mina_curves::pasta::Vesta;
 use poly_commitment::{commitment::CommitmentCurve, SRS as _};
 
 use saffron::{
@@ -12,7 +11,7 @@ use saffron::{
         testing::{generate_random_inst_wit_core, generate_random_inst_wit_relaxed},
         verify_relaxed,
     },
-    ScalarField,
+    Curve, ScalarField,
 };
 
 fn bench_folding(c: &mut Criterion) {
@@ -23,7 +22,7 @@ fn bench_folding(c: &mut Criterion) {
     let mut rng = o1_utils::tests::make_test_rng(None);
 
     let srs = poly_commitment::precomputed_srs::get_srs_test();
-    let group_map = <Vesta as CommitmentCurve>::Map::setup();
+    let group_map = <Curve as CommitmentCurve>::Map::setup();
 
     let domain: EvaluationDomains<ScalarField> =
         EvaluationDomains::<ScalarField>::create(srs.size()).unwrap();

--- a/saffron/benches/read_proof_bench.rs
+++ b/saffron/benches/read_proof_bench.rs
@@ -3,7 +3,6 @@
 use ark_ff::UniformRand;
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use kimchi::{circuits::domains::EvaluationDomains, groupmap::GroupMap};
-use mina_curves::pasta::Fp;
 use poly_commitment::{commitment::CommitmentCurve, ipa::SRS, SRS as _};
 use rand::rngs::OsRng;
 use saffron::{
@@ -22,7 +21,7 @@ fn generate_test_data(
 
     // Generate data with specified size
     let data = Data {
-        data: (0..size).map(|_| Fp::rand(&mut rng)).collect(),
+        data: (0..size).map(|_| ScalarField::rand(&mut rng)).collect(),
     };
 
     // Create data commitment

--- a/saffron/src/commitment.rs
+++ b/saffron/src/commitment.rs
@@ -1,8 +1,7 @@
-use crate::{diff::Diff, utils};
+use crate::{diff::Diff, utils, Sponge};
 use ark_ec::{AffineRepr, CurveGroup, VariableBaseMSM};
 use ark_poly::univariate::DensePolynomial;
 use kimchi::curve::KimchiCurve;
-use mina_poseidon::FqSponge;
 use poly_commitment::{ipa::SRS, SRS as _};
 use rayon::prelude::*;
 use tracing::instrument;
@@ -70,8 +69,8 @@ pub fn commit_sparse<G: KimchiCurve>(
 /// Takes commitments C_i, computes α = hash(C_0 || C_1 || ... || C_n),
 /// returns ∑ α^i C_i.
 #[instrument(skip_all, level = "debug")]
-pub fn combine_commitments<G: AffineRepr, EFqSponge: FqSponge<G::BaseField, G, G::ScalarField>>(
-    sponge: &mut EFqSponge,
+pub fn combine_commitments<G: AffineRepr, Spng: Sponge<G::BaseField, G, G::ScalarField>>(
+    sponge: &mut Spng,
     commitments: &[G],
 ) -> (G, G::ScalarField) {
     for commitment in commitments.iter() {

--- a/saffron/src/diff.rs
+++ b/saffron/src/diff.rs
@@ -99,14 +99,16 @@ impl<F: PrimeField> Diff<F> {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::utils::{chunk_size_in_bytes, min_encoding_chunks, test_utils::UserData};
+    use crate::{
+        utils::{chunk_size_in_bytes, min_encoding_chunks, test_utils::UserData},
+        ScalarField,
+    };
     use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
-    use mina_curves::pasta::Fp;
     use once_cell::sync::Lazy;
     use proptest::prelude::*;
     use rand::Rng;
 
-    static DOMAIN: Lazy<Radix2EvaluationDomain<Fp>> =
+    static DOMAIN: Lazy<Radix2EvaluationDomain<ScalarField>> =
         Lazy::new(|| Radix2EvaluationDomain::new(1 << 16).unwrap());
 
     pub fn randomize_data(threshold: f64, data: &[u8]) -> Vec<u8> {
@@ -145,7 +147,7 @@ pub mod tests {
         ) {
             let min_len = xs.len().min(ys.len());
             let (xs, ys) = (&xs[..min_len], &ys[..min_len]) ;
-            let diffs = Diff::<Fp>::create_from_bytes(&*DOMAIN, xs, ys);
+            let diffs = Diff::<ScalarField>::create_from_bytes(&*DOMAIN, xs, ys);
             prop_assert!(diffs.is_ok());
             let diffs = diffs.unwrap();
 
@@ -188,7 +190,7 @@ pub mod tests {
         ) {
             let mut ys = randomize_data(threshold, &data);
             ys.append(&mut extra);
-            let diff = Diff::<Fp>::create_from_bytes(&*DOMAIN, &data, &ys);
+            let diff = Diff::<ScalarField>::create_from_bytes(&*DOMAIN, &data, &ys);
             prop_assert!(diff.is_err());
         }
     }

--- a/saffron/src/lib.rs
+++ b/saffron/src/lib.rs
@@ -10,19 +10,20 @@ pub mod storage;
 pub mod storage_proof;
 pub mod utils;
 
-use mina_curves::pasta::{Fp, Fq, ProjectiveVesta, Vesta, VestaParameters};
 use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 
+pub use mina_poseidon::FqSponge as Sponge;
+
 pub const SRS_SIZE: usize = 1 << 16;
 
-pub type Curve = Vesta;
-pub type ProjectiveCurve = ProjectiveVesta;
-pub type CurveParameters = VestaParameters;
-pub type ScalarField = Fp;
-pub type BaseField = Fq;
+pub type Curve = mina_curves::pasta::Vesta;
+pub type ProjectiveCurve = mina_curves::pasta::ProjectiveVesta;
+pub type CurveParameters = mina_curves::pasta::VestaParameters;
+pub type ScalarField = <CurveParameters as ark_ec::CurveConfig>::ScalarField;
+pub type BaseField = <CurveParameters as ark_ec::CurveConfig>::BaseField;
 
-pub type CurveFqSponge = DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>;
-pub type CurveFrSponge = DefaultFrSponge<ScalarField, PlonkSpongeConstantsKimchi>;
+pub type CurveSponge = DefaultFqSponge<CurveParameters, PlonkSpongeConstantsKimchi>;
+pub type CurveScalarSponge = DefaultFrSponge<ScalarField, PlonkSpongeConstantsKimchi>;

--- a/saffron/src/lib.rs
+++ b/saffron/src/lib.rs
@@ -10,10 +10,7 @@ pub mod storage;
 pub mod storage_proof;
 pub mod utils;
 
-use mina_poseidon::{
-    constants::PlonkSpongeConstantsKimchi,
-    sponge::{DefaultFqSponge, DefaultFrSponge},
-};
+use mina_poseidon::{constants::PlonkSpongeConstantsKimchi, sponge::DefaultFqSponge};
 
 pub use mina_poseidon::FqSponge as Sponge;
 
@@ -26,4 +23,3 @@ pub type ScalarField = <CurveParameters as ark_ec::CurveConfig>::ScalarField;
 pub type BaseField = <CurveParameters as ark_ec::CurveConfig>::BaseField;
 
 pub type CurveSponge = DefaultFqSponge<CurveParameters, PlonkSpongeConstantsKimchi>;
-pub type CurveScalarSponge = DefaultFrSponge<ScalarField, PlonkSpongeConstantsKimchi>;

--- a/saffron/src/lib.rs
+++ b/saffron/src/lib.rs
@@ -26,5 +26,3 @@ pub type BaseField = Fq;
 
 pub type CurveFqSponge = DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>;
 pub type CurveFrSponge = DefaultFrSponge<ScalarField, PlonkSpongeConstantsKimchi>;
-
-//pub type ScalarSponge = DefaultFrSponge<Fp, SpongeParams>;

--- a/saffron/src/lib.rs
+++ b/saffron/src/lib.rs
@@ -19,9 +19,9 @@ pub use mina_poseidon::FqSponge as Sponge;
 
 pub const SRS_SIZE: usize = 1 << 16;
 
-pub type Curve = mina_curves::pasta::Vesta;
-pub type ProjectiveCurve = mina_curves::pasta::ProjectiveVesta;
-pub type CurveParameters = mina_curves::pasta::VestaParameters;
+pub type Curve = mina_curves::pasta::Pallas;
+pub type ProjectiveCurve = mina_curves::pasta::ProjectivePallas;
+pub type CurveParameters = mina_curves::pasta::PallasParameters;
 pub type ScalarField = <CurveParameters as ark_ec::CurveConfig>::ScalarField;
 pub type BaseField = <CurveParameters as ark_ec::CurveConfig>::BaseField;
 

--- a/saffron/src/main.rs
+++ b/saffron/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
 use clap::Parser;
-use kimchi::{curve::KimchiCurve, groupmap::GroupMap};
+use kimchi::groupmap::GroupMap;
 use poly_commitment::{commitment::CommitmentCurve, ipa::SRS, PolyComm, SRS as _};
 use rand::rngs::OsRng;
 use saffron::{
@@ -9,7 +9,8 @@ use saffron::{
     cli::{self, HexString},
     commitment, encoding, env,
     storage_proof::{self, StorageProof},
-    Curve, CurveSponge, ScalarField, Sponge,
+    utils::new_sponge,
+    Curve, ScalarField, Sponge,
 };
 use std::{
     fs::File,
@@ -85,7 +86,7 @@ fn encode_file(args: cli::EncodeFileArgs) -> Result<()> {
             .expect("if assert-commitment is requested, challenge-seed must be provided");
         let challenge_seed: ScalarField = encoding::encode(&challenge_seed_args.0);
 
-        let mut sponge = CurveSponge::new(Curve::other_curve_sponge_params());
+        let mut sponge = new_sponge();
         sponge.absorb_fr(&[challenge_seed]);
         let (combined_data_commitment, _challenge) =
             commitment::combine_commitments(&mut sponge, blob.commitments.as_slice());
@@ -123,7 +124,7 @@ pub fn compute_commitment(args: cli::ComputeCommitmentArgs) -> Result<HexString>
     let blob = FieldBlob::from_bytes(&srs, domain_fp, buf.as_slice());
 
     let challenge_seed: ScalarField = encoding::encode(&args.challenge_seed.0);
-    let mut sponge = CurveSponge::new(Curve::other_curve_sponge_params());
+    let mut sponge = new_sponge();
     sponge.absorb_fr(&[challenge_seed]);
     let (combined_data_commitment, _challenge) =
         commitment::combine_commitments(&mut sponge, blob.commitments.as_slice());
@@ -167,7 +168,7 @@ pub fn storage_proof(args: cli::StorageProofArgs) -> Result<HexString> {
         let group_map = <Curve as CommitmentCurve>::Map::setup();
         let mut rng = OsRng;
 
-        let mut sponge = CurveSponge::new(Curve::other_curve_sponge_params());
+        let mut sponge = new_sponge();
         sponge.absorb_fr(&[challenge_seed]);
         let (_combined_data_commitment, challenge) =
             commitment::combine_commitments(&mut sponge, blob.commitments.as_slice());

--- a/saffron/src/read_proof.rs
+++ b/saffron/src/read_proof.rs
@@ -24,15 +24,15 @@
 use crate::{
     commitment::*,
     storage::Data,
-    utils::{evals_to_polynomial, evals_to_polynomial_and_commitment},
-    Curve, CurveSponge, ScalarField, Sponge,
+    utils::{evals_to_polynomial, evals_to_polynomial_and_commitment, new_sponge},
+    Curve, ScalarField, Sponge,
 };
 use ark_ff::{Field, One, Zero};
 use ark_poly::{
     univariate::DensePolynomial, EvaluationDomain, Evaluations, Polynomial,
     Radix2EvaluationDomain as R2D,
 };
-use kimchi::{circuits::domains::EvaluationDomains, curve::KimchiCurve};
+use kimchi::circuits::domains::EvaluationDomains;
 use poly_commitment::{
     commitment::{combined_inner_product, BatchEvaluationProof, CommitmentCurve, Evaluation},
     ipa::{OpeningProof, SRS},
@@ -143,7 +143,7 @@ where
 {
     let data = &data.data;
 
-    let mut curve_sponge = CurveSponge::new(Curve::other_curve_sponge_params());
+    let mut curve_sponge = new_sponge();
 
     let data_poly = evals_to_polynomial(data.to_vec(), domain.d1);
 
@@ -191,7 +191,7 @@ where
     let evaluation_point = curve_sponge.challenge();
 
     // Fiat Shamir - absorbing evaluations
-    let mut scalar_sponge = CurveSponge::new(Curve::other_curve_sponge_params());
+    let mut scalar_sponge = new_sponge();
     scalar_sponge.absorb_fr(&[curve_sponge.clone().digest()]);
 
     let data_eval = data_poly.evaluate(&evaluation_point);
@@ -256,7 +256,7 @@ pub fn verify<RNG>(
 where
     RNG: RngCore + CryptoRng,
 {
-    let mut curve_sponge = CurveSponge::new(Curve::other_curve_sponge_params());
+    let mut curve_sponge = new_sponge();
     curve_sponge.absorb_g(&[
         data_comm.cm,
         *query_comm,
@@ -266,7 +266,7 @@ where
 
     let evaluation_point = curve_sponge.challenge();
 
-    let mut scalar_sponge = CurveSponge::new(Curve::other_curve_sponge_params());
+    let mut scalar_sponge = new_sponge();
     scalar_sponge.absorb_fr(&[curve_sponge.clone().digest()]);
 
     let vanishing_poly_at_zeta = domain.d1.vanishing_polynomial().evaluate(&evaluation_point);

--- a/saffron/src/read_proof.rs
+++ b/saffron/src/read_proof.rs
@@ -25,14 +25,14 @@ use crate::{
     commitment::*,
     storage::Data,
     utils::{evals_to_polynomial, evals_to_polynomial_and_commitment},
-    Curve, CurveScalarSponge, CurveSponge, ScalarField, Sponge,
+    Curve, CurveSponge, ScalarField, Sponge,
 };
 use ark_ff::{Field, One, Zero};
 use ark_poly::{
     univariate::DensePolynomial, EvaluationDomain, Evaluations, Polynomial,
     Radix2EvaluationDomain as R2D,
 };
-use kimchi::{circuits::domains::EvaluationDomains, curve::KimchiCurve, plonk_sponge::FrSponge};
+use kimchi::{circuits::domains::EvaluationDomains, curve::KimchiCurve};
 use poly_commitment::{
     commitment::{combined_inner_product, BatchEvaluationProof, CommitmentCurve, Evaluation},
     ipa::{OpeningProof, SRS},
@@ -191,22 +191,19 @@ where
     let evaluation_point = curve_sponge.challenge();
 
     // Fiat Shamir - absorbing evaluations
-    let mut scalar_sponge = CurveScalarSponge::new(Curve::sponge_params());
-    scalar_sponge.absorb(&curve_sponge.clone().digest());
+    let mut scalar_sponge = CurveSponge::new(Curve::other_curve_sponge_params());
+    scalar_sponge.absorb_fr(&[curve_sponge.clone().digest()]);
 
     let data_eval = data_poly.evaluate(&evaluation_point);
     let query_eval = query_poly.evaluate(&evaluation_point);
     let answer_eval = answer_poly.evaluate(&evaluation_point);
     let quotient_eval = quotient_poly.evaluate(&evaluation_point);
 
-    for eval in [data_eval, query_eval, answer_eval, quotient_eval].into_iter() {
-        scalar_sponge.absorb(&eval);
-    }
+    scalar_sponge.absorb_fr(&[data_eval, query_eval, answer_eval, quotient_eval]);
 
-    let (_, endo_r) = Curve::endos();
     // Generate scalars used as combiners for sub-statements within our IPA opening proof.
-    let polyscale = scalar_sponge.challenge().to_field(endo_r);
-    let evalscale = scalar_sponge.challenge().to_field(endo_r);
+    let polyscale = scalar_sponge.challenge();
+    let evalscale = scalar_sponge.challenge();
 
     // Creating the polynomials for the batch proof
     // Gathering all polynomials to use in the opening proof
@@ -269,8 +266,8 @@ where
 
     let evaluation_point = curve_sponge.challenge();
 
-    let mut scalar_sponge = CurveScalarSponge::new(Curve::sponge_params());
-    scalar_sponge.absorb(&curve_sponge.clone().digest());
+    let mut scalar_sponge = CurveSponge::new(Curve::other_curve_sponge_params());
+    scalar_sponge.absorb_fr(&[curve_sponge.clone().digest()]);
 
     let vanishing_poly_at_zeta = domain.d1.vanishing_polynomial().evaluate(&evaluation_point);
     let quotient_eval = {
@@ -280,21 +277,16 @@ where
                 .unwrap_or_else(|| panic!("Inverse fails only with negligible probability"))
     };
 
-    for eval in [
+    scalar_sponge.absorb_fr(&[
         proof.data_eval,
         proof.query_eval,
         proof.answer_eval,
         quotient_eval,
-    ]
-    .into_iter()
-    {
-        scalar_sponge.absorb(&eval);
-    }
+    ]);
 
-    let (_, endo_r) = Curve::endos();
     // Generate scalars used as combiners for sub-statements within our IPA opening proof.
-    let polyscale = scalar_sponge.challenge().to_field(endo_r);
-    let evalscale = scalar_sponge.challenge().to_field(endo_r);
+    let polyscale = scalar_sponge.challenge();
+    let evalscale = scalar_sponge.challenge();
 
     let coms_and_evaluations = vec![
         Evaluation {

--- a/saffron/src/storage.rs
+++ b/saffron/src/storage.rs
@@ -142,13 +142,10 @@ pub fn update<F: PrimeField>(path: &str, diff: &Diff<F>) -> std::io::Result<()> 
 #[cfg(test)]
 mod tests {
     use crate::{
-        diff::Diff,
-        encoding, storage,
-        storage::{Commitment, Data},
-        Curve, ScalarField, SRS_SIZE,
+        commitment::Commitment, diff::Diff, encoding, storage, storage::Data, Curve, ScalarField,
+        SRS_SIZE,
     };
     use ark_ff::{One, UniformRand, Zero};
-    use mina_curves::pasta::Fp;
     use poly_commitment::ipa::SRS;
     use rand::Rng;
     use std::fs;
@@ -173,7 +170,7 @@ mod tests {
         let mut data = Data::of_bytes(&data_bytes);
         // Setting the first value of data to zero will make the updated bytes
         // with the well chosen diff
-        data.data[0] = Fp::zero();
+        data.data[0] = ScalarField::zero();
         let data_comm = data.to_commitment(&srs);
 
         let read_consistency = {
@@ -195,12 +192,14 @@ mod tests {
                 let addresses: Vec<u64> = (0..nb_updates)
                     .map(|_| (rng.gen_range(0..data.len() as u64)))
                     .collect();
-                let mut diff_values: Vec<ScalarField> =
-                    addresses.iter().map(|_| Fp::rand(&mut rng)).collect();
+                let mut diff_values: Vec<ScalarField> = addresses
+                    .iter()
+                    .map(|_| ScalarField::rand(&mut rng))
+                    .collect();
                 // The first value is replaced by a scalar that would
                 // overflow 31 bytes, so the update is not consistent and the
                 // test fails if this case is not handled
-                diff_values[0] = Fp::zero() - Fp::one();
+                diff_values[0] = ScalarField::zero() - ScalarField::one();
                 Diff {
                     region,
                     addresses,

--- a/saffron/src/utils.rs
+++ b/saffron/src/utils.rs
@@ -1,4 +1,7 @@
-use crate::encoding::{decode_into, encoding_size};
+use crate::{
+    encoding::{decode_into, encoding_size},
+    Curve, CurveSponge, Sponge,
+};
 use ark_ec::{AffineRepr, CurveGroup, VariableBaseMSM};
 use ark_ff::PrimeField;
 use ark_poly::{
@@ -10,6 +13,10 @@ use poly_commitment::{ipa::SRS, SRS as _};
 use std::marker::PhantomData;
 use thiserror::Error;
 use tracing::instrument;
+
+pub fn new_sponge() -> CurveSponge {
+    CurveSponge::new(Curve::other_curve_sponge_params())
+}
 
 pub(crate) fn evals_to_polynomial<F: PrimeField>(
     evals: Vec<F>,


### PR DESCRIPTION
This PR aims to simplify sponge handling in Saffron. These changes were first part of a previous PR, but their consequences on the verifying circuit needs to be examined more carefully (see https://github.com/o1-labs/proof-systems/pull/3276#discussion_r2190229956).