### PR TITLE
Fix xtask linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ format: ## Format the code
 		taplo fmt
 
 lint: ## Lint the code
-		cargo clippy --all --all-features --all-targets --tests --exclude xtask $(CARGO_EXTRA_ARGS) -- -W clippy::all -D warnings
+		cargo clippy --all --all-features --all-targets --tests $(CARGO_EXTRA_ARGS) -- -W clippy::all -D warnings
 
 generate-test-coverage-report: ## Generate the code coverage report
 		@echo ""

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -126,7 +126,7 @@ fn build_kimchi_stubs(target_dir: Option<&str>, offline: bool) -> Result<()> {
     let target_dir = target_dir.unwrap_or("target/kimchi_stubs_build");
 
     let mut cmd = Command::new("cargo");
-    cmd.args(&[
+    cmd.args([
         "build",
         "--release",
         "-p",


### PR DESCRIPTION
Needed to remove a single character to fix this instead of explude it when linting

