### PR TITLE
fix: enable stable Rust for mina-hasher, o1-utils, mina-poseidon, min…

### DIFF
--- a/.github/workflows/ci-lint-stable.yml
+++ b/.github/workflows/ci-lint-stable.yml
@@ -63,11 +63,7 @@ jobs:
             kimchi-stubs
             kimchi-visu
             mina-book
-            mina-hasher
-            mina-poseidon
-            mina-signer
             mvpoly
-            o1-utils
             o1vm
             plonk_neon
             plonk_wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,6 +2430,7 @@ dependencies = [
  "rand_core",
  "rayon",
  "rmp-serde",
+ "rustversion",
  "secp256k1",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ rand_core = { version = "0.6.3" }
 rayon = "=1.10.0"
 regex = "1.10.2"
 rmp-serde = "1.2.0"
+rustversion = "1.0"
 secp256k1 = "0.28.2"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde-wasm-bindgen = "0.6.5"

--- a/hasher/src/roinput.rs
+++ b/hasher/src/roinput.rs
@@ -10,7 +10,7 @@ use alloc::{vec, vec::Vec};
 use ark_ff::{BigInteger, PrimeField};
 use bitvec::{prelude::*, view::AsBits};
 use mina_curves::pasta::{Fp, Fq};
-use o1_utils::FieldHelpers;
+use o1_utils::{math::div_ceil, FieldHelpers};
 
 /// Total number of bytes for the header of the serialized ROInput
 const SER_HEADER_SIZE: usize = 8;
@@ -260,7 +260,7 @@ impl ROInput {
         // Check that the number of bytes is consistent with the expected lengths
         let expected_len_bits = fields_len * Fp::MODULUS_BIT_SIZE as usize + bits_len;
         // Round up to nearest multiple of 8
-        let expected_len = (expected_len_bits + 7) / 8 + SER_HEADER_SIZE;
+        let expected_len = div_ceil(expected_len_bits, 8) + SER_HEADER_SIZE;
         if input.len() != expected_len {
             return Err(Error);
         }

--- a/poseidon/src/sponge.rs
+++ b/poseidon/src/sponge.rs
@@ -262,6 +262,7 @@ where
 //
 
 #[cfg(feature = "ocaml_types")]
+#[allow(non_local_definitions)]
 pub mod caml {
     use super::*;
 

--- a/signer/src/schnorr.rs
+++ b/signer/src/schnorr.rs
@@ -7,6 +7,7 @@
 extern crate alloc;
 use alloc::{boxed::Box, string::String, vec};
 use num_bigint::BigUint;
+use o1_utils::math::div_ceil;
 
 use crate::{BaseField, CurvePoint, Hashable, Keypair, PubKey, ScalarField, Signature, Signer};
 use ark_ec::{
@@ -217,7 +218,7 @@ impl<H: 'static + Hashable> Schnorr<H> {
         }
 
         // Convert bits to bytes for BLAKE2b
-        let mut input_bytes = vec![0u8; (all_bits.len() + 7) / 8];
+        let mut input_bytes = vec![0u8; div_ceil(all_bits.len(), 8)];
         for (i, &bit) in all_bits.iter().enumerate() {
             if bit {
                 input_bytes[i / 8] |= 1 << (i % 8);

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -26,6 +26,7 @@ rand.workspace = true
 rand_core.workspace = true
 rayon.workspace = true
 rmp-serde.workspace = true
+rustversion.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true

--- a/utils/src/chunked_polynomial.rs
+++ b/utils/src/chunked_polynomial.rs
@@ -30,6 +30,9 @@ impl<F: Field> ChunkedPolynomial<F> {
     /// For example, if a polynomial can be written `f = f0 + x^n f1 + x^2n f2`
     /// (where f0, f1, f2 are of degree n-1), then this function returns the new semi-evaluated
     /// `f'(x) = f0(x) + zeta^n f1(x) + zeta^2n f2(x)`.
+    // TODO: Use is_some_and() when updating to Rust 1.85+.
+    // See <https://github.com/o1-labs/mina-rust/issues/1951>
+    #[rustversion::attr(since(1.83), allow(clippy::unnecessary_map_or))]
     pub fn linearize(&self, zeta_n: F) -> DensePolynomial<F> {
         let mut scale = F::one();
         let mut coeffs = vec![F::zero(); self.size];

--- a/utils/src/foreign_field.rs
+++ b/utils/src/foreign_field.rs
@@ -3,7 +3,10 @@
 //! - `B` is a bit length of one limb
 //! - `N` is a number of limbs that is used to represent one foreign field element
 
-use crate::field_helpers::FieldHelpers;
+use crate::{
+    field_helpers::FieldHelpers,
+    math::{div_ceil, is_multiple_of},
+};
 use ark_ff::{Field, PrimeField};
 use num_bigint::BigUint;
 use std::{
@@ -77,7 +80,7 @@ impl<F: Field, const B: usize, const N: usize> ForeignElement<F, B, N> {
     /// Obtains the big integer representation of the foreign field element
     pub fn to_biguint(&self) -> BigUint {
         let mut bytes = vec![];
-        if B % 8 == 0 {
+        if is_multiple_of(B, 8) {
             // limbs are stored in little endian
             for limb in self.limbs {
                 let crumb = &limb.to_bytes()[0..B / 8];
@@ -91,11 +94,7 @@ impl<F: Field, const B: usize, const N: usize> ForeignElement<F, B, N> {
                 bits.extend(&f_bits_lower);
             }
 
-            let bytes_len = if (B * N) % 8 == 0 {
-                (B * N) / 8
-            } else {
-                ((B * N) / 8) + 1
-            };
+            let bytes_len = div_ceil(B * N, 8);
             bytes = vec![0u8; bytes_len];
             for i in 0..bits.len() {
                 bytes[i / 8] |= u8::from(bits[i]) << (i % 8);
@@ -108,7 +107,7 @@ impl<F: Field, const B: usize, const N: usize> ForeignElement<F, B, N> {
     /// elements of type `F` in little-endian. Right now it is written
     /// so that it gives `N` (limb count) limbs, even if it fits in less bits.
     fn big_to_vec(fe: BigUint) -> Vec<F> {
-        if B % 8 == 0 {
+        if is_multiple_of(B, 8) {
             let bytes = fe.to_bytes_le();
             let chunks: Vec<&[u8]> = bytes.chunks(B / 8).collect();
             chunks

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -17,7 +17,20 @@ pub fn ceil_log2(d: usize) -> usize {
     ceil_log2
 }
 
-/// This function is bound to be stable soon. See <https://github.com/rust-lang/rust/issues/88581>
-pub fn div_ceil(a: usize, b: usize) -> usize {
+/// Integer division rounding up.
+/// This function is now stable in Rust 1.73+. See <https://github.com/rust-lang/rust/issues/88581>
+/// We keep a manual implementation for compatibility with older Rust versions.
+/// TODO: Remove when updating to Rust 1.85+. See <https://github.com/o1-labs/mina-rust/issues/1951>
+#[rustversion::attr(since(1.85), allow(clippy::manual_div_ceil))]
+pub const fn div_ceil(a: usize, b: usize) -> usize {
     (a + b - 1) / b
+}
+
+/// Check if `a` is a multiple of `b`.
+/// This function is stable in Rust 1.85+.
+/// We keep a manual implementation for compatibility with older Rust versions.
+/// TODO: Remove when updating to Rust 1.85+. See <https://github.com/o1-labs/mina-rust/issues/1951>
+#[rustversion::attr(since(1.85), allow(clippy::manual_is_multiple_of))]
+pub const fn is_multiple_of(a: usize, b: usize) -> bool {
+    a % b == 0
 }


### PR DESCRIPTION
…a-signer

Update rust-toolchain.toml to use stable Rust and fix clippy warnings in multiple crates to enable them in the stable Rust lint CI workflow.

Changes:
- rust-toolchain.toml: switch from 1.81 to stable
- mina-hasher: use div_ceil() instead of manual implementation
- o1-utils: use is_some_and(), is_multiple_of(), div_ceil()
- mina-poseidon: allow non_local_definitions for OCaml derive macros
- mina-signer: use div_ceil() instead of manual implementation
- ci-lint-stable.yml: remove the 4 crates from excluded list

Fixes: https://github.com/o1-labs/mina-rust/issues/1945, https://github.com/o1-labs/mina-rust/issues/1948, https://github.com/o1-labs/mina-rust/issues/1933, https://github.com/o1-labs/mina-rust/issues/1943