### PR TITLE
chore: specify rust-lld, clang breaks here

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -65,7 +65,7 @@ fn main() -> Result<()> {
 type RustVersion<'a> = Option<&'a str>;
 
 fn build_wasm(out_dir: &str, target: Target, rust_version: RustVersion) -> Result<()> {
-    const RUSTFLAGS: &str = "-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--max-memory=4294967296";
+    const RUSTFLAGS: &str = "-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--max-memory=4294967296 -C linker=rust-lld";
 
     let cargo_target_dir = env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
     let artifact_dir = PathBuf::from(format!("{cargo_target_dir}/bin"));


### PR DESCRIPTION
on macOS, some builds tend towards using `clang`, when they should be using `rust-lld`, especially since `wasm-pack` is invoking this build.

we also cannot overwrite this flag, since `RUSTFLAGS` isn't respected by the `wasm-pack` invocation here, so I must open this code to modify it :(((

this branch mainly to enable native github actions workflows (no nix)