### PR TITLE
ci(lint-stable): enable kimchi-stubs crate

### DIFF
--- a/.github/workflows/ci-lint-stable.yml
+++ b/.github/workflows/ci-lint-stable.yml
@@ -58,7 +58,6 @@ jobs:
           EXCLUDED_CRATES=(
             arrabbiata
             kimchi-msm
-            kimchi-stubs
             kimchi-visu
             mina-book
             mvpoly


### PR DESCRIPTION
## Summary

- Enable `kimchi-stubs` crate for stable Rust linting in CI
- kimchi-stubs already passes clippy on stable Rust without any changes needed

## Test plan

- [ ] Verify CI passes

Closes https://github.com/o1-labs/mina-rust/issues/1936