### PR TITLE
kimchi_bindings: Add support for rayon worker pools with different sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ and this project adheres to
 
 ### [kimchi-stubs](./kimchi-stubs)
 
+#### Added
+
+- Add `<field>_vector_clear`, letting the caller eagerly release a consumed
+  vector's Rust-side allocation. OCaml only sees the pointer, so its GC never
+  feels the (potentially large) backing buffer
+  ([#3592](https://github.com/o1-labs/proof-systems/pull/3592))
+- Run proving inside a scoped rayon thread pool sized by `KIMCHI_PROVE_THREADS`,
+  falling back to the global pool when unset. Pools are reused across proves via
+  a per-thread-count freelist, bounded by `KIMCHI_PROVE_POOL_CAP` (default 2) so
+  idle pools do not accumulate. This lets a long-running worker prove different
+  tasks at different thread counts without rebuilding its global pool; the
+  thread count does not affect the proof
+  ([#3592](https://github.com/o1-labs/proof-systems/pull/3592))
+
 #### Fixed
 
 - Treat public evaluations of oracles as vectors for chunking coherence

--- a/kimchi-stubs/src/field_vector.rs
+++ b/kimchi-stubs/src/field_vector.rs
@@ -27,6 +27,16 @@ macro_rules! impl_vector_old {
                 (*v).push(x.into());
             }
 
+            // Empty the vector and release its backing allocation. OCaml only
+            // sees the pointer, so its GC never feels the (potentially large)
+            // Rust buffer; this lets a caller free it eagerly when done.
+            #[ocaml_gen::func]
+            #[ocaml::func]
+            pub fn [<$name:snake _clear>](mut v: $name) {
+                (*v).clear();
+                (*v).shrink_to_fit();
+            }
+
             #[ocaml_gen::func]
             #[ocaml::func]
             pub fn [<$name:snake _get>](

--- a/kimchi-stubs/src/lib.rs
+++ b/kimchi-stubs/src/lib.rs
@@ -123,11 +123,20 @@ pub(crate) fn with_prove_pool<R: Send>(f: impl FnOnce() -> R + Send) -> R {
             })
     };
     let result = pool.install(f);
-    prove_pool_cache()
-        .lock()
-        .unwrap()
-        .entry(n)
-        .or_default()
-        .push(pool);
+    // Return the warm pool for reuse, but bound the freelist (default 2 per N,
+    // override with KIMCHI_PROVE_POOL_CAP) so idle pools do not accumulate
+    // unbounded resident memory across a long conversion; overflow pools are
+    // dropped, joining their threads.
+    let cap = std::env::var("KIMCHI_PROVE_POOL_CAP")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(2);
+    {
+        let mut cache = prove_pool_cache().lock().unwrap();
+        let free = cache.entry(n).or_default();
+        if free.len() < cap {
+            free.push(pool);
+        }
+    }
     result
 }

--- a/kimchi-stubs/src/lib.rs
+++ b/kimchi-stubs/src/lib.rs
@@ -76,6 +76,18 @@ pub use {
     poly_commitment::{commitment::caml::CamlPolyComm, ipa::caml::CamlOpeningProof},
 };
 
+/// Per-thread-count freelist of warm rayon pools, reused across proves so a
+/// long-running worker does not pay thread-spawn + cold-cache cost on every
+/// compression proof.
+fn prove_pool_cache() -> &'static std::sync::Mutex<
+    std::collections::HashMap<usize, Vec<std::sync::Arc<rayon::ThreadPool>>>,
+> {
+    static CACHE: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<usize, Vec<std::sync::Arc<rayon::ThreadPool>>>>,
+    > = std::sync::OnceLock::new();
+    CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
 /// Run a proving closure in a scoped rayon thread pool sized by
 /// `KIMCHI_PROVE_THREADS`, falling back to the global pool when unset. Lets a
 /// long-running worker prove different tasks at different thread counts -- e.g.
@@ -83,16 +95,39 @@ pub use {
 /// low-concurrency compression proofs -- without rebuilding its global pool.
 ///
 /// The thread count does not affect the proof, so this is VK-preserving.
+///
+/// Pools are checked out of a per-N freelist and returned after use: warm
+/// threads are reused, but concurrent proves of the same N each get their own
+/// pool (the freelist grows to the peak concurrency for that N), so parallelism
+/// is preserved.
 pub(crate) fn with_prove_pool<R: Send>(f: impl FnOnce() -> R + Send) -> R {
-    match std::env::var("KIMCHI_PROVE_THREADS")
+    let n = match std::env::var("KIMCHI_PROVE_THREADS")
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
     {
-        Some(n) if n >= 1 => rayon::ThreadPoolBuilder::new()
-            .num_threads(n)
-            .build()
-            .expect("KIMCHI_PROVE_THREADS thread pool")
-            .install(f),
-        _ => f(),
-    }
+        Some(n) if n >= 1 => n,
+        _ => return f(),
+    };
+    let pool = {
+        let mut cache = prove_pool_cache().lock().unwrap();
+        cache
+            .get_mut(&n)
+            .and_then(|free| free.pop())
+            .unwrap_or_else(|| {
+                std::sync::Arc::new(
+                    rayon::ThreadPoolBuilder::new()
+                        .num_threads(n)
+                        .build()
+                        .expect("KIMCHI_PROVE_THREADS thread pool"),
+                )
+            })
+    };
+    let result = pool.install(f);
+    prove_pool_cache()
+        .lock()
+        .unwrap()
+        .entry(n)
+        .or_default()
+        .push(pool);
+    result
 }

--- a/kimchi-stubs/src/lib.rs
+++ b/kimchi-stubs/src/lib.rs
@@ -75,3 +75,24 @@ pub use {
     mina_poseidon::sponge::caml::CamlScalarChallenge,
     poly_commitment::{commitment::caml::CamlPolyComm, ipa::caml::CamlOpeningProof},
 };
+
+/// Run a proving closure in a scoped rayon thread pool sized by
+/// `KIMCHI_PROVE_THREADS`, falling back to the global pool when unset. Lets a
+/// long-running worker prove different tasks at different thread counts -- e.g.
+/// low rayon for the many parallel base proofs, high rayon for the
+/// low-concurrency compression proofs -- without rebuilding its global pool.
+///
+/// The thread count does not affect the proof, so this is VK-preserving.
+pub(crate) fn with_prove_pool<R: Send>(f: impl FnOnce() -> R + Send) -> R {
+    match std::env::var("KIMCHI_PROVE_THREADS")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+    {
+        Some(n) if n >= 1 => rayon::ThreadPoolBuilder::new()
+            .num_threads(n)
+            .build()
+            .expect("KIMCHI_PROVE_THREADS thread pool")
+            .install(f),
+        _ => f(),
+    }
+}

--- a/kimchi-stubs/src/pasta_fp_plonk_proof.rs
+++ b/kimchi-stubs/src/pasta_fp_plonk_proof.rs
@@ -99,15 +99,17 @@ pub fn caml_pasta_fp_plonk_proof_create(
     // Release the runtime lock so that other threads can run using it while we generate the proof.
     runtime.releasing_runtime(|| {
         let group_map = GroupMap::<Fq>::setup();
-        let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge, _>(
-            &group_map,
-            witness,
-            &runtime_tables,
-            index,
-            prev,
-            None,
-            &mut rand::rngs::OsRng,
-        )
+        let proof = crate::with_prove_pool(|| {
+            ProverProof::create_recursive::<EFqSponge, EFrSponge, _>(
+                &group_map,
+                witness,
+                &runtime_tables,
+                index,
+                prev,
+                None,
+                &mut rand::rngs::OsRng,
+            )
+        })
         .map_err(|e| ocaml::Error::Error(e.into()))?;
         Ok((proof, public_input).into())
     })

--- a/kimchi-stubs/src/pasta_fq_plonk_proof.rs
+++ b/kimchi-stubs/src/pasta_fq_plonk_proof.rs
@@ -100,19 +100,21 @@ pub fn caml_pasta_fq_plonk_proof_create(
     // generate the proof.
     runtime.releasing_runtime(|| {
         let group_map = GroupMap::<Fp>::setup();
-        let proof = ProverProof::create_recursive::<
-            DefaultFqSponge<PallasParameters, PlonkSpongeConstantsKimchi, FULL_ROUNDS>,
-            DefaultFrSponge<Fq, PlonkSpongeConstantsKimchi, FULL_ROUNDS>,
-            _,
-        >(
-            &group_map,
-            witness,
-            &runtime_tables,
-            index,
-            prev,
-            None,
-            &mut rand::rngs::OsRng,
-        )
+        let proof = crate::with_prove_pool(|| {
+            ProverProof::create_recursive::<
+                DefaultFqSponge<PallasParameters, PlonkSpongeConstantsKimchi, FULL_ROUNDS>,
+                DefaultFrSponge<Fq, PlonkSpongeConstantsKimchi, FULL_ROUNDS>,
+                _,
+            >(
+                &group_map,
+                witness,
+                &runtime_tables,
+                index,
+                prev,
+                None,
+                &mut rand::rngs::OsRng,
+            )
+        })
         .map_err(|e| ocaml::Error::Error(e.into()))?;
         Ok((proof, public_input).into())
     })


### PR DESCRIPTION
This PR adds a `with_prover_pool` helper and a cache of rayon worker pools to access it, such the the prover invoked over the bindings can be run with different parallelism configurations. This is particularly useful when pipelining a tree of proofs -- for example, using a low rayon number while proving the leaves in parallel, all the way up to max cores for the tip.

Since the pool descriptions take up some memory, the number of cached rayon worked pools is governed by a cap set by the environment variable `KIMCHI_PROVE_POOL_CAP`. The pool that any prove job is initiated with is chosen via `KIMCHI_PROVE_THREADS`, which can be varied on the OCaml side by updating the contents of the environment variables.

This is used extensively in the nori optimised prover, and the maximum performance requires this. This is deliberately the least invasive mechanism from the perspective of the bindings consumers that do not use it, and also is designed such that e.g. the snark workers could harness it from a coordination layer without interfering with the snark worker internals.

This PR has been split out of the work on optimising nori native proving in OCaml for easy review.