### PR TITLE
kimchi-stubs: in-place Bigstring to_bytes/of_bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,13 @@ and this project adheres to
 
 #### Added
 
+- Add in-place `caml_pasta_{fp,fq}_{to_bytes_into,of_bytes_from}` and
+  `caml_bigint_256_{to_bytes_into,of_bytes_from}`, which serialize into, or
+  deserialize from, a caller-provided `Bigstring` at an offset. Same wire bytes
+  as `to_bytes` / `of_bytes`, but with no intermediate `bytes` allocation, so a
+  bin_prot writer or reader for a field element allocates nothing. Out-of-range
+  offsets raise `Invalid_argument`
+  ([#3627](https://github.com/o1-labs/proof-systems/issues/3627))
 - Add `<field>_vector_clear`, letting the caller eagerly release a consumed
   vector's Rust-side allocation. OCaml only sees the pointer, so its GC never
   feels the (potentially large) backing buffer

--- a/kimchi-stubs/src/arkworks/bigint_256.rs
+++ b/kimchi-stubs/src/arkworks/bigint_256.rs
@@ -1,4 +1,4 @@
-use crate::caml::caml_bytes_string::CamlBytesString;
+use crate::caml::{caml_bigstring::CamlBigstring, caml_bytes_string::CamlBytesString};
 use ark_ff::{BigInteger as ark_BigInteger, BigInteger256};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use core::{
@@ -228,6 +228,44 @@ pub fn caml_bigint_256_of_bytes(x: &[u8]) -> Result<CamlBigInteger256, ocaml::Er
     Ok(CamlBigInteger256(result))
 }
 
+/// Serialize `x` into `buf[pos .. pos + 32]`, the same bytes as
+/// `caml_bigint_256_to_bytes`, without allocating. Raises `Invalid_argument`
+/// when the window does not fit in `buf`.
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn caml_bigint_256_to_bytes_into(
+    x: ocaml::Pointer<CamlBigInteger256>,
+    mut buf: CamlBigstring,
+    pos: ocaml::Int,
+) -> Result<(), ocaml::Error> {
+    let dst = buf.slice_mut(
+        pos,
+        core::mem::size_of::<BigInteger256>(),
+        "caml_bigint_256_to_bytes_into",
+    )?;
+    x.as_ref().0.serialize_compressed(dst).unwrap();
+    Ok(())
+}
+
+/// Deserialize from `buf[pos .. pos + 32]`, the same semantics as
+/// `caml_bigint_256_of_bytes`, without copying the bytes out first. Raises
+/// `Invalid_argument` when the window does not fit in `buf`.
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn caml_bigint_256_of_bytes_from(
+    buf: CamlBigstring,
+    pos: ocaml::Int,
+) -> Result<CamlBigInteger256, ocaml::Error> {
+    let src = buf.slice(
+        pos,
+        core::mem::size_of::<BigInteger256>(),
+        "caml_bigint_256_of_bytes_from",
+    )?;
+    let result = BigInteger256::deserialize_compressed(src)
+        .map_err(|_| ocaml::Error::Message("deserialization error"))?;
+    Ok(CamlBigInteger256(result))
+}
+
 #[ocaml_gen::func]
 #[ocaml::func]
 pub fn caml_bigint_256_deep_copy(x: CamlBigInteger256) -> CamlBigInteger256 {
@@ -253,5 +291,30 @@ mod tests {
         let x2: BigUint = y.into();
         assert!(x2 == x);
         println!("biguint.to_string: {}", x2);
+    }
+
+    /// The in-place path writes the same bytes as `to_bytes`, at the offset,
+    /// and reads them back.
+    #[test]
+    fn in_place_bytes_match_to_bytes() {
+        let x = BigInteger256::from(0xdead_beef_u64);
+        let len = core::mem::size_of::<BigInteger256>();
+
+        let mut expected = vec![0u8; len];
+        x.serialize_compressed(&mut expected[..]).unwrap();
+
+        let mut buf = vec![0xffu8; 3 * len];
+        let range =
+            crate::caml::caml_bigstring::checked_range(buf.len(), len as ocaml::Int, len, "t")
+                .unwrap();
+        x.serialize_compressed(&mut buf[range.clone()]).unwrap();
+
+        assert_eq!(&buf[range.clone()], &expected[..]);
+        assert!(buf[..len].iter().all(|&b| b == 0xff));
+        assert!(buf[2 * len..].iter().all(|&b| b == 0xff));
+        assert_eq!(
+            BigInteger256::deserialize_compressed(&buf[range]).unwrap(),
+            x
+        );
     }
 }

--- a/kimchi-stubs/src/arkworks/pasta_fp.rs
+++ b/kimchi-stubs/src/arkworks/pasta_fp.rs
@@ -1,4 +1,7 @@
-use crate::{arkworks::CamlBigInteger256, caml::caml_bytes_string::CamlBytesString};
+use crate::{
+    arkworks::CamlBigInteger256,
+    caml::{caml_bigstring::CamlBigstring, caml_bytes_string::CamlBytesString},
+};
 use ark_ff::{FftField, Field, One, PrimeField, UniformRand, Zero};
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -323,8 +326,72 @@ pub fn caml_pasta_fp_of_bytes(x: &[u8]) -> Result<CamlFp, ocaml::Error> {
     Ok(CamlFp(x))
 }
 
+/// Serialize `x` into `buf[pos .. pos + 32]`, the same bytes as
+/// `caml_pasta_fp_to_bytes`, without allocating. Raises `Invalid_argument`
+/// when the window does not fit in `buf`.
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn caml_pasta_fp_to_bytes_into(
+    x: ocaml::Pointer<CamlFp>,
+    mut buf: CamlBigstring,
+    pos: ocaml::Int,
+) -> Result<(), ocaml::Error> {
+    let dst = buf.slice_mut(
+        pos,
+        core::mem::size_of::<Fp>(),
+        "caml_pasta_fp_to_bytes_into",
+    )?;
+    x.as_ref().0.serialize_compressed(dst).unwrap();
+    Ok(())
+}
+
+/// Deserialize from `buf[pos .. pos + 32]`, the same semantics as
+/// `caml_pasta_fp_of_bytes`, without copying the bytes out first. Raises
+/// `Invalid_argument` when the window does not fit in `buf`.
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn caml_pasta_fp_of_bytes_from(
+    buf: CamlBigstring,
+    pos: ocaml::Int,
+) -> Result<CamlFp, ocaml::Error> {
+    let src = buf.slice(
+        pos,
+        core::mem::size_of::<Fp>(),
+        "caml_pasta_fp_of_bytes_from",
+    )?;
+    let x = Fp::deserialize_compressed(src)?;
+    Ok(CamlFp(x))
+}
+
 #[ocaml_gen::func]
 #[ocaml::func]
 pub fn caml_pasta_fp_deep_copy(x: CamlFp) -> CamlFp {
     x
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The in-place path writes the same bytes as `to_bytes`, at the offset,
+    /// and reads them back.
+    #[test]
+    fn in_place_bytes_match_to_bytes() {
+        let x: Fp = UniformRand::rand(&mut rand::thread_rng());
+        let len = core::mem::size_of::<Fp>();
+
+        let mut expected = vec![0u8; len];
+        x.serialize_compressed(&mut expected[..]).unwrap();
+
+        let mut buf = vec![0xffu8; 3 * len];
+        let range =
+            crate::caml::caml_bigstring::checked_range(buf.len(), len as ocaml::Int, len, "t")
+                .unwrap();
+        x.serialize_compressed(&mut buf[range.clone()]).unwrap();
+
+        assert_eq!(&buf[range.clone()], &expected[..]);
+        assert!(buf[..len].iter().all(|&b| b == 0xff));
+        assert!(buf[2 * len..].iter().all(|&b| b == 0xff));
+        assert_eq!(Fp::deserialize_compressed(&buf[range]).unwrap(), x);
+    }
 }

--- a/kimchi-stubs/src/arkworks/pasta_fq.rs
+++ b/kimchi-stubs/src/arkworks/pasta_fq.rs
@@ -1,4 +1,7 @@
-use crate::{arkworks::CamlBigInteger256, caml::caml_bytes_string::CamlBytesString};
+use crate::{
+    arkworks::CamlBigInteger256,
+    caml::{caml_bigstring::CamlBigstring, caml_bytes_string::CamlBytesString},
+};
 use ark_ff::{FftField, Field, One, PrimeField, UniformRand, Zero};
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -323,8 +326,72 @@ pub fn caml_pasta_fq_of_bytes(x: &[u8]) -> Result<CamlFq, ocaml::Error> {
     Ok(CamlFq(x))
 }
 
+/// Serialize `x` into `buf[pos .. pos + 32]`, the same bytes as
+/// `caml_pasta_fq_to_bytes`, without allocating. Raises `Invalid_argument`
+/// when the window does not fit in `buf`.
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn caml_pasta_fq_to_bytes_into(
+    x: ocaml::Pointer<CamlFq>,
+    mut buf: CamlBigstring,
+    pos: ocaml::Int,
+) -> Result<(), ocaml::Error> {
+    let dst = buf.slice_mut(
+        pos,
+        core::mem::size_of::<Fq>(),
+        "caml_pasta_fq_to_bytes_into",
+    )?;
+    x.as_ref().0.serialize_compressed(dst).unwrap();
+    Ok(())
+}
+
+/// Deserialize from `buf[pos .. pos + 32]`, the same semantics as
+/// `caml_pasta_fq_of_bytes`, without copying the bytes out first. Raises
+/// `Invalid_argument` when the window does not fit in `buf`.
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn caml_pasta_fq_of_bytes_from(
+    buf: CamlBigstring,
+    pos: ocaml::Int,
+) -> Result<CamlFq, ocaml::Error> {
+    let src = buf.slice(
+        pos,
+        core::mem::size_of::<Fq>(),
+        "caml_pasta_fq_of_bytes_from",
+    )?;
+    let x = Fq::deserialize_compressed(src)?;
+    Ok(CamlFq(x))
+}
+
 #[ocaml_gen::func]
 #[ocaml::func]
 pub fn caml_pasta_fq_deep_copy(x: CamlFq) -> CamlFq {
     x
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The in-place path writes the same bytes as `to_bytes`, at the offset,
+    /// and reads them back.
+    #[test]
+    fn in_place_bytes_match_to_bytes() {
+        let x: Fq = UniformRand::rand(&mut rand::thread_rng());
+        let len = core::mem::size_of::<Fq>();
+
+        let mut expected = vec![0u8; len];
+        x.serialize_compressed(&mut expected[..]).unwrap();
+
+        let mut buf = vec![0xffu8; 3 * len];
+        let range =
+            crate::caml::caml_bigstring::checked_range(buf.len(), len as ocaml::Int, len, "t")
+                .unwrap();
+        x.serialize_compressed(&mut buf[range.clone()]).unwrap();
+
+        assert_eq!(&buf[range.clone()], &expected[..]);
+        assert!(buf[..len].iter().all(|&b| b == 0xff));
+        assert!(buf[2 * len..].iter().all(|&b| b == 0xff));
+        assert_eq!(Fq::deserialize_compressed(&buf[range]).unwrap(), x);
+    }
 }

--- a/kimchi-stubs/src/caml/caml_bigstring.rs
+++ b/kimchi-stubs/src/caml/caml_bigstring.rs
@@ -1,0 +1,127 @@
+//! A caller-provided byte buffer passed in from OCaml as a `Bigstring`
+//! (`(char, int8_unsigned_elt, c_layout) Bigarray.Array1.t`).
+//!
+//! Stubs that take a [`CamlBigstring`] plus an offset can serialize into, or
+//! deserialize from, the caller's buffer in place, without allocating an
+//! intermediate `bytes` on the OCaml heap. This is what Mina's bin_prot
+//! readers and writers for field elements need: `bin_write_t` gets a buffer
+//! and a position, and `bin_read_t` gets the same.
+
+use ocaml::{bigarray::Array1, CamlError, Error, FromValue, IntoValue, Runtime, Value};
+use ocaml_gen::{const_random, Env, OCamlDesc};
+
+pub struct CamlBigstring(pub Array1<u8>);
+
+unsafe impl IntoValue for CamlBigstring {
+    fn into_value(self, rt: &Runtime) -> Value {
+        self.0.into_value(rt)
+    }
+}
+
+unsafe impl<'a> FromValue<'a> for CamlBigstring {
+    fn from_value(v: Value) -> Self {
+        CamlBigstring(FromValue::from_value(v))
+    }
+}
+
+impl OCamlDesc for CamlBigstring {
+    fn ocaml_desc(_env: &Env, _generics: &[&str]) -> String {
+        // Spelled out rather than `Bigstring.t` so the generated bindings do
+        // not depend on Core being opened; this is exactly `Core.Bigstring.t`.
+        "(char, Stdlib.Bigarray.int8_unsigned_elt, Stdlib.Bigarray.c_layout) \
+         Stdlib.Bigarray.Array1.t"
+            .to_string()
+    }
+
+    fn unique_id() -> u128 {
+        const_random!(u128)
+    }
+}
+
+/// Bounds-check `pos .. pos + len` against a buffer of `buf_len` bytes.
+///
+/// Returns `Invalid_argument fname` (as the OCaml `Bigstring` blit functions
+/// do) when `pos` is negative or the window does not fit, so a bad offset
+/// surfaces as an OCaml exception instead of a Rust panic across the FFI.
+pub fn checked_range(
+    buf_len: usize,
+    pos: ocaml::Int,
+    len: usize,
+    fname: &'static str,
+) -> Result<core::ops::Range<usize>, Error> {
+    let out_of_bounds = || Error::Caml(CamlError::InvalidArgument(fname));
+    let start: usize = pos.try_into().map_err(|_| out_of_bounds())?;
+    let end = start.checked_add(len).ok_or_else(out_of_bounds)?;
+    if end > buf_len {
+        return Err(out_of_bounds());
+    }
+    Ok(start..end)
+}
+
+impl CamlBigstring {
+    /// The `len` bytes starting at `pos`, or `Invalid_argument fname`.
+    pub fn slice(&self, pos: ocaml::Int, len: usize, fname: &'static str) -> Result<&[u8], Error> {
+        let range = checked_range(self.0.len(), pos, len, fname)?;
+        Ok(&self.0.data()[range])
+    }
+
+    /// The `len` bytes starting at `pos`, mutably, or `Invalid_argument fname`.
+    pub fn slice_mut(
+        &mut self,
+        pos: ocaml::Int,
+        len: usize,
+        fname: &'static str,
+    ) -> Result<&mut [u8], Error> {
+        let range = checked_range(self.0.len(), pos, len, fname)?;
+        Ok(&mut self.0.data_mut()[range])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_invalid_argument(e: Error, fname: &str) -> bool {
+        matches!(e, Error::Caml(CamlError::InvalidArgument(s)) if s == fname)
+    }
+
+    #[test]
+    fn range_fits() {
+        assert_eq!(checked_range(64, 0, 32, "f").unwrap(), 0..32);
+        assert_eq!(checked_range(64, 32, 32, "f").unwrap(), 32..64);
+        assert_eq!(checked_range(32, 0, 32, "f").unwrap(), 0..32);
+        assert_eq!(checked_range(0, 0, 0, "f").unwrap(), 0..0);
+    }
+
+    #[test]
+    fn range_rejects_overrun() {
+        assert!(is_invalid_argument(
+            checked_range(64, 33, 32, "f").unwrap_err(),
+            "f"
+        ));
+        assert!(is_invalid_argument(
+            checked_range(31, 0, 32, "f").unwrap_err(),
+            "f"
+        ));
+        assert!(is_invalid_argument(
+            checked_range(64, 64, 1, "f").unwrap_err(),
+            "f"
+        ));
+    }
+
+    #[test]
+    fn range_rejects_negative_pos() {
+        assert!(is_invalid_argument(
+            checked_range(64, -1, 32, "f").unwrap_err(),
+            "f"
+        ));
+    }
+
+    #[test]
+    fn range_rejects_overflow() {
+        assert!(is_invalid_argument(
+            checked_range(64, ocaml::Int::MAX, 32, "f").unwrap_err(),
+            "f"
+        ));
+    }
+}

--- a/kimchi-stubs/src/caml/mod.rs
+++ b/kimchi-stubs/src/caml/mod.rs
@@ -1,3 +1,4 @@
+pub mod caml_bigstring;
 pub mod caml_bytes_string;
 
 #[macro_use]


### PR DESCRIPTION
Add `caml_pasta_{fp,fq}_{to_bytes_into,of_bytes_from}` and `caml_bigint_256_{to_bytes_into,of_bytes_from}`, which serialize into, or deserialize from, a caller-provided Bigstring at an offset. Same wire bytes as to_bytes / of_bytes, but with no intermediate `bytes` allocation, so Mina's bin_prot writer and reader for a field element can allocate nothing.

The buffer is passed as a new `CamlBigstring` wrapper around `ocaml::bigarray::Array1<u8>`, described to ocaml-gen as `(char, int8_unsigned_elt, c_layout) Bigarray.Array1.t`, i.e. `Core.Bigstring.t`. Out-of-range or negative offsets raise Invalid_argument instead of panicking across the FFI.

Fixes #3627