### PR TITLE
fix(utils): handle i32::MIN in i32_to_field

### DIFF
--- a/utils/src/field_helpers.rs
+++ b/utils/src/field_helpers.rs
@@ -243,7 +243,7 @@ pub fn i32_to_field<F: From<u64> + Neg<Output = F>>(i: i32) -> F {
     if i >= 0 {
         F::from(i as u64)
     } else {
-        -F::from(-i as u64)
+        -F::from(u64::from(i.unsigned_abs()))
     }
 }
 

--- a/utils/tests/field_helpers.rs
+++ b/utils/tests/field_helpers.rs
@@ -1,10 +1,10 @@
 use ark_ec::AffineRepr;
-use ark_ff::{BigInteger, One, PrimeField};
+use ark_ff::{BigInteger, One, PrimeField, Zero};
 use mina_curves::pasta::Pallas as CurvePoint;
 use num_bigint::BigUint;
 use o1_utils::{
     field_helpers::{FieldHelpersError, Result},
-    BigUintFieldHelpers, FieldHelpers,
+    i32_to_field, BigUintFieldHelpers, FieldHelpers,
 };
 
 /// Base field element type
@@ -153,4 +153,10 @@ fn field_big() {
     let bi = BigUint::from_bytes_le(&bytes);
     assert_eq!(fe.to_biguint(), bi);
     assert_eq!(bi.to_field::<BaseField>().unwrap(), fe);
+}
+
+#[test]
+fn i32_to_field_handles_min_value() {
+    let value: BaseField = i32_to_field(i32::MIN);
+    assert_eq!(value + BaseField::from(1_u64 << 31), BaseField::zero());
 }


### PR DESCRIPTION
## Summary

Fix `i32_to_field` for the `i32::MIN` edge case.

The previous implementation converted negative values with `-i as u64`. This overflows for `i32::MIN`, since its absolute value cannot be represented as an `i32`. With overflow checks enabled, this causes a panic before the value can be converted into the field.

This change uses `i32::unsigned_abs()` for the negative branch, preserving the existing mapping of negative integers to the negated field element while avoiding the intermediate signed overflow.

## Testing

- `git diff --check`
- `cargo fmt --check -- utils/src/field_helpers.rs utils/tests/field_helpers.rs`

I also verified the overflow root cause with a minimal `rustc -Coverflow-checks=y` reproduction: the old `-i` expression panics for `i32::MIN`, while the new `unsigned_abs()` conversion succeeds.

