### PR TITLE
ci(lint-stable): enable plonk_wasm crate

### DIFF
--- a/.github/workflows/ci-lint-stable.yml
+++ b/.github/workflows/ci-lint-stable.yml
@@ -57,7 +57,6 @@ jobs:
           # See https://github.com/o1-labs/mina-rust/issues/1926 for tracking.
           EXCLUDED_CRATES=(
             mina-book
-            plonk_wasm
           )
 
           # Count workspace members


### PR DESCRIPTION
## Summary
- Enable the plonk_wasm crate for stable Rust clippy linting

## Test plan
- [ ] CI passes with stable Rust clippy on plonk_wasm

Part of the stable Rust migration effort tracked in https://github.com/o1-labs/mina-rust/issues/1926