### PR TITLE
fix(mina-curves): add asm feature for stable Rust compatibility

### DIFF
--- a/.github/workflows/ci-lint-stable.yml
+++ b/.github/workflows/ci-lint-stable.yml
@@ -47,7 +47,6 @@ jobs:
           # See https://github.com/o1-labs/mina-rust/issues/1926 for tracking.
           EXCLUDED_CRATES=(
             arrabbiata
-            arkworks
             export_test_vectors
             groupmap
             internal-tracing
@@ -56,7 +55,6 @@ jobs:
             kimchi-stubs
             kimchi-visu
             mina-book
-            mina-curves
             mina-hasher
             mina-poseidon
             mina-signer

--- a/curves/Cargo.toml
+++ b/curves/Cargo.toml
@@ -9,6 +9,14 @@ readme = "../README.md"
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+default = ["asm"]
+# The MontConfig derive macro from ark_ff generates code with cfg(feature = "asm").
+# This feature enables assembly optimizations in ark_ff.
+asm = []
+# Disable the compile-time check that ensures asm is enabled.
+no-asm-check = []
+
 [dependencies]
 ark-bn254.workspace = true
 ark-ec.workspace = true

--- a/curves/src/lib.rs
+++ b/curves/src/lib.rs
@@ -1,2 +1,10 @@
+// Compile-time check to ensure asm feature is enabled for optimal performance.
+// This check can be disabled by enabling the `no-asm-check` feature.
+#[cfg(all(not(feature = "asm"), not(feature = "no-asm-check")))]
+compile_error!(
+    "The `asm` feature is not enabled. This may result in suboptimal performance. \
+     Enable the `asm` feature or set `no-asm-check` to suppress this error."
+);
+
 pub mod named;
 pub mod pasta;


### PR DESCRIPTION
The MontConfig derive macro from ark_ff generates code with cfg(feature = "asm"). Define this feature in mina-curves to satisfy the cfg check on stable Rust.

Also enables arkworks and mina-curves in the stable lint CI.

Closes https://github.com/o1-labs/mina-rust/issues/1929 Closes https://github.com/o1-labs/mina-rust/issues/1931