### PR TITLE
export-test-vectors: modestly improve + add in CI

### DIFF
--- a/.github/workflows/test-export-vectors.yml
+++ b/.github/workflows/test-export-vectors.yml
@@ -1,0 +1,104 @@
+name: Test Export Test Vectors
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.ref }}-export-vectors
+  cancel-in-progress: true
+
+env:
+  RUSTFLAGS: -Coverflow-checks=y -Cdebug-assertions=y
+  CARGO_INCREMENTAL: 1
+  CARGO_TERM_COLOR: always
+  RUST_MIN_STACK: 31457280
+
+jobs:
+  test-export-vectors:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Use shared Rust toolchain setting up steps
+        uses: ./.github/actions/toolchain-shared
+        with:
+          rust_toolchain_version: "1.81"
+
+      - name: Use shared OCaml setting up steps
+        uses: ./.github/actions/ocaml-shared
+        with:
+          ocaml_version: "4.14.2"
+
+      - name: Build export_test_vectors binary
+        run: |
+          eval $(opam env)
+          cargo build --bin export_test_vectors --all-features
+
+      - name: Test export_test_vectors commands
+        run: |
+          # Test all valid command combinations
+          FORMATS="b10 hex"
+          MODES="legacy kimchi"
+
+          eval $(opam env)
+
+          for format in $FORMATS; do
+            for mode in $MODES; do
+              echo "Testing $format $mode mode..."
+              cargo run --bin export_test_vectors --all-features -- $format $mode /tmp/test_${format}_${mode}.json
+            done
+          done
+
+          echo "Testing stdout output..."
+          cargo run --bin export_test_vectors --all-features -- b10 legacy - > /tmp/test_stdout.json
+
+      - name: Verify output files
+        run: |
+          # Check that output files exist and are valid JSON
+          echo "Verifying output files..."
+
+          FORMATS="b10 hex"
+          MODES="legacy kimchi"
+
+          # Check all format/mode combinations
+          for format in $FORMATS; do
+            for mode in $MODES; do
+              file="/tmp/test_${format}_${mode}.json"
+              if [ -f "$file" ]; then
+                echo "✓ $file exists"
+                # Verify it's valid JSON
+                if jq empty "$file" 2>/dev/null; then
+                  echo "✓ $file is valid JSON"
+                else
+                  echo "✗ $file is not valid JSON"
+                  exit 1
+                fi
+              else
+                echo "✗ $file does not exist"
+                exit 1
+              fi
+            done
+          done
+
+          # Check stdout output file
+          file="/tmp/test_stdout.json"
+          if [ -f "$file" ]; then
+            echo "✓ $file exists"
+            # Verify it's valid JSON
+            if jq empty "$file" 2>/dev/null; then
+              echo "✓ $file is valid JSON"
+            else
+              echo "✗ $file is not valid JSON"
+              exit 1
+            fi
+          else
+            echo "✗ $file does not exist"
+            exit 1
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,7 @@ version = "0.1.0"
 dependencies = [
  "ark-ff",
  "ark-serialize",
+ "clap 4.4.18",
  "hex",
  "mina-curves",
  "mina-poseidon",

--- a/poseidon/export_test_vectors/Cargo.toml
+++ b/poseidon/export_test_vectors/Cargo.toml
@@ -12,6 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 ark-ff.workspace = true
 ark-serialize.workspace = true
+clap = { workspace = true, features = ["derive"] }
 hex.workspace = true
 mina-curves.workspace = true
 mina-poseidon.workspace = true

--- a/poseidon/export_test_vectors/Cargo.toml
+++ b/poseidon/export_test_vectors/Cargo.toml
@@ -13,12 +13,11 @@ license = "Apache-2.0"
 ark-ff.workspace = true
 ark-serialize.workspace = true
 hex.workspace = true
+mina-curves.workspace = true
+mina-poseidon.workspace = true
 num-bigint.workspace = true
+o1-utils.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
-
-mina-curves.workspace = true
-mina-poseidon.workspace = true
-o1-utils.workspace = true

--- a/poseidon/export_test_vectors/README.md
+++ b/poseidon/export_test_vectors/README.md
@@ -1,0 +1,51 @@
+# Export Test Vectors
+
+A command-line tool for exporting test vectors from the mina-poseidon crate.
+
+## Usage
+
+```bash
+cargo run --bin export_test_vectors --all-features -- <MODE> <PARAM_TYPE> <OUTPUT_FILE>
+```
+
+### Arguments
+
+- `<MODE>`: Output format for the test vectors
+  - `b10`: Base-10 format
+  - `hex`: Hexadecimal format
+
+- `<PARAM_TYPE>`: Parameter type to use
+  - `legacy`: Legacy parameters
+  - `kimchi`: Kimchi parameters
+
+- `<OUTPUT_FILE>`: Output file path, use `-` for stdout
+
+### Examples
+
+```bash
+# Export b10 legacy vectors to a file
+cargo run --bin export_test_vectors --all-features -- b10 legacy vectors.json
+
+# Export hex kimchi vectors to stdout
+cargo run --bin export_test_vectors --all-features -- hex kimchi -
+
+# Export hex legacy vectors to a file
+cargo run --bin export_test_vectors --all-features -- hex legacy test_vectors.json
+```
+
+### Help
+
+```bash
+cargo run --bin export_test_vectors --all-features -- --help
+```
+
+## Building
+
+```bash
+cargo build --bin export_test_vectors --all-features
+```
+
+## Testing
+
+The tool is tested in CI with all valid command combinations. See
+`.github/workflows/test-export-vectors.yml` for the test suite.

--- a/poseidon/export_test_vectors/src/main.rs
+++ b/poseidon/export_test_vectors/src/main.rs
@@ -1,12 +1,12 @@
+use clap::{Parser, ValueEnum};
 use core::str::FromStr;
 use std::{
-    env,
     fs::File,
     io::{self, Write},
 };
 mod vectors;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, ValueEnum)]
 pub enum Mode {
     B10,
     Hex,
@@ -24,7 +24,7 @@ impl FromStr for Mode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, ValueEnum)]
 pub enum ParamType {
     Legacy,
     Kimchi,
@@ -42,45 +42,32 @@ impl FromStr for ParamType {
     }
 }
 
