### PR TITLE
Add expression versions of the permutation terms

### DIFF
--- a/kimchi/src/circuits/berkeley_columns.rs
+++ b/kimchi/src/circuits/berkeley_columns.rs
@@ -287,6 +287,10 @@ impl<'a, F: FftField> ColumnEnvironment<'a, F, BerkeleyChallengeTerm, BerkeleyCh
         self.vanishes_on_zero_knowledge_and_previous_rows
     }
 
+    fn permutation_vanishing_polynomial(&self) -> &'a Evaluations<F, D<F>> {
+        self.permutation_vanishing_polynomial
+    }
+
     fn l0_1(&self) -> F {
         self.l0_1
     }
@@ -321,6 +325,8 @@ pub struct Environment<'a, F: FftField> {
     pub coefficient: &'a [Evaluations<F, D<F>>; COLUMNS],
     /// The polynomial that vanishes on the zero-knowledge rows and the row before.
     pub vanishes_on_zero_knowledge_and_previous_rows: &'a Evaluations<F, D<F>>,
+    /// The polynomial that vanishes on the zero-knowledge rows.
+    pub permutation_vanishing_polynomial: &'a Evaluations<F, D<F>>,
     /// The permutation aggregation polynomial.
     pub z: &'a Evaluations<F, D<F>>,
     /// The index selector polynomials.

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -7,7 +7,8 @@ use crate::{
         gate::CurrOrNext,
         lookup::lookups::{LookupPattern, LookupPatterns},
         polynomials::{
-            foreign_field_common::KimchiForeignElement, permutation::eval_vanishes_on_last_n_rows,
+            foreign_field_common::KimchiForeignElement,
+            permutation::{coset_shifts, eval_vanishes_on_last_n_rows},
         },
     },
     collections::{HashMap, HashSet},
@@ -134,6 +135,32 @@ pub fn l0_1<F: FftField>(d: D<F>) -> F {
     d.elements()
         .skip(1)
         .fold(F::one(), |acc, omega_j| acc * (F::one() - omega_j))
+}
+
+/// The root of unity a row offset names, `omega^i`.
+pub fn root_of_unity<F: FftField>(domain: &D<F>, zk_rows: u64, i: &RowOffset) -> F {
+    let offset = if i.zk_rows {
+        -(zk_rows as i32) + i.offset
+    } else {
+        i.offset
+    };
+    if offset < 0 {
+        domain
+            .group_gen
+            .pow([-offset as u64])
+            .inverse()
+            .expect("a root of unity is invertible")
+    } else {
+        domain.group_gen.pow([offset as u64])
+    }
+}
+
+/// The polynomial vanishing on the given rows, `prod_j (x - omega^i_j)`,
+/// evaluated at `pt`.
+pub fn vanishing_on_rows<F: FftField>(domain: D<F>, zk_rows: u64, rows: &[RowOffset], pt: F) -> F {
+    rows.iter().fold(F::one(), |acc, i| {
+        acc * (pt - root_of_unity(&domain, zk_rows, i))
+    })
 }
 
 // Compute the ith unnormalized lagrange basis
