### PR TITLE
ci(lint-stable): enable turshi crate

### DIFF
--- a/.github/workflows/ci-lint-stable.yml
+++ b/.github/workflows/ci-lint-stable.yml
@@ -61,7 +61,6 @@ jobs:
             o1vm
             plonk_neon
             plonk_wasm
-            turshi
             xtask
           )
 


### PR DESCRIPTION
## Summary

- Enable `turshi` crate for stable Rust linting in CI
- turshi already passes clippy on stable Rust without any changes needed

## Test plan

- [ ] Verify CI passes

Closes https://github.com/o1-labs/mina-rust/issues/1946