### PR TITLE
mina-signature: add method to return a dummy sig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [mina-signer](./signer)
 
+#### Added
+
+- Implement a method to return a dummy signature
+  ([#3327](https://github.com/o1-labs/proof-systems/pull/3327))
+
 #### Changed
 - (No changes in current release)
 

--- a/signer/src/signature.rs
+++ b/signer/src/signature.rs
@@ -1,6 +1,7 @@
 //! Mina signature structure and associated helpers
 
 use crate::{BaseField, ScalarField};
+use ark_ff::One;
 use core::fmt;
 use o1_utils::FieldHelpers;
 
@@ -18,6 +19,15 @@ impl Signature {
     /// Create a new signature
     pub fn new(rx: BaseField, s: ScalarField) -> Self {
         Self { rx, s }
+    }
+
+    /// Create a dummy signature, whose components are both equal to one.
+    /// Use it with caution.
+    pub fn dummy() -> Self {
+        Self {
+            rx: BaseField::one(),
+            s: ScalarField::one(),
+        }
     }
 }
 


### PR DESCRIPTION
As for https://github.com/o1-labs/proof-systems/pull/3326, it is for the Rust node, as part of https://github.com/o1-labs/mina-rust/pull/1299/files