### PR TITLE
ci(lint-stable): enable o1vm crate

### DIFF
--- a/.github/workflows/ci-lint-stable.yml
+++ b/.github/workflows/ci-lint-stable.yml
@@ -57,7 +57,6 @@ jobs:
           # See https://github.com/o1-labs/mina-rust/issues/1926 for tracking.
           EXCLUDED_CRATES=(
             mina-book
-            o1vm
             plonk_neon
             plonk_wasm
           )


### PR DESCRIPTION
## Summary
- Enable the o1vm crate for stable Rust clippy linting

## Test plan
- [ ] CI passes with stable Rust clippy on o1vm

Part of the stable Rust migration effort tracked in https://github.com/o1-labs/mina-rust/issues/1926