### PR TITLE
kimchi: stop computing the witness evaluations nothing reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,8 @@ and this project adheres to
 - Stop computing the witness evaluations that nothing reads.
   `ConstraintSystem::evaluate` built the witness over `d4` as well as `d8`, and
   a row-shifted copy of the witness over each, none of which had a reader:
-  constraints referring to the next row are evaluated by shifting the index
-  into the unshifted evaluations, and `ColumnEnvironment` has no accessor for a
+  constraints referring to the next row are evaluated by shifting the index into
+  the unshifted evaluations, and `ColumnEnvironment` has no accessor for a
   shifted column. `WitnessOverDomains` now holds only the witness and the
   permutation accumulator over `d8`, plus the shifted accumulator the
   permutation argument compares against, and `WitnessShifts` is gone.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to
   disk while allowing the OS page cache to evict unused pages
   ([#3569](https://github.com/o1-labs/proof-systems/pull/3569))
 
+#### Removed
+
+- Stop computing the witness evaluations that nothing reads.
+  `ConstraintSystem::evaluate` built the witness over `d4` as well as `d8`, and
+  a row-shifted copy of the witness over each, none of which had a reader:
+  constraints referring to the next row are evaluated by shifting the index
+  into the unshifted evaluations, and `ColumnEnvironment` has no accessor for a
+  shifted column. `WitnessOverDomains` now holds only the witness and the
+  permutation accumulator over `d8`, plus the shifted accumulator the
+  permutation argument compares against, and `WitnessShifts` is gone.
+  ([#3598](https://github.com/o1-labs/proof-systems/pull/3598))
+
 ### [kimchi-napi](./kimchi-napi)
 
 #### Fixed

--- a/kimchi/src/circuits/constraints.rs
+++ b/kimchi/src/circuits/constraints.rs
@@ -29,7 +29,7 @@ use serde_with::serde_as;
 
 #[cfg(feature = "prover")]
 use {
-    crate::circuits::polynomial::{WitnessEvals, WitnessOverDomains, WitnessShifts},
+    crate::circuits::polynomial::{WitnessEvals, WitnessOverDomains},
     crate::prover_index::ProverIndex,
     o1_utils::ExtendedEvaluations,
     poly_commitment::SRS,
@@ -498,56 +498,12 @@ impl<F: PrimeField> ConstraintSystem<F> {
             (res.try_into().unwrap(), z8)
         };
 
-        let w4: [E<F, D<F>>; COLUMNS] = (0..COLUMNS)
-            .into_par_iter()
-            .map(|i| {
-                E::<F, D<F>>::from_vec_and_domain(
-                    (0..self.domain.d4.size)
-                        .map(|j| w8[i].evals[2 * j as usize])
-                        .collect(),
-                    self.domain.d4,
-                )
-            })
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
-
-        let z4 = DP::<F>::zero().evaluate_over_domain_by_ref(D::<F>::new(1).unwrap());
-        let z8_shift8 = z8.shift(8);
-
-        let d4_next_w: [_; COLUMNS] = w4
-            .par_iter()
-            .map(|w4_i| w4_i.shift(4))
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
-
-        let d8_next_w: [_; COLUMNS] = w8
-            .par_iter()
-            .map(|w8_i| w8_i.shift(8))
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
-
         WitnessOverDomains {
-            d4: WitnessShifts {
-                next: WitnessEvals {
-                    w: d4_next_w,
-                    // TODO(mimoo): change z to an Option? Or maybe not, we might actually need this dummy evaluation in the aggregated evaluation proof
-                    z: z4.clone(), // dummy evaluation
-                },
-                this: WitnessEvals {
-                    w: w4,
-                    z: z4, // dummy evaluation
-                },
+            this: WitnessEvals {
+                w: w8,
+                z: z8.clone(),
             },
-            d8: WitnessShifts {
-                next: WitnessEvals {
-                    w: d8_next_w,
-                    z: z8_shift8,
-                },
-                this: WitnessEvals { w: w8, z: z8 },
-            },
+            z_next: z8.shift(8),
         }
     }
 

--- a/kimchi/src/circuits/polynomial.rs
+++ b/kimchi/src/circuits/polynomial.rs
@@ -15,20 +15,18 @@ pub struct WitnessEvals<F: FftField> {
     pub z: Evaluations<F, D<F>>,
 }
 
-#[derive(Clone)]
-pub struct WitnessShifts<F: FftField> {
-    /// this wire evaluations
-    pub this: WitnessEvals<F>,
-    /// next wire evaluations
-    pub next: WitnessEvals<F>,
-}
-
+/// The witness and the permutation accumulator, evaluated over `d8`.
+///
+/// Only the values the quotient is built from: constraints referring to the
+/// next row are evaluated by shifting the index into these same evaluations,
+/// so no separately shifted copy of the witness is kept.
 #[derive(Clone)]
 pub struct WitnessOverDomains<F: FftField> {
-    /// evaluations over domain d4
-    pub d4: WitnessShifts<F>,
-    /// evaluations over domain d8
-    pub d8: WitnessShifts<F>,
+    /// The wires and the permutation accumulator at each row.
+    pub this: WitnessEvals<F>,
+    /// The permutation accumulator one row on, which the permutation argument
+    /// compares against the accumulator in [`Self::this`].
+    pub z_next: Evaluations<F, D<F>>,
 }
 
 // PLOOKUP

--- a/kimchi/src/circuits/polynomials/permutation.rs
+++ b/kimchi/src/circuits/polynomials/permutation.rs
@@ -272,7 +272,6 @@ where
             // (w[6](x) + gamma + x * beta * shift[6])
             // in evaluation form in d8
             let shifts: Evaluations<F, D<F>> = &lagrange
-                .d8
                 .this
                 .w
                 .par_iter()
@@ -285,7 +284,7 @@ where
                     l
                 })
                 .unwrap()
-                * &lagrange.d8.this.z.clone();
+                * &lagrange.this.z.clone();
 
             // sigmas = z(x * w) *
             // (w8[0] + gamma + sigma[0] * beta) *
@@ -293,7 +292,6 @@ where
             // (w8[6] + gamma + sigma[6] * beta)
             // in evaluation form in d8
             let sigmas = &lagrange
-                .d8
                 .this
                 .w
                 .par_iter()
@@ -309,7 +307,7 @@ where
                     l
                 })
                 .unwrap()
-                * &lagrange.d8.next.z.clone();
+                * &lagrange.z_next.clone();
 
             &(&shifts - &sigmas).scale(alpha0)
                 * &self.cs.precomputations().permutation_vanishing_polynomial_l

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -754,13 +754,13 @@ where
                         .joint_combiner
                         .unwrap_or(G::ScalarField::zero()),
                 },
