### PR TITLE
fix lookup selectors to use `num_chunks` for chunking 

### DIFF
--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1399,22 +1399,22 @@ where
             if let Some(runtime_lookup_table_selector) = &lcs.runtime_selector {
                 polynomials.push((
                     evaluations_form(runtime_lookup_table_selector),
-                    non_hiding(1),
+                    non_hiding(num_chunks),
                 ))
             }
             if let Some(xor_lookup_selector) = &lcs.lookup_selectors.xor {
-                polynomials.push((evaluations_form(xor_lookup_selector), non_hiding(1)))
+                polynomials.push((evaluations_form(xor_lookup_selector), non_hiding(num_chunks)))
             }
             if let Some(lookup_gate_selector) = &lcs.lookup_selectors.lookup {
-                polynomials.push((evaluations_form(lookup_gate_selector), non_hiding(1)))
+                polynomials.push((evaluations_form(lookup_gate_selector), non_hiding(num_chunks)))
             }
             if let Some(range_check_lookup_selector) = &lcs.lookup_selectors.range_check {
-                polynomials.push((evaluations_form(range_check_lookup_selector), non_hiding(1)))
+                polynomials.push((evaluations_form(range_check_lookup_selector), non_hiding(num_chunks)))
             }
             if let Some(foreign_field_mul_lookup_selector) = &lcs.lookup_selectors.ffmul {
                 polynomials.push((
                     evaluations_form(foreign_field_mul_lookup_selector),
-                    non_hiding(1),
+                    non_hiding(num_chunks),
                 ))
             }
         }


### PR DESCRIPTION
lookup selector polynomials used `non_hiding(1)` instead of `non_hiding(num_chunks)`