### PR TITLE
Fused constraint evaluator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to
 - Treat public evaluations of oracles as vectors for chunking coherence
   ([#3577](https://github.com/o1-labs/proof-systems/pull/3577))
 
+### [o1-utils](./utils)
+
+#### Added
+
+- Add `cfg_chunks_mut!`, the mutable-chunks counterpart to the existing
+  `cfg_iter!` family, so callers can chunk in parallel without depending on
+  `rayon` unconditionally
+  ([#3586](https://github.com/o1-labs/proof-systems/pull/3586))
+
 ## 0.7.0
 
 ### [kimchi-napi](./kimchi-napi)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to
 - Add an optional mmap-backed prover-index cache for loading proving keys from
   disk while allowing the OS page cache to evict unused pages
   ([#3569](https://github.com/o1-labs/proof-systems/pull/3569))
+- Add an opt-in fused row-wise constraint evaluator, which compiles the
+  constraint expression to a flat bytecode and walks the domain a block at a
+  time instead of materialising a full-domain `Evaluations` per sub-expression.
+  Off by default; selected via `KIMCHI_FUSED_EVAL` (`1` to use it, `verify` to
+  run both paths and assert they agree). Falls back to the vectorised path for
+  any expression it cannot compile
+  ([#3590](https://github.com/o1-labs/proof-systems/pull/3590))
 
 ### [kimchi-napi](./kimchi-napi)
 

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -1880,6 +1880,50 @@ enum Either<A, B> {
     Right(B),
 }
 
+/// Execution mode for the experimental fused row-wise evaluator.
+/// `KIMCHI_FUSED_EVAL=1` uses it (falling back to the vectorised path for
+/// expressions it does not handle); `=verify` runs both and asserts they agree.
+fn fused_eval_mode() -> u8 {
+    #[cfg(feature = "std")]
+    {
+        match std::env::var("KIMCHI_FUSED_EVAL").as_deref() {
+            Ok("verify") => 2,
+            Ok("1") | Ok("use") => 1,
+            _ => 0,
+        }
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        0
+    }
+}
+
+/// Flat bytecode for the fused evaluator: a stack machine walked once per domain
+/// row, with intermediates living in a register frame rather than full-domain
+/// arrays.
+enum FOp {
+    Lit(usize),
+    Col(usize),
+    Aux(usize),
+    Add,
+    Sub,
+    Mul,
+    Square,
+    Double,
+    Pow(u64),
+    StoreReg(usize),
+    LoadReg(usize),
+}
+
+/// A witness-column access resolved for the fused evaluator: at row `i` it reads
+/// `evals[(scale * i + offset) % len]` -- the same indexing as `SubEvals`.
+struct FCol<'a, F> {
+    evals: &'a [F],
+    scale: usize,
+    offset: usize,
+    len: usize,
+}
+
 impl<F: FftField, Column: Copy> Expr<F, Column> {
     /// Evaluate an expression into a field element.
     pub fn evaluate<Evaluations: ColumnEvaluations<F, Column = Column>>(
@@ -1944,6 +1988,11 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
         &self,
         env: &Environment,
     ) -> Evaluations<F, D<F>> {
+        if fused_eval_mode() == 1 {
+            if let Some(f) = self.evaluations_fused(env) {
+                return f;
+            }
+        }
         let d1_size = env.get_domain(Domain::D1).size;
         let deg = self.degree(d1_size, env.get_constants().zk_rows);
         let d = if deg <= d1_size {
@@ -1963,7 +2012,7 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
             Either::Right(id) => cache.get(&id).unwrap().clone(),
         };
 
-        match evals {
+        let result = match evals {
             EvalResult::Evals { evals, domain } => {
                 assert_eq!(domain, d);
                 evals
@@ -1986,7 +2035,330 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
                     evals.evals[(scale * i + (d_sub as usize) * s) % evals.evals.len()]
                 })
             }
+        };
+        if fused_eval_mode() == 2 {
+            if let Some(f) = self.evaluations_fused(env) {
+                assert_eq!(
+                    f.evals, result.evals,
+                    "fused evaluator disagrees with vectorised path"
+                );
+            }
         }
+        result
+    }
+
+    /// Experimental: evaluate this expression over d8 with a fused, row-wise
+    /// stack-machine bytecode -- intermediates live in registers, not full-domain
+    /// arrays. Returns `None` for anything the spike does not handle (below d8,
+    /// feature flags, vanishing/Lagrange atoms), so callers fall back.
+    fn evaluations_fused<'a, ChallengeTerm, Challenge, Environment>(
+        &self,
+        env: &Environment,
+    ) -> Option<Evaluations<F, D<F>>>
+    where
+        Challenge: Index<ChallengeTerm, Output = F>,
+        Environment: ColumnEnvironment<'a, F, ChallengeTerm, Challenge, Column = Column>,
+    {
+        let d1_size = env.get_domain(Domain::D1).size;
+        let deg = self.degree(d1_size, env.get_constants().zk_rows);
+        // Handle the d4 (generic + low-degree gates) and d8 (high-degree gates)
+        // constraints. d1-degree constraints are cheap and rare -> fall back.
+        let d = if deg <= d1_size {
+            return None;
+        } else if deg <= 4 * d1_size {
+            Domain::D4
+        } else if deg <= 8 * d1_size {
+            Domain::D8
+        } else {
+            return None;
+        };
+
+        let mut code: Vec<FOp> = Vec::new();
+        let mut lits: Vec<F> = Vec::new();
+        let mut cols: Vec<FCol<'a, F>> = Vec::new();
+        let mut aux: Vec<Vec<F>> = Vec::new();
+        let mut regs: HashMap<CacheId, usize> = HashMap::new();
+        let mut n_reg = 0usize;
+        let mut depth = 0usize;
+        let mut max_depth = 0usize;
+        self.fcompile(
+            env,
+            d,
+            &mut code,
+            &mut lits,
+            &mut cols,
+            &mut aux,
+            &mut regs,
+            &mut n_reg,
+            &mut depth,
+            &mut max_depth,
+        )
+        .ok()?;
+
+        let dom = env.get_domain(d);
+        let n = dom.size as usize;
+        let regbase = max_depth;
+        let frame = (max_depth + n_reg).max(1);
+        // Block-at-a-time: each opcode processes `B` consecutive rows (lanes), so
+        // the `match` dispatch is amortised over the block and the working set
+        // (frame * B field elements) stays L1-resident. Stack slot `s` occupies
+        // lanes `st[s*B .. s*B + B]`.
+        const B: usize = 8;
+        let chunk = 1usize << 14; // multiple of B
+        let mut out = vec![F::zero(); n];
+        o1_utils::cfg_chunks_mut!(out, chunk)
+            .enumerate()
+            .for_each(|(ci, slots)| {
+                let base = ci * chunk;
+                let mut st = vec![F::zero(); frame * B];
+                let len = slots.len();
+                let mut off = 0usize;
+                while off < len {
+                    let blk = B.min(len - off);
+                    let idx0 = base + off;
+                    let mut sp = 0usize;
+                    // SAFETY: the compile pass bounds every slot/lit/col index; `sp`
+                    // never exceeds `max_depth`, `regbase + r < frame`, `l < blk <= B`,
+                    // and the column index is reduced mod `len`.
+                    unsafe {
+                        for op in &code {
+                            match op {
+                                FOp::Lit(i) => {
+                                    let v = *lits.get_unchecked(*i);
+                                    let d0 = sp * B;
+                                    for l in 0..blk {
+                                        *st.get_unchecked_mut(d0 + l) = v;
+                                    }
+                                    sp += 1;
+                                }
+                                FOp::Col(i) => {
+                                    let c = cols.get_unchecked(*i);
+                                    let d0 = sp * B;
+                                    for l in 0..blk {
+                                        let raw = c.scale * (idx0 + l) + c.offset;
+                                        let j = if raw < c.len { raw } else { raw % c.len };
+                                        *st.get_unchecked_mut(d0 + l) = *c.evals.get_unchecked(j);
+                                    }
+                                    sp += 1;
+                                }
+                                FOp::Aux(i) => {
+                                    // Materialised over `d`, indexed directly by row.
+                                    let a = aux.get_unchecked(*i);
+                                    let d0 = sp * B;
+                                    for l in 0..blk {
+                                        *st.get_unchecked_mut(d0 + l) = *a.get_unchecked(idx0 + l);
+                                    }
+                                    sp += 1;
+                                }
+                                FOp::Add => {
+                                    sp -= 1;
+                                    let (t0, s0) = ((sp - 1) * B, sp * B);
+                                    for l in 0..blk {
+                                        let v = *st.get_unchecked(s0 + l);
+                                        *st.get_unchecked_mut(t0 + l) += v;
+                                    }
+                                }
+                                FOp::Sub => {
+                                    sp -= 1;
+                                    let (t0, s0) = ((sp - 1) * B, sp * B);
+                                    for l in 0..blk {
+                                        let v = *st.get_unchecked(s0 + l);
+                                        *st.get_unchecked_mut(t0 + l) -= v;
+                                    }
+                                }
+                                FOp::Mul => {
+                                    sp -= 1;
+                                    let (t0, s0) = ((sp - 1) * B, sp * B);
+                                    for l in 0..blk {
+                                        let v = *st.get_unchecked(s0 + l);
+                                        *st.get_unchecked_mut(t0 + l) *= v;
+                                    }
+                                }
+                                FOp::Square => {
+                                    let t0 = (sp - 1) * B;
+                                    for l in 0..blk {
+                                        st.get_unchecked_mut(t0 + l).square_in_place();
+                                    }
+                                }
+                                FOp::Double => {
+                                    let t0 = (sp - 1) * B;
+                                    for l in 0..blk {
+                                        st.get_unchecked_mut(t0 + l).double_in_place();
+                                    }
+                                }
+                                FOp::Pow(p) => {
+                                    let t0 = (sp - 1) * B;
+                                    for l in 0..blk {
+                                        let v = st.get_unchecked(t0 + l).pow([*p]);
+                                        *st.get_unchecked_mut(t0 + l) = v;
+                                    }
+                                }
+                                FOp::StoreReg(r) => {
+                                    let (d0, s0) = ((regbase + *r) * B, (sp - 1) * B);
+                                    for l in 0..blk {
+                                        *st.get_unchecked_mut(d0 + l) = *st.get_unchecked(s0 + l);
+                                    }
+                                }
+                                FOp::LoadReg(r) => {
+                                    let (d0, s0) = (sp * B, (regbase + *r) * B);
+                                    for l in 0..blk {
+                                        *st.get_unchecked_mut(d0 + l) = *st.get_unchecked(s0 + l);
+                                    }
+                                    sp += 1;
+                                }
+                            }
+                        }
+                        for l in 0..blk {
+                            *slots.get_unchecked_mut(off + l) = *st.get_unchecked(l);
+                        }
+                    }
+                    off += blk;
+                }
+            });
+
+        Some(Evaluations::from_vec_and_domain(out, dom))
+    }
+
+    /// Lower the expression tree into [`FOp`] bytecode (post-order). `Err` means
+    /// an unsupported node was hit and the caller should fall back.
+    #[allow(clippy::too_many_arguments)]
+    fn fcompile<'a, ChallengeTerm, Challenge, Environment>(
+        &self,
+        env: &Environment,
+        d: Domain,
+        code: &mut Vec<FOp>,
+        lits: &mut Vec<F>,
+        cols: &mut Vec<FCol<'a, F>>,
+        aux: &mut Vec<Vec<F>>,
+        regs: &mut HashMap<CacheId, usize>,
+        n_reg: &mut usize,
+        depth: &mut usize,
+        max_depth: &mut usize,
+    ) -> Result<(), ()>
+    where
+        Challenge: Index<ChallengeTerm, Output = F>,
+        Environment: ColumnEnvironment<'a, F, ChallengeTerm, Challenge, Column = Column>,
+    {
+        use ExprInner::*;
+        use Operations::*;
+        match self {
+            Atom(Constant(x)) => {
+                lits.push(*x);
+                code.push(FOp::Lit(lits.len() - 1));
+                *depth += 1;
+                *max_depth = (*max_depth).max(*depth);
+            }
+            Atom(Cell(v)) => {
+                match env.get_column(&v.col) {
+                    None => {
+                        lits.push(F::zero());
+                        code.push(FOp::Lit(lits.len() - 1));
+                    }
+                    Some(e) => {
+                        let d_sub = env.column_domain(&v.col) as usize;
+                        let scale = d_sub / (d as usize);
+                        if scale == 0 {
+                            return Err(());
+                        }
+                        cols.push(FCol {
+                            evals: e.evals.as_slice(),
+                            scale,
+                            offset: d_sub * v.row.shift(),
+                            len: e.evals.len(),
+                        });
+                        code.push(FOp::Col(cols.len() - 1));
+                    }
+                }
+                *depth += 1;
+                *max_depth = (*max_depth).max(*depth);
+            }
+            Add(a, b) => {
+                a.fcompile(env, d, code, lits, cols, aux, regs, n_reg, depth, max_depth)?;
+                b.fcompile(env, d, code, lits, cols, aux, regs, n_reg, depth, max_depth)?;
+                code.push(FOp::Add);
+                *depth -= 1;
+            }
+            Sub(a, b) => {
+                a.fcompile(env, d, code, lits, cols, aux, regs, n_reg, depth, max_depth)?;
+                b.fcompile(env, d, code, lits, cols, aux, regs, n_reg, depth, max_depth)?;
+                code.push(FOp::Sub);
+                *depth -= 1;
+            }
+            Mul(a, b) => {
+                a.fcompile(env, d, code, lits, cols, aux, regs, n_reg, depth, max_depth)?;
+                b.fcompile(env, d, code, lits, cols, aux, regs, n_reg, depth, max_depth)?;
+                code.push(FOp::Mul);
+                *depth -= 1;
+            }
+            Square(a) => {
+                a.fcompile(env, d, code, lits, cols, aux, regs, n_reg, depth, max_depth)?;
+                code.push(FOp::Square);
+            }
+            Double(a) => {
+                a.fcompile(env, d, code, lits, cols, aux, regs, n_reg, depth, max_depth)?;
+                code.push(FOp::Double);
+            }
+            Pow(a, p) => {
+                a.fcompile(env, d, code, lits, cols, aux, regs, n_reg, depth, max_depth)?;
+                code.push(FOp::Pow(*p));
+            }
+            Cache(id, e) => match regs.get(id) {
+                Some(&r) => {
+                    code.push(FOp::LoadReg(r));
+                    *depth += 1;
+                    *max_depth = (*max_depth).max(*depth);
+                }
+                None => {
+                    e.fcompile(env, d, code, lits, cols, aux, regs, n_reg, depth, max_depth)?;
+                    let r = *n_reg;
+                    *n_reg += 1;
+                    regs.insert(*id, r);
+                    code.push(FOp::StoreReg(r));
+                }
+            },
+            // Feature flags are fixed for a proof: resolve at compile time and
+            // only lower the live branch (no per-row branch).
+            IfFeature(feature, e1, e2) => {
+                if feature.is_enabled() {
+                    e1.fcompile(env, d, code, lits, cols, aux, regs, n_reg, depth, max_depth)?;
+                } else {
+                    e2.fcompile(env, d, code, lits, cols, aux, regs, n_reg, depth, max_depth)?;
+                }
+            }
+            // The zk/previous-rows vanishing polynomial is a borrowed d8 column.
+            Atom(VanishesOnZeroKnowledgeAndPreviousRows) => {
+                let e = env.vanishes_on_zero_knowledge_and_previous_rows();
+                let d_sub = Domain::D8 as usize;
+                let scale = d_sub / (d as usize);
+                if scale == 0 {
+                    return Err(());
+                }
+                cols.push(FCol {
+                    evals: e.evals.as_slice(),
+                    scale,
+                    offset: 0,
+                    len: e.evals.len(),
+                });
+                code.push(FOp::Col(cols.len() - 1));
+                *depth += 1;
+                *max_depth = (*max_depth).max(*depth);
+            }
+            // The unnormalized Lagrange basis is materialised over `d` (owned);
+            // precompute it once and load it like a column.
+            Atom(UnnormalizedLagrangeBasis(i)) => {
+                let offset = if i.zk_rows {
+                    -(env.get_constants().zk_rows as i32) + i.offset
+                } else {
+                    i.offset
+                };
+                let evals = unnormalized_lagrange_evals(env.l0_1(), offset, d, env);
+                aux.push(evals.evals);
+                code.push(FOp::Aux(aux.len() - 1));
+                *depth += 1;
+                *max_depth = (*max_depth).max(*depth);
+            }
+        }
+        Ok(())
     }
 
     fn evaluations_helper<

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -2198,9 +2198,22 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
                                 }
                                 FOp::Pow(p) => {
                                     let t0 = (sp - 1) * B;
-                                    for l in lstart..blk {
-                                        let v = st.get_unchecked(t0 + l).pow([*p]);
-                                        *st.get_unchecked_mut(t0 + l) = v;
+                                    if *p == 7 {
+                                        // x^7 = (x^2)^2 * x^2 * x -- the Poseidon
+                                        // S-box, evaluated ~4M times/proof over d8.
+                                        // A fixed 2-square/2-mul chain avoids the
+                                        // generic bigint exponentiation in [pow].
+                                        for l in lstart..blk {
+                                            let x = *st.get_unchecked(t0 + l);
+                                            let x2 = x.square();
+                                            let x4 = x2.square();
+                                            *st.get_unchecked_mut(t0 + l) = x4 * x2 * x;
+                                        }
+                                    } else {
+                                        for l in lstart..blk {
+                                            let v = st.get_unchecked(t0 + l).pow([*p]);
+                                            *st.get_unchecked_mut(t0 + l) = v;
+                                        }
                                     }
                                 }
                                 FOp::StoreReg(r) => {

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -2105,6 +2105,16 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
         // lanes `st[s*B .. s*B + B]`.
         const B: usize = 8;
         let chunk = 1usize << 14; // multiple of B
+
+        // 7n packing: for a d8 result every 8th row is a d1 row, where every
+        // constraint vanishes for a satisfying witness -- so the honest prover's
+        // value there is zero. Since the chunk and block sizes are multiples of
+        // 8, those rows are exactly lane 0 of every block: starting the lane
+        // loops at 1 skips them, leaving the zeros `out` was allocated with.
+        // That is 1/8 fewer column reads and bytecode steps. (d4 keeps every
+        // lane -- the generic constraint equals the public input on the
+        // public-input rows.)
+        let lstart = if (d as usize) == 8 { 1usize } else { 0usize };
         let mut out = vec![F::zero(); n];
         o1_utils::cfg_chunks_mut!(out, chunk)
             .enumerate()
@@ -2126,7 +2136,7 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
                                 FOp::Lit(i) => {
                                     let v = *lits.get_unchecked(*i);
                                     let d0 = sp * B;
-                                    for l in 0..blk {
+                                    for l in lstart..blk {
                                         *st.get_unchecked_mut(d0 + l) = v;
                                     }
                                     sp += 1;
@@ -2134,7 +2144,7 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
                                 FOp::Col(i) => {
                                     let c = cols.get_unchecked(*i);
                                     let d0 = sp * B;
-                                    for l in 0..blk {
+                                    for l in lstart..blk {
                                         let raw = c.scale * (idx0 + l) + c.offset;
                                         let j = if raw < c.len { raw } else { raw % c.len };
                                         *st.get_unchecked_mut(d0 + l) = *c.evals.get_unchecked(j);
@@ -2145,7 +2155,7 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
                                     // Materialised over `d`, indexed directly by row.
                                     let a = aux.get_unchecked(*i);
                                     let d0 = sp * B;
-                                    for l in 0..blk {
+                                    for l in lstart..blk {
                                         *st.get_unchecked_mut(d0 + l) = *a.get_unchecked(idx0 + l);
                                     }
                                     sp += 1;
@@ -2153,7 +2163,7 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
                                 FOp::Add => {
                                     sp -= 1;
                                     let (t0, s0) = ((sp - 1) * B, sp * B);
-                                    for l in 0..blk {
+                                    for l in lstart..blk {
                                         let v = *st.get_unchecked(s0 + l);
                                         *st.get_unchecked_mut(t0 + l) += v;
                                     }
@@ -2161,7 +2171,7 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
                                 FOp::Sub => {
                                     sp -= 1;
                                     let (t0, s0) = ((sp - 1) * B, sp * B);
-                                    for l in 0..blk {
+                                    for l in lstart..blk {
                                         let v = *st.get_unchecked(s0 + l);
                                         *st.get_unchecked_mut(t0 + l) -= v;
                                     }
@@ -2169,46 +2179,46 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
                                 FOp::Mul => {
                                     sp -= 1;
                                     let (t0, s0) = ((sp - 1) * B, sp * B);
-                                    for l in 0..blk {
+                                    for l in lstart..blk {
                                         let v = *st.get_unchecked(s0 + l);
                                         *st.get_unchecked_mut(t0 + l) *= v;
                                     }
                                 }
                                 FOp::Square => {
                                     let t0 = (sp - 1) * B;
-                                    for l in 0..blk {
+                                    for l in lstart..blk {
                                         st.get_unchecked_mut(t0 + l).square_in_place();
                                     }
                                 }
                                 FOp::Double => {
                                     let t0 = (sp - 1) * B;
-                                    for l in 0..blk {
+                                    for l in lstart..blk {
                                         st.get_unchecked_mut(t0 + l).double_in_place();
                                     }
                                 }
                                 FOp::Pow(p) => {
                                     let t0 = (sp - 1) * B;
-                                    for l in 0..blk {
+                                    for l in lstart..blk {
                                         let v = st.get_unchecked(t0 + l).pow([*p]);
                                         *st.get_unchecked_mut(t0 + l) = v;
                                     }
                                 }
                                 FOp::StoreReg(r) => {
                                     let (d0, s0) = ((regbase + *r) * B, (sp - 1) * B);
-                                    for l in 0..blk {
+                                    for l in lstart..blk {
                                         *st.get_unchecked_mut(d0 + l) = *st.get_unchecked(s0 + l);
                                     }
                                 }
                                 FOp::LoadReg(r) => {
                                     let (d0, s0) = (sp * B, (regbase + *r) * B);
-                                    for l in 0..blk {
+                                    for l in lstart..blk {
                                         *st.get_unchecked_mut(d0 + l) = *st.get_unchecked(s0 + l);
                                     }
                                     sp += 1;
                                 }
                             }
                         }
-                        for l in 0..blk {
+                        for l in lstart..blk {
                             *slots.get_unchecked_mut(off + l) = *st.get_unchecked(l);
                         }
                     }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -37,6 +37,19 @@ macro_rules! cfg_iter_mut {
     }};
 }
 
+/// Returns a parallel iterator over mutable chunks when the `parallel` feature
+/// is enabled, otherwise returns a sequential one.
+#[macro_export]
+macro_rules! cfg_chunks_mut {
+    ($e:expr, $size:expr) => {{
+        #[cfg(feature = "parallel")]
+        let result = $e.par_chunks_mut($size);
+        #[cfg(not(feature = "parallel"))]
+        let result = $e.chunks_mut($size);
+        result
+    }};
+}
+
 /// Returns a parallel consuming iterator when the `parallel` feature is enabled,
 /// otherwise returns a sequential consuming iterator.
 #[macro_export]


### PR DESCRIPTION
This PR implements a 'fused' evaluator for expressions. This is used to compute the constraint evaluations for the quotient in a more efficient way (in terms of both memory and time).

The biggest win is to avoid creating a stack of d8 vectors while evaluating: instead of computing every intermediate value in the stack-based interpreter as a full-width vector, it evaluates the entire expression of a block of rows (currently hard-coded as size 8), and writes back the results to the final output vector. This performs better than the old algorithm even when ignoring the benefits to RAM consumption.

Embedded in this is the same optimisation as implemented in #3588: the d1 rows are omitted, since their evaluations will be calculated as 0 values there anyway (for a valid witness). The caveat around prover failures for invalid witnesses thus applies here too -- in the same way that a Groth16 prover will never catch a constraint failure unless they explicitly evaluate the constraints or check the proof, a prover using this option will produce an invalid proof for an invalid witness.

This is currently behind an env-var feature flag `KIMCHI_FUSED_EVAL`. This was done to allow it to be used for nori without changing the algorithm out from under Mina and o1js unilaterally, even while using the same compiled rust binary object. Reviewer-TODO: determine a better treatment for configurability if required.

his PR has been split out of the work on optimising nori native proving in OCaml for easy review.