### PR TITLE
benches: fail the mina prover bench on proof-creation errors

### DIFF
--- a/kimchi/benches/proof_criterion_mina.rs
+++ b/kimchi/benches/proof_criterion_mina.rs
@@ -50,19 +50,22 @@ pub fn bench_proof_creation_mina(c: &mut Criterion) {
             format!("proof creation (mina, vesta, circuit seed {})", seed),
             |b| {
                 b.iter(|| {
-                    black_box(ProverProof::<
-                        Vesta,
-                        OpeningProof<Vesta, FULL_ROUNDS>,
-                        FULL_ROUNDS,
-                    >::create_recursive::<BaseSpongeVesta, ScalarSpongeVesta, _>(
-                        &group_map,
-                        witness.clone(),
-                        &runtime_tables,
-                        &index,
-                        prev.clone(),
-                        None,
-                        &mut rand::rngs::OsRng,
-                    ))
+                    black_box(
+                        ProverProof::<
+                            Vesta,
+                            OpeningProof<Vesta, FULL_ROUNDS>,
+                            FULL_ROUNDS,
+                        >::create_recursive::<BaseSpongeVesta, ScalarSpongeVesta, _>(
+                            &group_map,
+                            witness.clone(),
+                            &runtime_tables,
+                            &index,
+                            prev.clone(),
+                            None,
+                            &mut rand::rngs::OsRng,
+                        )
+                        .expect("proof creation failed: the benchmark inputs no longer satisfy the constraint system"),
+                    )
                 })
             },
         );
@@ -80,19 +83,22 @@ pub fn bench_proof_creation_mina(c: &mut Criterion) {
             format!("proof creation (mina, pallas, circuit seed {})", seed),
             |b| {
                 b.iter(|| {
-                    black_box(ProverProof::<
-                        Pallas,
-                        OpeningProof<Pallas, FULL_ROUNDS>,
-                        FULL_ROUNDS,
-                    >::create_recursive::<BaseSpongePallas, ScalarSpongePallas, _>(
-                        &group_map,
-                        witness.clone(),
-                        &runtime_tables,
-                        &index,
-                        prev.clone(),
-                        None,
-                        &mut rand::rngs::OsRng,
-                    ))
+                    black_box(
+                        ProverProof::<
+                            Pallas,
+                            OpeningProof<Pallas, FULL_ROUNDS>,
+                            FULL_ROUNDS,
+                        >::create_recursive::<BaseSpongePallas, ScalarSpongePallas, _>(
+                            &group_map,
+                            witness.clone(),
+                            &runtime_tables,
+                            &index,
+                            prev.clone(),
+                            None,
+                            &mut rand::rngs::OsRng,
+                        )
+                        .expect("proof creation failed: the benchmark inputs no longer satisfy the constraint system"),
+                    )
                 })
             },
         );


### PR DESCRIPTION
## Problem

`proof_criterion_mina` wraps the prover call in `black_box(...)` without unwrapping the `Result`, so criterion times whatever happens — including a prover that returns `Err`.

That has been the case in CI since **2026-02-23**: commit 64129ce4eb (#3514) added the EndoMul distinct-point constraint `(xp - xr) * (xr - xs) * inv = 1`, which requires a new witness column. The serialized fixtures in `o1labs-ci-test-data/serialised-test-mina-circuits/` were generated **2025-06-11** and don't carry it, so every bench iteration since has failed at `rest of division by vanishing polynomial` (~0.9 s to fail on the CI runner) and the regression job has been comparing failure-time against failure-time. Verified by instrumenting `divide_by_vanishing_poly` (`res_zero=false` on all 45 iterations at current master) and git-bisecting the fixture validity over Oct 2025 → Mar 2026: first bad commit is 64129ce4eb.

Consequence: any PR that changes *where* the prover stops shows a spurious timing delta. Concretely, mrmr1993's skip-d1-rows branch forces the quotient numerator to be divisible by construction, so the prover no longer errors and runs the full pipeline — CI reported that as a **+163% regression** when it is actually fail-fast vs complete proof (on valid witnesses that branch benches *faster*).

## Fix

`.expect()` the prover result in both curve arms, so an unsatisfiable fixture panics the bench immediately instead of being silently timed.

## Heads-up

With this merged, the `benches-mina-prover` job will (correctly) fail on master until the fixtures are regenerated with a post-#3514 witness generator that fills the EndoMul `inv` column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcoXpnzQ2ufCzqzB1tZtfm