### PR TITLE
Fused chunked expression evaluation for the prover's quotient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to
 
 #### Added
 
+- `Expr::evaluations_fused`, a fused chunked expression evaluator: compiles
+  the expression to a flat tape and evaluates it in a single pass over
+  cache-resident chunks, eliminating the per-node full-domain intermediate
+  buffers of `Expr::evaluations` while producing bit-identical results. The
+  prover's quotient computation now uses it for the gate, generic, and lookup
+  constraint evaluations
 - A frozen `expr_eval` benchmark for gate-constraint expression evaluation,
   covering every gate type at cache-resident and memory-bound domain sizes
   ([#3603](https://github.com/o1-labs/proof-systems/pull/3603))

--- a/kimchi/Cargo.toml
+++ b/kimchi/Cargo.toml
@@ -86,6 +86,10 @@ name = "expr_eval"
 harness = false
 
 [[bench]]
+name = "expr_eval_fused"
+harness = false
+
+[[bench]]
 name = "proof_criterion_mina"
 harness = false
 

--- a/kimchi/benches/expr_eval_fused.rs
+++ b/kimchi/benches/expr_eval_fused.rs
@@ -1,0 +1,191 @@
+//! Benchmark for the fused chunked expression evaluator, mirroring the
+//! frozen `expr_eval` benchmark case-for-case so `evaluations_fused` can be
+//! compared directly against the legacy `Expr::evaluations` numbers:
+//! same synthetic environment construction, same constraint expressions,
+//! same domain sizes, same case names under the `expr_eval_fused` group.
+//!
+//! Run with `cargo bench -p kimchi --bench expr_eval_fused`.
+
+use ark_ff::UniformRand;
+use ark_poly::{EvaluationDomain, Evaluations, Radix2EvaluationDomain as D};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use kimchi::{
+    alphas::Alphas,
+    circuits::{
+        argument::{Argument, ArgumentType},
+        berkeley_columns::{BerkeleyChallenges, Environment, E},
+        domains::EvaluationDomains,
+        expr::{self, l0_1, Constants},
+        gate::GateType,
+        polynomials::{
+            complete_add::CompleteAdd,
+            endomul_scalar::EndomulScalar,
+            endosclmul::EndosclMul,
+            foreign_field_add::circuitgates::ForeignFieldAdd,
+            foreign_field_mul::circuitgates::ForeignFieldMul,
+            poseidon::Poseidon,
+            range_check::circuitgates::{RangeCheck0, RangeCheck1},
+            rot::Rot64,
+            varbasemul::VarbaseMul,
+            xor::Xor16,
+        },
+        wires::COLUMNS,
+    },
+};
+use mina_curves::pasta::Fp;
+use rand::Rng;
+use std::{array, collections::HashMap};
+
+struct EnvData {
+    domain: EvaluationDomains<Fp>,
+    witness: [Evaluations<Fp, D<Fp>>; COLUMNS],
+    coefficient: [Evaluations<Fp, D<Fp>>; COLUMNS],
+    vanishes: Evaluations<Fp, D<Fp>>,
+    z: Evaluations<Fp, D<Fp>>,
+    selectors: Vec<(GateType, Evaluations<Fp, D<Fp>>)>,
+    alpha: Fp,
+    beta: Fp,
+    gamma: Fp,
+}
+
+fn rand_evals(rng: &mut impl Rng, d: D<Fp>) -> Evaluations<Fp, D<Fp>> {
+    Evaluations::from_vec_and_domain((0..d.size()).map(|_| Fp::rand(rng)).collect(), d)
+}
+
+fn make_env_data(rng: &mut impl Rng, d1_log2: u32) -> EnvData {
+    let domain = EvaluationDomains::<Fp>::create(1 << d1_log2).unwrap();
+    EnvData {
+        domain,
+        witness: array::from_fn(|_| rand_evals(rng, domain.d8)),
+        coefficient: array::from_fn(|_| rand_evals(rng, domain.d8)),
+        vanishes: rand_evals(rng, domain.d8),
+        z: rand_evals(rng, domain.d8),
+        selectors: vec![
+            (GateType::Poseidon, rand_evals(rng, domain.d8)),
+            (GateType::VarBaseMul, rand_evals(rng, domain.d8)),
+            (GateType::EndoMul, rand_evals(rng, domain.d8)),
+            (GateType::EndoMulScalar, rand_evals(rng, domain.d8)),
+            (GateType::CompleteAdd, rand_evals(rng, domain.d4)),
+            (GateType::RangeCheck0, rand_evals(rng, domain.d8)),
+            (GateType::RangeCheck1, rand_evals(rng, domain.d8)),
+            (GateType::ForeignFieldAdd, rand_evals(rng, domain.d8)),
+            (GateType::ForeignFieldMul, rand_evals(rng, domain.d8)),
+            (GateType::Xor16, rand_evals(rng, domain.d8)),
+            (GateType::Rot64, rand_evals(rng, domain.d8)),
+        ],
+        alpha: Fp::rand(rng),
+        beta: Fp::rand(rng),
+        gamma: Fp::rand(rng),
+    }
+}
+
+fn make_env(data: &EnvData) -> Environment<'_, Fp> {
+    let index: HashMap<_, _> = data.selectors.iter().map(|(g, e)| (*g, e)).collect();
+    Environment {
+        witness: &data.witness,
+        coefficient: &data.coefficient,
+        vanishes_on_zero_knowledge_and_previous_rows: &data.vanishes,
+        z: &data.z,
+        index,
+        l0_1: l0_1(data.domain.d1),
+        constants: Constants {
+            endo_coefficient: mina_poseidon::sponge::endo_coefficient::<Fp>(),
+            mds: &mina_poseidon::pasta::fp_kimchi::static_params().mds,
+            zk_rows: 3,
+        },
+        challenges: BerkeleyChallenges {
+            alpha: data.alpha,
+            beta: data.beta,
+            gamma: data.gamma,
+            joint_combiner: Fp::from(0u64),
+        },
+        domain: data.domain,
+        lookup: None,
+    }
+}
+
+fn make_alphas(alpha: Fp) -> Alphas<Fp> {
+    let mut alphas = Alphas::<Fp>::default();
+    alphas.register(
+        ArgumentType::Gate(GateType::Zero),
+        VarbaseMul::<Fp>::CONSTRAINTS,
+    );
+    alphas.instantiate(alpha);
+    alphas
+}
+
+fn gate_exprs(alphas: &Alphas<Fp>) -> Vec<(&'static str, E<Fp>)> {
+    let mut cache = expr::Cache::default();
+    vec![
+        (
+            "poseidon",
+            Poseidon::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "varbase_mul",
+            VarbaseMul::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "endoscl_mul",
+            EndosclMul::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "endomul_scalar",
+            EndomulScalar::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "complete_add",
+            CompleteAdd::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "range_check0",
+            RangeCheck0::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "range_check1",
+            RangeCheck1::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "foreign_field_add",
+            ForeignFieldAdd::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "foreign_field_mul",
+            ForeignFieldMul::combined_constraints(alphas, &mut cache),
+        ),
+        ("xor16", Xor16::combined_constraints(alphas, &mut cache)),
+        ("rot64", Rot64::combined_constraints(alphas, &mut cache)),
+    ]
+}
+
+fn benchmark_expr_eval_fused(c: &mut Criterion) {
+    let mut group = c.benchmark_group("expr_eval_fused");
+    let mut rng = o1_utils::tests::make_test_rng(Some([0u8; 32]));
+
+    for d1_log2 in [10u32, 16] {
+        let data = make_env_data(&mut rng, d1_log2);
+        let env = make_env(&data);
+        let alphas = make_alphas(data.alpha);
+        let exprs = gate_exprs(&alphas);
+
+        if d1_log2 > 12 {
+            group.sample_size(20);
+        }
+        for (name, e) in exprs.iter().take(5) {
+            group.bench_function(format!("evaluations/{name}/{d1_log2}"), |b| {
+                b.iter(|| black_box(e.evaluations_fused(&env)))
+            });
+        }
+        group.bench_function(format!("evaluations/all_gates/{d1_log2}"), |b| {
+            b.iter(|| {
+                for (_, e) in &exprs {
+                    black_box(e.evaluations_fused(&env));
+                }
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_expr_eval_fused);
+criterion_main!(benches);

--- a/kimchi/src/circuits/expr.rs
+++ b/kimchi/src/circuits/expr.rs
@@ -589,7 +589,7 @@ pub enum FeatureFlag {
 }
 
 impl FeatureFlag {
-    fn is_enabled(&self) -> bool {
+    pub(crate) fn is_enabled(&self) -> bool {
         todo!("Handle features")
     }
 }
@@ -1052,7 +1052,7 @@ enum EvalResult<'a, F: FftField> {
 /// = (omega^{q n} omega_8^{r n} - 1) / (omega_8^k - omega^i)
 /// = ((omega_8^n)^r - 1) / (omega_8^k - omega^i)
 /// = ((omega_8^n)^r - 1) / (omega^q omega_8^r - omega^i)
-fn unnormalized_lagrange_evals<
+pub(crate) fn unnormalized_lagrange_evals<
     'a,
     F: FftField,
     ChallengeTerm,
@@ -1908,6 +1908,20 @@ impl<F: FftField, Column: PartialEq + Copy, ChallengeTerm: Copy>
     ) -> Evaluations<F, D<F>> {
         self.evaluate_constants(env).evaluations(env)
     }
+
+    /// Like [`Self::evaluations`], but evaluated with the fused chunked
+    /// evaluator ([`crate::circuits::expr_fused`]): bit-identical result, no
+    /// full-domain intermediate allocations.
+    pub fn evaluations_fused<
+        'a,
+        Challenge: Index<ChallengeTerm, Output = F>,
+        Environment: ColumnEnvironment<'a, F, ChallengeTerm, Challenge, Column = Column> + Sync,
+    >(
+        &self,
+        env: &Environment,
+    ) -> Evaluations<F, D<F>> {
+        self.evaluate_constants(env).evaluations_fused(env)
+    }
 }
 
 /// Use as a result of the expression evaluations routine.
@@ -2025,6 +2039,21 @@ impl<F: FftField, Column: Copy> Expr<F, Column> {
                 })
             }
         }
+    }
+
+    /// Like [`Self::evaluations`], but evaluated with the fused chunked
+    /// evaluator ([`crate::circuits::expr_fused`]): bit-identical result, no
+    /// full-domain intermediate allocations.
+    pub fn evaluations_fused<
+        'a,
+        ChallengeTerm,
+        Challenge: Index<ChallengeTerm, Output = F>,
+        Environment: ColumnEnvironment<'a, F, ChallengeTerm, Challenge, Column = Column> + Sync,
+    >(
+        &self,
+        env: &Environment,
+    ) -> Evaluations<F, D<F>> {
+        crate::circuits::expr_fused::evaluations_fused(self, env)
     }
 
     fn evaluations_helper<

--- a/kimchi/src/circuits/expr_fused.rs
+++ b/kimchi/src/circuits/expr_fused.rs
@@ -618,11 +618,27 @@ where
     let n = res_domain.size();
     let mut out = vec![F::zero(); n];
 
+    // One statically-partitioned task per worker, each with a single scratch
+    // reused across its chunks. Chunks are uniform work (same tape), so
+    // fine-grained work stealing buys nothing here, and `for_each_init`-style
+    // adaptive splitting would re-create the scratch pool per split segment --
+    // measured at hundreds of MB of allocation churn per proof, cancelling
+    // the evaluator's savings over the legacy kernels.
     #[cfg(feature = "parallel")]
-    out.par_chunks_mut(CHUNK).enumerate().for_each_init(
-        || Scratch::new(tape.n_slots, tape.cols.len()),
-        |sc, (ci, chunk)| run_chunk(&tape, ci * CHUNK, chunk, sc),
-    );
+    {
+        let n_chunks = n.div_ceil(CHUNK);
+        let n_tasks = rayon::current_num_threads().clamp(1, n_chunks.max(1));
+        let chunks_per_task = n_chunks.div_ceil(n_tasks);
+        out.par_chunks_mut(CHUNK * chunks_per_task)
+            .enumerate()
+            .for_each(|(ti, task_out)| {
+                let mut sc = Scratch::new(tape.n_slots, tape.cols.len());
+                let base = ti * chunks_per_task * CHUNK;
+                for (ci, chunk) in task_out.chunks_mut(CHUNK).enumerate() {
+                    run_chunk(&tape, base + ci * CHUNK, chunk, &mut sc);
+                }
+            });
+    }
     #[cfg(not(feature = "parallel"))]
     {
         let mut sc = Scratch::new(tape.n_slots, tape.cols.len());

--- a/kimchi/src/circuits/expr_fused.rs
+++ b/kimchi/src/circuits/expr_fused.rs
@@ -1,0 +1,635 @@
+//! Fused, chunked evaluation of constraint expressions over a domain.
+//!
+//! [`Expr::evaluations`](crate::circuits::expr::Expr::evaluations) walks the
+//! expression tree materializing a full-domain evaluation vector per node: at
+//! d1 = 2^14 the five always-on gate constraints allocate ~186 fresh 4 MiB
+//! intermediates per proof, and every node is its own parallel kernel launch.
+//! This module instead compiles the expression once into a flat RPN tape with
+//! pre-resolved column references, then evaluates the whole tape in a single
+//! pass over fixed-size chunks. Each worker keeps a small scratch pool of
+//! chunk-sized buffers, so no full-domain intermediates are ever allocated
+//! and each chunk's working set stays cache-resident.
+//!
+//! The result is bit-identical to `Expr::evaluations`: the same domain is
+//! selected from the expression degree, and field operations are performed in
+//! the same order per point (verified against the legacy evaluator on every
+//! gate type, and end-to-end on full quotient polynomials).
+//!
+//! Design notes, grounded in paired measurements against the legacy
+//! evaluator on the gate constraints:
+//!
+//! - The win is removing per-node full-domain passes (memory traffic and
+//!   kernel-launch overhead); the field-operation count per point is
+//!   unchanged. Measured 1.5-2.7x per gate depending on domain size.
+//! - Column gathers are deduplicated: every occurrence of the same column
+//!   with the same stride and shift shares one per-chunk gather.
+//! - Evaluating a *sum* of gate constraints in one pass measures the same as
+//!   evaluating the gates separately: the executor is compute-bound, so
+//!   callers should keep the natural one-expression-per-gate structure.
+
+use crate::{
+    circuits::{
+        domains::Domain,
+        expr::{
+            unnormalized_lagrange_evals, CacheId, ColumnEnvironment, Expr, ExprInner, Operations,
+            Variable,
+        },
+    },
+    collections::HashMap,
+};
+use alloc::{vec, vec::Vec};
+use ark_ff::FftField;
+use ark_poly::{EvaluationDomain, Evaluations, Radix2EvaluationDomain as D};
+use core::ops::Index;
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+/// Rows evaluated per tape execution. At 32 bytes per field element a chunk
+/// buffer is 128 KiB, so a tape's working set (a few operand buffers plus the
+/// gathered columns it references) stays L2-resident. Swept on the gate
+/// constraints: 1024-8192 measures flat, matching the plateau found for the
+/// legacy kernels' parallelism grain.
+const CHUNK: usize = 1 << 12;
+
+/// A column reference with everything needed to gather a chunk of its
+/// evaluations into the result domain, resolved at compile time.
+struct ColRef<'t, F: FftField> {
+    evals: &'t Evaluations<F, D<F>>,
+    /// `column_domain / result_domain` (the legacy kernels' `scale`)
+    scale: usize,
+    /// `column_domain * row_shift`, the constant index offset
+    offset: usize,
+    /// `evals.len() - 1`; the column lives over a radix-2 domain, so the
+    /// wrap-around is a bitmask (the legacy kernels' `mod_pow2`)
+    mask: usize,
+}
+
+enum Tok<F> {
+    Scalar(F),
+    /// Push a chunk of `cols[i]`, gathered once per chunk and shared by every
+    /// occurrence of the column in the tape
+    Col(usize),
+    Add,
+    Sub,
+    Mul,
+    Square,
+    Double,
+    Pow(u64),
+    /// Move the top of stack into cache slot `i` (leaves a reference on the
+    /// stack)
+    Store(usize),
+    /// Push a read-only reference to cache slot `i`
+    Load(usize),
+}
+
+struct Tape<'t, F: FftField> {
+    toks: Vec<Tok<F>>,
+    cols: Vec<ColRef<'t, F>>,
+    n_slots: usize,
+}
+
+impl<'t, F: FftField> Tape<'t, F> {
+    /// Deduplicated column registration: every occurrence of the same
+    /// underlying evaluation vector with the same stride and shift shares one
+    /// `cols` entry, so the executor gathers it once per chunk instead of
+    /// once per occurrence.
+    fn col_index(&mut self, evals: &'t Evaluations<F, D<F>>, scale: usize, offset: usize) -> usize {
+        if let Some(i) = self
+            .cols
+            .iter()
+            .position(|c| core::ptr::eq(c.evals, evals) && c.scale == scale && c.offset == offset)
+        {
+            return i;
+        }
+        let m = evals.evals.len();
+        assert!(m.is_power_of_two());
+        self.cols.push(ColRef {
+            evals,
+            scale,
+            offset,
+            mask: m - 1,
+        });
+        self.cols.len() - 1
+    }
+}
+
+/// Collect the distinct (renormalized) row offsets of every
+/// `UnnormalizedLagrangeBasis` atom reachable in the expression, so their
+/// evaluation vectors can be materialized once before the tape is compiled.
+fn collect_lagrange_offsets<F, Column>(e: &Expr<F, Column>, zk_rows: u64, out: &mut Vec<i32>) {
+    use Operations::*;
+    match e {
+        Atom(ExprInner::UnnormalizedLagrangeBasis(row)) => {
+            let offset = if row.zk_rows {
+                -(zk_rows as i32) + row.offset
+            } else {
+                row.offset
+            };
+            if !out.contains(&offset) {
+                out.push(offset);
+            }
+        }
+        Atom(_) => {}
+        Add(e1, e2) | Sub(e1, e2) | Mul(e1, e2) => {
+            collect_lagrange_offsets(e1, zk_rows, out);
+            collect_lagrange_offsets(e2, zk_rows, out);
+        }
+        Square(x) | Double(x) | Pow(x, _) | Cache(_, x) => {
+            collect_lagrange_offsets(x, zk_rows, out)
+        }
+        IfFeature(feature, e1, e2) => {
+            if feature.is_enabled() {
+                collect_lagrange_offsets(e1, zk_rows, out)
+            } else {
+                collect_lagrange_offsets(e2, zk_rows, out)
+            }
+        }
+    }
+}
+
+fn compile<'t, 'a: 't, F, ChallengeTerm, Challenge, Environment, Column>(
+    e: &Expr<F, Column>,
+    env: &Environment,
+    res_domain: Domain,
+    lagrange: &'t [(i32, Evaluations<F, D<F>>)],
+    tape: &mut Tape<'t, F>,
+    slots: &mut HashMap<CacheId, usize>,
+) where
+    F: FftField,
+    Column: Copy,
+    Challenge: Index<ChallengeTerm, Output = F>,
+    Environment: ColumnEnvironment<'a, F, ChallengeTerm, Challenge, Column = Column>,
+{
+    use Operations::*;
+    match e {
+        Atom(ExprInner::Constant(x)) => tape.toks.push(Tok::Scalar(*x)),
+        Atom(ExprInner::Cell(Variable { col, row })) => match env.get_column(col) {
+            None => tape.toks.push(Tok::Scalar(F::zero())),
+            Some(evals) => {
+                let d_sub = env.column_domain(col) as usize;
+                let scale = d_sub / (res_domain as usize);
+                assert!(scale != 0, "column domain smaller than result domain");
+                let i = tape.col_index(evals, scale, d_sub * row.shift());
+                tape.toks.push(Tok::Col(i));
+            }
+        },
+        Atom(ExprInner::VanishesOnZeroKnowledgeAndPreviousRows) => {
+            let evals = env.vanishes_on_zero_knowledge_and_previous_rows();
+            let d_sub = Domain::D8 as usize;
+            let scale = d_sub / (res_domain as usize);
+            assert!(scale != 0, "column domain smaller than result domain");
+            let i = tape.col_index(evals, scale, 0);
+            tape.toks.push(Tok::Col(i));
+        }
+        Atom(ExprInner::UnnormalizedLagrangeBasis(row)) => {
+            let zk_rows = env.get_constants().zk_rows;
+            let offset = if row.zk_rows {
+                -(zk_rows as i32) + row.offset
+            } else {
+                row.offset
+            };
+            let evals = lagrange
+                .iter()
+                .find(|(o, _)| *o == offset)
+                .map(|(_, e)| e)
+                .expect("lagrange basis evaluations materialized in the prepass");
+            // materialized directly at the result domain: unit stride, no shift
+            let i = tape.col_index(evals, 1, 0);
+            tape.toks.push(Tok::Col(i));
+        }
+        Add(e1, e2) => {
+            compile(e1, env, res_domain, lagrange, tape, slots);
+            compile(e2, env, res_domain, lagrange, tape, slots);
+            tape.toks.push(Tok::Add);
+        }
+        Sub(e1, e2) => {
+            compile(e1, env, res_domain, lagrange, tape, slots);
+            compile(e2, env, res_domain, lagrange, tape, slots);
+            tape.toks.push(Tok::Sub);
+        }
+        Mul(e1, e2) => {
+            compile(e1, env, res_domain, lagrange, tape, slots);
+            compile(e2, env, res_domain, lagrange, tape, slots);
+            tape.toks.push(Tok::Mul);
+        }
+        Square(x) => {
+            compile(x, env, res_domain, lagrange, tape, slots);
+            tape.toks.push(Tok::Square);
+        }
+        Double(x) => {
+            compile(x, env, res_domain, lagrange, tape, slots);
+            tape.toks.push(Tok::Double);
+        }
+        Pow(x, p) => {
+            compile(x, env, res_domain, lagrange, tape, slots);
+            tape.toks.push(Tok::Pow(*p));
+        }
+        Cache(id, x) => match slots.get(id) {
+            Some(s) => tape.toks.push(Tok::Load(*s)),
+            None => {
+                compile(x, env, res_domain, lagrange, tape, slots);
+                let s = tape.n_slots;
+                tape.n_slots += 1;
+                slots.insert(*id, s);
+                tape.toks.push(Tok::Store(s));
+            }
+        },
+        IfFeature(feature, e1, e2) => {
+            if feature.is_enabled() {
+                compile(e1, env, res_domain, lagrange, tape, slots)
+            } else {
+                compile(e2, env, res_domain, lagrange, tape, slots)
+            }
+        }
+    }
+}
+
+/// A value on the evaluation stack: a scalar, an owned scratch buffer
+/// (index into the pool), a read-only cache slot reference, or a read-only
+/// gathered-column reference.
+#[derive(Clone, Copy)]
+enum Val<F> {
+    Scalar(F),
+    Buf(usize),
+    Slot(usize),
+    Col(usize),
+}
+
+/// Per-slot storage for one chunk.
+#[derive(Clone, Copy)]
+enum SlotVal<F> {
+    Empty,
+    Scalar(F),
+    /// Pool buffer owned by the slot for the duration of the chunk
+    Buf(usize),
+}
+
+struct Scratch<F> {
+    pool: Vec<Vec<F>>,
+    free: Vec<usize>,
+    slots: Vec<SlotVal<F>>,
+    /// Per-chunk lazily gathered column buffers (pool indices), shared by
+    /// every occurrence of the column in the tape
+    col_cache: Vec<Option<usize>>,
+    stack: Vec<Val<F>>,
+}
+
+impl<F: FftField> Scratch<F> {
+    fn new(n_slots: usize, n_cols: usize) -> Self {
+        Scratch {
+            pool: vec![],
+            free: vec![],
+            slots: vec![SlotVal::Empty; n_slots],
+            col_cache: vec![None; n_cols],
+            stack: vec![],
+        }
+    }
+
+    fn reset(&mut self) {
+        self.free = (0..self.pool.len()).collect();
+        self.slots.iter_mut().for_each(|s| *s = SlotVal::Empty);
+        self.col_cache.iter_mut().for_each(|c| *c = None);
+        self.stack.clear();
+    }
+
+    /// A free buffer, never aliasing a live (non-freed) buffer.
+    fn alloc(&mut self) -> usize {
+        match self.free.pop() {
+            Some(i) => i,
+            None => {
+                self.pool.push(vec![F::zero(); CHUNK]);
+                self.pool.len() - 1
+            }
+        }
+    }
+
+    /// Copy a (possibly borrowed) buffer into a fresh owned one.
+    fn copy_into_owned(&mut self, src: usize, len: usize) -> usize {
+        let dst = self.alloc();
+        let (d, s) = two_bufs(&mut self.pool, dst, src);
+        d[..len].copy_from_slice(&s[..len]);
+        dst
+    }
+
+    /// Resolve a stack value to (pool index, owned-by-stack).
+    fn resolve(&self, v: Val<F>) -> Option<(usize, bool)> {
+        match v {
+            Val::Scalar(_) => None,
+            Val::Buf(i) => Some((i, true)),
+            Val::Slot(s) => match self.slots[s] {
+                SlotVal::Buf(i) => Some((i, false)),
+                _ => unreachable!("slot used before store"),
+            },
+            Val::Col(c) => Some((self.col_cache[c].expect("column used before gather"), false)),
+        }
+    }
+}
+
+/// Two distinct pool buffers, first mutable and second shared.
+fn two_bufs<F>(pool: &mut [Vec<F>], dst: usize, src: usize) -> (&mut Vec<F>, &Vec<F>) {
+    assert_ne!(dst, src);
+    if dst < src {
+        let (a, b) = pool.split_at_mut(src);
+        (&mut a[dst], &b[0])
+    } else {
+        let (a, b) = pool.split_at_mut(dst);
+        (&mut b[0], &a[src])
+    }
+}
+
+fn unary<F: FftField>(
+    sc: &mut Scratch<F>,
+    a: Val<F>,
+    len: usize,
+    scalar_op: impl Fn(F) -> F,
+    buf_op: impl Fn(&mut F),
+) -> Val<F> {
+    match sc.resolve(a) {
+        None => match a {
+            Val::Scalar(x) => Val::Scalar(scalar_op(x)),
+            _ => unreachable!(),
+        },
+        Some((i, owned)) => {
+            let i = if owned { i } else { sc.copy_into_owned(i, len) };
+            sc.pool[i][..len].iter_mut().for_each(&buf_op);
+            Val::Buf(i)
+        }
+    }
+}
+
+fn binary<F: FftField>(
+    sc: &mut Scratch<F>,
+    op: &Tok<F>,
+    a: Val<F>,
+    b: Val<F>,
+    len: usize,
+) -> Val<F> {
+    #[inline]
+    fn apply<F: FftField>(op: &Tok<F>, x: F, y: F) -> F {
+        match op {
+            Tok::Add => x + y,
+            Tok::Sub => x - y,
+            Tok::Mul => x * y,
+            _ => unreachable!(),
+        }
+    }
+    match (sc.resolve(a), sc.resolve(b)) {
+        (None, None) => match (a, b) {
+            (Val::Scalar(x), Val::Scalar(y)) => Val::Scalar(apply(op, x, y)),
+            _ => unreachable!(),
+        },
+        // scalar (op) buffer
+        (None, Some((i, owned))) => {
+            let x = match a {
+                Val::Scalar(x) => x,
+                _ => unreachable!(),
+            };
+            let i = if owned { i } else { sc.copy_into_owned(i, len) };
+            sc.pool[i][..len]
+                .iter_mut()
+                .for_each(|e| *e = apply(op, x, *e));
+            Val::Buf(i)
+        }
+        // buffer (op) scalar
+        (Some((i, owned)), None) => {
+            let y = match b {
+                Val::Scalar(y) => y,
+                _ => unreachable!(),
+            };
+            let i = if owned { i } else { sc.copy_into_owned(i, len) };
+            sc.pool[i][..len]
+                .iter_mut()
+                .for_each(|e| *e = apply(op, *e, y));
+            Val::Buf(i)
+        }
+        (Some((ia, a_owned)), Some((ib, b_owned))) => {
+            if ia == ib {
+                // same underlying buffer, e.g. Load(s) op Load(s)
+                let j = sc.alloc();
+                let (dst, src) = two_bufs(&mut sc.pool, j, ia);
+                for (o, e) in dst[..len].iter_mut().zip(&src[..len]) {
+                    *o = apply(op, *e, *e);
+                }
+                Val::Buf(j)
+            } else if a_owned {
+                let (dst, src) = two_bufs(&mut sc.pool, ia, ib);
+                for (o, e) in dst[..len].iter_mut().zip(&src[..len]) {
+                    *o = apply(op, *o, *e);
+                }
+                if b_owned {
+                    sc.free.push(ib);
+                }
+                Val::Buf(ia)
+            } else if b_owned {
+                let (dst, src) = two_bufs(&mut sc.pool, ib, ia);
+                for (o, e) in dst[..len].iter_mut().zip(&src[..len]) {
+                    *o = apply(op, *e, *o);
+                }
+                Val::Buf(ib)
+            } else {
+                // both borrowed: copy a, then fold b in
+                let j = sc.copy_into_owned(ia, len);
+                let (dst, src) = two_bufs(&mut sc.pool, j, ib);
+                for (o, e) in dst[..len].iter_mut().zip(&src[..len]) {
+                    *o = apply(op, *o, *e);
+                }
+                Val::Buf(j)
+            }
+        }
+    }
+}
+
+fn pow<F: FftField>(sc: &mut Scratch<F>, a: Val<F>, p: u64, len: usize) -> Val<F> {
+    if p == 0 {
+        return Val::Scalar(F::one());
+    }
+    if let Val::Scalar(x) = a {
+        return Val::Scalar(x.pow([p]));
+    }
+    let base = match sc.resolve(a) {
+        Some((i, true)) => i,
+        Some((i, false)) => sc.copy_into_owned(i, len),
+        None => unreachable!(),
+    };
+    if p == 1 {
+        return Val::Buf(base);
+    }
+    // acc = base, then square-and-multiply over the remaining bits
+    let acc = sc.copy_into_owned(base, len);
+    let bits = 64 - p.leading_zeros();
+    for k in (0..bits - 1).rev() {
+        sc.pool[acc][..len].iter_mut().for_each(|e| {
+            e.square_in_place();
+        });
+        if (p >> k) & 1 == 1 {
+            let (dst, src) = two_bufs(&mut sc.pool, acc, base);
+            for (o, e) in dst[..len].iter_mut().zip(&src[..len]) {
+                *o *= *e;
+            }
+        }
+    }
+    sc.free.push(base);
+    Val::Buf(acc)
+}
+
+fn run_chunk<F: FftField>(tape: &Tape<F>, chunk_start: usize, out: &mut [F], sc: &mut Scratch<F>) {
+    let len = out.len();
+    sc.reset();
+
+    for tok in &tape.toks {
+        match tok {
+            Tok::Scalar(x) => sc.stack.push(Val::Scalar(*x)),
+            Tok::Col(c) => {
+                if sc.col_cache[*c].is_none() {
+                    let col = &tape.cols[*c];
+                    let src = &col.evals.evals;
+                    let base = col.scale * chunk_start + col.offset;
+                    let i = sc.alloc();
+                    let buf = &mut sc.pool[i];
+                    for (j, b) in buf[..len].iter_mut().enumerate() {
+                        *b = src[(base + col.scale * j) & col.mask];
+                    }
+                    sc.col_cache[*c] = Some(i);
+                }
+                sc.stack.push(Val::Col(*c));
+            }
+            Tok::Add | Tok::Sub | Tok::Mul => {
+                let b = sc.stack.pop().unwrap();
+                let a = sc.stack.pop().unwrap();
+                let r = binary(sc, tok, a, b, len);
+                sc.stack.push(r);
+            }
+            Tok::Square => {
+                let a = sc.stack.pop().unwrap();
+                let r = unary(
+                    sc,
+                    a,
+                    len,
+                    |x| x.square(),
+                    |x| {
+                        x.square_in_place();
+                    },
+                );
+                sc.stack.push(r);
+            }
+            Tok::Double => {
+                let a = sc.stack.pop().unwrap();
+                let r = unary(
+                    sc,
+                    a,
+                    len,
+                    |x| x.double(),
+                    |x| {
+                        x.double_in_place();
+                    },
+                );
+                sc.stack.push(r);
+            }
+            Tok::Pow(p) => {
+                let a = sc.stack.pop().unwrap();
+                let r = pow(sc, a, *p, len);
+                sc.stack.push(r);
+            }
+            Tok::Store(s) => {
+                let v = sc.stack.pop().unwrap();
+                match v {
+                    Val::Scalar(x) => {
+                        sc.slots[*s] = SlotVal::Scalar(x);
+                        sc.stack.push(Val::Scalar(x));
+                    }
+                    Val::Buf(i) => {
+                        // the slot takes ownership of the buffer
+                        sc.slots[*s] = SlotVal::Buf(i);
+                        sc.stack.push(Val::Slot(*s));
+                    }
+                    Val::Slot(other) => {
+                        // cache of a cache: share the same storage
+                        sc.slots[*s] = sc.slots[other];
+                        sc.stack.push(Val::Slot(*s));
+                    }
+                    Val::Col(c) => {
+                        // cache of a bare column: share its gathered buffer
+                        sc.slots[*s] =
+                            SlotVal::Buf(sc.col_cache[c].expect("column used before gather"));
+                        sc.stack.push(Val::Slot(*s));
+                    }
+                }
+            }
+            Tok::Load(s) => match sc.slots[*s] {
+                SlotVal::Scalar(x) => sc.stack.push(Val::Scalar(x)),
+                SlotVal::Buf(_) => sc.stack.push(Val::Slot(*s)),
+                SlotVal::Empty => unreachable!("load before store"),
+            },
+        }
+    }
+
+    let top = sc.stack.pop().unwrap();
+    assert!(sc.stack.is_empty(), "unbalanced tape");
+    match sc.resolve(top) {
+        None => match top {
+            Val::Scalar(x) => out.iter_mut().for_each(|o| *o = x),
+            _ => unreachable!(),
+        },
+        Some((i, _)) => out.copy_from_slice(&sc.pool[i][..len]),
+    }
+}
+
+/// Fused equivalent of [`Expr::evaluations`]: same domain selection,
+/// bit-identical result, no full-domain intermediates.
+pub fn evaluations_fused<'a, F, ChallengeTerm, Challenge, Environment, Column>(
+    e: &Expr<F, Column>,
+    env: &Environment,
+) -> Evaluations<F, D<F>>
+where
+    F: FftField,
+    Column: Copy,
+    Challenge: Index<ChallengeTerm, Output = F>,
+    Environment: ColumnEnvironment<'a, F, ChallengeTerm, Challenge, Column = Column> + Sync,
+{
+    let d1_size = env.get_domain(Domain::D1).size;
+    let deg = e.degree(d1_size, env.get_constants().zk_rows);
+    let d = if deg <= d1_size {
+        Domain::D1
+    } else if deg <= 4 * d1_size {
+        Domain::D4
+    } else if deg <= 8 * d1_size {
+        Domain::D8
+    } else {
+        panic!("constraint had degree {deg} > d8 ({})", 8 * d1_size);
+    };
+    let res_domain = env.get_domain(d);
+
+    // materialize the unnormalized lagrange basis columns the expression
+    // uses (usually none) so the tape can reference them like any column
+    let mut lag_offsets = vec![];
+    collect_lagrange_offsets(e, env.get_constants().zk_rows, &mut lag_offsets);
+    let lagrange: Vec<(i32, Evaluations<F, D<F>>)> = lag_offsets
+        .into_iter()
+        .map(|i| (i, unnormalized_lagrange_evals(env.l0_1(), i, d, env)))
+        .collect();
+
+    let mut tape = Tape {
+        toks: vec![],
+        cols: vec![],
+        n_slots: 0,
+    };
+    compile(e, env, d, &lagrange, &mut tape, &mut HashMap::new());
+
+    let n = res_domain.size();
+    let mut out = vec![F::zero(); n];
+
+    #[cfg(feature = "parallel")]
+    out.par_chunks_mut(CHUNK).enumerate().for_each_init(
+        || Scratch::new(tape.n_slots, tape.cols.len()),
+        |sc, (ci, chunk)| run_chunk(&tape, ci * CHUNK, chunk, sc),
+    );
+    #[cfg(not(feature = "parallel"))]
+    {
+        let mut sc = Scratch::new(tape.n_slots, tape.cols.len());
+        for (ci, chunk) in out.chunks_mut(CHUNK).enumerate() {
+            run_chunk(&tape, ci * CHUNK, chunk, &mut sc);
+        }
+    }
+
+    Evaluations::<F, D<F>>::from_vec_and_domain(out, res_domain)
+}

