### PR TITLE
Fat proofs: return the oracle challenges from the prover instead of recomputing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to
   disk while allowing the OS page cache to evict unused pages
   ([#3569](https://github.com/o1-labs/proof-systems/pull/3569))
 
+#### Changed
+
+- **Breaking:** `ProverProof::create_recursive` now returns a `FatProverProof`,
+  wrapping the proof together with the oracle challenges, public-input
+  evaluations and Fq-sponge digest the prover already computed, so a downstream
+  wrap can skip recomputing them. `ProverProof` and `OpeningProof` are
+  unchanged; existing callers take `.proof`
+  ([#3591](https://github.com/o1-labs/proof-systems/pull/3591))
+
 ### [kimchi-napi](./kimchi-napi)
 
 #### Fixed
@@ -25,6 +34,15 @@ and this project adheres to
   ([#3577](https://github.com/o1-labs/proof-systems/pull/3577))
 
 ### [kimchi-stubs](./kimchi-stubs)
+
+#### Added
+
+- Add `caml_pasta_fp_plonk_proof_create_with_oracles`, a step-prover entry point
+  returning the proof together with the oracle challenges the prover already
+  computed, so the OCaml wrap can skip `caml_pasta_fp_plonk_oracles_create`. Its
+  OCaml binding is hand-written rather than generated, because `ocaml_gen`
+  cannot resolve `CamlOracles` from this module's scope
+  ([#3591](https://github.com/o1-labs/proof-systems/pull/3591))
 
 #### Fixed
 
@@ -37,6 +55,17 @@ and this project adheres to
 
 - Treat public evaluations of oracles as vectors for chunking coherence
   ([#3577](https://github.com/o1-labs/proof-systems/pull/3577))
+
+### [poly-commitment](./poly-commitment)
+
+#### Changed
+
+- **Breaking:** `OpenProof::open` now returns an `OpeningProofFat<Self, F>`,
+  carrying the opening proof together with the IPA folding prechallenges the
+  prover computes and previously discarded (empty for non-folding schemes such
+  as KZG). The thin `OpeningProof` type is unchanged; callers recover it via
+  `.inner()` / `.proof` and the challenges via `.challenges()`
+  ([#3591](https://github.com/o1-labs/proof-systems/pull/3591))
 
 ## 0.7.0
 

--- a/kimchi-napi/src/proof.rs
+++ b/kimchi-napi/src/proof.rs
@@ -819,7 +819,7 @@ macro_rules! impl_proof {
                 };
 
                 match maybe_proof {
-                    Ok(proof) => Ok((proof, public_input).into()),
+                    Ok(fat) => Ok((fat.proof, public_input).into()),
                     Err(err) => Err(NapiError::new(Status::GenericFailure, err.to_string())),
                 }
             }

--- a/kimchi-stubs/src/pasta_fp_plonk_proof.rs
+++ b/kimchi-stubs/src/pasta_fp_plonk_proof.rs
@@ -14,6 +14,7 @@ use kimchi::{
         lookup::runtime_tables::{caml::CamlRuntimeTable, RuntimeTable},
         polynomial::COLUMNS,
     },
+    oracles::caml::CamlOracles,
     proof::{
         PointEvaluations, ProofEvaluations, ProverCommitments, ProverProof, RecursionChallenge,
     },
@@ -111,6 +112,87 @@ pub fn caml_pasta_fp_plonk_proof_create(
         .map_err(|e| ocaml::Error::Error(e.into()))?
         .proof;
         Ok((proof, public_input).into())
+    })
+}
+
+/// Like [`caml_pasta_fp_plonk_proof_create`], but also returns the oracle
+/// challenges the prover already computed, so the caller (the wrap) can skip
+/// recomputing them via `caml_pasta_fp_plonk_oracles_create`.
+///
+/// The OCaml binding is hand-written (see `kimchi_bindings_extra.ml`): ocaml_gen
+/// cannot emit a signature mentioning `CamlOracles` from this module's scope, so
+/// `#[ocaml_gen::func]` is intentionally omitted.
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_proof_create_with_oracles(
+    index: CamlPastaFpPlonkIndexPtr<'static>,
+    witness: Vec<CamlFpVector>,
+    runtime_tables: Vec<CamlRuntimeTable<CamlFp>>,
+    prev_challenges: Vec<CamlFp>,
+    prev_sgs: Vec<CamlGVesta>,
+) -> Result<(CamlProofWithPublic<CamlGVesta, CamlFp>, CamlOracles<CamlFp>), ocaml::Error> {
+    {
+        index
+            .as_ref()
+            .0
+            .srs
+            .with_lagrange_basis(index.as_ref().0.cs.domain.d1);
+    }
+
+    let prev = if prev_challenges.is_empty() {
+        Vec::new()
+    } else {
+        let challenges_per_sg = prev_challenges.len() / prev_sgs.len();
+        prev_sgs
+            .into_iter()
+            .map(Into::<Vesta>::into)
+            .enumerate()
+            .map(|(i, sg)| {
+                let chals = prev_challenges[(i * challenges_per_sg)..(i + 1) * challenges_per_sg]
+                    .iter()
+                    .map(Into::<Fp>::into)
+                    .collect();
+                let comm = PolyComm::<Vesta> { chunks: vec![sg] };
+                RecursionChallenge { chals, comm }
+            })
+            .collect()
+    };
+
+    let witness: Vec<Vec<_>> = witness.iter().map(|x| (**x).clone()).collect();
+    let witness: [Vec<_>; COLUMNS] = witness
+        .try_into()
+        .map_err(|_| ocaml::Error::Message("the witness should be a column of 15 vectors"))?;
+    let index: &ProverIndex<FULL_ROUNDS, Vesta, Srs> = &index.as_ref().0;
+    let runtime_tables: Vec<RuntimeTable<Fp>> =
+        runtime_tables.into_iter().map(Into::into).collect();
+
+    let public_input = witness[0][0..index.cs.public].to_vec();
+
+    let runtime = unsafe { ocaml::Runtime::recover_handle() };
+
+    runtime.releasing_runtime(|| {
+        let group_map = GroupMap::<Fq>::setup();
+        let fat = ProverProof::create_recursive::<EFqSponge, EFrSponge, _>(
+            &group_map,
+            witness,
+            &runtime_tables,
+            index,
+            prev,
+            None,
+            &mut rand::rngs::OsRng,
+        )
+        .map_err(|e| ocaml::Error::Error(e.into()))?;
+        let fo = fat.fat_oracles;
+        let oracles = CamlOracles {
+            o: fo.oracles.into(),
+            public_evals: (fo.public_evals[0][0].into(), fo.public_evals[1][0].into()),
+            opening_prechallenges: fo
+                .opening_prechallenges
+                .iter()
+                .map(|x| (*x).into())
+                .collect(),
+            digest_before_evaluations: fo.digest.into(),
+        };
+        Ok(((fat.proof, public_input).into(), oracles))
     })
 }
 

--- a/kimchi-stubs/src/pasta_fp_plonk_proof.rs
+++ b/kimchi-stubs/src/pasta_fp_plonk_proof.rs
@@ -108,7 +108,8 @@ pub fn caml_pasta_fp_plonk_proof_create(
             None,
             &mut rand::rngs::OsRng,
         )
-        .map_err(|e| ocaml::Error::Error(e.into()))?;
+        .map_err(|e| ocaml::Error::Error(e.into()))?
+        .proof;
         Ok((proof, public_input).into())
     })
 }
@@ -176,7 +177,8 @@ pub fn caml_pasta_fp_plonk_proof_create_and_verify(
             None,
             &mut rand::rngs::OsRng,
         )
-        .map_err(|e| ocaml::Error::Error(e.into()))?;
+        .map_err(|e| ocaml::Error::Error(e.into()))?
+        .proof;
 
         let verifier_index = index.verifier_index();
 
@@ -306,7 +308,8 @@ pub fn caml_pasta_fp_plonk_proof_example_with_lookup(
         None,
         &mut rand::rngs::OsRng,
     )
-    .unwrap();
+    .unwrap()
+    .proof;
 
     let caml_prover_proof = (proof, vec![public_input]).into();
 
@@ -472,7 +475,8 @@ pub fn caml_pasta_fp_plonk_proof_example_with_foreign_field_mul(
         None,
         &mut rand::rngs::OsRng,
     )
-    .unwrap();
+    .unwrap()
+    .proof;
     (
         CamlPastaFpPlonkIndex(IndexHandle::Owned(Box::new(index))),
         (proof, vec![]).into(),
@@ -544,7 +548,8 @@ pub fn caml_pasta_fp_plonk_proof_example_with_range_check(
         None,
         &mut rand::rngs::OsRng,
     )
-    .unwrap();
+    .unwrap()
+    .proof;
     (
         CamlPastaFpPlonkIndex(IndexHandle::Owned(Box::new(index))),
         (proof, vec![]).into(),
@@ -620,7 +625,8 @@ pub fn caml_pasta_fp_plonk_proof_example_with_range_check0(
         None,
         &mut rand::rngs::OsRng,
     )
-    .unwrap();
+    .unwrap()
+    .proof;
     (
         CamlPastaFpPlonkIndex(IndexHandle::Owned(Box::new(index))),
         (proof, vec![]).into(),
@@ -749,7 +755,8 @@ pub fn caml_pasta_fp_plonk_proof_example_with_ffadd(
         None,
         &mut rand::rngs::OsRng,
     )
-    .unwrap();
+    .unwrap()
+    .proof;
     (
         CamlPastaFpPlonkIndex(IndexHandle::Owned(Box::new(index))),
         public_input.into(),
@@ -842,7 +849,8 @@ pub fn caml_pasta_fp_plonk_proof_example_with_xor(
         None,
         &mut rand::rngs::OsRng,
     )
-    .unwrap();
+    .unwrap()
+    .proof;
     (
         CamlPastaFpPlonkIndex(IndexHandle::Owned(Box::new(index))),
         (public_input.0.into(), public_input.1.into()),
@@ -938,7 +946,8 @@ pub fn caml_pasta_fp_plonk_proof_example_with_rot(
         None,
         &mut rand::rngs::OsRng,
     )
-    .unwrap();
+    .unwrap()
+    .proof;
     (
         CamlPastaFpPlonkIndex(IndexHandle::Owned(Box::new(index))),
         (public_input.0.into(), public_input.1.into()),

--- a/kimchi-stubs/src/pasta_fq_plonk_proof.rs
+++ b/kimchi-stubs/src/pasta_fq_plonk_proof.rs
@@ -113,7 +113,8 @@ pub fn caml_pasta_fq_plonk_proof_create(
             None,
             &mut rand::rngs::OsRng,
         )
-        .map_err(|e| ocaml::Error::Error(e.into()))?;
+        .map_err(|e| ocaml::Error::Error(e.into()))?
+        .proof;
         Ok((proof, public_input).into())
     })
 }

--- a/kimchi-wasm/src/plonk_proof.rs
+++ b/kimchi-wasm/src/plonk_proof.rs
@@ -710,7 +710,7 @@ macro_rules! impl_proof {
                 });
 
                 return match maybe_proof {
-                    Ok(proof) => Ok((proof, public_input).into()),
+                    Ok(fat) => Ok((fat.proof, public_input).into()),
                     Err(err) => Err(JsError::from(err))
                 }
             }

--- a/kimchi/src/proof.rs
+++ b/kimchi/src/proof.rs
@@ -194,6 +194,29 @@ where
     pub prev_challenges: Vec<RecursionChallenge<G>>,
 }
 
+/// Oracle challenges the prover already computed during proving. The wrap
+/// recomputes these from the proof (`O.create`, ~52ms); the step prover can hand
+/// them over instead. This is the subset the wrap consumes -- the challenges,
+/// the public-input evaluations, and the Fq-sponge digest.
+#[derive(Debug, Clone)]
+pub struct FatOracles<F: ark_ff::Field> {
+    pub oracles: crate::circuits::scalars::RandomOracles<F>,
+    pub public_evals: [Vec<F>; 2],
+    pub digest: F,
+}
+
+/// A [`ProverProof`] plus the prover's [`FatOracles`]. The step (Vesta) prover
+/// returns this; existing callers that only want the proof extract `.proof`,
+/// leaving the cryptographic proof type and its API untouched.
+pub struct FatProverProof<G, OpeningProof, const FULL_ROUNDS: usize>
+where
+    G: CommitmentCurve,
+    OpeningProof: OpenProof<G, FULL_ROUNDS>,
+{
+    pub proof: ProverProof<G, OpeningProof, FULL_ROUNDS>,
+    pub fat_oracles: FatOracles<G::ScalarField>,
+}
+
 /// Stores the accumulator from a previously verified IPA (Inner Product Argument).
 ///
 /// In recursive proof composition, when we verify a proof, the IPA verification

--- a/kimchi/src/proof.rs
+++ b/kimchi/src/proof.rs
@@ -197,12 +197,15 @@ where
 /// Oracle challenges the prover already computed during proving. The wrap
 /// recomputes these from the proof (`O.create`, ~52ms); the step prover can hand
 /// them over instead. This is the subset the wrap consumes -- the challenges,
-/// the public-input evaluations, and the Fq-sponge digest.
+/// the public-input evaluations, the Fq-sponge digest, and the IPA opening
+/// prechallenges.
 #[derive(Debug, Clone)]
 pub struct FatOracles<F: ark_ff::Field> {
     pub oracles: crate::circuits::scalars::RandomOracles<F>,
     pub public_evals: [Vec<F>; 2],
     pub digest: F,
+    /// The IPA folding prechallenges (the wrap's `opening_prechallenges`).
+    pub opening_prechallenges: Vec<F>,
 }
 
 /// A [`ProverProof`] plus the prover's [`FatOracles`]. The step (Vesta) prover

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1439,7 +1439,7 @@ where
 
         //~ 1. Create an aggregated evaluation proof for all of these polynomials at $\zeta$ and $\zeta\omega$ using $u$ and $v$.
         internal_tracing::checkpoint!(internal_traces; create_aggregated_ipa);
-        let proof = OpenProof::open(
+        let opening_fat = OpenProof::open(
             &*index.srs,
             group_map,
             &polynomials,
@@ -1449,6 +1449,10 @@ where
             fq_sponge_before_evaluations,
             rng,
         );
+        // The IPA folding prechallenges, surfaced for the fat proof so the wrap
+        // need not recompute them.
+        let opening_prechallenges = opening_fat.challenges().to_vec();
+        let proof = opening_fat.inner();
 
         let lookup = lookup_context
             .aggreg_comm
@@ -1498,6 +1502,7 @@ where
                 None => [vec![], vec![]],
             },
             digest: fq_digest_before_evaluations,
+            opening_prechallenges,
         };
 
         Ok(crate::proof::FatProverProof { proof, fat_oracles })

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -84,6 +84,9 @@ where
     /// The joint combiner used to join the columns of lookup tables
     joint_combiner: Option<F>,
 
+    /// The joint-combiner prechallenge (kept for the fat-proof oracle).
+    joint_combiner_chal: Option<ScalarChallenge<F>>,
+
     /// The power of the joint_combiner that can be used to add a table_id column
     /// to the concatenated lookup tables.
     table_id_combiner: Option<F>,
@@ -157,6 +160,7 @@ where
             None,
             rng,
         )
+        .map(|fat| fat.proof)
     }
 
     /// This function constructs prover's recursive zk-proof from the witness &
@@ -178,7 +182,7 @@ where
         prev_challenges: Vec<RecursionChallenge<G>>,
         blinders: Option<[Option<PolyComm<G::ScalarField>>; COLUMNS]>,
         rng: &mut RNG,
-    ) -> Result<Self>
+    ) -> Result<crate::proof::FatProverProof<G, OpeningProof, FULL_ROUNDS>>
     where
         EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField, FULL_ROUNDS>,
         EFrSponge: FrSponge<G::ScalarField>,
@@ -460,8 +464,9 @@ where
             };
 
             //~~ * Derive the scalar joint combiner $j$ from $j'$ using the endomorphism (TODO: specify)
