### PR TITLE
Use o1-labs fork of cargo-specification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,9 +137,10 @@ jobs:
         with:
           ocaml_version: ${{ matrix.ocaml_version }}
 
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-spec
+      - name: Install cargo-spec from o1-labs fork
+        run: |
+          cargo install --git https://github.com/o1-labs/cargo-specification.git \
+            --branch main cargo-spec
 
       - name: Install markdownlint
         run: |

--- a/book/specifications/README.md
+++ b/book/specifications/README.md
@@ -7,15 +7,16 @@ The `specifications/` directory hosts specifications-related code:
 - [kimchi/](kimchi/) contains the specification for the proof system
 
 The specifications are written using
-[cargo-spec](https://crates.io/crates/cargo-spec), which combines markdown files
-as well as text extracted directly from the code.
+[cargo-spec](https://github.com/o1-labs/cargo-specification), which combines
+markdown files as well as text extracted directly from the code.
 
 ## Set up
 
-Install cargo-spec:
+Install cargo-spec from the o1-labs fork:
 
 ```console
-$ cargo install cargo-spec
+$ cargo install --git https://github.com/o1-labs/cargo-specification.git \
+    --branch main cargo-spec
 ```
 
 You will also need markdownlint:


### PR DESCRIPTION
## Summary

- Switch from crates.io cargo-spec to o1-labs fork main branch
- Update CI workflow to install from git repository
- Update specifications README with new installation instructions

## Test plan

- [ ] CI passes with the o1-labs fork
- [ ] Specification builds correctly