### PR TITLE
ci(lint-stable): enable mvpoly crate

### DIFF
--- a/.github/workflows/ci-lint-stable.yml
+++ b/.github/workflows/ci-lint-stable.yml
@@ -58,7 +58,6 @@ jobs:
           EXCLUDED_CRATES=(
             arrabbiata
             mina-book
-            mvpoly
             o1vm
             plonk_neon
             plonk_wasm


### PR DESCRIPTION
## Summary

- Enable `mvpoly` crate for stable Rust linting in CI
- mvpoly already passes clippy on stable Rust without any changes needed

## Test plan

- [ ] Verify CI passes

Closes https://github.com/o1-labs/mina-rust/issues/1940