-            let joint_combiner: G::ScalarField =
-                ScalarChallenge::new(joint_combiner).to_field(endo_r);
+            let joint_combiner_chal = ScalarChallenge::new(joint_combiner);
+            lookup_context.joint_combiner_chal = Some(joint_combiner_chal.clone());
+            let joint_combiner: G::ScalarField = joint_combiner_chal.to_field(endo_r);
 
             //~~ * If multiple lookup tables are involved,
             //~~   set the `table_id_combiner` as the $j^i$ with $i$ the maximum width of any used table.
@@ -1164,10 +1169,11 @@ where
 
         //~ 1. Setup the Fr-Sponge
         let fq_sponge_before_evaluations = fq_sponge.clone();
+        let fq_digest_before_evaluations = fq_sponge.digest();
         let mut fr_sponge = EFrSponge::from(G::sponge_params());
 
         //~ 1. Squeeze the Fq-sponge and absorb the result with the Fr-Sponge.
-        fr_sponge.absorb(&fq_sponge.digest());
+        fr_sponge.absorb(&fq_digest_before_evaluations);
 
         //~ 1. Absorb the previous recursion challenges.
         let prev_challenge_digest = {
@@ -1468,7 +1474,33 @@ where
 
         internal_tracing::checkpoint!(internal_traces; create_recursive_done);
 
-        Ok(proof)
+        // Collect the oracle challenges the prover already computed, so the
+        // wrap can skip recomputing them (`O.create`). Side-data only.
+        let fat_oracles = crate::proof::FatOracles {
+            oracles: crate::circuits::scalars::RandomOracles {
+                joint_combiner: lookup_context
+                    .joint_combiner_chal
+                    .clone()
+                    .zip(lookup_context.joint_combiner),
+                beta,
+                gamma,
+                alpha_chal: alpha_chal.clone(),
+                alpha,
+                zeta,
+                v,
+                u,
+                zeta_chal: zeta_chal.clone(),
+                v_chal: v_chal.clone(),
+                u_chal: u_chal.clone(),
+            },
+            public_evals: match &proof.evals.public {
+                Some(p) => [p.zeta.clone(), p.zeta_omega.clone()],
+                None => [vec![], vec![]],
+            },
+            digest: fq_digest_before_evaluations,
+        };
+
+        Ok(crate::proof::FatProverProof { proof, fat_oracles })
     }
 }
 

