### PR TITLE
perf: cheaper DomainConstantEvaluations and perm_quot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to
 
 #### Changed
 
+- Build `poly_x_d1` by walking the d8 domain points instead of FFT-ing the
+  polynomial `x`, and drop the `constant_1_d4` / `constant_1_d8` all-ones
+  vectors (`gamma` is folded into the permutation argument per element). The
+  stored evaluations are unchanged and `precomputations` is `#[serde(skip)]`, so
+  proofs and the cached-key format are unaffected; this drops ~24 MB of resident
+  memory per materialised prover index
+  ([#3586](https://github.com/o1-labs/proof-systems/pull/3586))
+- Build the `perm_quot` shifts and sigmas terms in a single pass per element
+  rather than as three `Evaluations` temporaries each
+  ([#3586](https://github.com/o1-labs/proof-systems/pull/3586))
 - Lower the prover's peak memory by releasing the d8 evaluations once the
   linearization is done, rather than holding them to end-of-proof
   ([#3587](https://github.com/o1-labs/proof-systems/pull/3587))
@@ -73,6 +83,14 @@ and this project adheres to
 
 - Treat public evaluations of oracles as vectors for chunking coherence
   ([#3577](https://github.com/o1-labs/proof-systems/pull/3577))
+
+### [o1-utils](./utils)
+
+#### Added
+
+- Add `cfg_chunks_mut!`, the mutable-chunks counterpart to the existing
+  `cfg_iter!` family
+  ([#3586](https://github.com/o1-labs/proof-systems/pull/3586))
 
 ## 0.7.0
 

--- a/kimchi/Cargo.toml
+++ b/kimchi/Cargo.toml
@@ -135,3 +135,15 @@ sha2-compress = ["sha2/compress"]
 sha2-force-soft = ["sha2/force-soft"]
 sha2-loongarch64_asm = ["sha2/loongarch64_asm"]
 sha2-oid = ["sha2/oid"]
+
+[[bench]]
+name = "perm_quot"
+harness = false
+
+[[bench]]
+name = "constraint_evals"
+harness = false
+
+[[bench]]
+name = "dce_create"
+harness = false

--- a/kimchi/benches/README.md
+++ b/kimchi/benches/README.md
@@ -1,0 +1,31 @@
+# Prover benches
+
+These are written to be cherry-picked onto any branch and run there, so the same
+numbers can be compared across branches. They touch only new files plus an
+append to `kimchi/Cargo.toml`.
+
+| Bench                    | Measures                                                             | Relevant to  |
+| ------------------------ | -------------------------------------------------------------------- | ------------ |
+| `perm_quot`              | `ProverIndex::perm_quot`, plus `create_proof` for the share of total | #3586, #3589 |
+| `dce_create`             | `DomainConstantEvaluations::create`, 2^12–2^18                       | #3586        |
+| `constraint_evals`       | `Expr::evaluations` for the d4 and d8 gate constraints               | #3588        |
+| `alloc_report` (example) | Bytes allocated, retained and peak                                   | all          |
+
+```sh
+cargo bench -p kimchi --bench perm_quot
+cargo run --release -p kimchi --example alloc_report
+```
+
+`perm_quot` and `constraint_evals` rebuild the prover's inputs the way
+`ProverProof::create` does — same witness padding, zk-row randomisation, real
+permutation accumulator — so they measure production-shaped data.
+
+Two things to watch when comparing across branches:
+
+- Build each branch with its own `CARGO_TARGET_DIR`. Cargo gives two worktrees
+  of the same package the same artifact hash and will silently reuse one
+  branch's binary for the other.
+- A single pair of cross-branch runs is not reliable. Long all-core benches
+  drift by ~10% over a session, which is larger than most of the effects being
+  measured. Alternate the branches over several rounds and compare paired
+  deltas.

--- a/kimchi/benches/constraint_evals.rs
+++ b/kimchi/benches/constraint_evals.rs
@@ -1,0 +1,212 @@
+//! Surgical A/B of the constraint-polynomial evaluation that PR #3588 changes.
+//!
+//! The PR claims "a 1/8 = 12.5% speed-up for this part of the prover". This
+//! file rebuilds the prover's `Environment` exactly as `ProverProof::create`
+//! does and times `Expr::evaluations(&env)` for the generic constraint (d4,
+//! stride 4 -> 25% of rows skipped) and for the always-on gate constraints
+//! (d8, stride 8 -> 12.5% of rows skipped).
+//!
+//! Byte-identical on both branches:
+//!   cargo bench --bench constraint_evals
+
+use ark_ff::{UniformRand, Zero};
+use ark_poly::{
+    univariate::DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as D,
+};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
+use kimchi::{
+    alphas::Alphas,
+    bench::BenchmarkCtx,
+    circuits::{
+        argument::{Argument, DynArgument},
+        berkeley_columns::{BerkeleyChallenges, Environment},
+        expr::{l0_1, Cache, Constants},
+        gate::{CircuitGate, GateType},
+        polynomials::{
+            complete_add::CompleteAdd,
+            endomul_scalar::EndomulScalar,
+            endosclmul::EndosclMul,
+            generic::{Generic, GenericGateSpec},
+            poseidon::Poseidon,
+            varbasemul::VarbaseMul,
+        },
+        wires::{Wire, COLUMNS},
+    },
+    curve::KimchiCurve,
+    prover_index::{testing::new_index_for_test, ProverIndex},
+};
+use mina_curves::pasta::{Fp, Vesta};
+use mina_poseidon::pasta::FULL_ROUNDS;
+use poly_commitment::ipa::SRS;
+use std::{array, collections::HashMap};
+
+type Index = ProverIndex<FULL_ROUNDS, Vesta, SRS<Vesta>>;
+
+struct Ctx {
+    index: Index,
+    w8: [Evaluations<Fp, D<Fp>>; COLUMNS],
+    z8: Evaluations<Fp, D<Fp>>,
+    precomp:
+        std::sync::Arc<kimchi::circuits::domain_constant_evaluation::DomainConstantEvaluations<Fp>>,
+    all_alphas: Alphas<Fp>,
+    alpha: Fp,
+    beta: Fp,
+    gamma: Fp,
+}
+
+fn setup(log_n: u32) -> Ctx {
+    let rng = &mut rand::rngs::OsRng;
+
+    let num_gates = ((1 << log_n) - 10) as usize;
+    let gates: Vec<CircuitGate<Fp>> = (0..num_gates)
+        .map(|row| {
+            CircuitGate::create_generic_gadget(
+                Wire::for_row(row),
+                GenericGateSpec::Const(1u32.into()),
+                None,
+            )
+        })
+        .collect();
+
+    let index: Index = new_index_for_test(gates, 0);
+    assert_eq!(index.cs.domain.d1.log_size_of_group, log_n);
+    let precomp = index.cs.precomputations();
+    let _ = index.column_evaluations.get();
+
+    // Prover-identical witness preparation.
+    let domain_size = index.cs.domain.d1.size();
+    let zk_rows = index.cs.zk_rows as usize;
+    let mut witness: [Vec<Fp>; COLUMNS] = array::from_fn(|_| vec![Fp::from(1u32); num_gates]);
+    for w in &mut witness {
+        w.extend(std::iter::repeat_n(Fp::zero(), domain_size - num_gates));
+        for row in w.iter_mut().rev().take(zk_rows) {
+            *row = Fp::rand(rng);
+        }
+    }
+    let witness_poly: [DensePolynomial<Fp>; COLUMNS] = array::from_fn(|i| {
+        Evaluations::<Fp, D<Fp>>::from_vec_and_domain(witness[i].clone(), index.cs.domain.d1)
+            .interpolate()
+    });
+
+    let beta = Fp::rand(rng);
+    let gamma = Fp::rand(rng);
+    let alpha = Fp::rand(rng);
+    let z_poly = index.perm_aggreg(&witness, &beta, &gamma, rng).unwrap();
+
+    // Evaluate over d8 directly rather than via `ConstraintSystem::evaluate`, so
+    // this bench compiles both before and after #3598 reshaped
+    // `WitnessOverDomains`. Same values either way.
+    let d8 = index.cs.domain.d8;
+    let w8: [Evaluations<Fp, D<Fp>>; COLUMNS] =
+        array::from_fn(|i| witness_poly[i].evaluate_over_domain_by_ref(d8));
+    let z8 = z_poly.evaluate_over_domain_by_ref(d8);
+
+    let mut all_alphas = index.powers_of_alpha.clone();
+    all_alphas.instantiate(alpha);
+
+    Ctx {
+        index,
+        precomp,
+        w8,
+        z8,
+        all_alphas,
+        alpha,
+        beta,
+        gamma,
+    }
+}
+
+fn make_env(ctx: &Ctx) -> Environment<'_, Fp> {
+    let ce = ctx.index.column_evaluations.get();
+    let mds = &<Vesta as KimchiCurve<FULL_ROUNDS>>::sponge_params().mds;
+    let mut index_evals = HashMap::new();
+    index_evals.insert(GateType::Generic, &ce.generic_selector4);
+    index_evals.insert(GateType::Poseidon, &ce.poseidon_selector8);
+    index_evals.insert(GateType::CompleteAdd, &ce.complete_add_selector4);
+    index_evals.insert(GateType::VarBaseMul, &ce.mul_selector8);
+    index_evals.insert(GateType::EndoMul, &ce.emul_selector8);
+    index_evals.insert(GateType::EndoMulScalar, &ce.endomul_scalar_selector8);
+
+    Environment {
+        constants: Constants {
+            endo_coefficient: ctx.index.cs.endo,
+            mds,
+            zk_rows: ctx.index.cs.zk_rows,
+        },
+        challenges: BerkeleyChallenges {
+            alpha: ctx.alpha,
+            beta: ctx.beta,
+            gamma: ctx.gamma,
+            joint_combiner: Fp::zero(),
+        },
+        witness: &ctx.w8,
+        coefficient: &ce.coefficients8,
+        vanishes_on_zero_knowledge_and_previous_rows: &ctx
+            .precomp
+            .vanishes_on_zero_knowledge_and_previous_rows,
+        z: &ctx.z8,
+        l0_1: l0_1(ctx.index.cs.domain.d1),
+        domain: ctx.index.cs.domain,
+        index: index_evals,
+        lookup: None,
+    }
+}
+
+fn bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("constraint_evals");
+    group.sampling_mode(SamplingMode::Flat);
+    group.measurement_time(std::time::Duration::from_secs(20));
+
+    for log_n in [10u32, 14, 16] {
+        let ctx = setup(log_n);
+        let env = make_env(&ctx);
+
+        // Build the constraint expressions ONCE, outside the timed region:
+        // `combined_constraints` is symbolic work whose cost is independent of
+        // the domain size, and it would otherwise swamp the measurement.
+        let mut cache = Cache::default();
+        let generic_constraint =
+            <Generic<Fp> as Argument<Fp>>::combined_constraints(&ctx.all_alphas, &mut cache);
+        let gate_list: [&dyn DynArgument<Fp>; 5] = [
+            &CompleteAdd::default(),
+            &VarbaseMul::default(),
+            &EndosclMul::default(),
+            &EndomulScalar::default(),
+            &Poseidon::default(),
+        ];
+        let gate_constraints: Vec<_> = gate_list
+            .iter()
+            .map(|g| g.combined_constraints(&ctx.all_alphas, &mut cache))
+            .collect();
+
+        // d4 path: stride 4, so the PR skips 25% of rows here.
+        group.bench_function(format!("generic (d4) (2^{log_n} rows)"), |b| {
+            b.iter(|| black_box(generic_constraint.evaluations(black_box(&env))))
+        });
+
+        // d8 path: stride 8, the 1/8 = 12.5% the PR claims.
+        group.bench_function(format!("gates (d8) (2^{log_n} rows)"), |b| {
+            b.iter(|| {
+                for constraint in &gate_constraints {
+                    black_box(constraint.evaluations(black_box(&env)));
+                }
+            })
+        });
+    }
+
+    group.finish();
+
+    let mut prf = c.benchmark_group("proof_for_ratio");
+    prf.sampling_mode(SamplingMode::Flat);
+    prf.measurement_time(std::time::Duration::from_secs(30));
+    prf.sample_size(10);
+    let log_n = 16u32;
+    let ctx = BenchmarkCtx::new(log_n);
+    prf.bench_function(format!("create_proof (2^{log_n} rows)"), |b| {
+        b.iter(|| black_box(ctx.create_proof()))
+    });
+    prf.finish()
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/kimchi/benches/dce_create.rs
+++ b/kimchi/benches/dce_create.rs
@@ -1,0 +1,27 @@
+//! Times `DomainConstantEvaluations::create`. Byte-identical on both sides.
+use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
+use kimchi::circuits::{
+    domain_constant_evaluation::DomainConstantEvaluations, domains::EvaluationDomains,
+};
+use mina_curves::pasta::Fp;
+
+fn bench(c: &mut Criterion) {
+    let mut g = c.benchmark_group("dce_create");
+    g.sampling_mode(SamplingMode::Flat);
+    g.measurement_time(std::time::Duration::from_secs(12));
+    g.sample_size(20);
+    for log_n in [12u32, 14, 16, 18] {
+        let domain = EvaluationDomains::<Fp>::create(1 << log_n).unwrap();
+        g.bench_function(format!("create (2^{log_n} rows)"), |b| {
+            b.iter(|| {
+                black_box(DomainConstantEvaluations::<Fp>::create(
+                    black_box(domain),
+                    3,
+                ))
+            })
+        });
+    }
+    g.finish()
+}
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/kimchi/benches/perm_quot.rs
+++ b/kimchi/benches/perm_quot.rs
@@ -1,0 +1,166 @@
+//! Option C: surgical A/B of `ProverIndex::perm_quot`, the only proving-path
+//! function touched by PR #3586.
+//!
+//! This file is byte-identical on both branches; run it on each and compare
+//! with criterion baselines:
+//!
+//!   cargo bench --bench perm_quot -- --save-baseline base   # on merge-base
+//!   cargo bench --bench perm_quot -- --baseline base        # on pr-3586
+//!
+//! It also measures a full `create_proof` at the same domain size, so the
+//! share-of-total ratio (and therefore the ceiling on any end-to-end gain)
+//! falls straight out of the two numbers.
+
+use ark_ff::{UniformRand, Zero};
+use ark_poly::{
+    univariate::DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as D,
+};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
+use kimchi::{
+    bench::BenchmarkCtx,
+    circuits::{
+        gate::CircuitGate,
+        polynomial::WitnessOverDomains,
+        polynomials::generic::GenericGateSpec,
+        wires::{Wire, COLUMNS},
+    },
+    prover_index::{testing::new_index_for_test, ProverIndex},
+};
+use mina_curves::pasta::{Fp, Vesta};
+use mina_poseidon::pasta::FULL_ROUNDS;
+use poly_commitment::ipa::SRS;
+use std::array;
+
+type Index = ProverIndex<FULL_ROUNDS, Vesta, SRS<Vesta>>;
+
+/// Everything `perm_quot` needs, built exactly the way `ProverProof::create`
+/// builds it (padding + zk-row randomisation + real permutation accumulator),
+/// so the benchmarked call sees production-shaped data.
+struct PermInputs {
+    index: Index,
+    lagrange: WitnessOverDomains<Fp>,
+    z_poly: DensePolynomial<Fp>,
+    beta: Fp,
+    gamma: Fp,
+    alphas: [Fp; 3],
+}
+
+fn setup(log_n: u32) -> PermInputs {
+    let rng = &mut rand::rngs::OsRng;
+
+    let num_gates = ((1 << log_n) - 10) as usize;
+    let gates = (0..num_gates)
+        .map(|row| {
+            CircuitGate::create_generic_gadget(
+                Wire::for_row(row),
+                GenericGateSpec::Const(1u32.into()),
+                None,
+            )
+        })
+        .collect();
+
+    let index: Index = new_index_for_test(gates, 0);
+    assert_eq!(index.cs.domain.d1.log_size_of_group, log_n);
+
+    // Force the lazy caches so their cost is not attributed to `perm_quot`.
+    let _ = index.cs.precomputations();
+    let _ = index.column_evaluations.get();
+
+    // Same witness preparation as the prover: pad to the domain, then
+    // randomise the trailing zk rows.
+    let domain_size = index.cs.domain.d1.size();
+    let zk_rows = index.cs.zk_rows as usize;
+    let mut witness: [Vec<Fp>; COLUMNS] = array::from_fn(|_| vec![Fp::from(1u32); num_gates]);
+    for w in &mut witness {
+        w.extend(std::iter::repeat_n(Fp::zero(), domain_size - num_gates));
+        for row in w.iter_mut().rev().take(zk_rows) {
+            *row = Fp::rand(rng);
+        }
+    }
+
+    let witness_poly: [DensePolynomial<Fp>; COLUMNS] = array::from_fn(|i| {
+        Evaluations::<Fp, D<Fp>>::from_vec_and_domain(witness[i].clone(), index.cs.domain.d1)
+            .interpolate()
+    });
+
+    let beta = Fp::rand(rng);
+    let gamma = Fp::rand(rng);
+    let z_poly = index
+        .perm_aggreg(&witness, &beta, &gamma, rng)
+        .expect("permutation aggregation failed");
+    let lagrange = index.cs.evaluate(&witness_poly, &z_poly);
+
+    // `perm_quot` consumes exactly three powers of alpha; their values do not
+    // affect the cost.
+    let alphas = [Fp::rand(rng), Fp::rand(rng), Fp::rand(rng)];
+
+    PermInputs {
+        index,
+        lagrange,
+        z_poly,
+        beta,
+        gamma,
+        alphas,
+    }
+}
+
+fn bench_perm_quot(c: &mut Criterion) {
+    let mut group = c.benchmark_group("perm_quot");
+    group.sampling_mode(SamplingMode::Flat);
+    group.measurement_time(std::time::Duration::from_secs(20));
+
+    for log_n in [10u32, 14, 16] {
+        let inputs = setup(log_n);
+        // Sanity: the call must actually succeed, not error out into a fast path.
+        inputs
+            .index
+            .perm_quot(
+                &inputs.lagrange,
+                inputs.beta,
+                inputs.gamma,
+                &inputs.z_poly,
+                inputs.alphas.into_iter(),
+            )
+            .expect("perm_quot failed");
+
+        group.bench_function(format!("perm_quot (2^{log_n} rows)"), |b| {
+            b.iter(|| {
+                black_box(
+                    inputs
+                        .index
+                        .perm_quot(
+                            black_box(&inputs.lagrange),
+                            inputs.beta,
+                            inputs.gamma,
+                            black_box(&inputs.z_poly),
+                            inputs.alphas.into_iter(),
+                        )
+                        .unwrap(),
+                )
+            })
+        });
+    }
+
+    group.finish()
+}
+
+/// Full proof at the same sizes, to turn the `perm_quot` delta into a share of
+/// the number that actually ships.
+fn bench_proof_for_ratio(c: &mut Criterion) {
+    let mut group = c.benchmark_group("proof_for_ratio");
+    group.sampling_mode(SamplingMode::Flat);
+    group.measurement_time(std::time::Duration::from_secs(30));
+    group.sample_size(10);
+
+    for log_n in [10u32, 14, 16] {
+        let ctx = BenchmarkCtx::new(log_n);
+        group.bench_function(format!("create_proof (2^{log_n} rows)"), |b| {
+            b.iter(|| black_box(ctx.create_proof()))
+        });
+    }
+
+    group.finish()
+}
+
+criterion_group!(benches, bench_perm_quot, bench_proof_for_ratio);
+criterion_main!(benches);

--- a/kimchi/examples/alloc_report.rs
+++ b/kimchi/examples/alloc_report.rs
@@ -1,0 +1,135 @@
+//! Option E: deterministic allocation / retained-memory accounting for PR #3586.
+//!
+//! Byte-identical on both branches. Counts are exact integers produced by a
+//! wrapping global allocator, so unlike wall-clock they need no statistics and
+//! no quiet machine:
+//!
+//!   cargo run --release --example alloc_report
+//!
+//! Reports, per domain size:
+//!   * dce_alloc_bytes      - bytes allocated building DomainConstantEvaluations (claim C1)
+//!   * dce_retained_bytes   - bytes the resulting struct holds (claim C3)
+//!   * index_alloc_bytes    - bytes allocated building a full prover index
+//!   * index_retained_bytes - bytes the prover index holds
+//!   * proof_alloc_bytes    - bytes allocated producing one proof (claim C2)
+//!   * proof_peak_bytes     - peak live-heap increase during one proof
+
+use kimchi::{
+    bench::BenchmarkCtx,
+    circuits::{domain_constant_evaluation::DomainConstantEvaluations, domains::EvaluationDomains},
+};
+use mina_curves::pasta::Fp;
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    sync::atomic::{AtomicUsize, Ordering::Relaxed},
+};
+
+static TOTAL: AtomicUsize = AtomicUsize::new(0);
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+fn on_alloc(size: usize) {
+    TOTAL.fetch_add(size, Relaxed);
+    let live = LIVE.fetch_add(size, Relaxed) + size;
+    PEAK.fetch_max(live, Relaxed);
+}
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let p = unsafe { System.alloc(layout) };
+        if !p.is_null() {
+            on_alloc(layout.size());
+        }
+        p
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let p = unsafe { System.alloc_zeroed(layout) };
+        if !p.is_null() {
+            on_alloc(layout.size());
+        }
+        p
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+        LIVE.fetch_sub(layout.size(), Relaxed);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let p = unsafe { System.realloc(ptr, layout, new_size) };
+        if !p.is_null() {
+            if new_size > layout.size() {
+                on_alloc(new_size - layout.size());
+            } else {
+                LIVE.fetch_sub(layout.size() - new_size, Relaxed);
+            }
+        }
+        p
+    }
+}
+
+#[global_allocator]
+static ALLOC: Counting = Counting;
+
+fn total() -> usize {
+    TOTAL.load(Relaxed)
+}
+fn live() -> usize {
+    LIVE.load(Relaxed)
+}
+fn reset_peak() {
+    PEAK.store(live(), Relaxed);
+}
+fn peak() -> usize {
+    PEAK.load(Relaxed)
+}
+
+fn main() {
+    // Warm rayon's pool and the lazily-initialised field/curve tables so their
+    // one-off allocations are not attributed to a measured phase.
+    {
+        let warm = BenchmarkCtx::new(10);
+        let _ = warm.create_proof();
+    }
+
+    const ZK_ROWS: u64 = 3;
+
+    for log_n in [10u32, 14, 16] {
+        let n = 1usize << log_n;
+
+        // --- claim C1 / C3: DomainConstantEvaluations ---
+        let domain = EvaluationDomains::<Fp>::create(n).unwrap();
+        let (t0, l0) = (total(), live());
+        let dce = DomainConstantEvaluations::<Fp>::create(domain, ZK_ROWS).unwrap();
+        let dce_alloc = total() - t0;
+        let dce_retained = live() - l0;
+        drop(dce);
+
+        // --- prover index ---
+        let (t1, l1) = (total(), live());
+        let ctx = BenchmarkCtx::new(log_n);
+        let index_alloc = total() - t1;
+        let index_retained = live() - l1;
+
+        // --- claim C2: one proof ---
+        reset_peak();
+        let t2 = total();
+        let l2 = live();
+        let proof = ctx.create_proof();
+        let proof_alloc = total() - t2;
+        let proof_peak = peak() - l2;
+        drop(proof);
+        drop(ctx);
+
+        println!("size = 2^{log_n}");
+        println!("  dce_alloc_bytes      = {dce_alloc}");
+        println!("  dce_retained_bytes   = {dce_retained}");
+        println!("  index_alloc_bytes    = {index_alloc}");
+        println!("  index_retained_bytes = {index_retained}");
+        println!("  proof_alloc_bytes    = {proof_alloc}");
+        println!("  proof_peak_bytes     = {proof_peak}");
+    }
+}

--- a/kimchi/src/circuits/domain_constant_evaluation.rs
+++ b/kimchi/src/circuits/domain_constant_evaluation.rs
@@ -37,9 +37,6 @@ pub struct DomainConstantEvaluations<F: FftField> {
     /// the polynomial `x` evaluated over domain.d8
     #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub poly_x_d1: E<F, D<F>>,
-    /// 0-th Lagrange evaluated over domain.d8
-    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
-    pub constant_1_d8: E<F, D<F>>,
     /// the polynomial that vanishes on the zero-knowledge rows and the row before
     #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub vanishes_on_zero_knowledge_and_previous_rows: E<F, D<F>>,
@@ -53,8 +50,6 @@ pub struct DomainConstantEvaluations<F: FftField> {
 impl<F: FftField> DomainConstantEvaluations<F> {
     pub fn create(domain: EvaluationDomains<F>, zk_rows: u64) -> Option<Self> {
         let poly_x_d1 = E::from_vec_and_domain(domain_points(domain.d8), domain.d8);
-        let constant_1_d8 =
-            E::<F, D<F>>::from_vec_and_domain(vec![F::one(); domain.d8.size()], domain.d8);
 
         let vanishes_on_zero_knowledge_and_previous_rows =
             vanishes_on_last_n_rows(domain.d1, zk_rows + 1).evaluate_over_domain(domain.d8);
@@ -69,7 +64,6 @@ impl<F: FftField> DomainConstantEvaluations<F> {
 
         Some(DomainConstantEvaluations {
             poly_x_d1,
-            constant_1_d8,
             vanishes_on_zero_knowledge_and_previous_rows,
             permutation_vanishing_polynomial_l,
             permutation_vanishing_polynomial_m,

--- a/kimchi/src/circuits/domain_constant_evaluation.rs
+++ b/kimchi/src/circuits/domain_constant_evaluation.rs
@@ -1,22 +1,40 @@
 //! This contains the [DomainConstantEvaluations] which is used to provide precomputations to a [ConstraintSystem](super::constraints::ConstraintSystem).
 
 use crate::circuits::domains::EvaluationDomains;
-use alloc::vec;
+use alloc::{vec, vec::Vec};
 use ark_ff::FftField;
 use ark_poly::{
-    univariate::DensePolynomial as DP, DenseUVPolynomial, EvaluationDomain, Evaluations as E,
+    univariate::DensePolynomial as DP, EvaluationDomain, Evaluations as E,
     Radix2EvaluationDomain as D,
 };
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
 use super::polynomials::permutation::{permutation_vanishing_polynomial, vanishes_on_last_n_rows};
 
+fn domain_points<F: FftField>(domain: D<F>) -> Vec<F> {
+    const CHUNK: usize = 1 << 14;
+    let gen = domain.group_gen;
+    let mut points = vec![F::one(); domain.size()];
+    o1_utils::cfg_chunks_mut!(points, CHUNK)
+        .enumerate()
+        .for_each(|(chunk_idx, chunk)| {
+            let mut x = gen.pow([(chunk_idx * CHUNK) as u64]);
+            for slot in chunk.iter_mut() {
+                *slot = x;
+                x *= gen;
+            }
+        });
+    points
+}
+
 #[serde_as]
 #[derive(Clone, Serialize, Deserialize, Debug)]
 /// pre-computed polynomials that depend only on the chosen field and domain
 pub struct DomainConstantEvaluations<F: FftField> {
-    /// 1-st Lagrange evaluated over domain.d8
+    /// the polynomial `x` evaluated over domain.d8
     #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub poly_x_d1: E<F, D<F>>,
     /// 0-th Lagrange evaluated over domain.d4
@@ -38,8 +56,7 @@ pub struct DomainConstantEvaluations<F: FftField> {
 
 impl<F: FftField> DomainConstantEvaluations<F> {
     pub fn create(domain: EvaluationDomains<F>, zk_rows: u64) -> Option<Self> {
-        let poly_x_d1 = DP::from_coefficients_slice(&[F::zero(), F::one()])
-            .evaluate_over_domain_by_ref(domain.d8);
+        let poly_x_d1 = E::from_vec_and_domain(domain_points(domain.d8), domain.d8);
         let constant_1_d4 =
             E::<F, D<F>>::from_vec_and_domain(vec![F::one(); domain.d4.size()], domain.d4);
         let constant_1_d8 =

--- a/kimchi/src/circuits/domain_constant_evaluation.rs
+++ b/kimchi/src/circuits/domain_constant_evaluation.rs
@@ -37,10 +37,6 @@ pub struct DomainConstantEvaluations<F: FftField> {
     /// the polynomial `x` evaluated over domain.d8
     #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub poly_x_d1: E<F, D<F>>,
-    /// 0-th Lagrange evaluated over domain.d4
-    // TODO(mimoo): be consistent with the paper/spec, call it L1 here or call it L0 there
-    #[serde_as(as = "o1_utils::serialization::SerdeAs")]
-    pub constant_1_d4: E<F, D<F>>,
     /// 0-th Lagrange evaluated over domain.d8
     #[serde_as(as = "o1_utils::serialization::SerdeAs")]
     pub constant_1_d8: E<F, D<F>>,
@@ -57,8 +53,6 @@ pub struct DomainConstantEvaluations<F: FftField> {
 impl<F: FftField> DomainConstantEvaluations<F> {
     pub fn create(domain: EvaluationDomains<F>, zk_rows: u64) -> Option<Self> {
         let poly_x_d1 = E::from_vec_and_domain(domain_points(domain.d8), domain.d8);
-        let constant_1_d4 =
-            E::<F, D<F>>::from_vec_and_domain(vec![F::one(); domain.d4.size()], domain.d4);
         let constant_1_d8 =
             E::<F, D<F>>::from_vec_and_domain(vec![F::one(); domain.d8.size()], domain.d8);
 
@@ -75,7 +69,6 @@ impl<F: FftField> DomainConstantEvaluations<F> {
 
         Some(DomainConstantEvaluations {
             poly_x_d1,
-            constant_1_d4,
             constant_1_d8,
             vanishes_on_zero_knowledge_and_previous_rows,
             permutation_vanishing_polynomial_l,

--- a/kimchi/src/circuits/polynomials/permutation.rs
+++ b/kimchi/src/circuits/polynomials/permutation.rs
@@ -234,9 +234,6 @@ where
 
         let zk_rows = self.cs.zk_rows as usize;
 
-        // constant gamma in evaluation form (in domain d8)
-        let gamma = &self.cs.precomputations().constant_1_d8.scale(gamma);
-
         //~ The quotient contribution of the permutation is split into two parts $perm$ and $bnd$.
         //~ They will be used by the prover.
         //~
@@ -277,7 +274,14 @@ where
                 .par_iter()
                 .zip(self.cs.shift.par_iter())
                 .map(|(witness, shift)| {
-                    &(witness + gamma) + &self.cs.precomputations().poly_x_d1.scale(beta * shift)
+                    let beta_shift = beta * shift;
+                    let evals: Vec<F> = witness
+                        .evals
+                        .par_iter()
+                        .zip(self.cs.precomputations().poly_x_d1.evals.par_iter())
+                        .map(|(w, x)| *w + gamma + beta_shift * x)
+                        .collect();
+                    Evaluations::<F, D<F>>::from_vec_and_domain(evals, self.cs.domain.d8)
                 })
                 .reduce_with(|mut l, r| {
                     l *= &r;
@@ -301,7 +305,15 @@ where
                         .permutation_coefficients8
                         .par_iter(),
                 )
-                .map(|(witness, sigma)| witness + &(gamma + &sigma.scale(beta)))
+                .map(|(witness, sigma)| {
+                    let evals: Vec<F> = witness
+                        .evals
+                        .par_iter()
+                        .zip(sigma.evals.par_iter())
+                        .map(|(w, s)| *w + gamma + beta * s)
+                        .collect();
+                    Evaluations::<F, D<F>>::from_vec_and_domain(evals, self.cs.domain.d8)
+                })
                 .reduce_with(|mut l, r| {
                     l *= &r;
                     l

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -37,6 +37,18 @@ macro_rules! cfg_iter_mut {
     }};
 }
 
+/// Returns a parallel iterator over mutable chunks when `parallel` is enabled.
+#[macro_export]
+macro_rules! cfg_chunks_mut {
+    ($e:expr, $size:expr) => {{
+        #[cfg(feature = "parallel")]
+        let result = $e.par_chunks_mut($size);
+        #[cfg(not(feature = "parallel"))]
+        let result = $e.chunks_mut($size);
+        result
+    }};
+}
+
 /// Returns a parallel consuming iterator when the `parallel` feature is enabled,
 /// otherwise returns a sequential consuming iterator.
 #[macro_export]


### PR DESCRIPTION
@mrmr1993 This is what I came up with after measuring the benefits from #3586, #3588 and #3589. I would suggest this PR as a replacement for those. I asked claude to commit some representative benches that could be used for those other branches (or at least as a strong template if they don't build for some reason). I would remove that commit before any merge, the benches aren't worth keeping.

I have tried to isolate what gave the permance boost from stuff that didn't at the cost of adding complexity. The overall proving speed is negligible, but there are some total allocation savings.

Everything here is behaviour-preserving, so I didn't add any tests

## What's kept, and what it buys

| Change | Origin | Benefit |
|---|---|---|
| Drop `constant_1_d4` / `constant_1_d8`, fold `gamma` in as a scalar | #3586 | −24 MiB resident per index, −464 MiB allocated per proof |
| Fuse the `perm_quot` shifts/sigmas terms into one pass | #3586 | −20% on `perm_quot` |
| Build `poly_x_d1` from the d8 domain points instead of an FFT | #3586 | −7% on `DomainConstantEvaluations::create` |

## What's dropped, and why

- **`eval_from_roots_over_d8`** (#3586) — evaluates the two vanishing
  polynomials from their roots instead of by FFT. Faster below 2^16, but a wash
  at 2^16 and slower than the FFTs it replaces at 2^18. It also restates the
  root set that `permutation_vanishing_polynomial` defines, so the two can
  silently desync. `create` is setup-time only, so this is complexity for a
  benefit that disappears at production sizes.
- **#3588** (skip d1 rows in `expr.rs`) — 237 lines across `EvalResult` plus a
  compensating public-input fix-up in the prover, for no measurable change.
- **#3589** (skip d1 rows in `perm_quot`) — the multiply skip is a real −6.2%,
  but the matching skip in the term construction costs +6.2% and cancels it.

Both d1-skip PRs also stop the prover detecting an invalid witness — that only
surfaces at verification time afterwards.

## Tradeoff

The honest summary is that the wall-clock wins are small in absolute terms.
`perm_quot` is under 2% of a proof, so −20% there is ~0.4% end-to-end, below the
noise floor on my machine. What justifies the change is the memory: −464 MiB of
allocation churn per proof and −24 MiB resident per index, both exact counts
rather than timings.

That's also why the omitted pieces are omitted. They are the ones where the
complexity is real and the measured saving is zero — skipping arithmetic inside
loops that still visit every element does not reduce the bytes moved, and the
per-element branch that buys the skip costs about what it saves.

## Benchmarks

Apple M5 Pro (18 cores), `--release`, Criterion. Timings are medians of runs
alternated between the two branches; memory is exact allocator counts.

| Measured at 2^16 | master | this branch |
|---|---|---|
| `perm_quot` | 36.6 ms | 28.4 ms |
| `DomainConstantEvaluations::create` | 5.9 ms | 5.5 ms |
| Index retained | 611 MB | 586 MB |
| Allocated per proof | 6.49 GB | 6.00 GB |
| Peak heap per proof | 778 MB | 747 MB |

Full suite passes (268 tests); every commit builds independently.