-/// Usage:
-/// cargo run --all-features \
-///           --bin export_test_vectors -- \
-///           [b10|hex]
-///           [legacy|kimchi]
-///           <OUTPUT_FILE>
+#[derive(Parser)]
+#[command(name = "export_test_vectors")]
+#[command(about = "Export test vectors for the mina-poseidon crate")]
+struct Args {
+    /// Output format for the test vectors
+    #[arg(value_enum)]
+    mode: Mode,
+
+    /// Parameter type to use
+    #[arg(value_enum)]
+    param_type: ParamType,
+
+    /// Output file path, use "-" for stdout
+    output_file: String,
+}
+
 pub fn main() {
-    let args: Vec<String> = env::args().collect();
-    match args.len() {
-        4 => {
-            // parse command-line args
-            let mode: Mode = args
-                .get(1)
-                .expect("missing mode")
-                .parse()
-                .expect("invalid mode");
-            let param_type: ParamType = args
-                .get(2)
-                .expect("missing param type")
-                .parse()
-                .expect("invalid param type");
-            let output_file = args.get(3).expect("missing file");
+    let args = Args::parse();
 
-            // generate vectors
-            let vectors = vectors::generate(mode, param_type);
+    // generate vectors
+    let vectors = vectors::generate(args.mode, args.param_type);
 
-            // save to output file
-            let writer: Box<dyn Write> = match output_file.as_str() {
-                "-" => Box::new(io::stdout()),
-                _ => Box::new(File::create(output_file).expect("could not create file")),
-            };
-            serde_json::to_writer_pretty(writer, &vectors).expect("could not write to file");
-        }
-        _ => {
-            println!(
-                "usage: cargo run -p export_test_vectors -- [{:?}|{:?}] [legacy|kimchi] <OUTPUT_FILE>",
-                Mode::Hex,
-                Mode::B10,
-            );
-        }
-    }
+    // save to output file
+    let writer: Box<dyn Write> = match args.output_file.as_str() {
+        "-" => Box::new(io::stdout()),
+        _ => Box::new(File::create(&args.output_file).expect("could not create file")),
+    };
+    serde_json::to_writer_pretty(writer, &vectors).expect("could not write to file");
 }

--- a/poseidon/export_test_vectors/src/main.rs
+++ b/poseidon/export_test_vectors/src/main.rs
@@ -1,90 +1,86 @@
+use core::str::FromStr;
+use std::{
+    env,
+    fs::File,
+    io::{self, Write},
+};
 mod vectors;
-use inner::*;
 
