### PR TITLE
release the witness at its last use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 #### Changed
 
+- Release the prover's `witness` at its last use rather than holding it to
+  end-of-proof. Proofs are unchanged
+  ([#3601](https://github.com/o1-labs/proof-systems/pull/3601))
 - Lower the prover's peak memory by releasing the d8 evaluations once the
   linearization is done, rather than holding them to end-of-proof
   ([#3587](https://github.com/o1-labs/proof-systems/pull/3587))

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -678,6 +678,8 @@ where
         internal_tracing::checkpoint!(internal_traces; z_permutation_aggregation_polynomial);
         let z_poly = index.perm_aggreg(&witness, &beta, &gamma, rng)?;
 
+        drop(witness);
+
         //~ 1. Commit (hiding) to the permutation aggregation polynomial $z$.
         let z_comm = index.srs.commit(&z_poly, num_chunks, rng);
 


### PR DESCRIPTION
`witness` gets passed by value into `create_recursive`, so it sticks around
until the function returns even though nothing reads it after `perm_aggreg`.
Peak memory happens about 200ms later, inside `perm_quot`, so we carry 60 MiB of
dead witness columns straight through the high-water mark.


You can't wrap a block around a function parameter, so a bare `drop` is the
smallest thing that works here. Same situation #3599 ran into.

### Benchmarks

Peak RSS from `/usr/bin/time -l`, peak heap from `dhat`, at 2^16,

| circuit | peak RSS | peak heap |
| --- | --- | --- |
| generic gates | -4.6% | -76 MiB |
| multi-range-check (lookups) | 0% | -60 MiB |

The 60 MiB leaves the live heap in both cases — the allocation site drops out of
dhat's at-peak census.

Timing is unchanged, and the proof bytes are identical before and after on both
circuits with a seeded RNG.
