### PR TITLE
ci(lint-stable): enable arrabbiata crate

### DIFF
--- a/.github/workflows/ci-lint-stable.yml
+++ b/.github/workflows/ci-lint-stable.yml
@@ -56,7 +56,6 @@ jobs:
           # Remove crates from this list as they are fixed.
           # See https://github.com/o1-labs/mina-rust/issues/1926 for tracking.
           EXCLUDED_CRATES=(
-            arrabbiata
             mina-book
             o1vm
             plonk_neon


### PR DESCRIPTION
## Summary

- Enable `arrabbiata` crate for stable Rust linting in CI
- arrabbiata already passes clippy on stable Rust without any changes needed

## Test plan

- [ ] Verify CI passes

Closes https://github.com/o1-labs/mina-rust/issues/1927