-/// "Usage: cargo run --all-features --bin export_test_vectors -- [hex|b10] [legacy|kimchi] <OUTPUT_FILE>",
-fn main() {
-    inner::main();
+#[derive(Debug)]
+pub enum Mode {
+    B10,
+    Hex,
 }
 
-mod inner {
-    use super::vectors;
-    use std::{
-        env,
-        fs::File,
-        io::{self, Write},
-        str::FromStr,
-    };
+impl FromStr for Mode {
+    type Err = ();
 
-    #[derive(Debug)]
-    pub enum Mode {
-        Hex,
-        B10,
-    }
-
-    impl FromStr for Mode {
-        type Err = ();
-
-        fn from_str(input: &str) -> Result<Self, Self::Err> {
-            match input.to_lowercase().as_str() {
-                "b10" => Ok(Mode::B10),
-                "hex" => Ok(Mode::Hex),
-                _ => Err(()),
-            }
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input.to_lowercase().as_str() {
+            "b10" => Ok(Mode::B10),
+            "hex" => Ok(Mode::Hex),
+            _ => Err(()),
         }
     }
+}
 
-    #[derive(Debug)]
-    pub enum ParamType {
-        Legacy,
-        Kimchi,
-    }
+#[derive(Debug)]
+pub enum ParamType {
+    Legacy,
+    Kimchi,
+}
 
-    impl FromStr for ParamType {
-        type Err = ();
+impl FromStr for ParamType {
+    type Err = ();
 
-        fn from_str(input: &str) -> Result<Self, Self::Err> {
-            match input.to_lowercase().as_str() {
-                "legacy" => Ok(ParamType::Legacy),
-                "kimchi" => Ok(ParamType::Kimchi),
-                _ => Err(()),
-            }
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input.to_lowercase().as_str() {
+            "legacy" => Ok(ParamType::Legacy),
+            "kimchi" => Ok(ParamType::Kimchi),
+            _ => Err(()),
         }
     }
+}
 
-    pub(crate) fn main() {
-        let args: Vec<String> = env::args().collect();
-        match args.len() {
-            4 => {
-                // parse command-line args
-                let mode: Mode = args
-                    .get(1)
-                    .expect("missing mode")
-                    .parse()
-                    .expect("invalid mode");
-                let param_type: ParamType = args
-                    .get(2)
-                    .expect("missing param type")
-                    .parse()
-                    .expect("invalid param type");
-                let output_file = args.get(3).expect("missing file");
+/// Usage:
+/// cargo run --all-features \
+///           --bin export_test_vectors -- \
+///           [b10|hex]
+///           [legacy|kimchi]
+///           <OUTPUT_FILE>
+pub fn main() {
+    let args: Vec<String> = env::args().collect();
+    match args.len() {
+        4 => {
+            // parse command-line args
+            let mode: Mode = args
+                .get(1)
+                .expect("missing mode")
+                .parse()
+                .expect("invalid mode");
+            let param_type: ParamType = args
+                .get(2)
+                .expect("missing param type")
+                .parse()
+                .expect("invalid param type");
+            let output_file = args.get(3).expect("missing file");
 
-                // generate vectors
-                let vectors = vectors::generate(mode, param_type);
+            // generate vectors
+            let vectors = vectors::generate(mode, param_type);
 
-                // save to output file
-                let writer: Box<dyn Write> = match output_file.as_str() {
-                    "-" => Box::new(io::stdout()),
-                    _ => Box::new(File::create(output_file).expect("could not create file")),
-                };
-                serde_json::to_writer_pretty(writer, &vectors).expect("could not write to file");
-            }
-            _ => {
-                println!(
+            // save to output file
+            let writer: Box<dyn Write> = match output_file.as_str() {
+                "-" => Box::new(io::stdout()),
+                _ => Box::new(File::create(output_file).expect("could not create file")),
+            };
+            serde_json::to_writer_pretty(writer, &vectors).expect("could not write to file");
+        }
+        _ => {
+            println!(
                 "usage: cargo run -p export_test_vectors -- [{:?}|{:?}] [legacy|kimchi] <OUTPUT_FILE>",
                 Mode::Hex,
                 Mode::B10,
             );
-            }
         }
     }
 }


### PR DESCRIPTION
Part of simplifying the build process of o1js.
The final goal is to get rid of this directory: https://github.com/o1-labs/o1js/tree/main/src/bindings/crypto/test-vectors.