-                witness: &lagrange.d8.this.w,
+                witness: &lagrange.this.w,
                 coefficient: &column_evaluations.coefficients8,
                 vanishes_on_zero_knowledge_and_previous_rows: &index
                     .cs
                     .precomputations()
                     .vanishes_on_zero_knowledge_and_previous_rows,
-                z: &lagrange.d8.this.z,
+                z: &lagrange.this.z,
                 l0_1: l0_1(index.cs.domain.d1),
                 domain: index.cs.domain,
                 index: index_evals,

--- a/kimchi/tests/test_expr.rs
+++ b/kimchi/tests/test_expr.rs
@@ -91,13 +91,13 @@ fn test_degree_tracking() {
             gamma: one,
             joint_combiner: one,
         },
-        witness: &domain_evals.d8.this.w,
+        witness: &domain_evals.this.w,
         coefficient: &index.column_evaluations.get().coefficients8,
         vanishes_on_zero_knowledge_and_previous_rows: &index
             .cs
             .precomputations()
             .vanishes_on_zero_knowledge_and_previous_rows,
-        z: &domain_evals.d8.this.z,
+        z: &domain_evals.this.z,
         l0_1: l0_1(index.cs.domain.d1),
         domain: index.cs.domain,
         index: HashMap::new(),


### PR DESCRIPTION
`ConstraintSystem::evaluate` returned the witness over `d4` as well as over `d8`, and a row-shifted copy of the witness over each. Nothing has ever read any of them.

Constraints that refer to the next row do not use a shifted copy: the expression framework evaluates them as `SubEvals { shift: 1, .. }` over the unshifted evaluations, and `ColumnEnvironment` has no accessor that could hand back a shifted column. The only readers of the result are `ConstraintSystem::perm_quot` and the prover's `Environment`, which between them take the witness and the permutation accumulator over `d8`, and the accumulator shifted by one row.

That leaves `WitnessOverDomains` holding what is read and nothing else, so `WitnessShifts` — which existed to pair a value with its shifted twin — goes with it.

Per proof this drops 15 subsampled `d4` witness evaluations, 15 shifted `d4` copies and 15 shifted `d8` copies: 240n field elements built, for a domain of size n, and never looked at.