### PR TITLE
fix: enable stable Rust for poly-commitment and export_test_vectors

### DIFF
--- a/.github/workflows/ci-lint-stable.yml
+++ b/.github/workflows/ci-lint-stable.yml
@@ -57,7 +57,6 @@ jobs:
           # See https://github.com/o1-labs/mina-rust/issues/1926 for tracking.
           EXCLUDED_CRATES=(
             arrabbiata
-            export_test_vectors
             kimchi
             kimchi-msm
             kimchi-stubs
@@ -67,7 +66,6 @@ jobs:
             o1vm
             plonk_neon
             plonk_wasm
-            poly-commitment
             turshi
             xtask
           )

--- a/poly-commitment/src/combine.rs
+++ b/poly-commitment/src/combine.rs
@@ -22,11 +22,12 @@ use ark_ec::{
 use ark_ff::{BitIteratorBE, Field, One, PrimeField, Zero};
 use itertools::Itertools;
 use mina_poseidon::sponge::ScalarChallenge;
+use o1_utils::math::is_multiple_of;
 use rayon::prelude::*;
 use std::ops::AddAssign;
 
 fn add_pairs_in_place<P: SWCurveConfig>(pairs: &mut Vec<SWJAffine<P>>) {
-    let len = if pairs.len() % 2 == 0 {
+    let len = if is_multiple_of(pairs.len(), 2) {
         pairs.len()
     } else {
         pairs.len() - 1

--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -269,7 +269,7 @@ where
     }
 }
 
-impl<'a, 'b, C: AffineRepr> Add<&'a PolyComm<C>> for &'b PolyComm<C> {
+impl<'a, C: AffineRepr> Add<&'a PolyComm<C>> for &PolyComm<C> {
     type Output = PolyComm<C>;
 
     fn add(self, other: &'a PolyComm<C>) -> PolyComm<C> {
@@ -290,7 +290,7 @@ impl<'a, 'b, C: AffineRepr> Add<&'a PolyComm<C>> for &'b PolyComm<C> {
     }
 }
 
-impl<'a, 'b, C: AffineRepr + Sub<Output = C::Group>> Sub<&'a PolyComm<C>> for &'b PolyComm<C> {
+impl<'a, C: AffineRepr + Sub<Output = C::Group>> Sub<&'a PolyComm<C>> for &PolyComm<C> {
     type Output = PolyComm<C>;
 
     fn sub(self, other: &'a PolyComm<C>) -> PolyComm<C> {
@@ -376,7 +376,7 @@ pub fn b_poly<F: Field>(chals: &[F], x: F) -> F {
         pow_twos.push(pow_twos[i - 1].square());
     }
 
-    product((0..k).map(|i| (F::one() + (chals[i] * pow_twos[k - 1 - i]))))
+    product((0..k).map(|i| F::one() + (chals[i] * pow_twos[k - 1 - i])))
 }
 
 pub fn b_poly_coefficients<F: Field>(chals: &[F]) -> Vec<F> {
@@ -638,6 +638,7 @@ pub fn combine_commitments<G: CommitmentCurve>(
 }
 
 #[cfg(feature = "ocaml_types")]
+#[allow(non_local_definitions)]
 pub mod caml {
     // polynomial commitment
     use super::PolyComm;

--- a/poly-commitment/src/ipa.rs
+++ b/poly-commitment/src/ipa.rs
@@ -891,7 +891,7 @@ impl<G: CommitmentCurve> SRS<G> {
         // polynomial commitments, we obtain a chunked commitment to the L_i
         // polynomials.
         let srs_size = self.g.len();
-        let num_elems = (n + srs_size - 1) / srs_size;
+        let num_elems = math::div_ceil(n, srs_size);
         let mut chunks = Vec::with_capacity(num_elems);
 
         // For each chunk
@@ -1027,6 +1027,7 @@ impl<G: AffineRepr> OpeningProof<G> {
 }
 
 #[cfg(feature = "ocaml_types")]
+#[allow(non_local_definitions)]
 pub mod caml {
     use super::OpeningProof;
     use ark_ec::AffineRepr;

--- a/poly-commitment/src/utils.rs
+++ b/poly-commitment/src/utils.rs
@@ -33,7 +33,7 @@ impl<F, P> ScaledChunkedPolynomial<F, P> {
     }
 }
 
-impl<'a, F: Field> ScaledChunkedPolynomial<F, &'a [F]> {
+impl<F: Field> ScaledChunkedPolynomial<F, &[F]> {
     /// Compute the resulting scaled polynomial.
     /// Example:
     /// Given the two polynomials `1 + 2X` and `3 + 4X`, and the scaling
@@ -74,9 +74,9 @@ impl<'a, F: Field> ScaledChunkedPolynomial<F, &'a [F]> {
 ///
 /// Parameters:
 /// - `plnms`: vector of polynomials, either in evaluations or coefficients form, together with
-///    a set of scalars representing their blinders.
+///   a set of scalars representing their blinders.
 /// - `polyscale`: scalar to combine the polynomials, which will be scaled based on the number of
-///    polynomials to combine.
+///   polynomials to combine.
 ///
 /// Output:
 /// - `combined_poly`: combined polynomial. The order of the output follows the order of `plnms`.

--- a/poly-commitment/tests/commitment.rs
+++ b/poly-commitment/tests/commitment.rs
@@ -78,7 +78,7 @@ impl AggregatedEvaluationProof {
     /// verify API understands
     pub fn verify_type(
         &self,
-    ) -> BatchEvaluationProof<Vesta, DefaultFqSponge<VestaParameters, SC>, OpeningProof<Vesta>>
+    ) -> BatchEvaluationProof<'_, Vesta, DefaultFqSponge<VestaParameters, SC>, OpeningProof<Vesta>>
     {
         let mut coms = vec![];
         for eval_com in &self.eval_commitments {

--- a/poly-commitment/tests/ipa_commitment.rs
+++ b/poly-commitment/tests/ipa_commitment.rs
@@ -8,7 +8,7 @@ use mina_curves::pasta::{Fp, Pallas, Vesta as VestaG, VestaParameters};
 use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi as SC, sponge::DefaultFqSponge, FqSponge,
 };
-use o1_utils::ExtendedDensePolynomial;
+use o1_utils::{math::div_ceil, ExtendedDensePolynomial};
 use poly_commitment::{
     commitment::{combined_inner_product, BatchEvaluationProof, CommitmentCurve, Evaluation},
     ipa::SRS,
@@ -96,7 +96,7 @@ fn test_offset_chunked_lagrange_commitments() {
     srs.get_lagrange_basis(domain);
 
     // Is this even taken into account?...
-    let num_chunks = (domain.size() + srs.g.len() - 1) / srs.g.len();
+    let num_chunks = div_ceil(domain.size(), srs.g.len());
     assert!(num_chunks == 2);
 
     let expected_lagrange_commitments: Vec<_> = (0..n)

--- a/utils/src/chunked_polynomial.rs
+++ b/utils/src/chunked_polynomial.rs
@@ -45,9 +45,6 @@ impl<F: Field> ChunkedPolynomial<F> {
             scale *= zeta_n;
         }
 
-        // TODO: Use is_some_and() when updating to Rust 1.85+.
-        // See <https://github.com/o1-labs/mina-rust/issues/1951>
-        #[allow(clippy::unnecessary_map_or)]
         while coeffs.last().map_or(false, |c| c.is_zero()) {
             coeffs.pop();
         }


### PR DESCRIPTION
## Summary

- Enable `poly-commitment` and `export_test_vectors` crates for stable Rust linting in CI
- Fix clippy warnings for Rust stable compatibility

## Changes

**export_test_vectors (https://github.com/o1-labs/mina-rust/issues/1944):**
- No code changes needed - already compatible
- Removed from CI excluded list

**poly-commitment (https://github.com/o1-labs/mina-rust/issues/1942):**
- Added `#[allow(non_local_definitions)]` to OCaml caml modules in `commitment.rs` and `ipa.rs`
- Fixed doc indentation in `utils.rs`
- Used `o1_utils::math::div_ceil` and `is_multiple_of` helpers
- Elided unnecessary lifetimes in impl blocks
- Fixed mismatched lifetime syntax in test file
- Removed from CI excluded list

## Test plan

- [x] `cargo clippy -p poly-commitment -p export_test_vectors --all-features --all-targets -- -W clippy::all -D warnings` passes
- [x] `cargo test -p poly-commitment -p export_test_vectors` passes

Fixes: https://github.com/o1-labs/mina-rust/issues/1942, https://github.com/o1-labs/mina-rust/issues/1944

**Note:** This PR is part of a PR train. Base branch is `dw/stable-rust-mina-hasher`.