### PR TITLE
Add pointer functions for lagrange basis web compatibility

### DIFF
--- a/plonk-wasm/src/srs.rs
+++ b/plonk-wasm/src/srs.rs
@@ -320,6 +320,33 @@ pub mod fp {
         });
         basis.iter().map(Into::into).collect()
     }
+
+    /// Web-compatible version that returns pointer for worker communication
+    #[wasm_bindgen]
+    pub fn caml_fp_srs_get_lagrange_basis_ptr(
+        srs: &WasmFpSrs,
+        domain_size: i32,
+    ) -> *mut WasmVector<WasmPolyComm> {
+        let result = caml_fp_srs_get_lagrange_basis(srs, domain_size);
+        let boxed = Box::new(result);
+        Box::into_raw(boxed)
+    }
+
+    /// Reads the lagrange basis from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it dereferences a raw pointer.
+    /// The pointer must be valid and point to a properly allocated WasmVector.
+    /// The pointer becomes invalid after this call (ownership transferred).
+    #[wasm_bindgen]
+    pub unsafe fn caml_fp_srs_get_lagrange_basis_read_from_ptr(
+        ptr: *mut WasmVector<WasmPolyComm>,
+    ) -> WasmVector<WasmPolyComm> {
+        // Reclaim ownership and extract data
+        let boxed = unsafe { Box::from_raw(ptr) };
+        *boxed  // Return owned data, automatically cleans up Box
+    }
 }
 
 pub mod fq {

--- a/plonk-wasm/src/srs.rs
+++ b/plonk-wasm/src/srs.rs
@@ -427,4 +427,31 @@ pub mod fq {
         });
         basis.iter().map(Into::into).collect()
     }
+
+    /// Web-compatible version that returns pointer for worker communication
+    #[wasm_bindgen]
+    pub fn caml_fq_srs_get_lagrange_basis_ptr(
+        srs: &WasmFqSrs,
+        domain_size: i32,
+    ) -> *mut WasmVector<WasmPolyComm> {
+        let result = caml_fq_srs_get_lagrange_basis(srs, domain_size);
+        let boxed = Box::new(result);
+        Box::into_raw(boxed)
+    }
+
+    /// Reads the lagrange basis from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it dereferences a raw pointer.
+    /// The pointer must be valid and point to a properly allocated WasmVector.
+    /// The pointer becomes invalid after this call (ownership transferred).
+    #[wasm_bindgen]
+    pub unsafe fn caml_fq_srs_get_lagrange_basis_read_from_ptr(
+        ptr: *mut WasmVector<WasmPolyComm>,
+    ) -> WasmVector<WasmPolyComm> {
+        // Reclaim ownership and extract data
+        let boxed = unsafe { Box::from_raw(ptr) };
+        *boxed  // Return owned data, automatically cleans up Box
+    }
 }


### PR DESCRIPTION
## Summary

This PR fixes the issue where `zkProgram.compile()` with cache writing hangs indefinitely in web browsers. The problem was that `caml_fp_srs_get_lagrange_basis` and `caml_fq_srs_get_lagrange_basis` functions return `WasmVector` types that cannot be transferred over the web worker synchronization API.

## Changes

**Added new pointer-based functions for web compatibility:**

### Fp Functions
- `caml_fp_srs_get_lagrange_basis_ptr` - Returns pointer for worker communication
- `caml_fp_srs_get_lagrange_basis_read_from_ptr` - Extracts data from pointer

### Fq Functions  
- `caml_fq_srs_get_lagrange_basis_ptr` - Returns pointer for worker communication
- `caml_fq_srs_get_lagrange_basis_read_from_ptr` - Extracts data from pointer

## Implementation Details

- **Zero breaking changes** - Original functions remain unchanged
- **Simplified approach** - New functions reuse existing implementations
- **Proven pattern** - Follows same approach as `lagrange_commitments_whole_domain_ptr`
- **Memory safe** - Uses `Box::into_raw()` and `Box::from_raw()` for pointer management

## Related PRs

This is part 1 of 3 for the complete fix:
1. **This PR**: proof-systems (Rust functions)
2. [mina#17615 (submodule reference update)](https://github.com/MinaProtocol/mina/pull/17615) 
3. [o1js#2404 (worker spec + TypeScript integration)](https://github.com/o1-labs/o1js/pull/2404)

## Files Changed

- `plonk-wasm/src/srs.rs` - Added 4 new pointer-based functions

**Commits:**
- Add Fp lagrange basis pointer functions for web compatibility
- Add Fq lagrange basis pointer functions for web compatibility