### PR TITLE
feat: add no-std feature to poly-commitment crate

### DIFF
--- a/.github/workflows/no-std.yml
+++ b/.github/workflows/no-std.yml
@@ -26,12 +26,12 @@ jobs:
           - { name: "mina-signer", path: "signer" } # https://github.com/o1-labs/mina-rust/issues/1995
           - { name: "groupmap", path: "groupmap" } # https://github.com/o1-labs/mina-rust/issues/1985
           - { name: "o1-utils", path: "utils" } # https://github.com/o1-labs/mina-rust/issues/1988
+          - { name: "poly-commitment", path: "poly-commitment" } # https://github.com/o1-labs/mina-rust/issues/1990
           # TODO: Add no-std feature to these crates
           # - { name: "wasm-types", path: "crates/wasm-types" }
           # - { name: "turshi", path: "turshi" } # https://github.com/o1-labs/mina-rust/issues/1986
           # - { name: "mina-curves", path: "curves" } # https://github.com/o1-labs/mina-rust/issues/1987
           # - { name: "internal-tracing", path: "internal-tracing" } # https://github.com/o1-labs/mina-rust/issues/1989
-          # - { name: "poly-commitment", path: "poly-commitment" } # https://github.com/o1-labs/mina-rust/issues/1990
           # - { name: "kimchi", path: "kimchi" } # https://github.com/o1-labs/mina-rust/issues/1991
           # - { name: "kimchi-msm", path: "msm" } # https://github.com/o1-labs/mina-rust/issues/1992
           # - { name: "mvpoly", path: "mvpoly" } # https://github.com/o1-labs/mina-rust/issues/1993

--- a/poly-commitment/Cargo.toml
+++ b/poly-commitment/Cargo.toml
@@ -42,6 +42,9 @@ rand_chacha.workspace = true
 ark-bn254.workspace = true
 
 [features]
+default = ["std"]
+std = []
+no-std = []
 ocaml_types = ["ocaml", "ocaml-gen"]
 
 [[bench]]

--- a/poly-commitment/src/ipa.rs
+++ b/poly-commitment/src/ipa.rs
@@ -13,6 +13,8 @@ use crate::{
     utils::combine_polys,
     BlindedCommitment, PolyComm, PolynomialsToCombine, SRS as SRSTrait,
 };
+#[cfg(feature = "no-std")]
+use alloc::{vec, vec::Vec};
 use ark_ec::{AffineRepr, CurveGroup, VariableBaseMSM};
 use ark_ff::{BigInteger, Field, One, PrimeField, UniformRand, Zero};
 use ark_poly::{
@@ -20,6 +22,7 @@ use ark_poly::{
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use blake2::{Blake2b512, Digest};
+use core::{cmp::min, iter::Iterator, ops::AddAssign};
 use groupmap::GroupMap;
 use mina_poseidon::{sponge::ScalarChallenge, FqSponge};
 use o1_utils::{
@@ -30,7 +33,6 @@ use rand::{CryptoRng, RngCore};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::{cmp::min, iter::Iterator, ops::AddAssign};
 
 #[serde_as]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

- Add `no-std` feature to poly-commitment with prover/verifier split
- SRS trait: verification methods (`max_poly_size`, `blinding_commitment`, `size`) available in no-std, prover methods require std
- OpenProof trait: `verify` method available in no-std, `open` method requires std
- Feature-gate std-only modules: combine, utils, ipa, kzg, lagrange_basis, precomputed_srs, hash_map_cache, pbt_srs
- Update commitment.rs: core types available in no-std, EndoCurve and multi_scalar_mul require std
- Add poly-commitment to CI no-std workflow

Fixes https://github.com/o1-labs/mina-rust/issues/1990

## Test plan

- [x] `cargo check -p poly-commitment --features no-std --no-default-features` passes
- [x] `cargo check -p poly-commitment` passes (std build)
- [x] `cargo clippy` passes for both modes