### PR TITLE
Revert constant functions in `poly-commitment` for CI nix failing jobs

### DIFF
--- a/poly-commitment/src/commitment.rs
+++ b/poly-commitment/src/commitment.rs
@@ -196,13 +196,13 @@ impl<A: Copy + Clone + CanonicalDeserialize + CanonicalSerialize> PolyComm<A> {
 
     /// Returns the number of chunks.
     #[must_use]
-    pub const fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.chunks.len()
     }
 
     /// Returns `true` if the commitment is empty.
     #[must_use]
-    pub const fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.chunks.is_empty()
     }
 


### PR DESCRIPTION
https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/40600#019c8c47-d139-431a-bfc1-91abe8439e31

```
error: builder for '/nix/store/43avlbj1m0mqqahg4qywyh0svgbglhcc-plonk_wasm-0.1.0.drv' failed with exit code 1;
--
last 10 log lines:
>     \|
>     = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
```