### PR TITLE
Remove FFTs from `DomainConstantEvaluations` and some in-memory precomputations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to
   disk while allowing the OS page cache to evict unused pages
   ([#3569](https://github.com/o1-labs/proof-systems/pull/3569))
 
+#### Changed
+
+- Build the `DomainConstantEvaluations` d8 evaluations in closed form instead of
+  by FFT, and drop the `constant_1_d4` / `constant_1_d8` all-ones vectors
+  (`gamma` is folded into the permutation argument per-element instead). The
+  stored evaluations are unchanged, and `precomputations` is `#[serde(skip)]`,
+  so proofs and the cached-key format are unaffected; this only makes the
+  per-circuit precomputation cheaper and drops ~24 MB of resident memory per
+  materialised prover index
+  ([#3586](https://github.com/o1-labs/proof-systems/pull/3586))
+
 ### [kimchi-napi](./kimchi-napi)
 
 #### Fixed

--- a/kimchi/src/circuits/domain_constant_evaluation.rs
+++ b/kimchi/src/circuits/domain_constant_evaluation.rs
@@ -1,15 +1,29 @@
 //! This contains the [DomainConstantEvaluations] which is used to provide precomputations to a [ConstraintSystem](super::constraints::ConstraintSystem).
 
 use crate::circuits::domains::EvaluationDomains;
+use alloc::vec::Vec;
 use ark_ff::FftField;
 use ark_poly::{
-    univariate::DensePolynomial as DP, DenseUVPolynomial, Evaluations as E,
+    univariate::DensePolynomial as DP, EvaluationDomain, Evaluations as E,
     Radix2EvaluationDomain as D,
 };
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-use super::polynomials::permutation::{permutation_vanishing_polynomial, vanishes_on_last_n_rows};
+use super::polynomials::permutation::permutation_vanishing_polynomial;
+
+/// Evaluate the polynomial `Π (x - root)` (given by its roots) at every point of
+/// `d8`, where `x_d8` holds the d8 domain points. For the low-degree vanishing
+/// polynomials this is far cheaper than padding to 8n coefficients and running
+/// an FFT, and it parallelises trivially over the points.
+fn eval_from_roots_over_d8<F: FftField>(x_d8: &[F], roots: &[F], d8: D<F>) -> E<F, D<F>> {
+    let evals: Vec<F> = o1_utils::cfg_iter!(x_d8)
+        .map(|z| roots.iter().map(|root| *z - *root).product())
+        .collect();
+    E::from_vec_and_domain(evals, d8)
+}
 
 #[serde_as]
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -30,19 +44,36 @@ pub struct DomainConstantEvaluations<F: FftField> {
 
 impl<F: FftField> DomainConstantEvaluations<F> {
     pub fn create(domain: EvaluationDomains<F>, zk_rows: u64) -> Option<Self> {
-        let poly_x_d1 = DP::from_coefficients_slice(&[F::zero(), F::one()])
-            .evaluate_over_domain_by_ref(domain.d8);
-
-        let vanishes_on_zero_knowledge_and_previous_rows =
-            vanishes_on_last_n_rows(domain.d1, zk_rows + 1).evaluate_over_domain(domain.d8);
-
         assert!(domain.d1.size > zk_rows);
 
-        // x^3 - x^2(w1+w2+w3) + x(w1w2+w1w3+w2w3) - w1w2w3
+        let omega = domain.d1.group_gen;
+        let n = domain.d1.size;
+
+        // `x` over d8 is just the d8 domain points (g8^row); recover them from
+        // the domain rather than through an FFT.
+        let x_d8: Vec<F> = domain.d8.elements().collect();
+
+        // Vanishes on the last (zk_rows + 1) rows: roots omega^{n-(zk_rows+1)} ..
+        // omega^{n-1}.
+        let zk_roots: Vec<F> = ((n - (zk_rows + 1))..n).map(|i| omega.pow([i])).collect();
+        let vanishes_on_zero_knowledge_and_previous_rows =
+            eval_from_roots_over_d8(&x_d8, &zk_roots, domain.d8);
+
+        // x^3 - x^2(w1+w2+w3) + x(w1w2+w1w3+w2w3) - w1w2w3, with the three roots
+        // omega^{n-zk_rows}, omega^{n-zk_rows+1}, omega^{n-1}.
         let permutation_vanishing_polynomial_m =
             permutation_vanishing_polynomial(domain.d1, zk_rows);
-        let permutation_vanishing_polynomial_l =
-            permutation_vanishing_polynomial_m.evaluate_over_domain_by_ref(domain.d8);
+        let permutation_vanishing_polynomial_l = eval_from_roots_over_d8(
+            &x_d8,
+            &[
+                omega.pow([n - zk_rows]),
+                omega.pow([n - zk_rows + 1]),
+                omega.pow([n - 1]),
+            ],
+            domain.d8,
+        );
+
+        let poly_x_d1 = E::from_vec_and_domain(x_d8, domain.d8);
 
         Some(DomainConstantEvaluations {
             poly_x_d1,

--- a/kimchi/src/circuits/domain_constant_evaluation.rs
+++ b/kimchi/src/circuits/domain_constant_evaluation.rs
@@ -4,7 +4,7 @@ use crate::circuits::domains::EvaluationDomains;
 use alloc::{vec, vec::Vec};
 use ark_ff::FftField;
 use ark_poly::{
-    univariate::DensePolynomial as DP, EvaluationDomain, Evaluations as E,
+    univariate::DensePolynomial as DP, EvaluationDomain, Evaluations as E, Polynomial,
     Radix2EvaluationDomain as D,
 };
 #[cfg(feature = "parallel")]
@@ -84,15 +84,12 @@ impl<F: FftField> DomainConstantEvaluations<F> {
         // omega^{n-zk_rows}, omega^{n-zk_rows+1}, omega^{n-1}.
         let permutation_vanishing_polynomial_m =
             permutation_vanishing_polynomial(domain.d1, zk_rows);
-        let permutation_vanishing_polynomial_l = eval_from_roots_over_d8(
-            &x_d8,
-            &[
-                omega.pow([n - zk_rows]),
-                omega.pow([n - zk_rows + 1]),
-                omega.pow([n - 1]),
-            ],
-            domain.d8,
-        );
+        let permutation_vanishing_polynomial_l = {
+            let evals: Vec<F> = o1_utils::cfg_iter!(x_d8)
+                .map(|z| permutation_vanishing_polynomial_m.evaluate(z))
+                .collect();
+            E::from_vec_and_domain(evals, domain.d8)
+        };
 
         let poly_x_d1 = E::from_vec_and_domain(x_d8, domain.d8);
 

--- a/kimchi/src/circuits/domain_constant_evaluation.rs
+++ b/kimchi/src/circuits/domain_constant_evaluation.rs
@@ -1,7 +1,7 @@
 //! This contains the [DomainConstantEvaluations] which is used to provide precomputations to a [ConstraintSystem](super::constraints::ConstraintSystem).
 
 use crate::circuits::domains::EvaluationDomains;
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use ark_ff::FftField;
 use ark_poly::{
     univariate::DensePolynomial as DP, EvaluationDomain, Evaluations as E,
@@ -13,6 +13,27 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
 use super::polynomials::permutation::permutation_vanishing_polynomial;
+
+/// The points of `domain` (`g^0, g^1, …`), computed in parallel. Each chunk
+/// seeds its first power with a single exponentiation and then walks a running
+/// product, so the work is `O(n)` multiplications spread across the cores with
+/// only one `pow` per chunk of overhead. For domains smaller than the chunk
+/// size this is a single sequential chunk, so the parallelism never dominates.
+fn domain_points<F: FftField>(domain: D<F>) -> Vec<F> {
+    const CHUNK: usize = 1 << 14;
+    let gen = domain.group_gen;
+    let mut points = vec![F::one(); domain.size()];
+    o1_utils::cfg_chunks_mut!(points, CHUNK)
+        .enumerate()
+        .for_each(|(chunk_idx, chunk)| {
+            let mut x = gen.pow([(chunk_idx * CHUNK) as u64]);
+            for slot in chunk.iter_mut() {
+                *slot = x;
+                x *= gen;
+            }
+        });
+    points
+}
 
 /// Evaluate the polynomial `Π (x - root)` (given by its roots) at every point of
 /// `d8`, where `x_d8` holds the d8 domain points. For the low-degree vanishing
@@ -51,7 +72,7 @@ impl<F: FftField> DomainConstantEvaluations<F> {
 
         // `x` over d8 is just the d8 domain points (g8^row); recover them from
         // the domain rather than through an FFT.
-        let x_d8: Vec<F> = domain.d8.elements().collect();
+        let x_d8 = domain_points(domain.d8);
 
         // Vanishes on the last (zk_rows + 1) rows: roots omega^{n-(zk_rows+1)} ..
         // omega^{n-1}.


### PR DESCRIPTION
This PR changes the algorithm for generating `DomainConstantEvaluations`, using the underlying structure of the precomputed terms instead of brute-force FFT-ing them. In particular, the zk-rows vanishing polynomial is the low-degree polynomial `(x - w^(n-3))(x - w^(n-2))(x - w^(n-1))`, and it's significantly faster to compute this directly on the evaluations of `x` instead of materialising it via the coefficients.

This PR has been split out of the work on optimising nori native proving in OCaml for easy review.