--- a/kimchi/src/circuits/mod.rs
+++ b/kimchi/src/circuits/mod.rs
@@ -7,6 +7,7 @@ pub mod constraints;
 pub mod domain_constant_evaluation;
 pub mod domains;
 pub mod expr;
+pub mod expr_fused;
 pub mod gate;
 pub mod lookup;
 pub mod polynomial;

--- a/kimchi/src/prover.rs
+++ b/kimchi/src/prover.rs
@@ -796,7 +796,7 @@ where
             let mut t4 = {
                 let generic_constraint =
                     generic::Generic::combined_constraints(&all_alphas, &mut cache);
-                let generic4 = generic_constraint.evaluations(&env);
+                let generic4 = generic_constraint.evaluations_fused(&env);
 
                 if cfg!(debug_assertions) {
                     let p4 = public_poly.evaluate_over_domain_by_ref(index.cs.domain.d4);
@@ -859,7 +859,7 @@ where
                 .filter_map(|(gate, is_enabled)| if is_enabled { Some(gate) } else { None })
                 {
                     let constraint = gate.combined_constraints(&all_alphas, &mut cache);
-                    let eval = constraint.evaluations(&env);
+                    let eval = constraint.evaluations_fused(&env);
                     if eval.domain().size == t4.domain().size {
                         t4 += &eval;
                     } else if eval.domain().size == t8.domain().size {
@@ -885,7 +885,7 @@ where
                     for (ii, (constraint, alpha_pow)) in
                         constraints.into_iter().zip_eq(lookup_alphas).enumerate()
                     {
-                        let mut eval = constraint.evaluations(&env);
+                        let mut eval = constraint.evaluations_fused(&env);
                         eval.evals.par_iter_mut().for_each(|x| *x *= alpha_pow);
 
                         if eval.domain().size == t4.domain().size {

--- a/kimchi/src/tests/expr_fused.rs
+++ b/kimchi/src/tests/expr_fused.rs
@@ -1,0 +1,271 @@
+//! Equivalence tests for the fused chunked expression evaluator:
+//! `Expr::evaluations_fused` must produce bit-identical results to the
+//! legacy `Expr::evaluations` on every gate-constraint expression and on
+//! targeted expressions covering the node types the gates do not exercise.
+
+use crate::{
+    alphas::Alphas,
+    circuits::{
+        argument::{Argument, ArgumentType},
+        berkeley_columns::{BerkeleyChallenges, Column, Environment, E},
+        domains::EvaluationDomains,
+        expr::{self, l0_1, Constants, Expr, ExprInner, Operations, RowOffset, Variable},
+        gate::{CurrOrNext, GateType},
+        polynomials::{
+            complete_add::CompleteAdd,
+            endomul_scalar::EndomulScalar,
+            endosclmul::EndosclMul,
+            foreign_field_add::circuitgates::ForeignFieldAdd,
+            foreign_field_mul::circuitgates::ForeignFieldMul,
+            poseidon::Poseidon,
+            range_check::circuitgates::{RangeCheck0, RangeCheck1},
+            rot::Rot64,
+            varbasemul::VarbaseMul,
+            xor::Xor16,
+        },
+        wires::COLUMNS,
+    },
+};
+use ark_ff::UniformRand;
+use ark_poly::{EvaluationDomain, Evaluations, Radix2EvaluationDomain as D};
+use mina_curves::pasta::Fp;
+use rand::Rng;
+use std::{array, collections::HashMap};
+
+struct EnvData {
+    domain: EvaluationDomains<Fp>,
+    witness: [Evaluations<Fp, D<Fp>>; COLUMNS],
+    coefficient: [Evaluations<Fp, D<Fp>>; COLUMNS],
+    vanishes: Evaluations<Fp, D<Fp>>,
+    z: Evaluations<Fp, D<Fp>>,
+    selectors: Vec<(GateType, Evaluations<Fp, D<Fp>>)>,
+    alpha: Fp,
+    beta: Fp,
+    gamma: Fp,
+}
+
+fn rand_evals(rng: &mut impl Rng, d: D<Fp>) -> Evaluations<Fp, D<Fp>> {
+    Evaluations::from_vec_and_domain((0..d.size()).map(|_| Fp::rand(rng)).collect(), d)
+}
+
+fn make_env_data(rng: &mut impl Rng, d1_log2: u32) -> EnvData {
+    let domain = EvaluationDomains::<Fp>::create(1 << d1_log2).unwrap();
+    EnvData {
+        domain,
+        witness: array::from_fn(|_| rand_evals(rng, domain.d8)),
+        coefficient: array::from_fn(|_| rand_evals(rng, domain.d8)),
+        vanishes: rand_evals(rng, domain.d8),
+        z: rand_evals(rng, domain.d8),
+        selectors: vec![
+            (GateType::Poseidon, rand_evals(rng, domain.d8)),
+            (GateType::VarBaseMul, rand_evals(rng, domain.d8)),
+            (GateType::EndoMul, rand_evals(rng, domain.d8)),
+            (GateType::EndoMulScalar, rand_evals(rng, domain.d8)),
+            (GateType::CompleteAdd, rand_evals(rng, domain.d4)),
+            (GateType::RangeCheck0, rand_evals(rng, domain.d8)),
+            (GateType::RangeCheck1, rand_evals(rng, domain.d8)),
+            (GateType::ForeignFieldAdd, rand_evals(rng, domain.d8)),
+            (GateType::ForeignFieldMul, rand_evals(rng, domain.d8)),
+            (GateType::Xor16, rand_evals(rng, domain.d8)),
+            (GateType::Rot64, rand_evals(rng, domain.d8)),
+        ],
+        alpha: Fp::rand(rng),
+        beta: Fp::rand(rng),
+        gamma: Fp::rand(rng),
+    }
+}
+
+fn make_env(data: &EnvData) -> Environment<'_, Fp> {
+    let index: HashMap<_, _> = data.selectors.iter().map(|(g, e)| (*g, e)).collect();
+    Environment {
+        witness: &data.witness,
+        coefficient: &data.coefficient,
+        vanishes_on_zero_knowledge_and_previous_rows: &data.vanishes,
+        z: &data.z,
+        index,
+        l0_1: l0_1(data.domain.d1),
+        constants: Constants {
+            endo_coefficient: mina_poseidon::sponge::endo_coefficient::<Fp>(),
+            mds: &mina_poseidon::pasta::fp_kimchi::static_params().mds,
+            zk_rows: 3,
+        },
+        challenges: BerkeleyChallenges {
+            alpha: data.alpha,
+            beta: data.beta,
+            gamma: data.gamma,
+            joint_combiner: Fp::from(0u64),
+        },
+        domain: data.domain,
+        lookup: None,
+    }
+}
+
+fn gate_exprs(alphas: &Alphas<Fp>) -> Vec<(&'static str, E<Fp>)> {
+    let mut cache = expr::Cache::default();
+    vec![
+        (
+            "poseidon",
+            Poseidon::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "varbase_mul",
+            VarbaseMul::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "endoscl_mul",
+            EndosclMul::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "endomul_scalar",
+            EndomulScalar::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "complete_add",
+            CompleteAdd::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "range_check0",
+            RangeCheck0::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "range_check1",
+            RangeCheck1::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "foreign_field_add",
+            ForeignFieldAdd::combined_constraints(alphas, &mut cache),
+        ),
+        (
+            "foreign_field_mul",
+            ForeignFieldMul::combined_constraints(alphas, &mut cache),
+        ),
+        ("xor16", Xor16::combined_constraints(alphas, &mut cache)),
+        ("rot64", Rot64::combined_constraints(alphas, &mut cache)),
+    ]
+}
+
+/// Every gate-constraint expression evaluates identically under the legacy
+/// and fused evaluators, at a sub-chunk domain (partial final chunk) and a
+/// multi-chunk domain.
+#[test]
+fn fused_matches_legacy_on_gate_constraints() {
+    let mut rng = o1_utils::tests::make_test_rng(Some([1u8; 32]));
+    for d1_log2 in [6u32, 10] {
+        let data = make_env_data(&mut rng, d1_log2);
+        let env = make_env(&data);
+        let mut alphas = Alphas::<Fp>::default();
+        alphas.register(
+            ArgumentType::Gate(GateType::Zero),
+            VarbaseMul::<Fp>::CONSTRAINTS,
+        );
+        alphas.instantiate(data.alpha);
+
+        for (name, e) in gate_exprs(&alphas) {
+            let legacy = e.evaluations(&env);
+            let fused = e.evaluations_fused(&env);
+            assert_eq!(
+                legacy.domain(),
+                fused.domain(),
+                "{name} domain (2^{d1_log2})"
+            );
+            assert_eq!(legacy.evals, fused.evals, "{name} evals (2^{d1_log2})");
+        }
+    }
+}
+
+/// Targeted expressions for node types the gate constraints do not reach:
+/// `UnnormalizedLagrangeBasis` (all offset shapes),
+/// `VanishesOnZeroKnowledgeAndPreviousRows`, `Pow` edge exponents, `Double`,
+/// and constant-only results.
+#[test]
+fn fused_matches_legacy_on_targeted_expressions() {
+    type FE = Expr<Fp, Column>;
+
+    fn cell(i: usize, row: CurrOrNext) -> FE {
+        Operations::Atom(ExprInner::Cell(Variable {
+            col: Column::Witness(i),
+            row,
+        }))
+    }
+    fn lagrange(zk_rows: bool, offset: i32) -> FE {
+        Operations::Atom(ExprInner::UnnormalizedLagrangeBasis(RowOffset {
+            zk_rows,
+            offset,
+        }))
+    }
+    fn constant(x: u64) -> FE {
+        Operations::Atom(ExprInner::Constant(Fp::from(x)))
+    }
+    fn add(a: FE, b: FE) -> FE {
+        Operations::Add(Box::new(a), Box::new(b))
+    }
+    fn sub(a: FE, b: FE) -> FE {
+        Operations::Sub(Box::new(a), Box::new(b))
+    }
+    fn mul(a: FE, b: FE) -> FE {
+        Operations::Mul(Box::new(a), Box::new(b))
+    }
+    fn pow(a: FE, p: u64) -> FE {
+        Operations::Pow(Box::new(a), p)
+    }
+    fn double(a: FE) -> FE {
+        Operations::Double(Box::new(a))
+    }
+    fn square(a: FE) -> FE {
+        Operations::Square(Box::new(a))
+    }
+    let vanishes: FE = Operations::Atom(ExprInner::VanishesOnZeroKnowledgeAndPreviousRows);
+
+    let cases: Vec<(&'static str, FE)> = vec![
+        (
+            "cell_product",
+            mul(cell(0, CurrOrNext::Curr), cell(1, CurrOrNext::Next)),
+        ),
+        (
+            "lagrange_offsets",
+            add(
+                add(lagrange(false, 0), lagrange(false, 3)),
+                add(lagrange(false, -1), lagrange(true, 0)),
+            ),
+        ),
+        (
+            "lagrange_times_cell",
+            mul(lagrange(true, -1), cell(2, CurrOrNext::Curr)),
+        ),
+        (
+            "vanishes_times_cell",
+            mul(vanishes, cell(3, CurrOrNext::Curr)),
+        ),
+        ("pow_zero", pow(cell(4, CurrOrNext::Curr), 0)),
+        ("pow_one", pow(cell(4, CurrOrNext::Curr), 1)),
+        ("pow_five", pow(cell(4, CurrOrNext::Curr), 5)),
+        (
+            "double_square",
+            double(square(sub(cell(5, CurrOrNext::Curr), constant(7)))),
+        ),
+        (
+            "constant_only",
+            add(constant(3), mul(constant(4), constant(5))),
+        ),
+        (
+            "scalar_buffer_mix",
+            sub(constant(11), mul(constant(2), cell(6, CurrOrNext::Next))),
+        ),
+    ];
+
+    let mut rng = o1_utils::tests::make_test_rng(Some([2u8; 32]));
+    for d1_log2 in [6u32, 10] {
+        let data = make_env_data(&mut rng, d1_log2);
+        let env = make_env(&data);
+        for (name, e) in &cases {
+            let legacy = e.evaluations(&env);
+            let fused = e.evaluations_fused(&env);
+            assert_eq!(
+                legacy.domain(),
+                fused.domain(),
+                "{name} domain (2^{d1_log2})"
+            );
+            assert_eq!(legacy.evals, fused.evals, "{name} evals (2^{d1_log2})");
+        }
+    }
+}

--- a/kimchi/src/tests/mod.rs
+++ b/kimchi/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod chunked;
 mod ec;
 mod endomul;
 mod endomul_scalar;
+mod expr_fused;
 mod foreign_field_add;
 mod foreign_field_mul;
 mod framework;


### PR DESCRIPTION
**Gate-constraint expression evaluation is a further 1.5-3.4x faster on top of #3603, and per-proof allocation drops 18-39% — with bit-identical evaluations.**

Stacked on #3603 (`perf/expr-eval`); draft until that lands and an end-to-end `proof_criterion` A/B is re-run on a cold machine (see caveat below).

`Expr::evaluations` materializes a full-domain vector per AST node and launches a parallel kernel per node — #3603 made those kernels as fast as they can be; this PR replaces the architecture for the prover's quotient path. `Expr::evaluations_fused` compiles the expression once into a flat RPN tape with pre-resolved, deduplicated column references, then evaluates the whole tape in one pass over 4096-row chunks with per-task scratch pools: no full-domain intermediates, cache-resident working set, one parallel region instead of hundreds. Results are bit-identical (same degree-based domain selection, same per-point operation order).

Changes (one commit each):

- the evaluator + `Expr::evaluations_fused` API, equivalence tests (all 11 gate types plus targeted expressions for every remaining node type, at sub-chunk and multi-chunk domains), and an `expr_eval_fused` benchmark mirroring the frozen `expr_eval` benchmark case-for-case
- switch the prover's quotient evaluations (generic, gate loop, lookup constraints) to the fused evaluator
- reuse scratch across chunks within each rayon task (`for_each_init` re-creates init state per split segment, which was churning back most of the allocation savings)

## Benchmarks

Same machine and methodology as #3603 (18 threads, paired interleaved rounds, medians). `cargo bench -p kimchi --bench expr_eval` vs `--bench expr_eval_fused`:

| case | 2^10: legacy → fused | 2^16: legacy → fused |
|---|---:|---:|
| `poseidon` | 21.8 → 6.9 ms (−68%) | 96.1 → 63.5 ms (−34%) |
| `varbase_mul` | 19.4 → 5.1 ms (−74%) | 85.1 → 53.6 ms (−37%) |
| `endomul_scalar` | 21.2 → 5.1 ms (−76%) | 83.2 → 54.8 ms (−34%) |
| `endoscl_mul` | 10.2 → 2.7 ms (−74%) | 45.3 → 30.0 ms (−34%) |
| `complete_add` | 3.8 → 1.1 ms (−71%) | 14.0 → 7.9 ms (−44%) |
| `all_gates` (11 gate types) | 139.7 → 40.6 ms (−71%) | 628.1 → 428.4 ms (−32%) |

In-prover, same-process paired measurement of the five always-on gate evaluations: 138 → 51 ms/proof at d1 = 2^14 and 279 → 181 ms/proof at 2^16 — about 6% of proof creation at either domain.

Allocation, exact counting-allocator numbers around `create_proof` only (counters reset after setup; SRS/index/Lagrange-basis construction contribute nothing): 2053 → 1688 MB/proof at 2^14 (−18%), 6655 → 4076 MB at 2^16 (−39%); single-threaded — the wasm-relevant shape — 2071 → 1519 MB (−27%) with peak-live above the post-setup baseline 360 → 311 MB. Multi-threaded peak-live and RSS are parity (the native allocator absorbed the old churn; footprint is owned by the resident SRS and IPA).

## Correctness

Bit-identical to the legacy evaluator: equivalence test suite in-repo; during development, per-gate asserts and full reconstructed-quotient polynomial equality across repeated proofs at 2^14 and 2^16, plus the debug-mode `check_constraint!` path over the fused prover (41 debug tests including lookups). Full release test suite green; builds clean without default features (serial fallback) and under clippy.

Measured nulls, kept out or documented: cross-gate fusion (a summed-expression single pass measures the same as per-gate passes — the executor is compute-bound, so the per-gate call structure stays); bitmask vs modulo gathers (too few wrap sites to matter; kept for consistency with #3603's kernels).

**Caveat:** an end-to-end `proof_criterion` A/B was attempted but discarded — thermal drift between runs exceeded the ~6% expected effect on the bench machine that day. The component-level and in-process numbers above are the reliable measurements; the end-to-end pairing should be redone cold before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNBKyEDBBLwgcHjHxukKCk
