### PR TITLE
CI: add merge_group trigger for merge queue support

### DIFF
--- a/.github/workflows/benches-mina-prover.yml
+++ b/.github/workflows/benches-mina-prover.yml
@@ -2,6 +2,7 @@ name: Bench mina circuits (check regressions against master)
 
 on:
   pull_request:
+  merge_group:
 
 env:
   OCAML_VERSION: "4.14.2"

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -16,6 +16,7 @@ name: Lint
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     workflows: [Nightly tests with the code coverage]
     types: [completed]
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -3,6 +3,7 @@ name: Global configuration for formatting related jobs
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
 
 jobs:
   run_rust_formatting:

--- a/.github/workflows/test-export-vectors.yml
+++ b/.github/workflows/test-export-vectors.yml
@@ -3,6 +3,7 @@ name: Test Export Test Vectors
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -3,6 +3,7 @@ name: Wasm
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches:
       - master


### PR DESCRIPTION
## Summary

- Add `merge_group` event trigger to all workflows that run on pull requests
- This enables GitHub's merge queue feature on the master branch

## Workflows updated

- `ci.yml` - Main CI workflow
- `ci-lint.yml` - Clippy linting
- `fmt.yml` - Rust formatting
- `test-export-vectors.yml` - Export vectors tests
- `wasm.yml` - WebAssembly builds
- `benches-mina-prover.yml` - Mina prover benchmarks

## Not updated

Label-triggered benchmark workflows are not updated as they are manually
triggered and not part of the standard PR checks:
- `benches.yml`
- `benches-mina-prover-set-baseline.yml`

## Test plan

- [ ] Verify CI passes on this PR
- [ ] After merge, test merge queue by adding a PR to the queue