### PR TITLE
ci(lint-stable): enable kimchi-visu crate

### DIFF
--- a/.github/workflows/ci-lint-stable.yml
+++ b/.github/workflows/ci-lint-stable.yml
@@ -57,7 +57,6 @@ jobs:
           # See https://github.com/o1-labs/mina-rust/issues/1926 for tracking.
           EXCLUDED_CRATES=(
             arrabbiata
-            kimchi-visu
             mina-book
             mvpoly
             o1vm


### PR DESCRIPTION
## Summary

- Enable `kimchi-visu` crate for stable Rust linting in CI
- kimchi-visu already passes clippy on stable Rust without any changes needed

## Test plan

- [ ] Verify CI passes

Closes https://github.com/o1-labs/mina-rust/issues/1938