### PR TITLE
ci(lint-stable): enable mina-book crate (all crates enabled)

### DIFF
--- a/.github/workflows/ci-lint-stable.yml
+++ b/.github/workflows/ci-lint-stable.yml
@@ -56,7 +56,6 @@ jobs:
           # Remove crates from this list as they are fixed.
           # See https://github.com/o1-labs/mina-rust/issues/1926 for tracking.
           EXCLUDED_CRATES=(
-            mina-book
           )
 
           # Count workspace members


### PR DESCRIPTION
## Summary
- Enable the mina-book crate for stable Rust clippy linting
- **This completes the stable Rust migration!** All workspace crates are now linted on stable Rust.

## Test plan
- [ ] CI passes with stable Rust clippy on all crates

Part of the stable Rust migration effort tracked in https://github.com/o1-labs/mina-rust/issues/1926