@@ -298,6 +325,21 @@ pub enum Operations<T> {
     Square(Box<Self>),
     Cache(CacheId, Box<Self>),
     IfFeature(FeatureFlag, Box<Self>, Box<Self>),
+    /// Divide by the polynomial vanishing on the given rows,
+    /// `prod_j (x - omega^i_j)`.
+    ///
+    /// There is no general division here, because an expression denotes a
+    /// polynomial and `f / g` is one only when `g` divides `f`. Naming the
+    /// divisor is what makes divisibility a property of the expression: this
+    /// says the operand vanishes on those rows, the same footing the quotient
+    /// polynomial stands on when it is divided by `x^n - 1`.
+    ///
+    /// It generalises [`ExprInner::UnnormalizedLagrangeBasis`], which is this
+    /// applied to [`ExprInner::VanishingPolynomial`] at a single row, to a set
+    /// of rows and any numerator that vanishes on them. That is what a
+    /// combination of Lagrange bases over their common denominator needs, and
+    /// what no tree of single-row atoms can express.
+    DivideByVanishingOn(Box<Self>, Vec<RowOffset>),
 }
 
 impl<T> From<T> for Operations<T> {
@@ -348,6 +390,9 @@ impl<T: Literal + Clone> Literal for Operations<T> {
             ),
             Self::Double(x) => Self::Double(Box::new(x.as_literal(constants))),
             Self::Square(x) => Self::Square(Box::new(x.as_literal(constants))),
+            Self::DivideByVanishingOn(x, rows) => {
+                Self::DivideByVanishingOn(Box::new(x.as_literal(constants)), rows.clone())
+            }
             Self::Cache(id, x) => Self::Cache(*id, Box::new(x.as_literal(constants))),
             Self::IfFeature(flag, if_true, if_false) => Self::IfFeature(
                 *flag,
@@ -423,6 +468,10 @@ impl<F: Copy, ChallengeTerm: Copy> Operations<ConstantExprInner<F, ChallengeTerm
                 x.to_polish(cache, res);
                 res.push(PolishToken::Dup);
                 res.push(PolishToken::Mul);
+            }
+            Operations::DivideByVanishingOn(x, rows) => {
+                x.to_polish(cache, res);
+                res.push(PolishToken::DivideByVanishingOn(rows.clone()));
             }
             Operations::Cache(id, x) => {
                 match cache.get(id) {
@@ -502,6 +551,9 @@ impl<F: Field, ChallengeTerm: Copy> ConstantExpr<F, ChallengeTerm> {
             Sub(x, y) => x.value(c, chals) - y.value(c, chals),
             Double(x) => x.value(c, chals).double(),
             Square(x) => x.value(c, chals).square(),
+            DivideByVanishingOn(_, _) => {
+                panic!("DivideByVanishingOn cannot occur in a constant expression")
+            }
             Cache(_, x) => {
                 // TODO: Use cache ID
                 x.value(c, chals)
@@ -594,7 +646,7 @@ impl FeatureFlag {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RowOffset {
     pub zk_rows: bool,
     pub offset: i32,
@@ -608,6 +660,28 @@ pub enum ExprInner<C, Column> {
     /// UnnormalizedLagrangeBasis(i) is
     /// (x^n - 1) / (x - omega^i)
     UnnormalizedLagrangeBasis(RowOffset),
+    /// The polynomial vanishing on the zero-knowledge rows, evaluated at the
+    /// point the expression is evaluated at.
+    ///
+    /// Distinct from [`ExprInner::VanishesOnZeroKnowledgeAndPreviousRows`],
+    /// which vanishes on one row more. This is the multiplier the permutation
+    /// argument uses to confine itself to the rows that carry witness data.
+    PermutationVanishingPolynomial,
+    /// The point the expression is evaluated at.
+    ///
+    /// Ordinarily implicit — an expression denotes a polynomial and the point
+    /// is where you evaluate it. `ft(zeta)` is not such a polynomial: it is
+    /// something the verifier computes, and it mentions the point directly.
+    EvaluationPoint,
+    /// `x^n - 1`, the polynomial vanishing on the whole domain.
+    ///
+    /// [`ExprInner::UnnormalizedLagrangeBasis`] is this divided by a single
+    /// row's factor.
+    VanishingPolynomial,
+    /// `omega^i`, the root of unity a row offset names.
+    RootOfUnity(RowOffset),
+    /// The domain's `i`th coset shift, as sampled by `Shifts::new`.
+    Shift(usize),
 }
 
 /// An multi-variate polynomial over the base ring `C` with
@@ -675,7 +749,12 @@ impl<T: Literal, Column: Clone> Literal for ExprInner<T, Column> {
             ExprInner::Constant(x) => ExprInner::Constant(x.as_literal(constants)),
             ExprInner::Cell(_)
             | ExprInner::VanishesOnZeroKnowledgeAndPreviousRows
-            | ExprInner::UnnormalizedLagrangeBasis(_) => self.clone(),
+            | ExprInner::UnnormalizedLagrangeBasis(_)
+            | ExprInner::PermutationVanishingPolynomial
+            | ExprInner::EvaluationPoint
+            | ExprInner::VanishingPolynomial
+            | ExprInner::RootOfUnity(_)
+            | ExprInner::Shift(_) => self.clone(),
         }
     }
 }
@@ -761,6 +840,10 @@ where
                     (Pow(Box::new(c_reduced), *power), false)
                 }
             }
+            DivideByVanishingOn(x, rows) => {
+                let (x, is_zero) = x.apply_feature_flags_inner(features);
+                (DivideByVanishingOn(Box::new(x), rows.clone()), is_zero)
+            }
             Cache(cache_id, c) => {
                 let (c_reduced, reduce_further) = c.apply_feature_flags_inner(features);
                 if reduce_further {
@@ -827,6 +910,15 @@ pub enum PolishToken<F, Column, ChallengeTerm> {
     Sub,
     VanishesOnZeroKnowledgeAndPreviousRows,
     UnnormalizedLagrangeBasis(RowOffset),
+    PermutationVanishingPolynomial,
+    EvaluationPoint,
+    VanishingPolynomial,
+    RootOfUnity(RowOffset),
+    Shift(usize),
+    /// Divide the top of the stack by the polynomial vanishing on these rows.
+    ///
+    /// See [`Operations::DivideByVanishingOn`].
+    DivideByVanishingOn(Vec<RowOffset>),
     Store,
     Load(usize),
     /// Skip the given number of tokens if the feature is enabled.
@@ -882,6 +974,17 @@ impl<F: FftField, Column: Copy, ChallengeTerm: Copy> PolishToken<F, Column, Chal
                 Constant(Mds { row, col }) => stack.push(c.mds[*row][*col]),
                 VanishesOnZeroKnowledgeAndPreviousRows => {
                     stack.push(eval_vanishes_on_last_n_rows(d, c.zk_rows + 1, pt))
+                }
+                PermutationVanishingPolynomial => {
+                    stack.push(eval_vanishes_on_last_n_rows(d, c.zk_rows, pt))
+                }
+                EvaluationPoint => stack.push(pt),
+                VanishingPolynomial => stack.push(d.evaluate_vanishing_polynomial(pt)),
+                RootOfUnity(i) => stack.push(root_of_unity(&d, c.zk_rows, i)),
+                Shift(i) => stack.push(coset_shifts(&d)[*i]),
+                DivideByVanishingOn(rows) => {
+                    let x = stack.pop().ok_or(ExprError::EmptyStack)?;
+                    stack.push(x / vanishing_on_rows(d, c.zk_rows, rows, pt));
                 }
                 UnnormalizedLagrangeBasis(i) => {
                     let offset = if i.zk_rows {
@@ -972,6 +1075,10 @@ impl<C, Column> Expr<C, Column> {
             Double(x) => x.degree(d1_size, zk_rows),
             Atom(Constant(_)) => 0,
             Atom(VanishesOnZeroKnowledgeAndPreviousRows) => zk_rows + 1,
+            Atom(PermutationVanishingPolynomial) => zk_rows,
+            Atom(EvaluationPoint) => 1,
+            Atom(VanishingPolynomial) => d1_size,
+            Atom(RootOfUnity(_)) | Atom(Shift(_)) => 0,
             Atom(UnnormalizedLagrangeBasis(_)) => d1_size,
             Atom(Cell(_)) => d1_size,
             Square(x) => 2 * x.degree(d1_size, zk_rows),
@@ -980,6 +1087,7 @@ impl<C, Column> Expr<C, Column> {
                 core::cmp::max((*x).degree(d1_size, zk_rows), (*y).degree(d1_size, zk_rows))
             }
             Pow(e, d) => d * e.degree(d1_size, zk_rows),
+            DivideByVanishingOn(e, rows) => e.degree(d1_size, zk_rows) - rows.len() as u64,
             Cache(_, e) => e.degree(d1_size, zk_rows),
             IfFeature(_, e1, e2) => {
                 core::cmp::max(e1.degree(d1_size, zk_rows), e2.degree(d1_size, zk_rows))
@@ -1672,6 +1780,15 @@ impl<F: FftField, Column: Copy, ChallengeTerm: Copy> Expr<ConstantExpr<F, Challe
                 c.to_polish(cache, res);
             }
             Expr::Atom(ExprInner::Cell(v)) => res.push(PolishToken::Cell(*v)),
+            Expr::Atom(ExprInner::PermutationVanishingPolynomial) => {
+                res.push(PolishToken::PermutationVanishingPolynomial);
+            }
+            Expr::Atom(ExprInner::EvaluationPoint) => res.push(PolishToken::EvaluationPoint),
+            Expr::Atom(ExprInner::VanishingPolynomial) => {
+                res.push(PolishToken::VanishingPolynomial);
+            }
+            Expr::Atom(ExprInner::RootOfUnity(i)) => res.push(PolishToken::RootOfUnity(*i)),
+            Expr::Atom(ExprInner::Shift(i)) => res.push(PolishToken::Shift(*i)),
             Expr::Atom(ExprInner::VanishesOnZeroKnowledgeAndPreviousRows) => {
                 res.push(PolishToken::VanishesOnZeroKnowledgeAndPreviousRows);
             }
@@ -1692,6 +1809,10 @@ impl<F: FftField, Column: Copy, ChallengeTerm: Copy> Expr<ConstantExpr<F, Challe
                 x.to_polish_(cache, res);
                 y.to_polish_(cache, res);
                 res.push(PolishToken::Mul);
+            }
+            Expr::DivideByVanishingOn(e, rows) => {
+                e.to_polish_(cache, res);
+                res.push(PolishToken::DivideByVanishingOn(rows.clone()));
             }
             Expr::Cache(id, e) => {
                 match cache.get(id) {
@@ -1759,10 +1880,18 @@ impl<F: FftField, Column: PartialEq + Copy, ChallengeTerm: Copy>
             Atom(VanishesOnZeroKnowledgeAndPreviousRows) => {
                 Atom(VanishesOnZeroKnowledgeAndPreviousRows)
             }
+            Atom(PermutationVanishingPolynomial) => Atom(PermutationVanishingPolynomial),
+            Atom(EvaluationPoint) => Atom(EvaluationPoint),
+            Atom(VanishingPolynomial) => Atom(VanishingPolynomial),
+            Atom(RootOfUnity(i)) => Atom(RootOfUnity(*i)),
+            Atom(Shift(i)) => Atom(Shift(*i)),
             Atom(UnnormalizedLagrangeBasis(i)) => Atom(UnnormalizedLagrangeBasis(*i)),
             Add(x, y) => x.evaluate_constants_(c, chals) + y.evaluate_constants_(c, chals),
             Mul(x, y) => x.evaluate_constants_(c, chals) * y.evaluate_constants_(c, chals),
             Sub(x, y) => x.evaluate_constants_(c, chals) - y.evaluate_constants_(c, chals),
+            DivideByVanishingOn(e, rows) => {
+                DivideByVanishingOn(Box::new(e.evaluate_constants_(c, chals)), rows.clone())
+            }
             Cache(id, e) => Cache(*id, Box::new(e.evaluate_constants_(c, chals))),
             IfFeature(feature, e1, e2) => IfFeature(
                 *feature,
@@ -1822,6 +1951,13 @@ impl<F: FftField, Column: PartialEq + Copy, ChallengeTerm: Copy>
             Atom(VanishesOnZeroKnowledgeAndPreviousRows) => {
                 Ok(eval_vanishes_on_last_n_rows(d, c.zk_rows + 1, pt))
             }
+            Atom(PermutationVanishingPolynomial) => {
+                Ok(eval_vanishes_on_last_n_rows(d, c.zk_rows, pt))
+            }
+            Atom(EvaluationPoint) => Ok(pt),
+            Atom(VanishingPolynomial) => Ok(d.evaluate_vanishing_polynomial(pt)),
+            Atom(RootOfUnity(i)) => Ok(root_of_unity(&d, c.zk_rows, i)),
+            Atom(Shift(i)) => Ok(coset_shifts(&d)[*i]),
             Atom(UnnormalizedLagrangeBasis(i)) => {
                 let offset = if i.zk_rows {
                     -(c.zk_rows as i32) + i.offset
@@ -1831,6 +1967,10 @@ impl<F: FftField, Column: PartialEq + Copy, ChallengeTerm: Copy>
                 Ok(unnormalized_lagrange_basis(&d, offset, &pt))
             }
             Atom(Cell(v)) => v.evaluate(evals),
+            DivideByVanishingOn(e, rows) => {
+                let x = e.evaluate_(d, pt, evals, c, chals)?;
+                Ok(x / vanishing_on_rows(d, c.zk_rows, rows, pt))
+            }
             Cache(_, e) => e.evaluate_(d, pt, evals, c, chals),
             IfFeature(feature, e1, e2) => {
                 if feature.is_enabled() {
@@ -1914,6 +2054,13 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
             Atom(VanishesOnZeroKnowledgeAndPreviousRows) => {
                 Ok(eval_vanishes_on_last_n_rows(d, zk_rows + 1, pt))
             }
+            Atom(PermutationVanishingPolynomial) => {
+                Ok(eval_vanishes_on_last_n_rows(d, zk_rows, pt))
+            }
+            Atom(EvaluationPoint) => Ok(pt),
+            Atom(VanishingPolynomial) => Ok(d.evaluate_vanishing_polynomial(pt)),
+            Atom(RootOfUnity(i)) => Ok(root_of_unity(&d, zk_rows, i)),
+            Atom(Shift(i)) => Ok(coset_shifts(&d)[*i]),
             Atom(UnnormalizedLagrangeBasis(i)) => {
                 let offset = if i.zk_rows {
                     -(zk_rows as i32) + i.offset
@@ -1923,6 +2070,10 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
                 Ok(unnormalized_lagrange_basis(&d, offset, &pt))
             }
             Atom(Cell(v)) => v.evaluate(evals),
+            DivideByVanishingOn(e, rows) => {
+                let x = e.evaluate(d, pt, zk_rows, evals)?;
+                Ok(x / vanishing_on_rows(d, zk_rows, rows, pt))
+            }
             Cache(_, e) => e.evaluate(d, pt, zk_rows, evals),
             IfFeature(feature, e1, e2) => {
                 if feature.is_enabled() {
@@ -2051,6 +2202,9 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
                 };
                 return Either::Left(res);
             }
+            Expr::DivideByVanishingOn(_, _) => {
+                panic!("DivideByVanishingOn states a verifier-side scalar, not a polynomial over the domain")
+            }
             Expr::Cache(id, e) => match cache.get(id) {
                 Some(_) => return Either::Right(*id),
                 None => {
@@ -2071,6 +2225,22 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
                         id.get_from(cache).unwrap().pow(*p, (d, env.get_domain(d)))
                     }
                 }
+            }
+            // These state quantities the verifier computes at a point. They
+            // cannot appear in the quotient, which is what this evaluates, so
+            // there is nothing to give a domain evaluation of.
+            Expr::Atom(ExprInner::PermutationVanishingPolynomial)
+            | Expr::Atom(ExprInner::EvaluationPoint)
+            | Expr::Atom(ExprInner::VanishingPolynomial) => {
+                panic!("this atom states a verifier-side scalar, not a polynomial over the domain")
+            }
+            Expr::Atom(ExprInner::RootOfUnity(i)) => EvalResult::Constant(root_of_unity(
+                &env.get_domain(Domain::D1),
+                env.get_constants().zk_rows,
+                i,
+            )),
+            Expr::Atom(ExprInner::Shift(i)) => {
+                EvalResult::Constant(coset_shifts(&env.get_domain(Domain::D1))[*i])
             }
             Expr::Atom(ExprInner::VanishesOnZeroKnowledgeAndPreviousRows) => EvalResult::SubEvals {
                 domain: Domain::D8,
@@ -2337,8 +2507,14 @@ where
             Add(x, y) | Sub(x, y) | Mul(x, y) => {
                 x.is_constant(evaluated) && y.is_constant(evaluated)
             }
-            Atom(VanishesOnZeroKnowledgeAndPreviousRows) => true,
+            Atom(VanishesOnZeroKnowledgeAndPreviousRows)
+            | Atom(PermutationVanishingPolynomial)
+            | Atom(EvaluationPoint)
+            | Atom(VanishingPolynomial)
+            | Atom(RootOfUnity(_))
+            | Atom(Shift(_)) => true,
             Atom(UnnormalizedLagrangeBasis(_)) => true,
+            DivideByVanishingOn(x, _) => x.is_constant(evaluated),
             Cache(_, x) => x.is_constant(evaluated),
             IfFeature(_, e1, e2) => e1.is_constant(evaluated) && e2.is_constant(evaluated),
         }
@@ -2382,11 +2558,19 @@ where
             Double(e) => {
                 HashMap::from_iter(e.monomials(ev).into_iter().map(|(m, c)| (m, c.double())))
             }
+            DivideByVanishingOn(_, _) => {
+                panic!("DivideByVanishingOn is not supported by linearization")
+            }
             Cache(_, e) => e.monomials(ev),
             Atom(UnnormalizedLagrangeBasis(i)) => constant(Atom(UnnormalizedLagrangeBasis(*i))),
             Atom(VanishesOnZeroKnowledgeAndPreviousRows) => {
                 constant(Atom(VanishesOnZeroKnowledgeAndPreviousRows))
             }
+            Atom(PermutationVanishingPolynomial) => constant(Atom(PermutationVanishingPolynomial)),
+            Atom(EvaluationPoint) => constant(Atom(EvaluationPoint)),
+            Atom(VanishingPolynomial) => constant(Atom(VanishingPolynomial)),
+            Atom(RootOfUnity(i)) => constant(Atom(RootOfUnity(*i))),
+            Atom(Shift(i)) => constant(Atom(Shift(*i))),
             Atom(Constant(c)) => constant(Atom(Constant(c.clone()))),
             Atom(Cell(var)) => sing(vec![*var], Atom(Constant(F::one()))),
             Add(e1, e2) => {
@@ -2902,6 +3086,9 @@ impl<T: FormattedOutput + Clone> FormattedOutput for Operations<T> {
             Sub(x, y) => format!("({} - {})", x.ocaml(cache), y.ocaml(cache)),
             Double(x) => format!("double({})", x.ocaml(cache)),
             Square(x) => format!("square({})", x.ocaml(cache)),
+            DivideByVanishingOn(x, rows) => {
+                format!("divide_by_vanishing_on({}, {rows:?})", x.ocaml(cache))
+            }
             Cache(id, e) => {
                 cache.insert(*id, e.as_ref().clone());
                 id.var_name()
@@ -2934,6 +3121,9 @@ impl<T: FormattedOutput + Clone> FormattedOutput for Operations<T> {
             Sub(x, y) => format!("({} - {})", x.latex(cache), y.latex(cache)),
             Double(x) => format!("2 ({})", x.latex(cache)),
             Square(x) => format!("({})^2", x.latex(cache)),
+            DivideByVanishingOn(x, rows) => {
+                format!("\\frac{{{}}}{{{rows:?}}}", x.latex(cache))
+            }
             Cache(id, e) => {
                 cache.insert(*id, e.as_ref().clone());
                 id.var_name()
@@ -2959,6 +3149,9 @@ impl<T: FormattedOutput + Clone> FormattedOutput for Operations<T> {
             Sub(x, y) => format!("({} - {})", x.text(cache), y.text(cache)),
             Double(x) => format!("double({})", x.text(cache)),
             Square(x) => format!("square({})", x.text(cache)),
+            DivideByVanishingOn(x, rows) => {
+                format!("divide_by_vanishing_on({}, {rows:?})", x.text(cache))
+            }
             Cache(id, e) => {
                 cache.insert(*id, e.as_ref().clone());
                 id.var_name()
@@ -3008,11 +3201,19 @@ where
             Atom(VanishesOnZeroKnowledgeAndPreviousRows) => {
                 "vanishes_on_zero_knowledge_and_previous_rows".to_string()
             }
+            Atom(PermutationVanishingPolynomial) => "permutation_vanishing_polynomial".to_string(),
+            Atom(EvaluationPoint) => "zeta".to_string(),
+            Atom(VanishingPolynomial) => "zeta_to_n_minus_1".to_string(),
+            Atom(RootOfUnity(i)) => format!("omega_to({}, {})", i.zk_rows, i.offset),
+            Atom(Shift(i)) => format!("shift({i})"),
             Add(x, y) => format!("({} + {})", x.ocaml(cache), y.ocaml(cache)),
             Mul(x, y) => format!("({} * {})", x.ocaml(cache), y.ocaml(cache)),
             Sub(x, y) => format!("({} - {})", x.ocaml(cache), y.ocaml(cache)),
             Pow(x, d) => format!("pow({}, {d})", x.ocaml(cache)),
             Square(x) => format!("square({})", x.ocaml(cache)),
+            DivideByVanishingOn(x, rows) => {
+                format!("divide_by_vanishing_on({}, {rows:?})", x.ocaml(cache))
+            }
             Cache(id, e) => {
                 cache.insert(*id, e.as_ref().clone());
                 id.var_name()
@@ -3060,11 +3261,19 @@ where
             Atom(VanishesOnZeroKnowledgeAndPreviousRows) => {
                 "vanishes\\_on\\_zero\\_knowledge\\_and\\_previous\\_row".to_string()
             }
+            Atom(PermutationVanishingPolynomial) => "permutation\\_vanishing".to_string(),
+            Atom(EvaluationPoint) => "\\zeta".to_string(),
+            Atom(VanishingPolynomial) => "(\\zeta^n - 1)".to_string(),
+            Atom(RootOfUnity(i)) => format!("\\omega^{{{}}}", i.offset),
+            Atom(Shift(i)) => format!("k_{{{i}}}"),
             Add(x, y) => format!("({} + {})", x.latex(cache), y.latex(cache)),
             Mul(x, y) => format!("({} \\cdot {})", x.latex(cache), y.latex(cache)),
             Sub(x, y) => format!("({} - {})", x.latex(cache), y.latex(cache)),
             Pow(x, d) => format!("{}^{{{d}}}", x.latex(cache)),
             Square(x) => format!("({})^2", x.latex(cache)),
+            DivideByVanishingOn(x, rows) => {
+                format!("\\frac{{{}}}{{{rows:?}}}", x.latex(cache))
+            }
             Cache(id, e) => {
                 cache.insert(*id, e.as_ref().clone());
                 id.latex_name()
@@ -3109,11 +3318,19 @@ where
             Atom(VanishesOnZeroKnowledgeAndPreviousRows) => {
                 "vanishes_on_zero_knowledge_and_previous_rows".to_string()
             }
+            Atom(PermutationVanishingPolynomial) => "permutation_vanishing_polynomial".to_string(),
+            Atom(EvaluationPoint) => "zeta".to_string(),
+            Atom(VanishingPolynomial) => "zeta_to_n_minus_1".to_string(),
+            Atom(RootOfUnity(i)) => format!("omega_to({}, {})", i.zk_rows, i.offset),
+            Atom(Shift(i)) => format!("shift({i})"),
             Add(x, y) => format!("({} + {})", x.text(cache), y.text(cache)),
             Mul(x, y) => format!("({} * {})", x.text(cache), y.text(cache)),
             Sub(x, y) => format!("({} - {})", x.text(cache), y.text(cache)),
             Pow(x, d) => format!("pow({}, {d})", x.text(cache)),
             Square(x) => format!("square({})", x.text(cache)),
+            DivideByVanishingOn(x, rows) => {
+                format!("divide_by_vanishing_on({}, {rows:?})", x.text(cache))
+            }
             Cache(id, e) => {
                 cache.insert(*id, e.as_ref().clone());
                 id.var_name()

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -114,6 +114,14 @@ pub trait ColumnEnvironment<
 
     fn vanishes_on_zero_knowledge_and_previous_rows(&self) -> &'a Evaluations<F, D<F>>;
 
+    /// The polynomial vanishing on the zero-knowledge rows — one row fewer than
+    /// [`ColumnEnvironment::vanishes_on_zero_knowledge_and_previous_rows`].
+    ///
+    /// This is the multiplier the permutation argument uses. A protocol without
+    /// zero-knowledge rows has no such polynomial and may reject the call, as it
+    /// already may for the one above.
+    fn permutation_vanishing_polynomial(&self) -> &'a Evaluations<F, D<F>>;
+
     /// Return the value `prod_{j != 1} (1 - omega^j)`, used for efficiently
     /// computing the evaluations of the unnormalized Lagrange basis polynomials.
     fn l0_1(&self) -> F;
@@ -2226,12 +2234,15 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
                     }
                 }
             }
+            Expr::Atom(ExprInner::PermutationVanishingPolynomial) => EvalResult::SubEvals {
+                domain: Domain::D8,
+                shift: 0,
+                evals: env.permutation_vanishing_polynomial(),
+            },
             // These state quantities the verifier computes at a point. They
             // cannot appear in the quotient, which is what this evaluates, so
             // there is nothing to give a domain evaluation of.
-            Expr::Atom(ExprInner::PermutationVanishingPolynomial)
-            | Expr::Atom(ExprInner::EvaluationPoint)
-            | Expr::Atom(ExprInner::VanishingPolynomial) => {
+            Expr::Atom(ExprInner::EvaluationPoint) | Expr::Atom(ExprInner::VanishingPolynomial) => {
                 panic!("this atom states a verifier-side scalar, not a polynomial over the domain")
             }
             Expr::Atom(ExprInner::RootOfUnity(i)) => EvalResult::Constant(root_of_unity(

--- a/kimchi/src/circuits/polynomials/permutation.rs
+++ b/kimchi/src/circuits/polynomials/permutation.rs
@@ -67,6 +67,30 @@ use {
     rand::{CryptoRng, RngCore},
 };
 
+/// The coset shifts of a domain, as sampled deterministically from it.
+///
+/// Split out of [`Shifts::new`] so that a caller wanting only the shifts does
+/// not pay for the cell map, which is domain-sized.
+pub fn coset_shifts<F: FftField>(domain: &D<F>) -> [F; PERMUTS] {
+    let mut shifts = [F::zero(); PERMUTS];
+
+    // first shift is the identity
+    shifts[0] = F::one();
+
+    // sample the other shifts
+    let mut i: u32 = 7;
+    for idx in 1..(PERMUTS) {
+        let mut shift = Shifts::sample(domain, &mut i);
+        // they have to be distincts
+        while shifts.contains(&shift) {
+            shift = Shifts::sample(domain, &mut i);
+        }
+        shifts[idx] = shift;
+    }
+
+    shifts
+}
+
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -147,21 +171,7 @@ where
 {
     /// Generates the shifts for a given domain
     pub fn new(domain: &D<F>) -> Self {
-        let mut shifts = [F::zero(); PERMUTS];
-
-        // first shift is the identity
-        shifts[0] = F::one();
-
-        // sample the other shifts
-        let mut i: u32 = 7;
-        for idx in 1..(PERMUTS) {
-            let mut shift = Self::sample(domain, &mut i);
-            // they have to be distincts
-            while shifts.contains(&shift) {
-                shift = Self::sample(domain, &mut i);
-            }
-            shifts[idx] = shift;
-        }
+        let shifts = coset_shifts(domain);
 
         // create a map of cells to their shifted value
         let map: [Vec<F>; PERMUTS] =

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -31,9 +31,9 @@ use crate::{
 use crate::circuits::{
     berkeley_columns::Column,
     constraints::FeatureFlags,
-    expr::{ConstantExpr, Expr, FeatureFlag, Linearization, PolishToken},
+    expr::{ConstantExpr, ConstantTerm, Expr, FeatureFlag, Linearization, PolishToken},
     gate::GateType,
-    wires::COLUMNS,
+    wires::{COLUMNS, PERMUTS},
 };
 use ark_ff::{FftField, PrimeField, Zero};
 
@@ -336,6 +336,154 @@ pub fn linearization_columns<F: FftField>(feature_flags: Option<&FeatureFlags>) 
     h
 }
 
+/// The permutation argument's contribution to the linearization: the scalar
+/// that multiplies the commitment to the last permutation polynomial, which is
+/// the one Maller's optimisation leaves unopened.
+///
+/// [`ConstraintSystem::perm_scalars`] computes the same value by hand, because
+/// the columns it reads — `Z` and the sigmas — are exactly the ones the
+/// linearization cannot mention. Stating it as an expression is what lets a
+/// verifier that already consumes the linearization as tokens consume this too,
+/// instead of carrying a second copy of it.
+///
+/// It is deliberately *not* folded into [`constraints_expr`]: doing that would
+/// move the permutation's terms into the constant term and change what every
+/// existing verifier computes. This is an additional statement about the same
+/// proof, not a change to the linearization.
+///
+/// The accumulator is cached at each step. Without the caches the tree would be
+/// re-emitted whole at every level, so a reader would compute all the factors
+/// before any of the products; with them the emitted stream alternates one
+/// factor, one multiplication, as the hand-written fold does.
+///
+/// [`ConstraintSystem::perm_scalars`]: crate::circuits::constraints::ConstraintSystem::perm_scalars
+pub fn permutation_scalar_expr<F: PrimeField>(
+    powers_of_alpha: &Alphas<F>,
+    cache: &mut expr::Cache,
+) -> Expr<ConstantExpr<F, BerkeleyChallengeTerm>, Column> {
+    use crate::circuits::gate::CurrOrNext::{Curr, Next};
+
+    type E<F> = Expr<ConstantExpr<F, BerkeleyChallengeTerm>, Column>;
+
+    // The iterator insists on being drained: the permutation registers three
+    // powers, and the other two belong to the boundary condition on `z`, which
+    // lives in `ft_eval0_expr` rather than here.
+    let exponents: Vec<u32> = powers_of_alpha
+        .get_exponents(ArgumentType::Permutation, permutation::CONSTRAINTS)
+        .collect();
+
+    let alpha_pow = |n: u32| -> E<F> {
+        Expr::Pow(
+            Box::new(E::<F>::from(BerkeleyChallengeTerm::Alpha)),
+            u64::from(n),
+        )
+    };
+
+    let init = E::<F>::cell(Column::Z, Next)
+        * E::<F>::from(BerkeleyChallengeTerm::Beta)
+        * alpha_pow(exponents[0])
+        * Expr::Atom(expr::ExprInner::PermutationVanishingPolynomial);
+
+    let mut acc = cache.cache(init);
+    for i in 0..PERMUTS - 1 {
+        let factor = E::<F>::from(BerkeleyChallengeTerm::Gamma)
+            + E::<F>::from(BerkeleyChallengeTerm::Beta)
+                * E::<F>::cell(Column::Permutation(i), Curr)
+            + E::<F>::cell(Column::Witness(i), Curr);
+        acc = cache.cache(acc * factor);
+    }
+
+    E::<F>::zero() - acc
+}
+
+/// `ft(zeta)`, less the two things a verifier already has to hand: the
+/// linearization's constant term, and the public input's evaluation.
+///
+/// The verifier computes all of this by hand (`verifier.rs`, `let ft_eval0 =
+/// {...}`) for the same reason the permutation scalar is computed by hand: most
+/// of it reads `Z` and the sigmas, which the linearization cannot mention.
+///
+/// The two omissions are where the circuit stops and the proof begins. The
+/// constant term is already a token stream of its own. The public input's
+/// evaluation arrives with the proof, in chunks, and the verifier combines and
+/// subtracts it — an expression over the circuit's columns has nothing to say
+/// about it. A reader subtracts both.
+///
+/// As in [`permutation_scalar_expr`], each fold's accumulator is cached so that
+/// the emitted stream alternates one factor with one multiplication.
+pub fn ft_eval0_expr<F: PrimeField>(
+    powers_of_alpha: &Alphas<F>,
+    cache: &mut expr::Cache,
+) -> Expr<ConstantExpr<F, BerkeleyChallengeTerm>, Column> {
+    use crate::circuits::{
+        expr::{ExprInner, RowOffset},
+        gate::CurrOrNext::{Curr, Next},
+    };
+
+    type E<F> = Expr<ConstantExpr<F, BerkeleyChallengeTerm>, Column>;
+
+    let exponents: Vec<u32> = powers_of_alpha
+        .get_exponents(ArgumentType::Permutation, permutation::CONSTRAINTS)
+        .collect();
+    let alpha_pow = |n: u32| -> E<F> {
+        Expr::Pow(
+            Box::new(E::<F>::from(BerkeleyChallengeTerm::Alpha)),
+            u64::from(n),
+        )
+    };
+    let zk = || -> E<F> { Expr::Atom(ExprInner::PermutationVanishingPolynomial) };
+    let zeta = || -> E<F> { Expr::Atom(ExprInner::EvaluationPoint) };
+    let first_row = RowOffset {
+        zk_rows: false,
+        offset: 0,
+    };
+    let first_zk_row = RowOffset {
+        zk_rows: true,
+        offset: 0,
+    };
+    let root = |r: RowOffset| -> E<F> { Expr::Atom(ExprInner::RootOfUnity(r)) };
+
+    // The permutation's product over the sigmas.
+    let mut permuted = cache.cache(
+        (E::<F>::cell(Column::Witness(PERMUTS - 1), Curr)
+            + E::<F>::from(BerkeleyChallengeTerm::Gamma))
+            * E::<F>::cell(Column::Z, Next)
+            * alpha_pow(exponents[0])
+            * zk(),
+    );
+    for i in 0..PERMUTS - 1 {
+        let factor = E::<F>::from(BerkeleyChallengeTerm::Beta)
+            * E::<F>::cell(Column::Permutation(i), Curr)
+            + E::<F>::cell(Column::Witness(i), Curr)
+            + E::<F>::from(BerkeleyChallengeTerm::Gamma);
+        permuted = cache.cache(factor * permuted);
+    }
+
+    // The same product over the identity permutation.
+    let mut identity = cache.cache(alpha_pow(exponents[0]) * zk() * E::<F>::cell(Column::Z, Curr));
+    for i in 0..PERMUTS {
+        let factor = E::<F>::from(BerkeleyChallengeTerm::Gamma)
+            + E::<F>::from(BerkeleyChallengeTerm::Beta) * zeta() * Expr::Atom(ExprInner::Shift(i))
+            + E::<F>::cell(Column::Witness(i), Curr);
+        identity = cache.cache(identity * factor);
+    }
+
+    // The boundary condition holding `z` to one at the first row and again
+    // where the zero-knowledge rows begin. Each term carries the other's
+    // denominator, so the two Lagrange bases come out of a single division.
+    let boundary_term = |alpha_offset: usize, r: RowOffset| -> E<F> {
+        Expr::Atom(ExprInner::VanishingPolynomial)
+            * alpha_pow(exponents[alpha_offset])
+            * (zeta() - root(r))
+    };
+    let numerator = (boundary_term(1, first_zk_row) + boundary_term(2, first_row))
+        * (E::<F>::from(ConstantExpr::from(ConstantTerm::Literal(F::one())))
+            - E::<F>::cell(Column::Z, Curr));
+
+    permuted - identity
+        + Expr::DivideByVanishingOn(Box::new(numerator), vec![first_zk_row, first_row])
+}
+
 /// Linearize the `expr`.
 ///
 /// If the `feature_flags` argument is `None`, this will generate an expression
@@ -364,4 +512,137 @@ pub fn expr_linearization<F: PrimeField>(
     assert_eq!(linearization.index_terms.len(), 0);
 
     (linearization, powers_of_alpha)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        circuits::{
+            berkeley_columns::BerkeleyChallenges,
+            constraints::ConstraintSystem,
+            expr::{Constants, PolishToken},
+            polynomials::permutation::{coset_shifts, eval_permutation_vanishing_polynomial, zk_w},
+            wires::PERMUTS,
+        },
+        proof::{PointEvaluations, ProofEvaluations},
+    };
+    use ark_ff::{Field, One, UniformRand};
+    use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as D};
+    use mina_curves::pasta::Fp;
+    use mina_poseidon::pasta::fp_kimchi;
+
+    /// Evaluations chosen so that no term of either expression can vanish by
+    /// accident, with the domain, point and challenges to read them against.
+    fn setup() -> (
+        ProofEvaluations<PointEvaluations<Fp>>,
+        D<Fp>,
+        Fp,
+        u64,
+        Constants<Fp>,
+        BerkeleyChallenges<Fp>,
+    ) {
+        let mut rng = o1_utils::tests::make_test_rng(None);
+        let mut field = |i: u64| Fp::from(i) + Fp::rand(&mut rng);
+
+        let mut evals = ProofEvaluations::<PointEvaluations<Fp>>::dummy_with_witness_evaluations(
+            core::array::from_fn(|i| field(i as u64 + 1)),
+            core::array::from_fn(|i| field(i as u64 + 100)),
+        );
+        evals.z = PointEvaluations {
+            zeta: field(7),
+            zeta_omega: field(11),
+        };
+        evals.s = core::array::from_fn(|i| PointEvaluations {
+            zeta: field(i as u64 + 200),
+            zeta_omega: field(i as u64 + 300),
+        });
+
+        let domain = D::<Fp>::new(1 << 6).unwrap();
+        let zeta = field(13);
+        let zk_rows = 3;
+        let constants = Constants {
+            endo_coefficient: Fp::one(),
+            mds: &fp_kimchi::static_params().mds,
+            zk_rows,
+        };
+        let challenges = BerkeleyChallenges {
+            alpha: field(17),
+            beta: field(19),
+            gamma: field(23),
+            joint_combiner: Fp::one(),
+        };
+        (evals, domain, zeta, zk_rows, constants, challenges)
+    }
+
+    /// The expression and the hand-written scalar are two statements of the
+    /// same thing, so the only check worth making is that they agree.
+    #[test]
+    fn permutation_scalar_expr_agrees_with_perm_scalars() {
+        let (evals, domain, zeta, zk_rows, constants, challenges) = setup();
+
+        let (_, mut powers_of_alpha) = constraints_expr::<Fp>(None, true);
+        let mut cache = expr::Cache::default();
+        let tokens = permutation_scalar_expr::<Fp>(&powers_of_alpha, &mut cache).to_polish();
+
+        let interpreted =
+            PolishToken::evaluate(&tokens, domain, zeta, &evals, &constants, &challenges).unwrap();
+
+        powers_of_alpha.instantiate(challenges.alpha);
+        let by_hand = ConstraintSystem::<Fp>::perm_scalars(
+            &evals,
+            challenges.beta,
+            challenges.gamma,
+            powers_of_alpha.get_alphas(ArgumentType::Permutation, permutation::CONSTRAINTS),
+            eval_permutation_vanishing_polynomial(domain, zk_rows, zeta),
+        );
+
+        assert_eq!(interpreted, by_hand);
+    }
+
+    /// The same check for `ft(zeta)`, against the formula transcribed from the
+    /// verifier — less the two terms the expression deliberately omits.
+    #[test]
+    fn ft_eval0_expr_agrees_with_the_verifier() {
+        let (evals, domain, zeta, zk_rows, constants, challenges) = setup();
+
+        let (_, mut powers_of_alpha) = constraints_expr::<Fp>(None, true);
+        let mut cache = expr::Cache::default();
+        let tokens = ft_eval0_expr::<Fp>(&powers_of_alpha, &mut cache).to_polish();
+
+        let interpreted =
+            PolishToken::evaluate(&tokens, domain, zeta, &evals, &constants, &challenges).unwrap();
+
+        powers_of_alpha.instantiate(challenges.alpha);
+        let alphas: Vec<Fp> = powers_of_alpha
+            .get_alphas(ArgumentType::Permutation, permutation::CONSTRAINTS)
+            .collect();
+        let (beta, gamma) = (challenges.beta, challenges.gamma);
+        let zkp = eval_permutation_vanishing_polynomial(domain, zk_rows, zeta);
+        let one = Fp::one();
+
+        let init = (evals.w[PERMUTS - 1].zeta + gamma) * evals.z.zeta_omega * alphas[0] * zkp;
+        let mut by_hand = evals
+            .w
+            .iter()
+            .zip(evals.s.iter())
+            .map(|(w, s)| (beta * s.zeta) + w.zeta + gamma)
+            .fold(init, |x, y| x * y);
+        by_hand -= evals
+            .w
+            .iter()
+            .zip(coset_shifts(&domain).iter())
+            .map(|(w, s)| gamma + (beta * zeta * s) + w.zeta)
+            .fold(alphas[0] * zkp * evals.z.zeta, |x, y| x * y);
+        let zeta1m1 = domain.evaluate_vanishing_polynomial(zeta);
+        let numerator = ((zeta1m1 * alphas[1] * (zeta - zk_w(domain, zk_rows)))
+            + (zeta1m1 * alphas[2] * (zeta - one)))
+            * (one - evals.z.zeta);
+        let denominator = ((zeta - zk_w(domain, zk_rows)) * (zeta - one))
+            .inverse()
+            .unwrap();
+        by_hand += numerator * denominator;
+
+        assert_eq!(interpreted, by_hand);
+    }
 }

--- a/kimchi/src/linearization.rs
+++ b/kimchi/src/linearization.rs
@@ -532,16 +532,20 @@ mod tests {
     use mina_curves::pasta::Fp;
     use mina_poseidon::pasta::fp_kimchi;
 
-    /// Evaluations chosen so that no term of either expression can vanish by
-    /// accident, with the domain, point and challenges to read them against.
-    fn setup() -> (
+    /// What [`setup`] hands back: the evaluations, plus the domain, point and
+    /// challenges to read them against.
+    type SetupData = (
         ProofEvaluations<PointEvaluations<Fp>>,
         D<Fp>,
         Fp,
         u64,
         Constants<Fp>,
         BerkeleyChallenges<Fp>,
-    ) {
+    );
+
+    /// Evaluations chosen so that no term of either expression can vanish by
+    /// accident, with the domain, point and challenges to read them against.
+    fn setup() -> SetupData {
         let mut rng = o1_utils::tests::make_test_rng(None);
         let mut field = |i: u64| Fp::from(i) + Fp::rand(&mut rng);
 

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -746,6 +746,10 @@ where
                     .cs
                     .precomputations()
                     .vanishes_on_zero_knowledge_and_previous_rows,
+                permutation_vanishing_polynomial: &index
+                    .cs
+                    .precomputations()
+                    .permutation_vanishing_polynomial_l,
                 z: &lagrange.d8.this.z,
                 l0_1: l0_1(index.cs.domain.d1),
                 domain: index.cs.domain,

--- a/kimchi/tests/test_expr.rs
+++ b/kimchi/tests/test_expr.rs
@@ -97,6 +97,10 @@ fn test_degree_tracking() {
             .cs
             .precomputations()
             .vanishes_on_zero_knowledge_and_previous_rows,
+        permutation_vanishing_polynomial: &index
+            .cs
+            .precomputations()
+            .permutation_vanishing_polynomial_l,
         z: &domain_evals.d8.this.z,
         l0_1: l0_1(index.cs.domain.d1),
         domain: index.cs.domain,

--- a/msm/src/column_env.rs
+++ b/msm/src/column_env.rs
@@ -171,6 +171,10 @@ impl<
         panic!("Not supposed to be used in MSM")
     }
 
+    fn permutation_vanishing_polynomial(&self) -> &'a Evaluations<F, Radix2EvaluationDomain<F>> {
+        panic!("Not supposed to be used in MSM")
+    }
+
     fn l0_1(&self) -> F {
         self.l0_1
     }

--- a/mvpoly/src/lib.rs
+++ b/mvpoly/src/lib.rs
@@ -141,6 +141,9 @@ pub trait MVPoly<F: PrimeField, const N: usize, const D: usize>:
             IfFeature(_c, _t, _f) => {
                 unimplemented!("The method is supposed to be used for generic multivariate expressions, not tied to a specific use case like Kimchi with this constructor")
             }
+            DivideByVanishingOn(_, _) => {
+                unimplemented!("The method is supposed to be used for generic multivariate expressions, not tied to a specific use case like Kimchi with this constructor")
+            }
         }
     }
 
@@ -167,7 +170,12 @@ pub trait MVPoly<F: PrimeField, const N: usize, const D: usize>:
                     ExprInner::UnnormalizedLagrangeBasis(_) => {
                         unimplemented!("Not used in this context")
                     }
-                    ExprInner::VanishesOnZeroKnowledgeAndPreviousRows => {
+                    ExprInner::VanishesOnZeroKnowledgeAndPreviousRows
+                    | ExprInner::PermutationVanishingPolynomial
+                    | ExprInner::EvaluationPoint
+                    | ExprInner::VanishingPolynomial
+                    | ExprInner::RootOfUnity(_)
+                    | ExprInner::Shift(_) => {
                         unimplemented!("Not used in this context")
                     }
                     ExprInner::Constant(c) => Self::from_constant(c),
@@ -212,6 +220,9 @@ pub trait MVPoly<F: PrimeField, const N: usize, const D: usize>:
                 unimplemented!("The method is supposed to be used for generic multivariate expressions, not tied to a specific use case like Kimchi with this constructor")
             }
             IfFeature(_c, _t, _f) => {
+                unimplemented!("The method is supposed to be used for generic multivariate expressions, not tied to a specific use case like Kimchi with this constructor")
+            }
+            DivideByVanishingOn(_, _) => {
                 unimplemented!("The method is supposed to be used for generic multivariate expressions, not tied to a specific use case like Kimchi with this constructor")
             }
         }

--- a/o1vm/src/pickles/column_env.rs
+++ b/o1vm/src/pickles/column_env.rs
@@ -131,6 +131,10 @@ impl<'a, F: FftField> TColumnEnvironment<'a, F, BerkeleyChallengeTerm, BerkeleyC
         panic!("Not supposed to be used in MIPS. We do not support zero-knowledge for now")
     }
 
+    fn permutation_vanishing_polynomial(&self) -> &'a Evaluations<F, Radix2EvaluationDomain<F>> {
+        panic!("Not supposed to be used in MIPS. We do not support zero-knowledge for now")
+    }
+
     fn l0_1(&self) -> F {
         self.l0_1
     }

--- a/o1vm/src/pickles/lookup_columns.rs
+++ b/o1vm/src/pickles/lookup_columns.rs
@@ -212,6 +212,10 @@ impl<'a, F: FftField> ColumnEnvironment<'a, F, LookupChallengeTerm, LookupChalle
         panic!("no zk is supposed to be used in this protocol")
     }
 
+    fn permutation_vanishing_polynomial(&self) -> &'a Evaluations<F, D<F>> {
+        panic!("no zk is supposed to be used in this protocol")
+    }
+
     fn l0_1(&self) -> F {
         self.l0_1
     }


### PR DESCRIPTION
This PR updates the expression framework to support the primitives needed for the permutation contributions to the linearization and the constant term -- both of which are currently manually implemented.

This change is currently unused, but forms an obvious extension to the PRs #3581 and https://github.com/MinaProtocol/mina/pull/18939: using this we can erase the remaining hard-coded constraints from the pickles code, and drive everything from the expression framework in rust.

Those neglected PRs should be reviewed before considering this one; it's unlikely to be useful on its own.