### PR TITLE
memory_profile: run over the mina circuit fixtures

### DIFF
--- a/.github/workflows/memory-profile.yml
+++ b/.github/workflows/memory-profile.yml
@@ -1,30 +1,30 @@
 #
-# Manually-triggered end-to-end prover memory profile, running the
-# kimchi memory_profile binary. The byte metrics are deterministic for
-# a given runner class, but scale with thread count (rayon scratch
-# buffers) — compare runs from the same runner class only.
+# Manually-triggered end-to-end prover memory profile over the serialised mina
+# circuit fixtures, compared against the merge base with master. Both runs
+# happen back to back on the same runner (like benches-mina-prover.yml): the
+# byte metrics are deterministic for a given runner class, so any nonzero
+# byte delta in the report is caused by the change under test.
 #
 
 name: Prover memory profile
 
 on:
   workflow_dispatch:
-    inputs:
-      srs_log2:
-        description: "log2 of the domain/SRS size (4..=28)"
-        required: false
-        default: "16"
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   memory_profile:
-    name: Run the prover memory profile
+    name: Memory-profile the mina fixtures against master
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          # Full history so the merge base can be checked out and profiled on
+          # this same runner.
+          fetch-depth: 0
 
       - name: Load versions
         id: versions
@@ -35,7 +35,35 @@ jobs:
         with:
           rust_toolchain_version: ${{ steps.versions.outputs.rust-msrv }}
 
-      - name: Run the prover memory profile
+      - name: Record the runner's CPU
+        run: lscpu || cat /proc/cpuinfo
+
+      - name: Resolve the revisions to compare
+        id: revs
         run: |
