### PR TITLE
Performance: skip constraint checks on `d1` rows where we expensively calculate 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to
   disk while allowing the OS page cache to evict unused pages
   ([#3569](https://github.com/o1-labs/proof-systems/pull/3569))
 
+#### Changed
+
+- Skip the d1 rows when evaluating constraints for the quotient. Every
+  constraint vanishes there for a satisfying witness, so the honest prover was
+  computing known zeros; the generic constraint's public-input rows are patched
+  back on afterwards. Proofs are unchanged
+  ([#3588](https://github.com/o1-labs/proof-systems/pull/3588))
+- As a consequence of the above, the prover's "rest of division by vanishing
+  polynomial" error can no longer fire: the quotient numerator is now divisible
+  by `Z_H` by construction. In release builds an unsatisfied witness produces a
+  proof that fails verification rather than an error from `create_recursive`.
+  Debug builds are unaffected, since `index.verify()` already rejects such a
+  witness earlier ([#3588](https://github.com/o1-labs/proof-systems/pull/3588))
+
 ### [kimchi-napi](./kimchi-napi)
 
 #### Fixed

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1194,6 +1194,29 @@ impl<'a, F: FftField> EvalResult<'a, F> {
         }
     }
 
+    /// Apply `op` in place to the non-d1 rows of an evaluation over `domain`,
+    /// leaving the d1 rows untouched: they are already zero from the skipping
+    /// materialization (`init_`) and every constraint vanishes on them, so there
+    /// is no need to compute the in-place combination there. This is the
+    /// in-place analogue of the skip in `init_`.
+    fn update_non_d1<H: Sync + Send + Fn(usize, &mut F)>(
+        mut evals: Evaluations<F, D<F>>,
+        domain: Domain,
+        op: H,
+    ) -> Evaluations<F, D<F>> {
+        let stride = domain as usize;
+        let skip_d1 = stride > 1;
+        let mask = stride - 1;
+        o1_utils::cfg_iter_mut!(evals.evals)
+            .enumerate()
+            .for_each(|(i, e)| {
+                if !skip_d1 || (i & mask) != 0 {
+                    op(i, e);
+                }
+            });
+        evals
+    }
+
     /// Call the internal function `init_` and return the computed evaluation as
     /// a value `Evals`.
     fn init<G: Sync + Send + Fn(usize) -> F>(res_domain: (Domain, D<F>), g: G) -> Self {
@@ -1207,10 +1230,11 @@ impl<'a, F: FftField> EvalResult<'a, F> {
         use EvalResult::*;
         match (self, other) {
             (Constant(x), Constant(y)) => Constant(x + y),
-            (Evals { domain, mut evals }, Constant(x))
-            | (Constant(x), Evals { domain, mut evals }) => {
-                o1_utils::cfg_iter_mut!(evals.evals).for_each(|e| *e += x);
-                Evals { domain, evals }
+            (Evals { domain, evals }, Constant(x)) | (Constant(x), Evals { domain, evals }) => {
+                Evals {
+                    domain,
+                    evals: Self::update_non_d1(evals, domain, |_, e| *e += x),
+                }
             }
             (
                 SubEvals {
@@ -1228,7 +1252,6 @@ impl<'a, F: FftField> EvalResult<'a, F> {
                     shift,
                 },
             ) => {
-                let n = res_domain.1.size();
                 let scale = (domain as usize) / (res_domain.0 as usize);
                 assert!(
                     scale != 0,
@@ -1236,20 +1259,14 @@ impl<'a, F: FftField> EvalResult<'a, F> {
                 column_domain and the evaluation domain of the
                 witnesses are the same"
                 );
-                let v: Vec<_> = o1_utils::cfg_into_iter!(0..n)
-                    .map(|i| {
-                        x + evals.evals[(scale * i + (domain as usize) * shift) % evals.evals.len()]
-                    })
-                    .collect();
-                Evals {
-                    domain: res_domain.0,
-                    evals: Evaluations::<F, D<F>>::from_vec_and_domain(v, res_domain.1),
-                }
+                EvalResult::init(res_domain, |i| {
+                    x + evals.evals[(scale * i + (domain as usize) * shift) % evals.evals.len()]
+                })
             }
             (
                 Evals {
                     domain: d1,
-                    evals: mut es1,
+                    evals: es1,
                 },
                 Evals {
                     domain: d2,
@@ -1257,10 +1274,9 @@ impl<'a, F: FftField> EvalResult<'a, F> {
                 },
             ) => {
                 assert_eq!(d1, d2);
-                es1 += &es2;
                 Evals {
                     domain: d1,
-                    evals: es1,
+                    evals: Self::update_non_d1(es1, d1, |i, e| *e += es2.evals[i]),
                 }
             }
             (
@@ -1269,16 +1285,10 @@ impl<'a, F: FftField> EvalResult<'a, F> {
                     shift: s,
                     evals: es_sub,
                 },
-                Evals {
-                    domain: d,
-                    mut evals,
-                },
+                Evals { domain: d, evals },
             )
             | (
-                Evals {
-                    domain: d,
-                    mut evals,
-                },
+                Evals { domain: d, evals },
                 SubEvals {
                     domain: d_sub,
                     shift: s,
@@ -1292,12 +1302,12 @@ impl<'a, F: FftField> EvalResult<'a, F> {
                 column_domain and the evaluation domain of the
                 witnesses are the same"
                 );
-                o1_utils::cfg_iter_mut!(evals.evals)
-                    .enumerate()
-                    .for_each(|(i, e)| {
-                        *e += es_sub.evals[(scale * i + (d_sub as usize) * s) % es_sub.evals.len()];
-                    });
-                Evals { evals, domain: d }
+                Evals {
+                    domain: d,
+                    evals: Self::update_non_d1(evals, d, |i, e| {
+                        *e += es_sub.evals[(scale * i + (d_sub as usize) * s) % es_sub.evals.len()]
+                    }),
+                }
             }
             (
                 SubEvals {
@@ -1325,18 +1335,10 @@ impl<'a, F: FftField> EvalResult<'a, F> {
                 column_domain and the evaluation domain of the
                 witnesses are the same"
                 );
-                let n = res_domain.1.size();
-                let v: Vec<_> = o1_utils::cfg_into_iter!(0..n)
-                    .map(|i| {
-                        es1.evals[(scale1 * i + (d1 as usize) * s1) % es1.evals.len()]
-                            + es2.evals[(scale2 * i + (d2 as usize) * s2) % es2.evals.len()]
-                    })
-                    .collect();
-
-                Evals {
-                    domain: res_domain.0,
-                    evals: Evaluations::<F, D<F>>::from_vec_and_domain(v, res_domain.1),
-                }
+                EvalResult::init(res_domain, |i| {
+                    es1.evals[(scale1 * i + (d1 as usize) * s1) % es1.evals.len()]
+                        + es2.evals[(scale2 * i + (d2 as usize) * s2) % es2.evals.len()]
+                })
             }
         }
     }
@@ -1345,14 +1347,14 @@ impl<'a, F: FftField> EvalResult<'a, F> {
         use EvalResult::*;
         match (self, other) {
             (Constant(x), Constant(y)) => Constant(x - y),
-            (Evals { domain, mut evals }, Constant(x)) => {
-                o1_utils::cfg_iter_mut!(evals.evals).for_each(|e| *e -= x);
-                Evals { domain, evals }
-            }
-            (Constant(x), Evals { domain, mut evals }) => {
-                o1_utils::cfg_iter_mut!(evals.evals).for_each(|e| *e = x - *e);
-                Evals { domain, evals }
-            }
+            (Evals { domain, evals }, Constant(x)) => Evals {
+                domain,
+                evals: Self::update_non_d1(evals, domain, |_, e| *e -= x),
+            },
+            (Constant(x), Evals { domain, evals }) => Evals {
+                domain,
+                evals: Self::update_non_d1(evals, domain, |_, e| *e = x - *e),
+            },
             (
                 SubEvals {
                     evals,
@@ -1395,7 +1397,7 @@ impl<'a, F: FftField> EvalResult<'a, F> {
             (
                 Evals {
                     domain: d1,
-                    evals: mut es1,
+                    evals: es1,
                 },
                 Evals {
                     domain: d2,
@@ -1403,10 +1405,9 @@ impl<'a, F: FftField> EvalResult<'a, F> {
                 },
             ) => {
                 assert_eq!(d1, d2);
-                es1 -= &es2;
                 Evals {
                     domain: d1,
-                    evals: es1,
+                    evals: Self::update_non_d1(es1, d1, |i, e| *e -= es2.evals[i]),
                 }
             }
             (
@@ -1415,10 +1416,7 @@ impl<'a, F: FftField> EvalResult<'a, F> {
                     shift: s,
                     evals: es_sub,
                 },
-                Evals {
-                    domain: d,
-                    mut evals,
-                },
+                Evals { domain: d, evals },
             ) => {
                 let scale = (d_sub as usize) / (d as usize);
                 assert!(
@@ -1427,20 +1425,16 @@ impl<'a, F: FftField> EvalResult<'a, F> {
                 column_domain and the evaluation domain of the
                 witnesses are the same"
                 );
-
-                o1_utils::cfg_iter_mut!(evals.evals)
-                    .enumerate()
-                    .for_each(|(i, e)| {
-                        *e = es_sub.evals[(scale * i + (d_sub as usize) * s) % es_sub.evals.len()]
-                            - *e;
-                    });
-                Evals { evals, domain: d }
-            }
-            (
                 Evals {
                     domain: d,
-                    mut evals,
-                },
+                    evals: Self::update_non_d1(evals, d, |i, e| {
+                        *e = es_sub.evals[(scale * i + (d_sub as usize) * s) % es_sub.evals.len()]
+                            - *e
+                    }),
+                }
+            }
+            (
+                Evals { domain: d, evals },
                 SubEvals {
                     domain: d_sub,
                     shift: s,
@@ -1454,12 +1448,12 @@ impl<'a, F: FftField> EvalResult<'a, F> {
                 column_domain and the evaluation domain of the
                 witnesses are the same"
                 );
-                o1_utils::cfg_iter_mut!(evals.evals)
-                    .enumerate()
-                    .for_each(|(i, e)| {
-                        *e -= es_sub.evals[(scale * i + (d_sub as usize) * s) % es_sub.evals.len()];
-                    });
-                Evals { evals, domain: d }
+                Evals {
+                    domain: d,
+                    evals: Self::update_non_d1(evals, d, |i, e| {
+                        *e -= es_sub.evals[(scale * i + (d_sub as usize) * s) % es_sub.evals.len()]
+                    }),
+                }
             }
             (
                 SubEvals {
@@ -1542,10 +1536,11 @@ impl<'a, F: FftField> EvalResult<'a, F> {
         use EvalResult::*;
         match (self, other) {
             (Constant(x), Constant(y)) => Constant(x * y),
-            (Evals { domain, mut evals }, Constant(x))
-            | (Constant(x), Evals { domain, mut evals }) => {
-                o1_utils::cfg_iter_mut!(evals.evals).for_each(|e| *e *= x);
-                Evals { domain, evals }
+            (Evals { domain, evals }, Constant(x)) | (Constant(x), Evals { domain, evals }) => {
+                Evals {
+                    domain,
+                    evals: Self::update_non_d1(evals, domain, |_, e| *e *= x),
+                }
             }
             (
                 SubEvals {
@@ -1577,7 +1572,7 @@ impl<'a, F: FftField> EvalResult<'a, F> {
             (
                 Evals {
                     domain: d1,
-                    evals: mut es1,
+                    evals: es1,
                 },
                 Evals {
                     domain: d2,
@@ -1585,10 +1580,9 @@ impl<'a, F: FftField> EvalResult<'a, F> {
                 },
             ) => {
                 assert_eq!(d1, d2);
-                es1 *= &es2;
                 Evals {
                     domain: d1,
-                    evals: es1,
+                    evals: Self::update_non_d1(es1, d1, |i, e| *e *= es2.evals[i]),
                 }
             }
             (
@@ -1597,16 +1591,10 @@ impl<'a, F: FftField> EvalResult<'a, F> {
                     shift: s,
                     evals: es_sub,
                 },
-                Evals {
-                    domain: d,
-                    mut evals,
-                },
+                Evals { domain: d, evals },
             )
             | (
-                Evals {
-                    domain: d,
-                    mut evals,
-                },
+                Evals { domain: d, evals },
                 SubEvals {
                     domain: d_sub,
                     shift: s,
@@ -1620,13 +1608,12 @@ impl<'a, F: FftField> EvalResult<'a, F> {
                 column_domainand the evaluation domain of the
                 witnesses are the same"
                 );
-
-                o1_utils::cfg_iter_mut!(evals.evals)
-                    .enumerate()
-                    .for_each(|(i, e)| {
-                        *e *= es_sub.evals[(scale * i + (d_sub as usize) * s) % es_sub.evals.len()];
-                    });
-                Evals { evals, domain: d }
+                Evals {
+                    domain: d,
+                    evals: Self::update_non_d1(evals, d, |i, e| {
+                        *e *= es_sub.evals[(scale * i + (d_sub as usize) * s) % es_sub.evals.len()]
+                    }),
+                }
             }
             (
                 SubEvals {

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1143,10 +1143,56 @@ impl<'a, F: FftField> EvalResult<'a, F> {
         g: G,
     ) -> Evaluations<F, D<F>> {
         let n = res_domain.1.size();
+        // For a satisfying witness every constraint vanishes on the d1 rows, so
+        // the honest prover computes zeros there; we skip the work and write the
+        // zeros directly.
+        //
+        // We only do this in the d8 domain: every degree-d8 constraint is zero on
+        // all of d1, but the generic (d4) constraint equals the public input on
+        // the public-input rows -- it is cancelled there by the public-input
+        // polynomial added later in coefficient form -- so it must be evaluated in
+        // full.
+        //
+        // The d1 rows of a d8 evaluation sit at indices that are multiples of 8;
+        // since that is a power of two we test with a mask (`i & 7`) rather than
+        // `%`, which the compiler cannot lower to a mask given a runtime divisor.
+        // Results that bypass this path get the same treatment via
+        // `zero_d1_rows`, which keeps the quotient numerator divisible by Z_H.
+        let stride = res_domain.0 as usize;
+        let skip_d1 = stride == 8;
+        let mask = stride - 1;
         Evaluations::<F, D<F>>::from_vec_and_domain(
-            o1_utils::cfg_into_iter!(0..n).map(g).collect(),
+            o1_utils::cfg_into_iter!(0..n)
+                .map(|i| {
+                    if skip_d1 && (i & mask) == 0 {
+                        F::zero()
+                    } else {
+                        g(i)
+                    }
+                })
+                .collect(),
             res_domain.1,
         )
+    }
+
+    /// Zero the d1 rows of an evaluation over `domain`. Every constraint is
+    /// identically zero on those rows for a satisfying witness, so forcing them
+    /// to zero is a no-op on a correct proof while letting the materialisation
+    /// paths above skip computing them. See [`Expr::evaluations`].
+    fn zero_d1_rows(evals: &mut Evaluations<F, D<F>>, domain: Domain) {
+        let stride = domain as usize;
+        // Only d8 constraints are skipped (see `init_`), so only they need their
+        // d1 rows forced to zero; d4 results (the generic constraint) are kept.
+        if stride == 8 {
+            let mask = stride - 1;
+            o1_utils::cfg_iter_mut!(evals.evals)
+                .enumerate()
+                .for_each(|(i, e)| {
+                    if (i & mask) == 0 {
+                        *e = F::zero();
+                    }
+                });
+        }
     }
 
     /// Call the internal function `init_` and return the computed evaluation as
@@ -1963,7 +2009,7 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
             Either::Right(id) => cache.get(&id).unwrap().clone(),
         };
 
-        match evals {
+        let mut result = match evals {
             EvalResult::Evals { evals, domain } => {
                 assert_eq!(domain, d);
                 evals
@@ -1986,7 +2032,12 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
                     evals.evals[(scale * i + (d_sub as usize) * s) % evals.evals.len()]
                 })
             }
-        }
+        };
+        // The materialisation paths skip the d1 rows; enforce zero there for any
+        // result that did not (e.g. a borrowed `Evals` returned directly), so the
+        // numerator stays divisible by Z_H regardless of which path produced it.
+        EvalResult::<'_, F>::zero_d1_rows(&mut result, d);
+        result
     }
 
     fn evaluations_helper<

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1147,19 +1147,20 @@ impl<'a, F: FftField> EvalResult<'a, F> {
         // the honest prover computes zeros there; we skip the work and write the
         // zeros directly.
         //
-        // We only do this in the d8 domain: every degree-d8 constraint is zero on
-        // all of d1, but the generic (d4) constraint equals the public input on
-        // the public-input rows -- it is cancelled there by the public-input
-        // polynomial added later in coefficient form -- so it must be evaluated in
-        // full.
+        // The one exception is the generic constraint, which equals the public
+        // input on the public-input rows. Rather than special-case it here, the
+        // prover adds the public input back onto those rows after this skip (the
+        // public-input polynomial, added later in coefficient form, then cancels
+        // it on d1) -- keeping the quotient numerator divisible by Z_H.
         //
-        // The d1 rows of a d8 evaluation sit at indices that are multiples of 8;
-        // since that is a power of two we test with a mask (`i & 7`) rather than
+        // The d1 rows of an evaluation over `res_domain.0` are the indices that
+        // are multiples of the domain-size ratio (4 for d4, 8 for d8). That is a
+        // power of two, so we test with a mask (`i & (stride - 1)`) rather than
         // `%`, which the compiler cannot lower to a mask given a runtime divisor.
         // Results that bypass this path get the same treatment via
-        // `zero_d1_rows`, which keeps the quotient numerator divisible by Z_H.
+        // `zero_d1_rows`.
         let stride = res_domain.0 as usize;
-        let skip_d1 = stride == 8;
+        let skip_d1 = stride > 1;
         let mask = stride - 1;
         Evaluations::<F, D<F>>::from_vec_and_domain(
             o1_utils::cfg_into_iter!(0..n)
@@ -1181,9 +1182,7 @@ impl<'a, F: FftField> EvalResult<'a, F> {
     /// paths above skip computing them. See [`Expr::evaluations`].
     fn zero_d1_rows(evals: &mut Evaluations<F, D<F>>, domain: Domain) {
         let stride = domain as usize;
-        // Only d8 constraints are skipped (see `init_`), so only they need their
-        // d1 rows forced to zero; d4 results (the generic constraint) are kept.
-        if stride == 8 {
+        if stride > 1 {
             let mask = stride - 1;
             o1_utils::cfg_iter_mut!(evals.evals)
                 .enumerate()

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -763,7 +763,20 @@ where
             let mut t4 = {
                 let generic_constraint =
                     generic::Generic::combined_constraints(&all_alphas, &mut cache);
-                let generic4 = generic_constraint.evaluations(&env);
+                let mut generic4 = generic_constraint.evaluations(&env);
+
+                // The generic constraint equals the public input on the
+                // public-input rows, but those (d1) rows were skipped while
+                // evaluating it. Add the public input back so interpolation
+                // recovers the generic gate exactly; the public-input
+                // polynomial (added below in coefficient form) then cancels it
+                // on d1, keeping the numerator divisible by Z_H.
+                {
+                    let stride = (index.cs.domain.d4.size / index.cs.domain.d1.size) as usize;
+                    for (row, p) in witness[0][..index.cs.public].iter().enumerate() {
+                        generic4.evals[stride * row] += p;
+                    }
+                }
 
                 if cfg!(debug_assertions) {
                     let p4 = public_poly.evaluate_over_domain_by_ref(index.cs.domain.d4);
@@ -867,19 +880,6 @@ where
 
                         check_constraint!(index, format!("lookup constraint #{ii}"), eval);
                     }
-                }
-            }
-
-            // The generic constraint equals the public input on the
-            // public-input rows, but those (d1) rows were skipped while
-            // evaluating it. Add the public input back onto t4 here so
-            // interpolation recovers the generic gate exactly; the public-input
-            // polynomial (added below in coefficient form) then cancels it on d1,
-            // keeping the numerator divisible by Z_H.
-            {
-                let stride = (index.cs.domain.d4.size / index.cs.domain.d1.size) as usize;
-                for (row, p) in witness[0][..index.cs.public].iter().enumerate() {
-                    t4.evals[stride * row] += p;
                 }
             }
 

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -870,6 +870,19 @@ where
                 }
             }
 
+            // The generic constraint equals the public input on the
+            // public-input rows, but those (d1) rows were skipped while
+            // evaluating it. Add the public input back onto t4 here so
+            // interpolation recovers the generic gate exactly; the public-input
+            // polynomial (added below in coefficient form) then cancels it on d1,
+            // keeping the numerator divisible by Z_H.
+            {
+                let stride = (index.cs.domain.d4.size / index.cs.domain.d1.size) as usize;
+                for (row, p) in witness[0][..index.cs.public].iter().enumerate() {
+                    t4.evals[stride * row] += p;
+                }
+            }
+
             // public polynomial
             let mut f = t4.interpolate() + t8.interpolate();
             f += &public_poly;


### PR DESCRIPTION
This PR modifies the computations for the constraint polynomial that feeds into the quotient, omitting calculations for `d1` -- where any valid witness is identically 0, as immediately checked by division by the vanishing polynomial -- achieving a `1/8 = 12.5%` speed-up for this part of the prover.

This comes at a cost: an invalid witness will now no longer be detected by the prover's division by the vanishing polynomial, and instead an invalid proof will only be caught by running the verifier on that proof. If this is an issue in practice, it's possible to run the verifier's check on the constraint polynomial at the end -- still wasteful, but not too expensive -- or to surface a dedicated call to run only that check which can be run optionally by consumers (and can e.g. be toggled in pickles by OCaml's snarky `eval_constraints` mechanism).

This PR has been split out of the work on optimising nori native proving in OCaml for easy review.