--- a/kimchi/src/tests/framework.rs
+++ b/kimchi/src/tests/framework.rs
@@ -526,7 +526,8 @@ where
             None,
             &mut rand::rngs::OsRng,
         )
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| e.to_string())?
+        .proof;
         println!("- time to create proof: {:?}s", start.elapsed().as_secs());
 
         if self.0.with_logs {
@@ -722,7 +723,8 @@ where
             None,
             rng,
         )
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| e.to_string())?
+        .proof;
 
         o1_utils::serialization::test_generic_serialization_regression_serde(proof, buf_expected);
 

--- a/o1vm/src/pickles/lookup_prover.rs
+++ b/o1vm/src/pickles/lookup_prover.rs
@@ -210,7 +210,8 @@ where
         eval_scale,
         fq_sponge_before_evaluations,
         rng,
-    );
+    )
+    .inner();
     (
         Proof {
             commitments,

--- a/o1vm/src/pickles/prover.rs
+++ b/o1vm/src/pickles/prover.rs
@@ -470,7 +470,8 @@ where
         u,
         fq_sponge_before_evaluations,
         rng,
-    );
+    )
+    .inner();
 
     Ok(Proof {
         commitments,

--- a/poly-commitment/src/ipa.rs
+++ b/poly-commitment/src/ipa.rs
@@ -829,7 +829,7 @@ impl<G: CommitmentCurve> SRS<G> {
         evalscale: G::ScalarField,
         mut sponge: EFqSponge,
         rng: &mut RNG,
-    ) -> OpeningProof<G, FULL_ROUNDS>
+    ) -> crate::OpeningProofFat<OpeningProof<G, FULL_ROUNDS>, G::ScalarField>
     where
         EFqSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField, FULL_ROUNDS>,
         RNG: RngCore + CryptoRng,
@@ -924,6 +924,9 @@ impl<G: CommitmentCurve> SRS<G> {
 
         let mut chals = vec![];
         let mut chal_invs = vec![];
+        // Folding prechallenges, surfaced in the fat opening so the prover can
+        // hand them to a downstream wrap (which would otherwise recompute them).
+        let mut prechals = vec![];
 
         // The main IPA folding loop that has log iterations.
         for _ in 0..rounds {
@@ -975,6 +978,7 @@ impl<G: CommitmentCurve> SRS<G> {
 
             chals.push(u);
             chal_invs.push(u_inv);
+            prechals.push(u_pre.inner());
 
             // IPA-folding polynomial coefficients
             a = o1_utils::cfg_iter!(a_hi)
@@ -1051,12 +1055,15 @@ impl<G: CommitmentCurve> SRS<G> {
         let z1 = a0 * c + d;
         let z2 = r_prime * c + r_delta;
 
-        OpeningProof {
-            delta,
-            lr,
-            z1,
-            z2,
-            sg: g0,
+        crate::OpeningProofFat {
+            proof: OpeningProof {
+                delta,
+                lr,
+                z1,
+                z2,
+                sg: g0,
+            },
+            challenges: prechals,
         }
     }
 }
@@ -1208,7 +1215,7 @@ impl<
         evalscale: <G as AffineRepr>::ScalarField,
         sponge: EFqSponge,
         rng: &mut RNG,
-    ) -> Self
+    ) -> crate::OpeningProofFat<Self, <G as AffineRepr>::ScalarField>
     where
         EFqSponge: Clone
             + FqSponge<<G as AffineRepr>::BaseField, G, <G as AffineRepr>::ScalarField, FULL_ROUNDS>,

--- a/poly-commitment/src/kzg.rs
+++ b/poly-commitment/src/kzg.rs
@@ -209,12 +209,16 @@ impl<
         _evalscale: <G as AffineRepr>::ScalarField,
         _sponge: EFqSponge,
         _rng: &mut RNG,
-    ) -> Self
+    ) -> crate::OpeningProofFat<Self, F>
     where
         EFqSponge: Clone + FqSponge<<G as AffineRepr>::BaseField, G, F, FULL_ROUNDS>,
         RNG: RngCore + CryptoRng,
     {
-        Self::create(srs, plnms, elm, polyscale).unwrap()
+        // KZG has no folding rounds, so there are no prechallenges to surface.
+        crate::OpeningProofFat {
+            proof: Self::create(srs, plnms, elm, polyscale).unwrap(),
+            challenges: vec![],
+        }
     }
 
     fn verify<EFqSponge, RNG>(

--- a/poly-commitment/src/lib.rs
+++ b/poly-commitment/src/lib.rs
@@ -251,6 +251,28 @@ type PolynomialsToCombine<'a, G: CommitmentCurve, D: EvaluationDomain<G::ScalarF
     PolyComm<G::ScalarField>,
 )];
 
