### PR TITLE
Improve prover peak RAM usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to
   disk while allowing the OS page cache to evict unused pages
   ([#3569](https://github.com/o1-labs/proof-systems/pull/3569))
 
+#### Changed
+
+- Lower the prover's peak memory by releasing the d8 evaluations once the
+  linearization is done, rather than holding them to end-of-proof
+  ([#3587](https://github.com/o1-labs/proof-systems/pull/3587))
+- Recover the joint lookup table's coefficient form by subsampling the d8
+  evaluations to the d1 subdomain instead of running a full d8 iFFT, and
+  parallelise the d8 lookup-table and sorted-polynomial construction. Proofs are
+  unchanged ([#3587](https://github.com/o1-labs/proof-systems/pull/3587))
+
 ### [kimchi-napi](./kimchi-napi)
 
 #### Fixed

--- a/kimchi/examples/prove_lookup_circuit.rs
+++ b/kimchi/examples/prove_lookup_circuit.rs
@@ -1,0 +1,118 @@
+//! Prove a range-check-heavy circuit, for profiling the prover's lookup path.
+//!
+//! The benches in this crate build circuits of generic gates only, so they
+//! never exercise the joint lookup table, the sorted polynomials or the
+//! lookup aggregation.
+//!
+//! This example builds a circuit of multi-range-check gadgets, which is the
+//! shape foreign-field arithmetic produces: every 3-limb value has its 88-bit
+//! limbs range-checked, so circuits dominated by foreign-field work are
+//! dominated by these gates. They draw on kimchi's fixed 12-bit range check
+//! table with several lookups per row, so both the joint lookup table and the
+//! sorted polynomials are substantial.
+//!
+//! Usage:
+//!
+//! ```text
+//! cargo run --release --example prove_lookup_circuit -- [LOG2_ROWS] [PROOFS]
+//! ```
+//!
+//! Defaults to a 2^14 domain and one proof. It prints elapsed time per proof;
+//! peak RSS is best measured from outside, e.g. with `/usr/bin/time -v`.
+//!
+//! Note that below about 2^13 the resulting domain can be larger than asked
+//! for, since the fixed 12-bit range check table occupies 4096 rows of its
+//! own; the printed setup line reports the domain actually used.
+
+use ark_ff::Zero;
+use groupmap::GroupMap;
+use kimchi::{
+    bench::{BaseSpongeVesta, ScalarSpongeVesta},
+    circuits::{gate::CircuitGate, polynomial::COLUMNS, polynomials::range_check},
+    proof::ProverProof,
+    prover_index::testing::new_index_for_test_with_lookups,
+};
+use mina_curves::pasta::{Fp, Vesta};
+use mina_poseidon::pasta::FULL_ROUNDS;
+use poly_commitment::{commitment::CommitmentCurve, ipa::OpeningProof};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::time::Instant;
+
+/// A multi-range-check gadget occupies this many rows.
+const ROWS_PER_GADGET: usize = 4;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let log2_rows: u32 = args
+        .next()
+        .map_or(14, |s| s.parse().expect("LOG2_ROWS must be an integer"));
+    let proofs: usize = args
+        .next()
+        .map_or(1, |s| s.parse().expect("PROOFS must be an integer"));
+
+    // Fixed seed: the circuit and witness must be identical across runs for a
+    // before/after comparison to mean anything.
+    let mut rng = StdRng::from_seed([7u8; 32]);
+
+    // Leave room for the zero-knowledge rows.
+    let num_gadgets = ((1usize << log2_rows) - 10) / ROWS_PER_GADGET;
+
+    let mut gates = vec![];
+    let mut curr_row = 0;
+    for _ in 0..num_gadgets {
+        CircuitGate::<Fp>::extend_multi_range_check(&mut gates, &mut curr_row);
+    }
+
+    // Three 88-bit limbs per gadget, as foreign-field arithmetic produces.
+    let mut witness: [Vec<Fp>; COLUMNS] = std::array::from_fn(|_| vec![]);
+    for _ in 0..num_gadgets {
+        let mut limb = || {
+            let hi: u64 = rng.gen::<u64>() >> 40; // 24 bits
+            let lo: u64 = rng.gen();
+            Fp::from(hi) * Fp::from(1u128 << 64) + Fp::from(lo)
+        };
+        let (v0, v1, v2) = (limb(), limb(), limb());
+        range_check::witness::extend_multi(&mut witness, v0, v1, v2);
+    }
+    // Pad the witness out to the gate count.
+    for col in witness.iter_mut() {
+        col.resize(gates.len(), Fp::zero());
+    }
+
+    let setup_start = Instant::now();
+    let index = new_index_for_test_with_lookups::<FULL_ROUNDS, Vesta>(
+        gates,
+        0,
+        0,
+        vec![],
+        None,
+        false,
+        None,
+        false,
+    );
+    let group_map = <Vesta as CommitmentCurve>::Map::setup();
+    eprintln!(
+        "setup: domain 2^{}, {} multi-range-check gadgets ({} rows), {:.2?}",
+        index.cs.domain.d1.log_size_of_group,
+        num_gadgets,
+        curr_row,
+        setup_start.elapsed()
+    );
+
+    for i in 0..proofs {
+        let start = Instant::now();
+        let proof: ProverProof<Vesta, OpeningProof<Vesta, FULL_ROUNDS>, FULL_ROUNDS> =
+            ProverProof::create::<BaseSpongeVesta, ScalarSpongeVesta, _>(
+                &group_map,
+                witness.clone(),
+                &[],
+                &index,
+                &mut rand::rngs::OsRng,
+            )
+            .expect("proving failed");
+        eprintln!("proof {}: {:.2?}", i, start.elapsed());
+        // Keep the proof alive until after the timer, so it cannot be
+        // optimised away.
+        std::hint::black_box(&proof);
+    }
+}

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -484,20 +484,21 @@ where
 
             //~~ * Compute the lookup table values as the combination of the lookup table entries.
             let joint_lookup_table_d8 = {
-                let mut evals = Vec::with_capacity(d1_size);
+                // Each row combines its own table entry independently of every
+                // other row, so this is a pure map over the d8 domain.
+                let evals = (0..(d1_size * 8))
+                    .into_par_iter()
+                    .map(|idx| {
+                        let table_id = match lcs.table_ids8.as_ref() {
+                            Some(table_ids8) => table_ids8.evals[idx],
+                            None =>
+                            // If there is no `table_ids8` in the constraint system,
+                            // every table ID is identically 0.
+                            {
+                                G::ScalarField::zero()
+                            }
+                        };
 
-                for idx in 0..(d1_size * 8) {
-                    let table_id = match lcs.table_ids8.as_ref() {
-                        Some(table_ids8) => table_ids8.evals[idx],
-                        None =>
-                        // If there is no `table_ids8` in the constraint system,
-                        // every table ID is identically 0.
-                        {
-                            G::ScalarField::zero()
-                        }
-                    };
-
-                    let combined_entry =
                         if !lcs.configuration.lookup_info.features.uses_runtime_tables {
                             let table_row = lcs.lookup_table8.iter().map(|e| &e.evals[idx]);
 
@@ -525,9 +526,9 @@ where
                                 table_row,
                                 &table_id,
                             )
-                        };
-                    evals.push(combined_entry);
-                }
+                        }
+                    })
+                    .collect();
 
                 Evaluations::from_vec_and_domain(evals, index.cs.domain.d8)
             };
@@ -592,9 +593,10 @@ where
 
             // precompute different forms of the sorted polynomials for later
             // TODO: We can avoid storing these coefficients.
-            let sorted_coeffs: Vec<_> = sorted.iter().map(|e| e.clone().interpolate()).collect();
+            let sorted_coeffs: Vec<_> =
+                sorted.par_iter().map(|e| e.clone().interpolate()).collect();
             let sorted8: Vec<_> = sorted_coeffs
-                .iter()
+                .par_iter()
                 .map(|v| v.evaluate_over_domain_by_ref(index.cs.domain.d8))
                 .collect();
 

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1146,7 +1146,17 @@ where
                     lin.interpolate()
                 };
 
+                // The constraint environment and the d8 evaluations it borrows
+                // (`lagrange`, and the lookup table / sorted / aggregation
+                // evaluations) are not needed past this point -- everything
+                // below operates on d1-sized polynomials. Those d8 buffers
+                // dominate the prover's peak memory, so releasing them here
+                // rather than at end-of-proof materially lowers the peak.
                 drop(env);
+                drop(lagrange);
+                lookup_context.joint_lookup_table_d8 = None;
+                lookup_context.sorted8 = None;
+                lookup_context.aggreg8 = None;
 
                 // see https://o1-labs.github.io/proof-systems/kimchi/maller_15.html#the-prover-side
                 f.to_chunked_polynomial(num_chunks, index.max_poly_size)

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -532,8 +532,22 @@ where
                 Evaluations::from_vec_and_domain(evals, index.cs.domain.d8)
             };
 
-            // TODO: This interpolation is avoidable.
-            let joint_lookup_table = joint_lookup_table_d8.interpolate_by_ref();
+            // Recover the d1 coefficient form of the joint table.
+            //
+            // `combine_table_entry` is a Horner fold over the table columns with
+            // constant (challenge) coefficients, so the joint table is a fixed
+            // linear combination of the columns -- each of which is the d8
+            // evaluation of a polynomial of degree < d1 -- and so has degree < d1
+            // itself. d1 is a subgroup of d8 (d8 = 8*d1, Radix2), so the joint
+            // table's d1 evaluations are exactly every 8th d8 evaluation, and a
+            // d1-sized iFFT over them recovers the coefficients exactly. This
+            // avoids the full d8 iFFT the interpolation here used to perform.
+            let joint_lookup_table = {
+                let d1_evals: Vec<G::ScalarField> = (0..d1_size)
+                    .map(|j| joint_lookup_table_d8.evals[8 * j])
+                    .collect();
+                Evaluations::from_vec_and_domain(d1_evals, index.cs.domain.d1).interpolate()
+            };
 
             //~~ * Compute the sorted evaluations.
             // TODO: Once we switch to committing using lagrange commitments,

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -544,8 +544,11 @@ where
             // d1-sized iFFT over them recovers the coefficients exactly. This
             // avoids the full d8 iFFT the interpolation here used to perform.
             let joint_lookup_table = {
-                let d1_evals: Vec<G::ScalarField> = (0..d1_size)
-                    .map(|j| joint_lookup_table_d8.evals[8 * j])
+                let d1_evals: Vec<G::ScalarField> = joint_lookup_table_d8
+                    .evals
+                    .iter()
+                    .step_by(8)
+                    .copied()
                     .collect();
                 Evaluations::from_vec_and_domain(d1_evals, index.cs.domain.d1).interpolate()
             };

--- a/kimchi/tests/test_domain.rs
+++ b/kimchi/tests/test_domain.rs
@@ -55,7 +55,7 @@ fn subsampling_d8_evals_to_d1_recovers_the_polynomial() {
 
         let evals_d8 = poly.evaluate_over_domain_by_ref(d.d8);
 
-        let subsampled: Vec<Fp> = (0..d.d1.size()).map(|j| evals_d8.evals[8 * j]).collect();
+        let subsampled: Vec<Fp> = evals_d8.evals.iter().step_by(8).copied().collect();
         let recovered = Evaluations::from_vec_and_domain(subsampled, d.d1).interpolate();
 
         assert_eq!(

--- a/kimchi/tests/test_domain.rs
+++ b/kimchi/tests/test_domain.rs
@@ -1,6 +1,9 @@
 #![cfg(feature = "prover")]
 
-use ark_ff::Field;
+use ark_ff::{Field, UniformRand};
+use ark_poly::{
+    univariate::DensePolynomial as DP, DenseUVPolynomial, EvaluationDomain, Evaluations,
+};
 use kimchi::circuits::domains::EvaluationDomains;
 use mina_curves::pasta::Fp;
 
@@ -14,5 +17,56 @@ fn test_create_domain() {
         println!("d4 = {:?}", d.d4.group_gen);
         println!("d4 = {:?}", d.d4.group_gen.pow([4]));
         println!("d1 = {:?}", d.d1.group_gen);
+    }
+}
+
+/// d1 is a subgroup of d8 (d8 = 8 * d1, both Radix2), so the d1 domain points
+/// are exactly every 8th d8 domain point.
+#[test]
+fn d1_is_the_8_stride_subgroup_of_d8() {
+    for log_n in 3..=10u32 {
+        let d = EvaluationDomains::<Fp>::create(1 << log_n).unwrap();
+        assert_eq!(d.d8.size(), 8 * d.d1.size());
+        for (j, x) in d.d1.elements().enumerate() {
+            assert_eq!(
+                x,
+                d.d8.element(8 * j),
+                "d1[{j}] != d8[8*{j}] at n=1<<{log_n}"
+            );
+        }
+    }
+}
+
+/// The prover recovers the joint lookup table's coefficient form by subsampling
+/// its d8 evaluations to d1 and running a d1-sized iFFT, rather than a full d8
+/// iFFT. That is exact for any polynomial of degree < d1 -- which the joint
+/// table is, being a fixed linear combination of the table columns. Pin the
+/// identity here so the prover's shortcut cannot silently stop being valid.
+#[test]
+fn subsampling_d8_evals_to_d1_recovers_the_polynomial() {
+    let mut rng = o1_utils::tests::make_test_rng(None);
+
+    for log_n in 3..=10u32 {
+        let d = EvaluationDomains::<Fp>::create(1 << log_n).unwrap();
+
+        // Any polynomial of degree < d1 -- the bound the joint lookup table meets.
+        let coeffs: Vec<Fp> = (0..d.d1.size()).map(|_| Fp::rand(&mut rng)).collect();
+        let poly = DP::from_coefficients_vec(coeffs);
+
+        let evals_d8 = poly.evaluate_over_domain_by_ref(d.d8);
+
+        let subsampled: Vec<Fp> = (0..d.d1.size()).map(|j| evals_d8.evals[8 * j]).collect();
+        let recovered = Evaluations::from_vec_and_domain(subsampled, d.d1).interpolate();
+
+        assert_eq!(
+            recovered, poly,
+            "subsampling failed to recover the polynomial at n=1<<{log_n}"
+        );
+        // ...and it agrees with the full d8 iFFT it replaces.
+        assert_eq!(
+            recovered,
+            evals_d8.interpolate_by_ref(),
+            "subsampling disagrees with the d8 interpolation at n=1<<{log_n}"
+        );
     }
 }


### PR DESCRIPTION
This PR
* reduces peak RAM by releasing the d8 evaluations once the linearization is done, instead of holding them until the end of the computation
* improves prover speed and reduces peak memory, by using sub-sampling to iFFT a d1-domain polynomial instead of a d8-domain one.

This PR has been split out of the work on optimising nori native proving in OCaml for easy review.