### PR TITLE
Free the quotient polynomial in the prover early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to
   disk while allowing the OS page cache to evict unused pages
   ([#3569](https://github.com/o1-labs/proof-systems/pull/3569))
 
+#### Changed
+
+- Release the quotient polynomial once the `ft` polynomial has been built,
+  rather than holding it until the end of the proof
+  ([#3594](https://github.com/o1-labs/proof-systems/pull/3594))
+
 ### [kimchi-napi](./kimchi-napi)
 
 #### Fixed

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -1144,6 +1144,8 @@ where
             &f_chunked - &t_chunked.scale(zeta_to_domain_size - G::ScalarField::one())
         };
 
+        drop(quotient_poly);
+
         //~ 1. construct the blinding part of the ft polynomial commitment
         //~    [see this section](https://o1-labs.github.io/proof-systems/kimchi/maller_15.html#evaluation-proof-and-blinding-factors)
         let blinding_ft = {


### PR DESCRIPTION
This PR drops the quotient polynomial after its final use, reducing the memory usage at the tail of the prover function.

The quotient polynomial is committed to in `t_comm` and then only borrowed by `to_chunked_polynomial` when building `ft`, so it is dead from that point on. Rust drops locals at end of scope rather than at last use, so it otherwise stays resident across the evaluation and opening phases -- 14 MB at a 2^16 domain.

Proofs are unchanged; the compiler rejects any later use.