### PR TITLE
Performance: skip permutation argument constraint checks on d1 rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to
   disk while allowing the OS page cache to evict unused pages
   ([#3569](https://github.com/o1-labs/proof-systems/pull/3569))
 
+#### Changed
+
+- Skip the d1 rows in the permutation quotient. The permutation contribution
+  vanishes there for a satisfying witness, so the honest prover was computing
+  known zeros. The quotient is unchanged, but as a consequence a witness that
+  violates the permutation argument no longer trips the prover's "rest of
+  division by vanishing polynomial" check in release builds; it produces a proof
+  that fails verification instead. Debug builds still reject it earlier via
+  `index.verify()` ([#3589](https://github.com/o1-labs/proof-systems/pull/3589))
+
 ### [kimchi-napi](./kimchi-napi)
 
 #### Fixed

--- a/kimchi/src/circuits/domain_constant_evaluation.rs
+++ b/kimchi/src/circuits/domain_constant_evaluation.rs
@@ -19,10 +19,6 @@ pub struct DomainConstantEvaluations<F: FftField> {
     /// 1-st Lagrange evaluated over domain.d8
     #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub poly_x_d1: E<F, D<F>>,
-    /// 0-th Lagrange evaluated over domain.d4
-    // TODO(mimoo): be consistent with the paper/spec, call it L1 here or call it L0 there
-    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
-    pub constant_1_d4: E<F, D<F>>,
     /// 0-th Lagrange evaluated over domain.d8
     #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub constant_1_d8: E<F, D<F>>,
@@ -40,8 +36,6 @@ impl<F: FftField> DomainConstantEvaluations<F> {
     pub fn create(domain: EvaluationDomains<F>, zk_rows: u64) -> Option<Self> {
         let poly_x_d1 = DP::from_coefficients_slice(&[F::zero(), F::one()])
             .evaluate_over_domain_by_ref(domain.d8);
-        let constant_1_d4 =
-            E::<F, D<F>>::from_vec_and_domain(vec![F::one(); domain.d4.size()], domain.d4);
         let constant_1_d8 =
             E::<F, D<F>>::from_vec_and_domain(vec![F::one(); domain.d8.size()], domain.d8);
 
@@ -58,7 +52,6 @@ impl<F: FftField> DomainConstantEvaluations<F> {
 
         Some(DomainConstantEvaluations {
             poly_x_d1,
-            constant_1_d4,
             constant_1_d8,
             vanishes_on_zero_knowledge_and_previous_rows,
             permutation_vanishing_polynomial_l,

--- a/kimchi/src/circuits/domain_constant_evaluation.rs
+++ b/kimchi/src/circuits/domain_constant_evaluation.rs
@@ -1,10 +1,9 @@
 //! This contains the [DomainConstantEvaluations] which is used to provide precomputations to a [ConstraintSystem](super::constraints::ConstraintSystem).
 
 use crate::circuits::domains::EvaluationDomains;
-use alloc::vec;
 use ark_ff::FftField;
 use ark_poly::{
-    univariate::DensePolynomial as DP, DenseUVPolynomial, EvaluationDomain, Evaluations as E,
+    univariate::DensePolynomial as DP, DenseUVPolynomial, Evaluations as E,
     Radix2EvaluationDomain as D,
 };
 use serde::{Deserialize, Serialize};
@@ -16,12 +15,9 @@ use super::polynomials::permutation::{permutation_vanishing_polynomial, vanishes
 #[derive(Clone, Serialize, Deserialize, Debug)]
 /// pre-computed polynomials that depend only on the chosen field and domain
 pub struct DomainConstantEvaluations<F: FftField> {
-    /// 1-st Lagrange evaluated over domain.d8
+    /// the polynomial `x` evaluated over domain.d8 (i.e. the d8 domain points)
     #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub poly_x_d1: E<F, D<F>>,
-    /// 0-th Lagrange evaluated over domain.d8
-    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
-    pub constant_1_d8: E<F, D<F>>,
     /// the polynomial that vanishes on the zero-knowledge rows and the row before
     #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub vanishes_on_zero_knowledge_and_previous_rows: E<F, D<F>>,
@@ -36,8 +32,6 @@ impl<F: FftField> DomainConstantEvaluations<F> {
     pub fn create(domain: EvaluationDomains<F>, zk_rows: u64) -> Option<Self> {
         let poly_x_d1 = DP::from_coefficients_slice(&[F::zero(), F::one()])
             .evaluate_over_domain_by_ref(domain.d8);
-        let constant_1_d8 =
-            E::<F, D<F>>::from_vec_and_domain(vec![F::one(); domain.d8.size()], domain.d8);
 
         let vanishes_on_zero_knowledge_and_previous_rows =
             vanishes_on_last_n_rows(domain.d1, zk_rows + 1).evaluate_over_domain(domain.d8);
@@ -52,7 +46,6 @@ impl<F: FftField> DomainConstantEvaluations<F> {
 
         Some(DomainConstantEvaluations {
             poly_x_d1,
-            constant_1_d8,
             vanishes_on_zero_knowledge_and_previous_rows,
             permutation_vanishing_polynomial_l,
             permutation_vanishing_polynomial_m,

--- a/kimchi/src/circuits/polynomials/permutation.rs
+++ b/kimchi/src/circuits/polynomials/permutation.rs
@@ -234,9 +234,6 @@ where
 
         let zk_rows = self.cs.zk_rows as usize;
 
-        // constant gamma in evaluation form (in domain d8)
-        let gamma = &self.cs.precomputations().constant_1_d8.scale(gamma);
-
         //~ The quotient contribution of the permutation is split into two parts $perm$ and $bnd$.
         //~ They will be used by the prover.
         //~
@@ -270,7 +267,9 @@ where
             // (w[0](x) + gamma + x * beta * shift[0]) *
             // (w[1](x) + gamma + x * beta * shift[1]) * ...
             // (w[6](x) + gamma + x * beta * shift[6])
-            // in evaluation form in d8
+            // in evaluation form in d8, computed in a single pass per element:
+            // gamma is a constant, so it needs no all-ones broadcast vector,
+            // and x is read straight off the cached d8 domain points.
             let shifts: Evaluations<F, D<F>> = &lagrange
                 .d8
                 .this
@@ -278,7 +277,14 @@ where
                 .par_iter()
                 .zip(self.cs.shift.par_iter())
                 .map(|(witness, shift)| {
-                    &(witness + gamma) + &self.cs.precomputations().poly_x_d1.scale(beta * shift)
+                    let beta_shift = beta * shift;
+                    let evals: Vec<F> = witness
+                        .evals
+                        .par_iter()
+                        .zip(self.cs.precomputations().poly_x_d1.evals.par_iter())
+                        .map(|(w, x)| *w + gamma + beta_shift * x)
+                        .collect();
+                    Evaluations::<F, D<F>>::from_vec_and_domain(evals, self.cs.domain.d8)
                 })
                 .reduce_with(|mut l, r| {
                     l *= &r;
@@ -291,7 +297,7 @@ where
             // (w8[0] + gamma + sigma[0] * beta) *
             // (w8[1] + gamma + sigma[1] * beta) * ...
             // (w8[6] + gamma + sigma[6] * beta)
-            // in evaluation form in d8
+            // in evaluation form in d8, computed in a single pass per element
             let sigmas = &lagrange
                 .d8
                 .this
@@ -303,7 +309,15 @@ where
                         .permutation_coefficients8
                         .par_iter(),
                 )
-                .map(|(witness, sigma)| witness + &(gamma + &sigma.scale(beta)))
+                .map(|(witness, sigma)| {
+                    let evals: Vec<F> = witness
+                        .evals
+                        .par_iter()
+                        .zip(sigma.evals.par_iter())
+                        .map(|(w, s)| *w + gamma + beta * s)
+                        .collect();
+                    Evaluations::<F, D<F>>::from_vec_and_domain(evals, self.cs.domain.d8)
+                })
                 .reduce_with(|mut l, r| {
                     l *= &r;
                     l

--- a/kimchi/src/circuits/polynomials/permutation.rs
+++ b/kimchi/src/circuits/polynomials/permutation.rs
@@ -203,6 +203,23 @@ where
     }
 }
 
+/// Multiply `l` by `r` element-wise over d8, skipping the d1 rows -- the indices
+/// that are multiples of 8, since d8 = 8 * d1. The permutation contribution
+/// vanishes on all of d1, so those rows are left at the zero that building the
+/// terms produced; only the non-d1 products need computing.
+#[cfg(feature = "prover")]
+fn mul_assign_skipping_d1<F: FftField>(l: &mut Evaluations<F, D<F>>, r: &Evaluations<F, D<F>>) {
+    l.evals
+        .par_iter_mut()
+        .enumerate()
+        .zip(r.evals.par_iter())
+        .for_each(|((i, a), b)| {
+            if i & 7 != 0 {
+                *a *= b;
+            }
+        });
+}
+
 #[cfg(feature = "prover")]
 impl<const FULL_ROUNDS: usize, F, G, Srs> ProverIndex<FULL_ROUNDS, G, Srs>
 where
@@ -282,12 +299,21 @@ where
                         .evals
                         .par_iter()
                         .zip(self.cs.precomputations().poly_x_d1.evals.par_iter())
-                        .map(|(w, x)| *w + gamma + beta_shift * x)
+                        .enumerate()
+                        .map(|(i, (w, x))| {
+                            // Skip the d1 rows (multiples of 8): the permutation
+                            // vanishes there, so the products land at zero.
+                            if i & 7 == 0 {
+                                F::zero()
+                            } else {
+                                *w + gamma + beta_shift * x
+                            }
+                        })
                         .collect();
                     Evaluations::<F, D<F>>::from_vec_and_domain(evals, self.cs.domain.d8)
                 })
                 .reduce_with(|mut l, r| {
-                    l *= &r;
+                    mul_assign_skipping_d1(&mut l, &r);
                     l
                 })
                 .unwrap()
@@ -314,12 +340,21 @@ where
                         .evals
                         .par_iter()
                         .zip(sigma.evals.par_iter())
-                        .map(|(w, s)| *w + gamma + beta * s)
+                        .enumerate()
+                        .map(|(i, (w, s))| {
+                            // Skip the d1 rows (multiples of 8): the permutation
+                            // vanishes there, so the products land at zero.
+                            if i & 7 == 0 {
+                                F::zero()
+                            } else {
+                                *w + gamma + beta * s
+                            }
+                        })
                         .collect();
                     Evaluations::<F, D<F>>::from_vec_and_domain(evals, self.cs.domain.d8)
                 })
                 .reduce_with(|mut l, r| {
-                    l *= &r;
+                    mul_assign_skipping_d1(&mut l, &r);
                     l
                 })
                 .unwrap()

--- a/kimchi/tests/test_domain_constant_evaluation.rs
+++ b/kimchi/tests/test_domain_constant_evaluation.rs
@@ -1,0 +1,128 @@
+//! [`DomainConstantEvaluations`] builds its d8 evaluations in closed form
+//! rather than by interpolating and running an FFT. These tests pin that the
+//! closed forms agree exactly with the polynomials they stand in for, so the
+//! cheaper construction cannot silently drift from the definitions the prover
+//! and verifier rely on.
+
+use ark_ff::{FftField, Field, One, Zero};
+use ark_poly::{
+    univariate::DensePolynomial as DP, DenseUVPolynomial, Evaluations as E, Polynomial,
+    Radix2EvaluationDomain as D,
+};
+use kimchi::circuits::{
+    domain_constant_evaluation::DomainConstantEvaluations,
+    domains::EvaluationDomains,
+    polynomials::permutation::{permutation_vanishing_polynomial, vanishes_on_last_n_rows},
+};
+use mina_curves::pasta::Fp;
+
+/// The construction each field used before it was given a closed form: build
+/// the polynomial in coefficient form and evaluate it over d8 by FFT.
+fn reference<F: FftField>(poly: &DP<F>, d8: D<F>) -> E<F, D<F>> {
+    poly.evaluate_over_domain_by_ref(d8)
+}
+
+/// Domain sizes and zk_rows worth exercising: small domains (where d8 is close
+/// to the number of zk rows) and larger ones, against every zk_rows the
+/// constraint system builds in practice.
+fn cases() -> impl Iterator<Item = (usize, u64)> {
+    (3u32..=10)
+        .flat_map(|log_n| [3u64, 5, 7].map(move |zk_rows| (1usize << log_n, zk_rows)))
+        // `create` requires only `n > zk_rows`; include that boundary, where
+        // the vanishing polynomial's roots reach the start of the domain.
+        .filter(|(n, zk_rows)| *n as u64 > *zk_rows)
+}
+
+#[test]
+fn poly_x_d1_is_the_d8_domain_points() {
+    for (n, zk_rows) in cases() {
+        let domain = EvaluationDomains::<Fp>::create(n).unwrap();
+        let dce = DomainConstantEvaluations::create(domain, zk_rows).unwrap();
+
+        // `poly_x_d1` holds the polynomial `x` over d8, i.e. the d8 domain
+        // points; it is read back as a plain slice by the permutation argument.
+        let expected = reference(
+            &DP::from_coefficients_slice(&[Fp::zero(), Fp::one()]),
+            domain.d8,
+        );
+        assert_eq!(
+            dce.poly_x_d1, expected,
+            "poly_x_d1 mismatch at n={n} zk_rows={zk_rows}"
+        );
+
+        // Equivalently: the i-th entry is g8^i.
+        let mut x = Fp::one();
+        for (i, point) in dce.poly_x_d1.evals.iter().enumerate() {
+            assert_eq!(*point, x, "poly_x_d1[{i}] mismatch at n={n}");
+            x *= domain.d8.group_gen;
+        }
+    }
+}
+
+#[test]
+fn vanishing_polynomials_match_their_interpolations() {
+    for (n, zk_rows) in cases() {
+        let domain = EvaluationDomains::<Fp>::create(n).unwrap();
+        let dce = DomainConstantEvaluations::create(domain, zk_rows).unwrap();
+
+        // Vanishes on the last zk_rows + 1 rows.
+        let expected = reference(&vanishes_on_last_n_rows(domain.d1, zk_rows + 1), domain.d8);
+        assert_eq!(
+            dce.vanishes_on_zero_knowledge_and_previous_rows, expected,
+            "vanishes_on_zero_knowledge_and_previous_rows mismatch at n={n} zk_rows={zk_rows}"
+        );
+
+        // The permutation vanishing polynomial, and its d8 evaluations.
+        let m = permutation_vanishing_polynomial(domain.d1, zk_rows);
+        assert_eq!(
+            dce.permutation_vanishing_polynomial_m, m,
+            "permutation_vanishing_polynomial_m mismatch at n={n} zk_rows={zk_rows}"
+        );
+        assert_eq!(
+            dce.permutation_vanishing_polynomial_l,
+            reference(&m, domain.d8),
+            "permutation_vanishing_polynomial_l mismatch at n={n} zk_rows={zk_rows}"
+        );
+    }
+}
+
+#[test]
+fn vanishing_polynomials_vanish_on_their_roots() {
+    for (n, zk_rows) in cases() {
+        let domain = EvaluationDomains::<Fp>::create(n).unwrap();
+        let dce = DomainConstantEvaluations::create(domain, zk_rows).unwrap();
+        let omega = domain.d1.group_gen;
+
+        // d1 row `i` sits at index `8 * i` of a d8 evaluation.
+        let at_row = |evals: &E<Fp, D<Fp>>, row: u64| evals.evals[8 * (row as usize)];
+
+        for i in (n as u64 - (zk_rows + 1))..(n as u64) {
+            assert!(
+                at_row(&dce.vanishes_on_zero_knowledge_and_previous_rows, i).is_zero(),
+                "vanishes_on_zero_knowledge_and_previous_rows nonzero at row {i} (n={n} zk_rows={zk_rows})"
+            );
+        }
+        // The row before the zk rows must *not* vanish, or the polynomial would
+        // be zeroing more of the domain than intended. (When the roots reach the
+        // start of the domain there is no such row.)
+        if let Some(row) = (n as u64).checked_sub(zk_rows + 2) {
+            assert!(
+                !at_row(&dce.vanishes_on_zero_knowledge_and_previous_rows, row).is_zero(),
+                "vanishes_on_zero_knowledge_and_previous_rows vanishes too early (n={n} zk_rows={zk_rows})"
+            );
+        }
+
+        for root in [
+            omega.pow([n as u64 - zk_rows]),
+            omega.pow([n as u64 - zk_rows + 1]),
+            omega.pow([n as u64 - 1]),
+        ] {
+            assert!(
+                dce.permutation_vanishing_polynomial_m
+                    .evaluate(&root)
+                    .is_zero(),
+                "permutation_vanishing_polynomial_m nonzero at a root (n={n} zk_rows={zk_rows})"
+            );
+        }
+    }
+}


### PR DESCRIPTION
This PR is the natural counterpart to #3588, which skips the d1 component of the permutation argument. The first commit in this series is shared with #3586.

This PR has been split out of the work on optimising nori native proving in OCaml for easy review.