### PR TITLE
Add an e2e prover memory profile under the diagnostics feature

### DIFF
--- a/.github/workflows/memory-profile.yml
+++ b/.github/workflows/memory-profile.yml
@@ -1,0 +1,41 @@
+#
+# Manually-triggered end-to-end prover memory profile, running the
+# kimchi memory_profile binary. The byte metrics are deterministic for
+# a given runner class, but scale with thread count (rayon scratch
+# buffers) — compare runs from the same runner class only.
+#
+
+name: Prover memory profile
+
+on:
+  workflow_dispatch:
+    inputs:
+      srs_log2:
+        description: "log2 of the domain/SRS size (4..=28)"
+        required: false
+        default: "16"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  memory_profile:
+    name: Run the prover memory profile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
+      - name: Use shared Rust toolchain setting up steps
+        uses: ./.github/actions/toolchain-shared
+        with:
+          rust_toolchain_version: ${{ steps.versions.outputs.rust-msrv }}
+
+      - name: Run the prover memory profile
+        run: |
+          cargo run --release -p kimchi --bin memory_profile \
+            --features diagnostics -- ${{ inputs.srs_log2 }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to
 - Add an optional mmap-backed prover-index cache for loading proving keys from
   disk while allowing the OS page cache to evict unused pages
   ([#3569](https://github.com/o1-labs/proof-systems/pull/3569))
+- Add a `memory_profile` binary under the `diagnostics` feature: proves the
+  canonical benchmark circuit (`kimchi::bench::BenchmarkCtx`) under a counting
+  global allocator and reports total bytes allocated, allocation count, peak
+  live bytes, and peak resident set for proof creation, for A/B comparisons of
+  prover memory changes
+  ([#3605](https://github.com/o1-labs/proof-systems/pull/3605))
 
 #### Changed
 

--- a/kimchi/Cargo.toml
+++ b/kimchi/Cargo.toml
@@ -76,6 +76,10 @@ iai.workspace = true
 name = "flamegraph"
 required-features = ["prover"]
 
+[[bin]]
+name = "memory_profile"
+required-features = ["prover", "diagnostics"]
+
 [[bench]]
 name = "proof_criterion"
 harness = false

--- a/kimchi/src/bin/memory_profile.rs
+++ b/kimchi/src/bin/memory_profile.rs
@@ -14,7 +14,8 @@
 //! cargo run --release -p kimchi --bin memory_profile --features diagnostics -- [srs_log2]
 //! ```
 //!
-//! `srs_log2` sets the domain/SRS size (default 16).
+//! `srs_log2` sets the domain/SRS size (default 16). The resident-set
+//! sampler interval is `KIMCHI_MEMORY_PROFILE_SAMPLE_MS` (default 25).
 
 use kimchi::bench::BenchmarkCtx;
 use std::time::Instant;
@@ -92,7 +93,13 @@ mod mem_profile {
     }
 
     pub fn start() -> Window {
-        let sampler = std::thread::spawn(|| {
+        let sample_ms: u64 = match std::env::var("KIMCHI_MEMORY_PROFILE_SAMPLE_MS") {
+            Err(_) => 25,
+            Ok(s) => s.parse().ok().filter(|ms| *ms >= 1).unwrap_or_else(|| {
+                panic!("KIMCHI_MEMORY_PROFILE_SAMPLE_MS must be a positive integer (ms), got {s:?}")
+            }),
+        };
+        let sampler = std::thread::spawn(move || {
             use tikv_jemalloc_ctl::{epoch, stats};
             while !STOP.load(Relaxed) {
                 if epoch::advance().is_ok() {
@@ -100,7 +107,7 @@ mod mem_profile {
                         PEAK_RESIDENT.fetch_max(r, Relaxed);
                     }
                 }
-                std::thread::sleep(core::time::Duration::from_millis(25));
+                std::thread::sleep(core::time::Duration::from_millis(sample_ms));
             }
         });
 

--- a/kimchi/src/bin/memory_profile.rs
+++ b/kimchi/src/bin/memory_profile.rs
@@ -150,8 +150,8 @@ fn main() {
     let setup_start = Instant::now();
     let ctx = BenchmarkCtx::new(srs_log2);
     println!(
-        "- setup time (index, verifier digest, lagrange basis): {:.1}s",
-        setup_start.elapsed().as_secs_f64()
+        "- setup time (index, verifier digest, lagrange basis): {} ms",
+        setup_start.elapsed().as_millis()
     );
 
     let window = mem_profile::start();
@@ -159,7 +159,7 @@ fn main() {
     let proof_and_public = ctx.create_proof();
     let prove_time = prove_start.elapsed();
     window.report("proof creation");
-    println!("- time to create proof: {:.1}s", prove_time.as_secs_f64());
+    println!("- time to create proof: {} ms", prove_time.as_millis());
 
     std::hint::black_box(proof_and_public);
 }

--- a/kimchi/src/bin/memory_profile.rs
+++ b/kimchi/src/bin/memory_profile.rs
@@ -1,0 +1,165 @@
+//! End-to-end prover memory profile.
+//!
+//! Proves the canonical benchmark circuit (`kimchi::bench::BenchmarkCtx`)
+//! under a counting global allocator and reports, for the proof-creation
+//! window: total bytes allocated, allocation count, peak live bytes (and its
+//! delta over the bytes live when the window opened), plus jemalloc's peak
+//! resident set sampled by a background thread. The process exists for this
+//! one measurement, so the counters are exact for a deterministic workload —
+//! a single run is the answer.
+//!
+//! Usage:
+//!
+//! ```text
+//! cargo run --release -p kimchi --bin memory_profile --features diagnostics -- [srs_log2]
+//! ```
+//!
+//! `srs_log2` sets the domain/SRS size (default 16).
+
+use kimchi::bench::BenchmarkCtx;
+use std::time::Instant;
+
+// A counting wrapper around jemalloc. jemalloc-ctl statistics still observe
+// the real allocator, while the counters capture what jemalloc cannot report
+// over a window: total bytes allocated, allocation count, and peak live
+// bytes. Counting is unconditional: this binary is the measurement.
+mod counting_alloc {
+    use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+    use std::alloc::{GlobalAlloc, Layout};
+    use tikv_jemallocator::Jemalloc;
+
+    pub static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+    pub static COUNT: AtomicUsize = AtomicUsize::new(0);
+    pub static CURRENT: AtomicUsize = AtomicUsize::new(0);
+    pub static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+    fn record_alloc(size: usize) {
+        ALLOCATED.fetch_add(size, Relaxed);
+        COUNT.fetch_add(1, Relaxed);
+        let live = CURRENT.fetch_add(size, Relaxed) + size;
+        PEAK.fetch_max(live, Relaxed);
+    }
+
+    struct CountingAlloc;
+
+    unsafe impl GlobalAlloc for CountingAlloc {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            let p = Jemalloc.alloc(layout);
+            if !p.is_null() {
+                record_alloc(layout.size());
+            }
+            p
+        }
+
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            let p = Jemalloc.alloc_zeroed(layout);
+            if !p.is_null() {
+                record_alloc(layout.size());
+            }
+            p
+        }
+
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            let p = Jemalloc.realloc(ptr, layout, new_size);
+            if !p.is_null() {
+                CURRENT.fetch_sub(layout.size(), Relaxed);
+                record_alloc(new_size);
+            }
+            p
+        }
+
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            CURRENT.fetch_sub(layout.size(), Relaxed);
+            Jemalloc.dealloc(ptr, layout)
+        }
+    }
+
+    #[global_allocator]
+    static GLOBAL: CountingAlloc = CountingAlloc;
+}
+
+/// An allocation profile over a window of execution.
+mod mem_profile {
+    use super::counting_alloc::{ALLOCATED, COUNT, CURRENT, PEAK};
+    use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering::Relaxed};
+
+    static STOP: AtomicBool = AtomicBool::new(false);
+    static PEAK_RESIDENT: AtomicUsize = AtomicUsize::new(0);
+
+    pub struct Window {
+        live_before: usize,
+        sampler: std::thread::JoinHandle<()>,
+    }
+
+    pub fn start() -> Window {
+        let sampler = std::thread::spawn(|| {
+            use tikv_jemalloc_ctl::{epoch, stats};
+            while !STOP.load(Relaxed) {
+                if epoch::advance().is_ok() {
+                    if let Ok(r) = stats::resident::read() {
+                        PEAK_RESIDENT.fetch_max(r, Relaxed);
+                    }
+                }
+                std::thread::sleep(core::time::Duration::from_millis(25));
+            }
+        });
+
+        // Reset the window counters after spawning the sampler, so the
+        // spawn's own allocations stay out of the profile.
+        let live_before = CURRENT.load(Relaxed);
+        ALLOCATED.store(0, Relaxed);
+        COUNT.store(0, Relaxed);
+        PEAK.store(live_before, Relaxed);
+        Window {
+            live_before,
+            sampler,
+        }
+    }
+
+    impl Window {
+        pub fn report(self, label: &str) {
+            STOP.store(true, Relaxed);
+            let _ = self.sampler.join();
+            let mb = |b: usize| b as f64 / (1u64 << 20) as f64;
+            println!(
+                "- {label} allocation profile: allocated={:.1} MB allocs={} \
+                 peak_live={:.1} MB peak_delta={:.1} MB peak_resident={:.1} MB",
+                mb(ALLOCATED.load(Relaxed)),
+                COUNT.load(Relaxed),
+                mb(PEAK.load(Relaxed)),
+                mb(PEAK.load(Relaxed).saturating_sub(self.live_before)),
+                mb(PEAK_RESIDENT.load(Relaxed)),
+            );
+        }
+    }
+}
+
+fn main() {
+    let srs_log2: u32 = match std::env::args().nth(1) {
+        None => 16,
+        Some(s) => s
+            .parse()
+            .unwrap_or_else(|_| panic!("srs_log2 must be an integer, got {s:?}")),
+    };
+    assert!(
+        (4..=28).contains(&srs_log2),
+        "srs_log2 must be in 4..=28, got {srs_log2}"
+    );
+    println!("PROVER MEMORY PROFILE: domain/SRS 2^{srs_log2}");
+
+    let setup_start = Instant::now();
+    let ctx = BenchmarkCtx::new(srs_log2);
+    println!(
+        "- setup time (index, verifier digest, lagrange basis): {:.1}s",
+        setup_start.elapsed().as_secs_f64()
+    );
+
+    let window = mem_profile::start();
+    let prove_start = Instant::now();
+    let proof_and_public = ctx.create_proof();
+    let prove_time = prove_start.elapsed();
+    window.report("proof creation");
+    println!("- time to create proof: {:.1}s", prove_time.as_secs_f64());
+
+    std::hint::black_box(proof_and_public);
+}


### PR DESCRIPTION
Timing regressions are covered by the criterion benches, but memory behavior is not: jemalloc's `stats::allocated` checkpoints (behind the `diagnostics` feature) only give point-in-time live bytes. This PR adds a standalone binary that profiles allocation over proof creation.

A `#[global_allocator]` is a process-wide singleton, so the profiler gets its own binary / process rather than living inside the test framework.

## Changes

- **`kimchi/src/bin/memory_profile.rs`** (`required-features = ["prover", "diagnostics"]`): proves the canonical benchmark circuit via `kimchi::bench::BenchmarkCtx` — the same circuit builder the criterion benches and the `flamegraph` bin use — under a counting wrapper around jemalloc. For the proof-creation window it reports: total bytes allocated, allocation count, peak live bytes (and its delta over bytes live at window open), plus jemalloc's peak resident set sampled every 25 ms by a background thread. Setup (index, verifier digest, Lagrange basis) completes before the window opens.
- `srs_log2` is a positional argument (default 16, validated to 4..=28).

The workload is deterministic, so a single run is the answer; to A/B a change, run at both revisions:

```
cargo run --release -p kimchi --bin memory_profile --features diagnostics -- 16
```

Allocated bytes are stable across runs; the allocation *count* is rayon-scheduling-noisy at 2^16+ — compare bytes.

## Sample output (Apple M5 Pro, 18 threads)

```
PROVER MEMORY PROFILE: domain/SRS 2^16
- setup time (index, verifier digest, lagrange basis): 528 ms
- proof creation allocation profile: allocated=6654.9 MB allocs=363946 peak_live=1340.8 MB peak_delta=758.0 MB peak_resident=1743.0 MB
- time to create proof: 1666 ms
```

## Sample output (CI, ubuntu-latest, 4 vCPU — via the manual `Prover memory profile` workflow)

```
PROVER MEMORY PROFILE: domain/SRS 2^16
- setup time (index, verifier digest, lagrange basis): 2426 ms
- proof creation allocation profile: allocated=6661.2 MB allocs=176269 peak_live=1294.7 MB peak_delta=712.1 MB peak_resident=1404.5 MB
- time to create proof: 7342 ms
```

Total allocated matches the M5 Pro run to 0.1%, while peak live/delta and alloc count differ — rayon scratch buffers scale with thread count. Compare runs from the same machine class only.