### PR TITLE
ci: add lint workflow for stable Rust

### DIFF
--- a/.github/workflows/ci-lint-stable.yml
+++ b/.github/workflows/ci-lint-stable.yml
@@ -67,7 +67,6 @@ jobs:
             plonk_wasm
             poly-commitment
             turshi
-            wasm-types
             xtask
           )
 


### PR DESCRIPTION
## Summary
- Add a new GitHub Actions workflow that runs clippy on stable Rust
- Initially all crates are excluded from linting
- As each crate is fixed to support stable Rust, it is removed from the exclude list

## Crates enabled in this PR
- [x] `wasm-types` - already passes clippy on stable (closes https://github.com/o1-labs/mina-rust/issues/1930)

## Related Issues
- Tracking issue: https://github.com/o1-labs/mina-rust/issues/1926
- Workflow issue: https://github.com/o1-labs/mina-rust/issues/1950

## How it works
The workflow defines an `EXCLUDED_CRATES` array containing workspace crates that don't yet pass clippy on stable. As each crate is fixed, it should be removed from this array so that CI starts checking it.

If all crates are excluded, the workflow exits successfully with a message instead of failing.

## Test plan
- [x] Verify the workflow runs successfully on this PR
- [x] Confirm that `wasm-types` is checked by clippy on stable