### PR TITLE
Update o1-utils `std` feature to avoid CI failures on Poseidon test vectors check

### DIFF
--- a/poseidon/export_test_vectors/Cargo.toml
+++ b/poseidon/export_test_vectors/Cargo.toml
@@ -17,7 +17,7 @@ hex.workspace = true
 mina-curves = { workspace = true, features = ["parallel"] }
 mina-poseidon = { workspace = true, features = ["parallel"] }
 num-bigint.workspace = true
-o1-utils.workspace = true
+o1-utils = { workspace = true, features = ["std"] }
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
After the no-std work was finalized, o1-utils is defined as no-std unless std is defined. But for the export-test-vectors of Poseidon to be executed you need to enable std. Otherwise CI on o1js is complaining.