### PR TITLE
kimchi-wasm: allow undefined OCaml symbols in native macOS cdylib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,11 @@ jobs:
           # stable/beta for macOS.
           # Skip macOS on PRs to improve CI velocity (macOS
           # runners are limited). macOS runs on master pushes
-          # only.
-          if [[ "$EVENT_NAME" == "push" \
-                && "$REF" == "refs/heads/master" ]]; then
+          # and manual dispatches (the latter so the full matrix
+          # can be exercised on a branch before merging).
+          if [[ ( "$EVENT_NAME" == "push" \
+                  && "$REF" == "refs/heads/master" ) \
+                || "$EVENT_NAME" == "workflow_dispatch" ]]; then
             VALUE=$(jq -nc \
               --arg msrv "$RUST_MSRV" \
               --arg stable "$RUST_STABLE" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ and this project adheres to
 
 - Treat public evaluations of oracles as vectors for chunking coherence
   ([#3577](https://github.com/o1-labs/proof-systems/pull/3577))
-- Allow undefined OCaml runtime symbols when linking the cdylib for native
-  macOS targets, fixing the macOS CI build broken since
+- Allow undefined OCaml runtime symbols when linking the cdylib for native macOS
+  targets, fixing the macOS CI build broken since
   [#3546](https://github.com/o1-labs/proof-systems/pull/3546)
 
 ## 0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to
 
 - Treat public evaluations of oracles as vectors for chunking coherence
   ([#3577](https://github.com/o1-labs/proof-systems/pull/3577))
+- Allow undefined OCaml runtime symbols when linking the cdylib for native
+  macOS targets, fixing the macOS CI build broken since
+  [#3546](https://github.com/o1-labs/proof-systems/pull/3546)
 
 ## 0.7.0
 

--- a/kimchi-wasm/build.rs
+++ b/kimchi-wasm/build.rs
@@ -1,0 +1,13 @@
+fn main() {
+    // When this crate is built for a native macOS target (e.g. as a
+    // dependency of kimchi-napi), the cdylib can end up referencing
+    // OCaml runtime symbols (through feature unification enabling
+    // kimchi/ocaml_types, which pulls in ocaml-boxroot-sys). Those
+    // symbols only exist in an OCaml process, so they must be left
+    // unresolved at link time. The equivalent rustflags in
+    // .cargo/config.toml are ignored whenever RUSTFLAGS is set (as in
+    // CI), hence this build script.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo::rustc-link-arg-cdylib=-Wl,-undefined,dynamic_lookup");
+    }
+}


### PR DESCRIPTION
Since kimchi-napi (added in #3546) depends on kimchi_wasm, the kimchi_wasm cdylib is also linked when building the workspace for a native target. With kimchi/ocaml_types enabled via feature unification, the dylib pulls in ocaml-boxroot-sys, whose boxroot.o references OCaml runtime symbols (caml_minor_gc_begin_hook, caml_minor_gc_end_hook, caml_scan_roots_hook) that only exist inside an OCaml process. ELF linkers allow such undefined symbols in shared libraries by default, but ld64 errors out, breaking the macOS CI jobs on master pushes.

.cargo/config.toml already passes -undefined,dynamic_lookup for aarch64-apple-darwin, but target rustflags from config are discarded whenever the RUSTFLAGS env var is set, which CI does globally. Emit the link arg from a build script instead: build-script link instructions are additive and unaffected by RUSTFLAGS, apply only to the cdylib target, and cover x86_64 macOS too.


# macOS CI fix — PR #3580 verification links

Fix for the `libkimchi_wasm.dylib` link failure breaking macOS CI on
`master` since [#3546](https://github.com/o1-labs/proof-systems/pull/3546).

- **Pull request:** <https://github.com/o1-labs/proof-systems/pull/3580>
- **All PR checks:** <https://github.com/o1-labs/proof-systems/pull/3580/checks>
- **Originally reported failure (master push):**
  <https://github.com/o1-labs/proof-systems/actions/runs/27420320479/job/81121018442>

## Full-matrix `workflow_dispatch` run on the fix branch

Run: <https://github.com/o1-labs/proof-systems/actions/runs/27446999353>
(30 success, 1 skipped, 0 failures)

Previously-failing macOS jobs, now passing:

| Job | Link |
| --- | --- |
| build (beta, macos-latest) — originally reported | <https://github.com/o1-labs/proof-systems/actions/runs/27446999353/job/81134248233> |
| tests (beta, macos-latest) | <https://github.com/o1-labs/proof-systems/actions/runs/27446999353/job/81134158785> |
| build (stable, macos-latest) | <https://github.com/o1-labs/proof-systems/actions/runs/27446999353/job/81134248298> |
| tests (stable, macos-latest) | <https://github.com/o1-labs/proof-systems/actions/runs/27446999353/job/81134158815> |
| build (1.92, macos-latest) | <https://github.com/o1-labs/proof-systems/actions/runs/27446999353/job/81134248216> |
| tests (1.92, macos-latest) | <https://github.com/o1-labs/proof-systems/actions/runs/27446999353/job/81134158794> |

## Benchmark job (flaky, passed on rerun)

<https://github.com/o1-labs/proof-systems/actions/runs/27446933704/job/81133919147>