+/// An opening proof together with the IPA folding prechallenges it produced.
+///
+/// For non-folding schemes (e.g. KZG) the challenges are empty. Returned by
+/// [`OpenProof::open`] so the prover can surface the challenges -- which the
+/// verifier would otherwise recompute -- without changing the thin proof type.
+pub struct OpeningProofFat<Proof, F> {
+    pub proof: Proof,
+    pub challenges: Vec<F>,
+}
+
+impl<Proof, F: Clone> OpeningProofFat<Proof, F> {
+    /// Recover the thin (cryptographic) opening proof.
+    pub fn inner(self) -> Proof {
+        self.proof
+    }
+
+    /// The IPA folding prechallenges (empty for non-folding schemes).
+    pub fn challenges(&self) -> &[F] {
+        &self.challenges
+    }
+}
+
 pub trait OpenProof<G: CommitmentCurve, const FULL_ROUNDS: usize>: Sized + Clone {
     type SRS: SRS<G> + core::fmt::Debug;
 
@@ -279,7 +301,7 @@ pub trait OpenProof<G: CommitmentCurve, const FULL_ROUNDS: usize>: Sized + Clone
         evalscale: <G as AffineRepr>::ScalarField,
         sponge: EFqSponge,
         rng: &mut RNG,
-    ) -> Self
+    ) -> OpeningProofFat<Self, <G as AffineRepr>::ScalarField>
     where
         EFqSponge: Clone
             + FqSponge<<G as AffineRepr>::BaseField, G, <G as AffineRepr>::ScalarField, FULL_ROUNDS>,

