### PR TITLE
Add missing Poseidon assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@ and this project adheres to
   ([#3467](https://github.com/o1-labs/proof-systems/pull/3467))
 - Add check that the state input length of `poseidon_block_cipher` is
   `SC::SPONGE_WIDTH` (e.g. 3)
-  ([#3467](https://github.com/o1-labs/proof-systems/pull/3467))
+  ([#3499](https://github.com/o1-labs/proof-systems/pull/3499))
 
 #### Changed
 

--- a/poseidon/src/permutation.rs
+++ b/poseidon/src/permutation.rs
@@ -129,10 +129,17 @@ pub fn half_rounds<F: Field, SC: SpongeConstants, const FULL_ROUNDS: usize>(
 /// states of length [`SpongeConstants::SPONGE_WIDTH`], the function will not
 /// incur in trailing-zeros padding type of collisions.
 ///
+/// # Panics
+///
+/// The function will panic if the length of the input state is not equal to the
+/// sponge width defined in the sponge constants.
+///
 pub fn poseidon_block_cipher<F: Field, SC: SpongeConstants, const FULL_ROUNDS: usize>(
     params: &ArithmeticSpongeParams<F, FULL_ROUNDS>,
     state: &mut [F],
 ) {
+    assert!(state.len() == SC::SPONGE_WIDTH);
+
     if SC::PERM_HALF_ROUNDS_FULL == 0 {
         if SC::PERM_INITIAL_ARK {
             state


### PR DESCRIPTION
It adds the assertion line (https://github.com/o1-labs/proof-systems/pull/3467#discussion_r2764856203) that was unintentionally removed from the diff of an already merged PR https://github.com/o1-labs/proof-systems/pull/3467

It adds a sanity check on the input state length of `poseidon_block_cipher` (a.k.a. 3) to warranty good functioning of the function. Just as a side note, we are always using it correctly, but it's good to have that check. 

Discussions with @richardpringle show that probably a slice of asserted length 3 is more efficient than arrays of length 3.