-          cargo run --release -p kimchi --bin memory_profile \
-            --features diagnostics -- ${{ inputs.srs_log2 }}
+          set -x
+          {
+            echo "head=$(git rev-parse HEAD)"
+            echo "base=$(git merge-base origin/master HEAD)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Profile the baseline (merge base with master)
+        run: |
+          set -x
+          git checkout --detach ${{ steps.revs.outputs.base }}
+          bash scripts/memory-profile-mina-circuits.sh /tmp/memory-profile-base.jsonl
+
+      - name: Profile this revision
+        run: |
+          set -x
+          git checkout --detach ${{ steps.revs.outputs.head }}
+          bash scripts/memory-profile-mina-circuits.sh /tmp/memory-profile-head.jsonl
+
+      - name: Render the comparison matrix
+        run: |
+          {
+            echo "## Prover memory profile: ${{ steps.revs.outputs.head }} vs ${{ steps.revs.outputs.base }}"
+            echo
+            python3 scripts/memory-profile-diff.py \
+              /tmp/memory-profile-base.jsonl /tmp/memory-profile-head.jsonl
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,6 +1703,7 @@ dependencies = [
  "ark-poly",
  "ark-serialize",
  "blake2",
+ "clap",
  "criterion",
  "groupmap",
  "hex",

--- a/kimchi/Cargo.toml
+++ b/kimchi/Cargo.toml
@@ -14,6 +14,8 @@ path = "src/lib.rs"
 bench = false       # needed for criterion (https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options)
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+clap = { workspace = true, features = ["derive"], optional = true }
+serde_json = { workspace = true, optional = true }
 tikv-jemalloc-ctl = { workspace = true, optional = true }
 tikv-jemallocator = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }
@@ -131,7 +133,7 @@ bn254 = ["ark-bn254"]
 wasm_types = ["wasm-bindgen"]
 save-test-proofs = ["prover"]
 check_feature_flags = []
-diagnostics = ["tikv-jemalloc-ctl", "tikv-jemallocator"]
+diagnostics = ["tikv-jemalloc-ctl", "tikv-jemallocator", "clap", "serde_json"]
 mmap_cache = ["libc"]
 sha2-asm = ["sha2/asm"]
 sha2-asm-aarch64 = ["sha2/asm-aarch64"]

--- a/kimchi/src/bin/memory_profile.rs
+++ b/kimchi/src/bin/memory_profile.rs
@@ -13,31 +13,39 @@
 //! Usage:
 //!
 //! ```text
-//! cargo run --release -p kimchi --bin memory_profile --features diagnostics -- [srs_log2]
-//! cargo run --release -p kimchi --bin memory_profile --features diagnostics -- <kimchi_inputs_CURVE_SEED.ser>
+//! cargo run --release -p kimchi --bin memory_profile --features diagnostics -- synthetic [--srs-log2 16]
+//! cargo run --release -p kimchi --bin memory_profile --features diagnostics -- fixture <kimchi_inputs_CURVE_SEED.ser>
 //! ```
 //!
-//! An integer argument selects the synthetic benchmark circuit and sets its
-//! domain/SRS size (default 16); a path selects a mina fixture, whose curve
-//! and seed are parsed from the filename exactly as in `proof_criterion_mina`.
+//! `synthetic` proves the benchmark circuit at the given domain/SRS size;
+//! `fixture` proves a mina fixture, whose curve and seed are parsed from the
+//! filename exactly as in `proof_criterion_mina`. Output is a single JSON
+//! object on stdout (byte counts, not MB), meant to be collected across
+//! fixtures and diffed against a baseline run — see
+//! `scripts/memory-profile-mina-circuits.sh` and
+//! `scripts/memory-profile-diff.py`.
 //! One fixture per invocation: jemalloc retains pages across proofs, so
 //! `peak_resident` is only trustworthy for the first proof in a process.
 //! The resident-set sampler interval is `KIMCHI_MEMORY_PROFILE_SAMPLE_MS`
 //! (default 25).
 
+use ark_ff::PrimeField;
+use clap::Parser;
 use groupmap::GroupMap;
 use kimchi::{
     bench::{
         bench_arguments_from_file, BaseSpongePallas, BaseSpongeVesta, BenchmarkCtx,
         ScalarSpongePallas, ScalarSpongeVesta,
     },
+    curve::KimchiCurve,
+    plonk_sponge::FrSponge,
     proof::ProverProof,
 };
 use mina_curves::{
     named::NamedCurve,
     pasta::{Pallas, Vesta},
 };
-use mina_poseidon::pasta::FULL_ROUNDS;
+use mina_poseidon::{pasta::FULL_ROUNDS, FqSponge};
 use poly_commitment::ipa::OpeningProof;
 use std::time::Instant;
 
@@ -144,122 +152,196 @@ mod mem_profile {
         }
     }
 
+    #[derive(serde::Serialize)]
+    pub struct Metrics {
+        #[serde(rename = "allocated_bytes")]
+        pub allocated: usize,
+        pub allocs: usize,
+        #[serde(rename = "peak_live_bytes")]
+        pub peak_live: usize,
+        #[serde(rename = "peak_delta_bytes")]
+        pub peak_delta: usize,
+        #[serde(rename = "peak_resident_bytes")]
+        pub peak_resident: usize,
+    }
+
     impl Window {
-        pub fn report(self, label: &str) {
+        pub fn finish(self) -> Metrics {
             STOP.store(true, Relaxed);
             let _ = self.sampler.join();
-            let mb = |b: usize| b as f64 / (1u64 << 20) as f64;
-            println!(
-                "- {label} allocation profile: allocated={:.1} MB allocs={} \
-                 peak_live={:.1} MB peak_delta={:.1} MB peak_resident={:.1} MB",
-                mb(ALLOCATED.load(Relaxed)),
-                COUNT.load(Relaxed),
-                mb(PEAK.load(Relaxed)),
-                mb(PEAK.load(Relaxed).saturating_sub(self.live_before)),
-                mb(PEAK_RESIDENT.load(Relaxed)),
-            );
+            let peak_live = PEAK.load(Relaxed);
+            Metrics {
+                allocated: ALLOCATED.load(Relaxed),
+                allocs: COUNT.load(Relaxed),
+                peak_live,
+                peak_delta: peak_live.saturating_sub(self.live_before),
+                peak_resident: PEAK_RESIDENT.load(Relaxed),
+            }
         }
     }
 }
 
-fn profile_synthetic(srs_log2: u32) {
-    assert!(
-        (4..=28).contains(&srs_log2),
-        "srs_log2 must be in 4..=28, got {srs_log2}"
-    );
-    println!("PROVER MEMORY PROFILE: domain/SRS 2^{srs_log2}");
+/// One profiled proof, as the JSON object written to stdout.
+#[derive(serde::Serialize)]
+struct Report<'a> {
+    workload: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    srs_log2: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    curve: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seed: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    domain_log2: Option<u32>,
+    setup_ms: u128,
+    prove_ms: u128,
+    #[serde(flatten)]
+    metrics: mem_profile::Metrics,
+}
 
+impl std::fmt::Display for Report<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&serde_json::to_string(self).map_err(|_| std::fmt::Error)?)
+    }
+}
+
+/// A serialised mina circuit fixture, addressed by the filename convention
+/// `kimchi_inputs_CURVE_SEED.ser` that `proof_criterion_mina` also uses.
+#[derive(Clone)]
+struct Fixture {
+    path: String,
+    curve: String,
+    seed: String,
+}
+
+impl std::str::FromStr for Fixture {
+    type Err = String;
+
+    fn from_str(path: &str) -> Result<Self, Self::Err> {
+        let (curve, seed) = path
+            .split('/')
+            .next_back()
+            .unwrap_or(path)
+            .strip_prefix("kimchi_inputs_")
+            .and_then(|s| s.strip_suffix(".ser"))
+            .and_then(|s| s.split_once('_'))
+            .ok_or_else(|| {
+                format!(
+                    "fixture filename must look like kimchi_inputs_CURVE_SEED.ser, got {path:?}"
+                )
+            })?;
+        Ok(Fixture {
+            path: path.to_string(),
+            curve: curve.to_string(),
+            seed: seed.to_string(),
+        })
+    }
+}
+
+fn profile_synthetic(srs_log2: u32) {
     let setup_start = Instant::now();
     let ctx = BenchmarkCtx::new(srs_log2);
-    println!(
-        "- setup time (index, verifier digest, lagrange basis): {} ms",
-        setup_start.elapsed().as_millis()
-    );
+    let setup_ms = setup_start.elapsed().as_millis();
 
     let window = mem_profile::start();
     let prove_start = Instant::now();
     let proof_and_public = ctx.create_proof();
-    let prove_time = prove_start.elapsed();
-    window.report("proof creation");
-    println!("- time to create proof: {} ms", prove_time.as_millis());
-
+    let prove_ms = prove_start.elapsed().as_millis();
+    let metrics = window.finish();
     std::hint::black_box(proof_and_public);
+
+    println!(
+        "{}",
+        Report {
+            workload: "synthetic",
+            srs_log2: Some(srs_log2),
+            curve: None,
+            seed: None,
+            domain_log2: None,
+            setup_ms,
+            prove_ms,
+            metrics,
+        }
+    );
 }
 
