### PR TITLE
CI: skip macOS tests and docs on PRs to improve velocity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,16 @@ jobs:
           echo 'rust_version=1.92' >> "$GITHUB_OUTPUT"
           echo 'os=ubuntu-latest' >> "$GITHUB_OUTPUT"
       - id: matrix
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
         run: |
           # Build matrix: 1.92/stable/beta for Ubuntu, stable/beta for macOS
           # We keep 1.92 to match mina-rust and MinaProtocol/mina.
-          cat > matrix.json << 'EOF'
+          # Skip macOS on PRs to improve CI velocity (macOS runners are limited)
+          # macOS runs on master pushes only
+          if [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/master" ]]; then
+            cat > matrix.json << 'EOF'
           {
             "include": [
               {"rust_toolchain_version": "1.92", "os": "ubuntu-latest"},
@@ -63,6 +69,17 @@ jobs:
             ]
           }
           EOF
+          else
+            cat > matrix.json << 'EOF'
+          {
+            "include": [
+              {"rust_toolchain_version": "1.92", "os": "ubuntu-latest"},
+              {"rust_toolchain_version": "stable", "os": "ubuntu-latest"},
+              {"rust_toolchain_version": "beta", "os": "ubuntu-latest"}
+            ]
+          }
+          EOF
+          fi
           echo "value=$(cat matrix.json | jq -c .)" >> "$GITHUB_OUTPUT"
 
   refresh-cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### CI
 
 - Remove Rust 1.81 from CI matrix, update MSRV to 1.92 to match mina-rust and MinaProtocol/mina ([#3419](https://github.com/o1-labs/proof-systems/pull/3419))
+- Skip macOS tests and docs jobs on PRs to improve CI velocity; macOS runs on master only
+  ([#3429](https://github.com/o1-labs/proof-systems/pull/3429),
+  [o1-labs/mina-rust#2024](https://github.com/o1-labs/mina-rust/issues/2024))
 
 ### [arrabbiata](./arrabbiata)
 


### PR DESCRIPTION
## Summary

- Skip `doc-and-spec` and `tests` jobs on macOS for PRs (run on master only)
- Keep `build` job on macOS for all PRs to ensure compilation works

This reduces macOS runner usage on PRs while maintaining full coverage on master.

## Tracking

- https://github.com/o1-labs/mina-rust/issues/2024
- Slack notification follow-up: https://github.com/o1-labs/mina-rust/issues/2023

## Test plan

- [ ] Verify macOS build job still runs on this PR
- [ ] Verify macOS tests/docs jobs are skipped on this PR
- [ ] After merge, verify macOS tests/docs run on master