### PR TITLE
ci(lint-stable): enable groupmap crate

### DIFF
--- a/.github/workflows/ci-lint-stable.yml
+++ b/.github/workflows/ci-lint-stable.yml
@@ -58,7 +58,6 @@ jobs:
           EXCLUDED_CRATES=(
             arrabbiata
             export_test_vectors
-            groupmap
             kimchi
             kimchi-msm
             kimchi-stubs


### PR DESCRIPTION
## Summary
Enable `groupmap` crate in the stable Rust lint CI.

The crate already passes clippy on stable Rust without any changes.

## Related Issues
Closes https://github.com/o1-labs/mina-rust/issues/1932

## Test plan
- [x] `cargo clippy -p groupmap` passes on stable Rust