-fn profile_mina_fixture(filename: &str) {
-    // Parse filename "kimchi_inputs_CURVENAME_SEED.ser" into two parameters,
-    // exactly as `proof_criterion_mina` does.
-    let (curve_name, seed): (&str, &str) = filename
-        .split('/')
-        .next_back()
-        .unwrap()
-        .strip_prefix("kimchi_inputs_")
-        .and_then(|s| s.strip_suffix(".ser"))
-        .and_then(|s| s.split_once('_'))
-        .unwrap_or_else(|| {
-            panic!("fixture filename must look like kimchi_inputs_CURVE_SEED.ser, got {filename:?}")
-        });
+fn profile_fixture_curve<G, BaseSponge, ScalarSponge>(fixture: &Fixture)
+where
+    G: KimchiCurve<FULL_ROUNDS> + NamedCurve,
+    G::BaseField: PrimeField,
+    BaseSponge: Clone + FqSponge<G::BaseField, G, G::ScalarField, FULL_ROUNDS>,
+    ScalarSponge: FrSponge<G::ScalarField>
+        + From<&'static mina_poseidon::poseidon::ArithmeticSpongeParams<G::ScalarField, FULL_ROUNDS>>,
+{
+    let setup_start = Instant::now();
+    let srs = poly_commitment::precomputed_srs::get_srs_test();
+    let (index, witness, runtime_tables, prev) =
+        bench_arguments_from_file::<FULL_ROUNDS, G, BaseSponge>(srs, fixture.path.clone());
+    let group_map = GroupMap::<_>::setup();
+    let domain_log2 = index.cs.domain.d1.size.trailing_zeros();
+    let setup_ms = setup_start.elapsed().as_millis();
 
-    macro_rules! profile_curve {
-        ($G:ty, $BaseSponge:ty, $ScalarSponge:ty) => {{
-            let setup_start = Instant::now();
-            let srs = poly_commitment::precomputed_srs::get_srs_test();
-            let (index, witness, runtime_tables, prev) =
-                bench_arguments_from_file::<FULL_ROUNDS, $G, $BaseSponge>(
-                    srs,
-                    filename.to_string(),
-                );
-            let group_map = GroupMap::<_>::setup();
-            println!(
-                "PROVER MEMORY PROFILE: mina fixture ({}, circuit seed {}), domain 2^{}",
-                curve_name,
-                seed,
-                index.cs.domain.d1.size.trailing_zeros(),
-            );
-            println!(
-                "- setup time (srs, deserialization, index): {} ms",
-                setup_start.elapsed().as_millis()
-            );
+    let window = mem_profile::start();
+    let prove_start = Instant::now();
+    let proof = ProverProof::<G, OpeningProof<G, FULL_ROUNDS>, FULL_ROUNDS>::create_recursive::<
+        BaseSponge,
+        ScalarSponge,
+        _,
+    >(
+        &group_map,
+        witness,
+        &runtime_tables,
+        &index,
+        prev,
+        None,
+        &mut rand::rngs::OsRng,
+    )
+    .expect("proof creation failed: the fixture no longer satisfies the constraint system");
+    let prove_ms = prove_start.elapsed().as_millis();
+    let metrics = window.finish();
+    std::hint::black_box(proof);
 
-            let window = mem_profile::start();
-            let prove_start = Instant::now();
-            let proof = ProverProof::<$G, OpeningProof<$G, FULL_ROUNDS>, FULL_ROUNDS>::create_recursive::<
-                $BaseSponge,
-                $ScalarSponge,
-                _,
-            >(
-                &group_map,
-                witness,
-                &runtime_tables,
-                &index,
-                prev,
-                None,
-                &mut rand::rngs::OsRng,
-            )
-            .expect("proof creation failed: the fixture no longer satisfies the constraint system");
-            let prove_time = prove_start.elapsed();
-            window.report("proof creation");
-            println!("- time to create proof: {} ms", prove_time.as_millis());
+    println!(
+        "{}",
+        Report {
+            workload: "fixture",
+            srs_log2: None,
+            curve: Some(&fixture.curve),
+            seed: Some(&fixture.seed),
+            domain_log2: Some(domain_log2),
+            setup_ms,
+            prove_ms,
+            metrics,
+        }
+    );
+}
 
-            std::hint::black_box(proof);
-        }};
-    }
-
-    if curve_name == Vesta::NAME {
-        profile_curve!(Vesta, BaseSpongeVesta, ScalarSpongeVesta);
-    } else if curve_name == Pallas::NAME {
-        profile_curve!(Pallas, BaseSpongePallas, ScalarSpongePallas);
+fn profile_mina_fixture(fixture: &Fixture) {
+    if fixture.curve == Vesta::NAME {
+        profile_fixture_curve::<Vesta, BaseSpongeVesta, ScalarSpongeVesta>(fixture);
+    } else if fixture.curve == Pallas::NAME {
+        profile_fixture_curve::<Pallas, BaseSpongePallas, ScalarSpongePallas>(fixture);
     } else {
-        panic!("Unsupported curve: {}", curve_name);
+        panic!("Unsupported curve: {}", fixture.curve);
     }
+}
+
+#[derive(Parser)]
+#[command(about = "End-to-end prover memory profile; emits one JSON object on stdout")]
+enum Cli {
+    /// Prove the synthetic benchmark circuit (kimchi::bench::BenchmarkCtx)
+    Synthetic {
+        /// log2 of the domain/SRS size
+        #[arg(long, default_value_t = 16, value_parser = clap::value_parser!(u32).range(4..=28))]
+        srs_log2: u32,
+    },
+    /// Prove a serialised mina circuit fixture (kimchi_inputs_CURVE_SEED.ser)
+    Fixture { fixture: Fixture },
 }
 
 fn main() {
-    match std::env::args().nth(1) {
-        None => profile_synthetic(16),
-        Some(s) => match s.parse::<u32>() {
-            Ok(srs_log2) => profile_synthetic(srs_log2),
-            Err(_) => profile_mina_fixture(&s),
-        },
+    match Cli::parse() {
+        Cli::Synthetic { srs_log2 } => profile_synthetic(srs_log2),
+        Cli::Fixture { fixture } => profile_mina_fixture(&fixture),
     }
 }

--- a/kimchi/src/bin/memory_profile.rs
+++ b/kimchi/src/bin/memory_profile.rs
@@ -1,23 +1,44 @@
 //! End-to-end prover memory profile.
 //!
-//! Proves the canonical benchmark circuit (`kimchi::bench::BenchmarkCtx`)
-//! under a counting global allocator and reports, for the proof-creation
-//! window: total bytes allocated, allocation count, peak live bytes (and its
-//! delta over the bytes live when the window opened), plus jemalloc's peak
-//! resident set sampled by a background thread. The process exists for this
-//! one measurement, so the counters are exact for a deterministic workload —
-//! a single run is the answer.
+//! Proves either the canonical benchmark circuit (`kimchi::bench::BenchmarkCtx`)
+//! or a serialised mina circuit fixture (the same `kimchi_inputs_*.ser` files
+//! the `proof_criterion_mina` bench consumes) under a counting global
+//! allocator and reports, for the proof-creation window: total bytes
+//! allocated, allocation count, peak live bytes (and its delta over the bytes
+//! live when the window opened), plus jemalloc's peak resident set sampled by
+//! a background thread. The process exists for this one measurement, so the
+//! counters are exact for a deterministic workload — a single run is the
+//! answer.
 //!
 //! Usage:
 //!
 //! ```text
 //! cargo run --release -p kimchi --bin memory_profile --features diagnostics -- [srs_log2]
+//! cargo run --release -p kimchi --bin memory_profile --features diagnostics -- <kimchi_inputs_CURVE_SEED.ser>
 //! ```
 //!
-//! `srs_log2` sets the domain/SRS size (default 16). The resident-set
-//! sampler interval is `KIMCHI_MEMORY_PROFILE_SAMPLE_MS` (default 25).
+//! An integer argument selects the synthetic benchmark circuit and sets its
+//! domain/SRS size (default 16); a path selects a mina fixture, whose curve
+//! and seed are parsed from the filename exactly as in `proof_criterion_mina`.
+//! One fixture per invocation: jemalloc retains pages across proofs, so
+//! `peak_resident` is only trustworthy for the first proof in a process.
+//! The resident-set sampler interval is `KIMCHI_MEMORY_PROFILE_SAMPLE_MS`
+//! (default 25).
 
-use kimchi::bench::BenchmarkCtx;
+use groupmap::GroupMap;
+use kimchi::{
+    bench::{
+        bench_arguments_from_file, BaseSpongePallas, BaseSpongeVesta, BenchmarkCtx,
+        ScalarSpongePallas, ScalarSpongeVesta,
+    },
+    proof::ProverProof,
+};
+use mina_curves::{
+    named::NamedCurve,
+    pasta::{Pallas, Vesta},
+};
+use mina_poseidon::pasta::FULL_ROUNDS;
+use poly_commitment::ipa::OpeningProof;
 use std::time::Instant;
 
 // A counting wrapper around jemalloc. jemalloc-ctl statistics still observe
@@ -141,13 +162,7 @@ mod mem_profile {
     }
 }
 
-fn main() {
-    let srs_log2: u32 = match std::env::args().nth(1) {
-        None => 16,
-        Some(s) => s
-            .parse()
-            .unwrap_or_else(|_| panic!("srs_log2 must be an integer, got {s:?}")),
-    };
+fn profile_synthetic(srs_log2: u32) {
     assert!(
         (4..=28).contains(&srs_log2),
         "srs_log2 must be in 4..=28, got {srs_log2}"
@@ -169,4 +184,82 @@ fn main() {
     println!("- time to create proof: {} ms", prove_time.as_millis());
 
     std::hint::black_box(proof_and_public);
+}
+
+fn profile_mina_fixture(filename: &str) {
+    // Parse filename "kimchi_inputs_CURVENAME_SEED.ser" into two parameters,
+    // exactly as `proof_criterion_mina` does.
+    let (curve_name, seed): (&str, &str) = filename
+        .split('/')
+        .next_back()
+        .unwrap()
+        .strip_prefix("kimchi_inputs_")
+        .and_then(|s| s.strip_suffix(".ser"))
+        .and_then(|s| s.split_once('_'))
+        .unwrap_or_else(|| {
+            panic!("fixture filename must look like kimchi_inputs_CURVE_SEED.ser, got {filename:?}")
+        });
+
+    macro_rules! profile_curve {
+        ($G:ty, $BaseSponge:ty, $ScalarSponge:ty) => {{
+            let setup_start = Instant::now();
+            let srs = poly_commitment::precomputed_srs::get_srs_test();
+            let (index, witness, runtime_tables, prev) =
+                bench_arguments_from_file::<FULL_ROUNDS, $G, $BaseSponge>(
+                    srs,
+                    filename.to_string(),
+                );
+            let group_map = GroupMap::<_>::setup();
+            println!(
+                "PROVER MEMORY PROFILE: mina fixture ({}, circuit seed {}), domain 2^{}",
+                curve_name,
+                seed,
+                index.cs.domain.d1.size.trailing_zeros(),
+            );
+            println!(
+                "- setup time (srs, deserialization, index): {} ms",
+                setup_start.elapsed().as_millis()
+            );
+
+            let window = mem_profile::start();
+            let prove_start = Instant::now();
+            let proof = ProverProof::<$G, OpeningProof<$G, FULL_ROUNDS>, FULL_ROUNDS>::create_recursive::<
+                $BaseSponge,
+                $ScalarSponge,
+                _,
+            >(
+                &group_map,
+                witness,
+                &runtime_tables,
+                &index,
+                prev,
+                None,
+                &mut rand::rngs::OsRng,
+            )
+            .expect("proof creation failed: the fixture no longer satisfies the constraint system");
+            let prove_time = prove_start.elapsed();
+            window.report("proof creation");
+            println!("- time to create proof: {} ms", prove_time.as_millis());
+
+            std::hint::black_box(proof);
+        }};
+    }
+
+    if curve_name == Vesta::NAME {
+        profile_curve!(Vesta, BaseSpongeVesta, ScalarSpongeVesta);
+    } else if curve_name == Pallas::NAME {
+        profile_curve!(Pallas, BaseSpongePallas, ScalarSpongePallas);
+    } else {
+        panic!("Unsupported curve: {}", curve_name);
+    }
+}
+
+fn main() {
+    match std::env::args().nth(1) {
+        None => profile_synthetic(16),
+        Some(s) => match s.parse::<u32>() {
+            Ok(srs_log2) => profile_synthetic(srs_log2),
+            Err(_) => profile_mina_fixture(&s),
+        },
+    }
 }

--- a/scripts/memory-profile-diff.py
+++ b/scripts/memory-profile-diff.py
@@ -7,18 +7,25 @@ Rows are joined on (workload, curve, seed). Peak byte metrics are
 deterministic for a given runner, so any nonzero delta there is caused by the
 change under test; allocation counts, peak_resident and the timings are noisy
 and only indicative.
+
+Exits nonzero if a gated metric (allocated, peak_live, peak_delta) grows by
+more than REGRESSION_THRESHOLD on any row. 1% of the peak is roughly one
+domain-sized d8 polynomial buffer (8·2^k·32 bytes), so the gate reads as
+"this change retains at least a polynomial's worth of extra memory".
 """
 
 import json
 import sys
 
+REGRESSION_THRESHOLD = 0.01
+
 METRICS = [
-    ("allocated_bytes", "allocated", "mb"),
-    ("allocs", "allocs*", "count"),
-    ("peak_live_bytes", "peak_live", "mb"),
-    ("peak_delta_bytes", "peak_delta", "mb"),
-    ("peak_resident_bytes", "peak_resident*", "mb"),
-    ("prove_ms", "prove*", "ms"),
+    ("allocated_bytes", "allocated", "mb", True),
+    ("allocs", "allocs*", "count", False),
+    ("peak_live_bytes", "peak_live", "mb", True),
+    ("peak_delta_bytes", "peak_delta", "mb", True),
+    ("peak_resident_bytes", "peak_resident*", "mb", False),
+    ("prove_ms", "prove*", "ms", False),
 ]
 
 
@@ -74,18 +81,26 @@ def main():
     if not common:
         sys.exit("no common (workload, curve, seed) rows between the two runs")
 
-    print("| fixture | " + " | ".join(label for _, label, _ in METRICS) + " |")
+    regressions = []
+    print("| fixture | " + " | ".join(label for _, label, _, _ in METRICS) + " |")
     print("|" + "---|" * (len(METRICS) + 1))
     for key in sorted(common):
         base, head = base_runs[key], head_runs[key]
-        cells = [fmt_cell(base[m], head[m], unit) for m, _, unit in METRICS]
+        cells = []
+        for m, label, unit, gated in METRICS:
+            cell = fmt_cell(base[m], head[m], unit)
+            if gated and base[m] and (head[m] - base[m]) / base[m] > REGRESSION_THRESHOLD:
+                cell = f"**{cell} ⚠**"
+                regressions.append(f"{row_label(key, head)}: {label} {fmt_value(base[m], unit)} -> {fmt_value(head[m], unit)}")
+            cells.append(cell)
         print(f"| {row_label(key, head)} | " + " | ".join(cells) + " |")
 
     print()
     print("Cells are `head (delta vs base, %)`. `peak_live` and `peak_delta` "
           "are deterministic per runner class and `allocated` is stable to "
           "well under 0.1%; metrics marked `*` (allocation count, resident "
-          "set, wall time) are noisy and only indicative.")
+          "set, wall time) are noisy and only indicative. Gated metrics fail "
+          f"the job on a >{REGRESSION_THRESHOLD:.0%} increase.")
 
     only_base = [k for k in base_runs if k not in head_runs]
     only_head = [k for k in head_runs if k not in base_runs]
@@ -93,6 +108,12 @@ def main():
         if keys:
             names = ", ".join(row_label(k, runs[k]) for k in sorted(keys))
             print(f"\nOnly in {label}: {names}")
+
+    if regressions:
+        print(f"\n**Memory regression detected ({len(regressions)}):**")
+        for r in regressions:
+            print(f"- {r}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/memory-profile-diff.py
+++ b/scripts/memory-profile-diff.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Diff two memory_profile JSONL runs and render the result as a markdown matrix.
+
+Usage: memory-profile-diff.py <base.jsonl> <head.jsonl>
+
+Rows are joined on (workload, curve, seed). Peak byte metrics are
+deterministic for a given runner, so any nonzero delta there is caused by the
+change under test; allocation counts, peak_resident and the timings are noisy
+and only indicative.
+"""
+
+import json
+import sys
+
+METRICS = [
+    ("allocated_bytes", "allocated", "mb"),
+    ("allocs", "allocs*", "count"),
+    ("peak_live_bytes", "peak_live", "mb"),
+    ("peak_delta_bytes", "peak_delta", "mb"),
+    ("peak_resident_bytes", "peak_resident*", "mb"),
+    ("prove_ms", "prove*", "ms"),
+]
+
+
+def load(path):
+    runs = {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            r = json.loads(line)
+            key = (r["workload"], r.get("curve", ""), r.get("seed", ""), r.get("srs_log2", ""))
+            runs[key] = r
+    return runs
+
+
+def fmt_value(v, unit):
+    if unit == "mb":
+        return f"{v / 2**20:.1f} MB"
+    if unit == "ms":
+        return f"{v} ms"
+    return str(v)
+
+
+def fmt_cell(base, head, unit):
+    delta = head - base
+    if delta == 0:
+        return f"{fmt_value(head, unit)} (=)"
+    pct = 100.0 * delta / base if base else float("inf")
+    sign = "+" if delta > 0 else "−"
+    if unit == "mb":
+        mag = f"{abs(delta) / 2**20:.1f} MB"
+    elif unit == "ms":
+        mag = f"{abs(delta)} ms"
+    else:
+        mag = str(abs(delta))
+    return f"{fmt_value(head, unit)} ({sign}{mag}, {sign}{abs(pct):.1f}%)"
+
+
+def row_label(key, run):
+    workload, curve, seed, srs_log2 = key
+    if workload == "synthetic":
+        return f"synthetic 2^{srs_log2}"
+    return f"{curve} {seed} 2^{run['domain_log2']}"
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit(__doc__)
+    base_runs, head_runs = load(sys.argv[1]), load(sys.argv[2])
+
+    common = [k for k in head_runs if k in base_runs]
+    if not common:
+        sys.exit("no common (workload, curve, seed) rows between the two runs")
+
+    print("| fixture | " + " | ".join(label for _, label, _ in METRICS) + " |")
+    print("|" + "---|" * (len(METRICS) + 1))
+    for key in sorted(common):
+        base, head = base_runs[key], head_runs[key]
+        cells = [fmt_cell(base[m], head[m], unit) for m, _, unit in METRICS]
+        print(f"| {row_label(key, head)} | " + " | ".join(cells) + " |")
+
+    print()
+    print("Cells are `head (delta vs base, %)`. `peak_live` and `peak_delta` "
+          "are deterministic per runner class and `allocated` is stable to "
+          "well under 0.1%; metrics marked `*` (allocation count, resident "
+          "set, wall time) are noisy and only indicative.")
+
+    only_base = [k for k in base_runs if k not in head_runs]
+    only_head = [k for k in head_runs if k not in base_runs]
+    for label, keys, runs in (("base", only_base, base_runs), ("head", only_head, head_runs)):
+        if keys:
+            names = ", ".join(row_label(k, runs[k]) for k in sorted(keys))
+            print(f"\nOnly in {label}: {names}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/memory-profile-mina-circuits.sh
+++ b/scripts/memory-profile-mina-circuits.sh
@@ -36,3 +36,7 @@ for fixture in "$FIXTURES_DIR"/kimchi_inputs_*.ser; do
   # peak_resident is only trustworthy for the first proof in a process.
   "${CARGO_TARGET_DIR:-target}/release/memory_profile" fixture "$fixture" >> "$OUT"
 done
+
+# 2^16 size anchor: no mina fixture reaches that domain size.
+echo "Profiling synthetic 2^16" >&2
+"${CARGO_TARGET_DIR:-target}/release/memory_profile" synthetic --srs-log2 16 >> "$OUT"

--- a/scripts/memory-profile-mina-circuits.sh
+++ b/scripts/memory-profile-mina-circuits.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Runs the kimchi memory_profile binary over every serialised mina circuit
+# fixture and appends one JSON line per fixture to the file given as $1.
+#
+# Fixtures are taken from $FIXTURES_DIR if set, otherwise downloaded from the
+# CI bucket (and cached in /tmp/mina-fixtures for the next invocation, so the
+# baseline and head runs of a comparison profile identical inputs).
+
+set -eu
+
+OUT=${1:?usage: $0 <output.jsonl>}
+
+list_objects() {
+  curl -s "https://storage.googleapis.com/storage/v1/b/o1labs-ci-test-data/o" | grep -o '"name": "serialised-test-mina-circuits/[^"]*.ser"' | cut -d'"' -f4
+}
+
+if [[ -z "${FIXTURES_DIR:-}" ]]; then
+  FIXTURES_DIR=/tmp/mina-fixtures
+  mkdir -p "$FIXTURES_DIR"
+  for object in $(list_objects); do
+    local_path="$FIXTURES_DIR/$(basename "$object")"
+    if [[ ! -s "$local_path" ]]; then
+      echo "Downloading $object" >&2
+      curl -s "https://storage.googleapis.com/o1labs-ci-test-data/$object" -o "$local_path"
+    fi
+  done
+fi
+
+cargo build --release -p kimchi --bin memory_profile --features diagnostics
+
+: > "$OUT"
+for fixture in "$FIXTURES_DIR"/kimchi_inputs_*.ser; do
+  echo "Profiling $(basename "$fixture")" >&2
+  # One process per fixture: jemalloc retains pages across proofs, so
+  # peak_resident is only trustworthy for the first proof in a process.
+  "${CARGO_TARGET_DIR:-target}/release/memory_profile" fixture "$fixture" >> "$OUT"
+done


### PR DESCRIPTION
The prover memory profiler (#3605) could only measure the synthetic `BenchmarkCtx` circuit. This teaches it to profile the real serialised mina circuits — the same `kimchi_inputs_CURVE_SEED.ser` fixtures `proof_criterion_mina` consumes (regenerated and re-uploaded after #3607) — and turns the CI workflow into a gated base-vs-head comparison.

**Binary** (clap-derived CLI, JSON-only output):
- `memory_profile synthetic [--srs-log2 16]` — the synthetic circuit
- `memory_profile fixture <path>` — loads a fixture via `bench_arguments_from_file`, parsing curve and seed from the filename exactly as the criterion bench does, and profiles `create_recursive` (setup outside the measurement window; proof creation unwrapped so a stale fixture fails loudly)
- One JSON object per run (byte counts, not MB); one fixture per process, since jemalloc retains pages and `peak_resident` is only trustworthy for the first proof

**Scripts** (the CI job is nothing but these, so the whole flow runs locally):
- `scripts/memory-profile-mina-circuits.sh <out.jsonl>` — profiles every fixture (GCS download, or `FIXTURES_DIR` override) plus a synthetic 2^16 row as a size anchor (no mina fixture reaches that domain)
- `scripts/memory-profile-diff.py <base.jsonl> <head.jsonl>` — joins on (workload, curve, seed) and renders a markdown matrix, cells `head (delta vs base, %)`

**Regression gate**: the diff exits nonzero if `allocated`, `peak_live`, or `peak_delta` grows by more than 1% on any row (offending cells flagged in the matrix). These metrics are deterministic per runner class, and 1% of peak is roughly one domain-sized d8 polynomial buffer, so the gate reads as "this change retains at least a polynomial's worth of extra memory". Allocation counts, resident set, and wall time are report-only — timing regressions remain the criterion bench's job.

**CI** (`memory-profile.yml`, dispatch-only): profiles the merge base with master and HEAD back to back on the same runner (the `benches-mina-prover.yml` shape, for the same reason), writes the matrix to the job summary, and fails on the gate.

Verified locally: both subcommands on both curves; the full pipeline base-vs-head over all fixtures for master vs #3602 (gate correctly silent on an improvement: allocated −1.8%, byte peaks bit-identical, and correctly firing with the sides reversed); identity diff all `=`.

Note: dispatching the workflow produces a comparison once the merge base contains this PR (same property as the criterion bench workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcoXpnzQ2ufCzqzB1tZtfm