--- a/poly-commitment/tests/commitment.rs
+++ b/poly-commitment/tests/commitment.rs
@@ -212,7 +212,8 @@ pub fn generate_random_opening_proof<RNG: Rng + CryptoRng>(
                 evalmask,
                 fq_sponge.clone(),
                 &mut rng,
-            );
+            )
+            .proof;
         time_open += timer.elapsed();
 
         // prepare for batch verification

--- a/poly-commitment/tests/ipa_commitment.rs
+++ b/poly-commitment/tests/ipa_commitment.rs
@@ -156,7 +156,9 @@ fn test_opening_proof() {
     // Generate a random number of evaluation point
     let nb_elem: u32 = rng.gen_range(1..7);
     let elm: Vec<Fp> = (0..nb_elem).map(|_| Fp::rand(&mut rng)).collect();
-    let opening_proof = srs.open(&group_map, &polys, &elm, v, u, sponge.clone(), rng);
+    let opening_proof = srs
+        .open(&group_map, &polys, &elm, v, u, sponge.clone(), rng)
+        .proof;
 
     // evaluate the polynomials at the points
     let poly1_chunked_evals: Vec<Vec<Fp>> = elm
@@ -332,7 +334,8 @@ fn test_dlog_commitment() {
                     evalmask,
                     sponge.clone(),
                     rng,
-                );
+                )
+                .proof;
             open += start.elapsed();
 
             let combined_inner_product = {


### PR DESCRIPTION
This PR modifies the prover API to forward the oracle challenges that it computes instead of discarding them. This is of particular interest to pickles, where a locally-produced proof runs the prover -- who computes the challenges as a matter of course anyway -- and then has to run large portions of the verifier on the proof to recompute those challenges.

This PR forms the foundation to forward the oracle values all the way up to the pickles prover at proving time, removing some overhead from pickles' recursion.

This PR has been split out of the work on optimising nori native proving in OCaml for easy review.