### PR TITLE
Fix master CI

### DIFF
--- a/poly-commitment/src/pbt_srs.rs
+++ b/poly-commitment/src/pbt_srs.rs
@@ -22,7 +22,7 @@ pub fn test_regression_commit_non_hiding_expected_number_of_chunks<
     G: CommitmentCurve,
     Srs: SRS<G>,
 >() {
-    let mut rng = &mut o1_utils::tests::make_test_rng(None);
+    let rng = &mut o1_utils::tests::make_test_rng(None);
     // maximum random srs size is 64
     let log2_srs_size = rng.gen_range(1..6);
     let srs_size = 1 << log2_srs_size;
@@ -33,7 +33,7 @@ pub fn test_regression_commit_non_hiding_expected_number_of_chunks<
     {
         // srs_size is the number of evaluation degree
         let poly_degree = srs_size - 1;
-        let poly = DensePolynomial::<G::ScalarField>::rand(poly_degree, &mut rng);
+        let poly = DensePolynomial::<G::ScalarField>::rand(poly_degree, rng);
         let commitment = srs.commit_non_hiding(&poly, 1);
         assert_eq!(commitment.len(), 1);
     }
@@ -45,7 +45,7 @@ pub fn test_regression_commit_non_hiding_expected_number_of_chunks<
         let poly_degree = srs_size - 1;
         // maximum 10 chunks for the test
         let k = rng.gen_range(2..10);
-        let poly = DensePolynomial::<G::ScalarField>::rand(poly_degree, &mut rng);
+        let poly = DensePolynomial::<G::ScalarField>::rand(poly_degree, rng);
         let commitment = srs.commit_non_hiding(&poly, k);
         assert_eq!(commitment.len(), k);
     }
@@ -64,7 +64,7 @@ pub fn test_regression_commit_non_hiding_expected_number_of_chunks<
     {
         let k = rng.gen_range(2..5);
         let poly_degree = k * srs_size - 1;
-        let poly = DensePolynomial::<G::ScalarField>::rand(poly_degree, &mut rng);
+        let poly = DensePolynomial::<G::ScalarField>::rand(poly_degree, rng);
         // if we request a number of chunks smaller than the multiple, we will
         // still get a number of chunks equals to the multiple.
         let requested_num_chunks = rng.gen_range(1..k);

--- a/signer/src/pubkey.rs
+++ b/signer/src/pubkey.rs
@@ -190,6 +190,7 @@ impl PubKey {
     }
 
     /// Borrow public key as curve point
+    #[must_use]
     pub const fn point(&self) -> &CurvePoint {
         &self.0
     }

--- a/signer/src/pubkey.rs
+++ b/signer/src/pubkey.rs
@@ -190,7 +190,7 @@ impl PubKey {
     }
 
     /// Borrow public key as curve point
-    #[must_use]
+    #[must_use = "borrowed curve point must be used"]
     pub const fn point(&self) -> &CurvePoint {
         &self.0
     }


### PR DESCRIPTION
This PR fixes the issues caused by the latest bump to rust's beta version. The last necessary such fix was [here](https://github.com/o1-labs/proof-systems/commit/c45f6524dd6ee60ac69cd2a0c6ee8b43e1e385c4).

Maintainers are invited to consider whether running a clippy lint against whatever the latest beta happens to be at any one moment is a sensible way to CI for lint bugs, or whether it's conducive to any forward progress in the repo.