### PR TITLE
poly-commitment: make multi_scalar_mul generic over Borrow

### DIFF
--- a/kimchi-stubs/src/oracles.rs
+++ b/kimchi-stubs/src/oracles.rs
@@ -45,10 +45,9 @@ macro_rules! impl_oracles {
                     .take(proof.proof.public.len())
                     .map(Into::into)
                     .collect();
-                let lgr_comm_refs: Vec<_> = lgr_comm.iter().collect();
 
                 let p_comm = PolyComm::<$G>::multi_scalar_mul(
-                    &lgr_comm_refs,
+                    &lgr_comm,
                     &proof
                         .proof
                         .public
@@ -122,10 +121,9 @@ macro_rules! impl_oracles {
                     .take(proof.proof.public.len())
                     .map(Into::into)
                     .collect();
-                let lgr_comm_refs: Vec<_> = lgr_comm.iter().collect();
 
                 let p_comm = PolyComm::<$G>::multi_scalar_mul(
-                    &lgr_comm_refs,
+                    &lgr_comm,
                     &proof
                         .proof
                         .public

--- a/kimchi/src/oracles.rs
+++ b/kimchi/src/oracles.rs
@@ -79,11 +79,10 @@ pub mod caml {
         CurveParams: poly_commitment::OpenProof<G, FULL_ROUNDS>,
     {
         let lgr_comm: Vec<PolyComm<G>> = lgr_comm.into_iter().take(public_input.len()).collect();
-        let lgr_comm_refs: Vec<_> = lgr_comm.iter().collect();
 
         let negated_public: Vec<_> = public_input.iter().map(|s| -*s).collect();
 
-        let p_comm = PolyComm::<G>::multi_scalar_mul(&lgr_comm_refs, &negated_public);
+        let p_comm = PolyComm::<G>::multi_scalar_mul(&lgr_comm, &negated_public);
 
         let oracles_result = proof.oracles::<EFqSponge, EFrSponge, CurveParams>(
             &index,

--- a/kimchi/src/verifier.rs
+++ b/kimchi/src/verifier.rs
@@ -839,12 +839,12 @@ where
         let lgr_comm = verifier_index
             .srs()
             .get_lagrange_basis(verifier_index.domain);
-        let com: Vec<_> = lgr_comm.iter().take(verifier_index.public).collect();
+        let com = &lgr_comm[..verifier_index.public];
         if public_input.is_empty() {
             PolyComm::new(vec![verifier_index.srs().blinding_commitment(); chunk_size])
         } else {
             let elm: Vec<_> = public_input.iter().map(|s| -*s).collect();
-            let public_comm = PolyComm::<G>::multi_scalar_mul(&com, &elm);
+            let public_comm = PolyComm::<G>::multi_scalar_mul(com, &elm);
             verifier_index
                 .srs()
                 .mask_custom(

--- a/plonk-wasm/src/oracles.rs
+++ b/plonk-wasm/src/oracles.rs
@@ -184,10 +184,8 @@ macro_rules! impl_oracles {
                         .take(proof.public.len())
                         .map(Into::into)
                         .collect();
-                    let lgr_comm_refs: Vec<_> = lgr_comm.iter().collect();
-
                     let p_comm = PolyComm::<$G>::multi_scalar_mul(
-                        &lgr_comm_refs,
+                        &lgr_comm,
                         &proof
                             .public
                             .iter()

--- a/poly-commitment/src/ipa.rs
+++ b/poly-commitment/src/ipa.rs
@@ -582,8 +582,7 @@ where
     ) -> PolyComm<G> {
         let basis = self.get_lagrange_basis(domain);
         let commit_evaluations = |evals: &Vec<G::ScalarField>, basis: &Vec<PolyComm<G>>| {
-            let basis_refs: Vec<_> = basis.iter().collect();
-            PolyComm::<G>::multi_scalar_mul(&basis_refs, evals)
+            PolyComm::<G>::multi_scalar_mul(basis, evals)
         };
         match domain.size.cmp(&plnm.domain().size) {
             std::cmp::Ordering::Less => {


### PR DESCRIPTION
Change multi_scalar_mul to accept &[B] where B: Borrow<Self>, allowing callers to pass both &[PolyComm<G>] and &[&PolyComm<G>] directly. This eliminates redundant Vec<&PolyComm> allocations at call sites that already own their data.